### PR TITLE
FINERACT-590

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/AccountNumberGenerator.java
@@ -108,6 +108,11 @@ public class AccountNumberGenerator {
                 break;
 
             }
+
+            // FINERACT-590
+            // Because account_no is limited to 20 chars, we can only use the first 10 chars of prefix - trim if necessary
+            prefix = prefix.substring(0, Math.min(prefix.length(), 10));
+
             accountNumber = StringUtils.overlay(accountNumber, prefix, 0, 0);
         }
         return accountNumber;


### PR DESCRIPTION
When adding prefix to account number, limit to 10 characters so that the account number is not longer than the database field (20 chars).