### PR TITLE
fix for FINERACT-243 : Constitution type is not required field

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
@@ -246,13 +246,7 @@ public final class ClientDataValidator {
             final LocalDate incorpValidityTill = this.fromApiJsonHelper.extractLocalDateNamed(ClientApiConstants.incorpValidityTillParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.incorpValidityTillParamName).value(incorpValidityTill).ignoreIfNull();
         }
-        
-        if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.constitutionIdParamName, element)) {
-            final Integer constitution = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(ClientApiConstants.constitutionIdParamName,
-                    element);
-            baseDataValidator.reset().parameter(ClientApiConstants.constitutionIdParamName).value(constitution).notNull().integerGreaterThanZero();
-        }
-        
+                
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mainBusinessLineIdParamName, element)) {
             final Integer mainBusinessLine = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(ClientApiConstants.mainBusinessLineIdParamName,
                     element);
@@ -529,11 +523,6 @@ public final class ClientDataValidator {
             baseDataValidator.reset().parameter(ClientApiConstants.incorpValidityTillParamName).value(incorpValidityTill);
         }
     	
-    	if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.constitutionIdParamName, element)) {
-            atLeastOneParameterPassedForUpdate = true;
-            final Integer constitutionId = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(ClientApiConstants.constitutionIdParamName, element);
-            baseDataValidator.reset().parameter(ClientApiConstants.constitutionIdParamName).value(constitutionId).notNull().integerGreaterThanZero();
-        }
     	
     	if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mainBusinessLineIdParamName, element)) {
             atLeastOneParameterPassedForUpdate = true;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientNonPerson.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientNonPerson.java
@@ -53,7 +53,7 @@ public class ClientNonPerson extends AbstractPersistableCustom<Long> {
     private Client client;
 	
 	@ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "constitution_cv_id", nullable = false)
+    @JoinColumn(name = "constitution_cv_id", nullable = true)
     private CodeValue constitution;
 	
 	@Column(name = "incorp_no", length = 50, nullable = true)
@@ -164,7 +164,6 @@ public class ClientNonPerson extends AbstractPersistableCustom<Long> {
 	public Map<String, Object> update(final JsonCommand command) {
 		
 		final Map<String, Object> actualChanges = new LinkedHashMap<>(9);
-		
 		if (command.isChangeInStringParameterNamed(ClientApiConstants.incorpNumberParamName, this.incorpNumber)) {
             final String newValue = command.stringValueOfParameterNamed(ClientApiConstants.incorpNumberParamName);
             actualChanges.put(ClientApiConstants.incorpNumberParamName, newValue);
@@ -205,4 +204,5 @@ public class ClientNonPerson extends AbstractPersistableCustom<Long> {
         return actualChanges;
 			
 	}
+	
 }

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V326__nonpersonclient_constitution_optional.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V326__nonpersonclient_constitution_optional.sql
@@ -1,0 +1,21 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+ALTER TABLE `mifostenant-default`.`m_client_non_person` 
+CHANGE COLUMN `constitution_cv_id` `constitution_cv_id` INT(11) NULL ;


### PR DESCRIPTION
	modified:   fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
	modified:   fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientNonPerson.java
	new file:   fineract-provider/src/main/resources/sql/migrations/core_db/V326__nonpersonclient_constitution_optional.sql

fix for FINERACT-243 : Constitution type is not required field