### PR TITLE
[MIFOSX-2310] User allowed to leave Max age for LOSS criteria blank.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaDefinition.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaDefinition.java
@@ -44,7 +44,7 @@ public class ProvisioningCriteriaDefinition extends AbstractPersistable<Long> {
     @Column(name = "min_age", nullable = false)
     private Long minimumAge;
 
-    @Column(name = "max_age", nullable = false)
+    @Column(name = "max_age", nullable = true)
     private Long maximumAge;
 
     @Column(name = "provision_percentage", nullable = false)
@@ -91,6 +91,11 @@ public class ProvisioningCriteriaDefinition extends AbstractPersistable<Long> {
     
     
     public boolean isOverlapping(ProvisioningCriteriaDefinition def) {
-        return this.minimumAge <= def.maximumAge && def.minimumAge <= this.maximumAge;
+        if(this.maximumAge == null || def.maximumAge == null){ //NUll symbolises infinity
+            return false;
+        }
+        else {
+            return this.minimumAge <= def.maximumAge && def.minimumAge <= this.maximumAge;
+        }
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/serialization/ProvisioningCriteriaDefinitionJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/serialization/ProvisioningCriteriaDefinitionJsonDeserializer.java
@@ -104,10 +104,20 @@ public class ProvisioningCriteriaDefinitionJsonDeserializer implements Provision
                         .parameterAtIndexArray(ProvisioningCriteriaConstants.JSON_MINIMUM_AGE_PARAM, i + 1).value(minimumAge).notNull()
                         .longZeroOrGreater() ;
 
-                Long maximumAge = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, jsonObject);
-                baseDataValidator.reset().parameter(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM)
-                        .parameterAtIndexArray(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, i + 1).value(maximumAge).notNull()
-                        .longGreaterThanNumber(ProvisioningCriteriaConstants.JSON_MINIMUM_AGE_PARAM, minimumAge, (i+1));
+
+                //Allow Max age of "Loss Category" to be blank => Symbolises infinity// NotNull check removed when  categoryId=4
+                if(categoryId == 4) {
+                    Long maximumAge = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, jsonObject);
+                    baseDataValidator.reset().parameter(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM)
+                            .parameterAtIndexArray(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, i + 1).value(maximumAge)
+                            .longGreaterThanNumber(ProvisioningCriteriaConstants.JSON_MINIMUM_AGE_PARAM, minimumAge, (i + 1));
+                } else {
+                    Long maximumAge = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, jsonObject);
+                    baseDataValidator.reset().parameter(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM)
+                            .parameterAtIndexArray(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, i + 1).value(maximumAge).notNull()
+                            .longGreaterThanNumber(ProvisioningCriteriaConstants.JSON_MINIMUM_AGE_PARAM, minimumAge, (i + 1));
+
+                }
 
                 
                 BigDecimal provisioningpercentage = this.fromApiJsonHelper.extractBigDecimalNamed(

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V295__allows_null_for_max_age_in_provisioning_criteria_definition_script.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V295__allows_null_for_max_age_in_provisioning_criteria_definition_script.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `m_provisioning_criteria_definition` MODIFY `max_age` bigint(20) ;


### PR DESCRIPTION
Under category we have STANDARD, SUB-STANDARD, DOUBTFUL and LOSS options. In which if the Loss is considered as the last category it would be better to set the Max Age as Infinity (Blank) so that for any loans which are due from very long period falls under that category.
