### PR TITLE
FINERACT-546 - remove group from center fix

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
@@ -132,19 +132,19 @@ public class CenterIntegrationTest {
         String newName = "TestCenterUpdateNew" + new Timestamp(new java.util.Date().getTime());
         String newExternalId = Utils.randomStringGenerator("newID_", 7, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
         int newStaffId = StaffHelper.createStaff(requestSpec, responseSpec);
-        int[] associateGroupMembers = generateGroupMembers(2, officeId);
+        int[] groupMembersForLink = generateGroupMembers(2, officeId);
 
-        int[] associateResponse = CenterHelper.associateGroups(resourceId, associateGroupMembers, requestSpec, responseSpec);
+        int[] associateResponse = CenterHelper.associateGroups(resourceId, groupMembersForLink, requestSpec, responseSpec);
         Arrays.sort(associateResponse);
-        Arrays.sort(associateGroupMembers);
-        Assert.assertArrayEquals(associateResponse, associateGroupMembers);
+        Arrays.sort(groupMembersForLink);
+        Assert.assertArrayEquals(associateResponse, groupMembersForLink);
 
         int[] newGroupMembers = new int[5];
         for (int i = 0; i < 5; i++) {
             if (i < 3) {
                 newGroupMembers[i] = groupMembers[i];
             } else {
-                newGroupMembers[i] = associateGroupMembers[i % 3];
+                newGroupMembers[i] = groupMembersForLink[i % 3];
             }
         }
 
@@ -164,6 +164,12 @@ public class CenterIntegrationTest {
         Assert.assertEquals(newExternalId, center.getExternalId());
         Assert.assertEquals((Integer)newStaffId, center.getStaffId());
         Assert.assertArrayEquals(newGroupMembers, center.getGroupMembers());
+        
+        //Reversing group association to test disassociateGroups command
+        int[] disAssociateResponse = CenterHelper.disassociateGroups(resourceId, groupMembersForLink, requestSpec, responseSpec);
+        Arrays.sort(disAssociateResponse);
+        Arrays.sort(groupMembersForLink);
+        Assert.assertArrayEquals(disAssociateResponse, groupMembersForLink);
     }
 
     @Test

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
@@ -113,11 +113,21 @@ public class CenterHelper {
 
     public static int[] associateGroups(final int id, final int[] groupMembers, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String ASSOCIATE_GROUP_CENTER_URL = CENTERS_URL + "/" + id + "?command=associateGroups&" + Utils.TENANT_IDENTIFIER;
+        return linkGroupsToCenterCommand(id, groupMembers, requestSpec, responseSpec, "associateGroups");
+    }
+
+    public static int[] disassociateGroups(final int id, final int[] groupMembers, final RequestSpecification requestSpec,
+            final ResponseSpecification responseSpec) {
+        return linkGroupsToCenterCommand(id, groupMembers, requestSpec, responseSpec, "disassociateGroups");
+    }
+
+    private static int[] linkGroupsToCenterCommand(final int id, final int[] groupMembers, final RequestSpecification requestSpec,
+            final ResponseSpecification responseSpec, String command) {
+        final String CENTER_GROUP_LINK_URL = CENTERS_URL + "/" + id + "?command=" + command + "&" + Utils.TENANT_IDENTIFIER;
         HashMap groupMemberHashMap = new HashMap();
         groupMemberHashMap.put("groupMembers", groupMembers);
-        System.out.println("---------------------------------ASSOCIATING GROUPS AT " + id + "--------------------------------------------");
-        HashMap hash = Utils.performServerPost(requestSpec, responseSpec, ASSOCIATE_GROUP_CENTER_URL,
+        System.out.println("---------------------------------" + command + " GROUPS AT " + id + "--------------------------------------------");
+        HashMap hash = Utils.performServerPost(requestSpec, responseSpec, CENTER_GROUP_LINK_URL,
                 new Gson().toJson(groupMemberHashMap), "changes");
         System.out.println(hash);
         ArrayList<String> arr = (ArrayList<String>) hash.get("groupMembers");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
@@ -884,7 +884,13 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
 
         final List<String> changes = centerForUpdate.disassociateGroups(groupMembers);
         if (!changes.isEmpty()) {
-            actualChanges.put(GroupingTypesApiConstants.clientMembersParamName, changes);
+        	changes.stream().forEach(groupId -> {
+        		Group group = this.groupRepository.findOneWithNotFoundDetection(Long.parseLong(groupId));
+        		group.setParent(null);
+        		group.resetHierarchy();
+        		this.groupRepository.saveAndFlush(group);
+        	});
+            actualChanges.put(GroupingTypesApiConstants.groupMembersParamName, changes);
         }
 
         this.groupRepository.saveAndFlush(centerForUpdate);


### PR DESCRIPTION
1. Center from which group being disassociated is really stored as parent of the group. Introduced a parent check method to fix disassociation of groups

2. Originally disassociateGroups command was returning result as 'clientMembers' - assuming this is typo. Fixed to return result as groupMembers
3. Updated test case CenterIntegrationTest to validate