### PR TITLE
FINERACT-190: Fixed client share activated user join

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
@@ -163,7 +163,7 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
     		.append("left join m_appuser sbu on sbu.id = sa.submitted_userid ")
     		.append("left join m_appuser rbu on rbu.id = sa.rejected_userid ")
     		.append("left join m_appuser abu on abu.id = sa.approved_userid ")
-    		.append("left join m_appuser avbu on rbu.id = sa.activated_userid ")
+    		.append("left join m_appuser avbu on avbu.id = sa.activated_userid ")
     		.append("left join m_appuser cbu on cbu.id = sa.closed_userid ") ;
     		schema = buff.toString() ;
 		}


### PR DESCRIPTION
When getting share account list under a client, if `rejected_userid` is set for the share account, the join condition for `activated_userid` was using the rejected user table in the join condition resulting in multiple instances of share account records which have both these columns set. Also the activated user details are incorrectly returned in the resultset. For example, see https://staging.openmf.org client 6 - Malabar Gold under "Closed" share accounts - 6 entries are visible for the same account.

The fix uses the correct table alias avbu in the join condition instead of rbu and so removes duplicate records and ensures correct activated user details are returned. Fixes FINERACT-190
