### PR TITLE
 Fineract-265:addressModuleNullPointerFix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/address/service/AddressWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/address/service/AddressWritePlatformServiceImpl.java
@@ -142,7 +142,13 @@ public class AddressWritePlatformServiceImpl implements AddressWritePlatformServ
 			final Long addressid = add.getId();
 			final Address addobj = this.addressRepository.getOne(addressid);
 
-			final boolean isActive = jsonObject.get("isActive").getAsBoolean();
+			//final boolean isActive = jsonObject.get("isActive").getAsBoolean();
+			boolean isActive=false;
+			if(jsonObject.get("isActive")!= null)
+			{
+				isActive= jsonObject.get("isActive").getAsBoolean();
+			}
+			
 
 			clientAddressobj = ClientAddress.fromJson(isActive, client, addobj, addressTypeIdObj);
 			this.clientAddressRepository.save(clientAddressobj);


### PR DESCRIPTION
This is a fix for a bug in address module. The address module throws a null pointer exception when the user creates a new client and puts in the address without activating it ( keeping the enable check box as unchecked). Now the code assumes that the address is not active by default and only checks for value if the parameter has one.