### PR TITLE
FINERACT-7: Sort loanInstallmentCharges before updating

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -4697,8 +4697,8 @@ public class Loan extends AbstractPersistableCustom<Long> {
         return loanCharges;
     }
 
-    public Set<LoanInstallmentCharge> generateInstallmentLoanCharges(final LoanCharge loanCharge) {
-        final Set<LoanInstallmentCharge> loanChargePerInstallments = new HashSet<>();
+    public List<LoanInstallmentCharge> generateInstallmentLoanCharges(final LoanCharge loanCharge) {
+        final List<LoanInstallmentCharge> loanChargePerInstallments = new ArrayList<>();
         if (loanCharge.isInstalmentFee()) {
             List<LoanRepaymentScheduleInstallment> installments = getRepaymentScheduleInstallments() ;
             for (final LoanRepaymentScheduleInstallment installment : installments) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
@@ -32,7 +32,7 @@ import org.apache.fineract.organisation.monetary.domain.Money;
 
 @Entity
 @Table(name = "m_loan_installment_charge")
-public class LoanInstallmentCharge extends AbstractPersistableCustom<Long> {
+public class LoanInstallmentCharge extends AbstractPersistableCustom<Long> implements Comparable {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "loan_charge_id", referencedColumnName = "id", nullable = false)
@@ -78,6 +78,10 @@ public class LoanInstallmentCharge extends AbstractPersistableCustom<Long> {
         this.amountPaid = null;
         this.amountWaived = null;
         this.amountWrittenOff = null;
+    }
+
+    public int compareTo(Object o) {
+        return this.installment.compareTo(((LoanInstallmentCharge)o).installment);
     }
 
     public void copyFrom(final LoanInstallmentCharge loanChargePerInstallment) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
@@ -43,7 +43,7 @@ import org.joda.time.LocalDate;
 
 @Entity
 @Table(name = "m_loan_repayment_schedule")
-public final class LoanRepaymentScheduleInstallment extends AbstractAuditableCustom<AppUser, Long> {
+public final class LoanRepaymentScheduleInstallment extends AbstractAuditableCustom<AppUser, Long> implements Comparable {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "loan_id", referencedColumnName="id")
@@ -164,6 +164,10 @@ public final class LoanRepaymentScheduleInstallment extends AbstractAuditableCus
         this.fromDate = null;
         this.dueDate = null;
         this.obligationsMet = false;
+    }
+
+    public int compareTo(Object o) {
+        return this.installmentNumber.compareTo(((LoanRepaymentScheduleInstallment)o).installmentNumber);
     }
 
     private BigDecimal defaultToNullIfZero(final BigDecimal value) {


### PR DESCRIPTION
Less than ideal fix (sorting overhead), but most topically contained. Potentially we should change the Sets to Lists, and or redefine the Entities, but that would affect too many things.

Have left a potentially iffy corner case in updateInstallmentCharges as is.

Additionally there is a pre-existing defect where a PersistenceException caused by an FK constraint is raised when all of the charges are waived. Have not investigated, potentially there is an existing bug.