### PR TITLE
Loan Product Office Name Parameter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/domain/AccountNumberFormatEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/domain/AccountNumberFormatEnumerations.java
@@ -33,7 +33,7 @@ public class AccountNumberFormatEnumerations {
     public final static Set<AccountNumberPrefixType> accountNumberPrefixesForClientAccounts = new HashSet<>(Arrays.asList(
             AccountNumberPrefixType.OFFICE_NAME, AccountNumberPrefixType.CLIENT_TYPE));
     public final static Set<AccountNumberPrefixType> accountNumberPrefixesForLoanAccounts = new HashSet<>(Arrays.asList(
-            AccountNumberPrefixType.OFFICE_NAME, AccountNumberPrefixType.LOAN_PRODUCT_SHORT_NAME));
+            AccountNumberPrefixType.OFFICE_NAME, AccountNumberPrefixType.LOAN_PRODUCT_SHORT_NAME, AccountNumberPrefixType.OFFICE_AND_LOAN_PRODUCT_NAME));
     public final static Set<AccountNumberPrefixType> accountNumberPrefixesForSavingsAccounts = new HashSet<>(Arrays.asList(
             AccountNumberPrefixType.OFFICE_NAME, AccountNumberPrefixType.SAVINGS_PRODUCT_SHORT_NAME));
     public final static Set<AccountNumberPrefixType> accountNumberPrefixesForCenters = new HashSet<>(Arrays.asList(
@@ -44,7 +44,7 @@ public class AccountNumberFormatEnumerations {
     public enum AccountNumberPrefixType {
         OFFICE_NAME(1, "accountNumberPrefixType.officeName"), CLIENT_TYPE(101, "accountNumberPrefixType.clientType"), LOAN_PRODUCT_SHORT_NAME(
                 201, "accountNumberPrefixType.loanProductShortName"), SAVINGS_PRODUCT_SHORT_NAME(301,
-                "accountNumberPrefixType.savingsProductShortName");
+                "accountNumberPrefixType.savingsProductShortName"), OFFICE_AND_LOAN_PRODUCT_NAME(401,"accountNumberPrefixType.officeNameandLoanProductShortName");
 
         private final Integer value;
         private final String code;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
@@ -45,6 +45,7 @@ public class AccountNumberGenerator {
     private final static String OFFICE_NAME = "officeName";
     private final static String LOAN_PRODUCT_SHORT_NAME = "loanProductShortName";
     private final static String SAVINGS_PRODUCT_SHORT_NAME = "savingsProductShortName";
+    private final static String OFFICE_AND_LOAD_PRODUCT_NAME ="officeAndLoanProductName";
 
     public String generate(Client client, AccountNumberFormat accountNumberFormat) {
         Map<String, String> propertyMap = new HashMap<>();
@@ -62,6 +63,7 @@ public class AccountNumberGenerator {
         propertyMap.put(ID, loan.getId().toString());
         propertyMap.put(OFFICE_NAME, loan.getOffice().getName());
         propertyMap.put(LOAN_PRODUCT_SHORT_NAME, loan.loanProduct().getShortName());
+        propertyMap.put(OFFICE_AND_LOAD_PRODUCT_NAME, loan.getOffice().getName()+ loan.loanProduct().getShortName());
         return generateAccountNumber(propertyMap, accountNumberFormat);
     }
 
@@ -91,6 +93,10 @@ public class AccountNumberGenerator {
                     prefix = propertyMap.get(LOAN_PRODUCT_SHORT_NAME);
                 break;
 
+                case OFFICE_AND_LOAN_PRODUCT_NAME:
+                	  prefix = getFirstLetters(propertyMap.get(OFFICE_NAME)).concat(propertyMap.get(LOAN_PRODUCT_SHORT_NAME));
+                break;
+
                 case SAVINGS_PRODUCT_SHORT_NAME:
                     prefix = propertyMap.get(SAVINGS_PRODUCT_SHORT_NAME);
                 break;
@@ -103,20 +109,29 @@ public class AccountNumberGenerator {
         }
         return accountNumber;
     }
-    
+
     public String generateGroupAccountNumber(Group group, AccountNumberFormat accountNumberFormat) {
     	Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(ID, group.getId().toString());
-        propertyMap.put(OFFICE_NAME, group.getOffice().getName());        
-        return generateAccountNumber(propertyMap, accountNumberFormat);
-    }
-    
-    public String generateCenterAccountNumber(Group group, AccountNumberFormat accountNumberFormat) {
-    	Map<String, String> propertyMap = new HashMap<>();
-        propertyMap.put(ID, group.getId().toString());
-        propertyMap.put(OFFICE_NAME, group.getOffice().getName());        
+        propertyMap.put(OFFICE_NAME, group.getOffice().getName());
         return generateAccountNumber(propertyMap, accountNumberFormat);
     }
 
+    public String generateCenterAccountNumber(Group group, AccountNumberFormat accountNumberFormat) {
+    	Map<String, String> propertyMap = new HashMap<>();
+        propertyMap.put(ID, group.getId().toString());
+        propertyMap.put(OFFICE_NAME, group.getOffice().getName());
+        return generateAccountNumber(propertyMap, accountNumberFormat);
+    }
+
+    public String getFirstLetters(String text)
+    {
+      String firstLetters = "";
+      for(String s : text.split(" "))
+      {
+        firstLetters += s.charAt(0);
+      }
+      return firstLetters;
+    }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
@@ -94,7 +94,7 @@ public class AccountNumberGenerator {
                 break;
 
                 case OFFICE_AND_LOAN_PRODUCT_NAME:
-                		prefix = propertyMap.get(OFFICE_AND_LOAN_PRODUCT_NAME);
+                	prefix = propertyMap.get(OFFICE_AND_LOAN_PRODUCT_NAME);
                 	break;
 
                 case SAVINGS_PRODUCT_SHORT_NAME:

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
@@ -45,7 +45,7 @@ public class AccountNumberGenerator {
     private final static String OFFICE_NAME = "officeName";
     private final static String LOAN_PRODUCT_SHORT_NAME = "loanProductShortName";
     private final static String SAVINGS_PRODUCT_SHORT_NAME = "savingsProductShortName";
-    private final static String OFFICE_AND_LOAD_PRODUCT_NAME ="officeAndLoanProductName";
+    private final static String OFFICE_AND_LOAN_PRODUCT_NAME ="officeAndLoanProductName";
 
     public String generate(Client client, AccountNumberFormat accountNumberFormat) {
         Map<String, String> propertyMap = new HashMap<>();
@@ -63,10 +63,10 @@ public class AccountNumberGenerator {
         propertyMap.put(ID, loan.getId().toString());
         propertyMap.put(OFFICE_NAME, loan.getOffice().getName());
         propertyMap.put(LOAN_PRODUCT_SHORT_NAME, loan.loanProduct().getShortName());
-        propertyMap.put(OFFICE_AND_LOAD_PRODUCT_NAME, loan.getOffice().getName()+ loan.loanProduct().getShortName());
+        propertyMap.put(OFFICE_AND_LOAN_PRODUCT_NAME, getFirstLetters(loan.getOffice().getName()).concat(loan.loanProduct().getShortName()));
         return generateAccountNumber(propertyMap, accountNumberFormat);
     }
-
+    
     public String generate(SavingsAccount savingsAccount, AccountNumberFormat accountNumberFormat) {
         Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(ID, savingsAccount.getId().toString());
@@ -94,8 +94,8 @@ public class AccountNumberGenerator {
                 break;
 
                 case OFFICE_AND_LOAN_PRODUCT_NAME:
-                	  prefix = getFirstLetters(propertyMap.get(OFFICE_NAME)).concat(propertyMap.get(LOAN_PRODUCT_SHORT_NAME));
-                break;
+                		prefix = propertyMap.get(OFFICE_AND_LOAN_PRODUCT_NAME);
+                	break;
 
                 case SAVINGS_PRODUCT_SHORT_NAME:
                     prefix = propertyMap.get(SAVINGS_PRODUCT_SHORT_NAME);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
@@ -95,7 +95,7 @@ public class AccountNumberGenerator {
 
                 case OFFICE_AND_LOAN_PRODUCT_NAME:
                 	prefix = propertyMap.get(OFFICE_AND_LOAN_PRODUCT_NAME);
-                	break;
+                break;
 
                 case SAVINGS_PRODUCT_SHORT_NAME:
                     prefix = propertyMap.get(SAVINGS_PRODUCT_SHORT_NAME);


### PR DESCRIPTION
For Those who needs to have account number format as

Office_Name = as Stripped with Initial Letters, 
Product_short_name = concatenating both OFFICE_NAME + PRODUCT SHORT NAME

This kind of series will be useful for MFI/NBFC and Integrator, to utilize this new kind of AccountNumberGeneration

@theupscale

From Upscale Team
