### PR TITLE
FINERACT-352 fix showing penalties after last loan's installment

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -2375,7 +2375,6 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
                 LoanRepaymentScheduleInstallment newEntry = new LoanRepaymentScheduleInstallment(loan, installments.size() + 1,
                         lastInstallment.getDueDate(), lastChargeDate, principal, interest, feeCharges, penaltyCharges,
                         recalculatedInterestComponent, compoundingDetails);
-                installments.add(newEntry);
                 loan.addLoanRepaymentScheduleInstallment(newEntry);
             }
         }


### PR DESCRIPTION
The new installment created in which penalties should be applied after loan's maturity date, was created twice. This messed up with the charges recalculation.