### PR TITLE
Adding a compress response filter,registering filter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/WebXmlConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/WebXmlConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.core.boot;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
 
+import org.apache.fineract.infrastructure.core.filters.ResponseCompressFilter;
 import org.apache.fineract.infrastructure.core.filters.ResponseCorsFilter;
 import org.apache.fineract.infrastructure.security.filter.TenantAwareBasicAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +64,8 @@ public class WebXmlConfiguration {
         jerseyServletRegistration.addInitParameter("com.sun.jersey.spi.container.ContainerResponseFilters",
                 ResponseCorsFilter.class.getName());
         jerseyServletRegistration.addInitParameter("com.sun.jersey.config.feature.DisableWADL", "true");
+        jerseyServletRegistration.addInitParameter("com.sun.jersey.spi.container.ContainerResponseFilters",
+                ResponseCompressFilter.class.getName());
         // debugging for development:
         // jerseyServletRegistration.addInitParameter("com.sun.jersey.spi.container.ContainerRequestFilters",
         // LoggingFilter.class.getName());

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/filters/ResponseCompressFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/filters/ResponseCompressFilter.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.filters;
+
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+import org.apache.fineract.infrastructure.core.writer.GZipResponseWriter;
+
+import javax.ws.rs.core.HttpHeaders;
+
+/**
+ * Filter that compresses the response using gzip
+ */
+
+public class ResponseCompressFilter implements ContainerResponseFilter {
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        if (request.getRequestHeaders().getFirst(HttpHeaders.ACCEPT_ENCODING).contains("gzip")) {
+            response.getHttpHeaders().add(HttpHeaders.CONTENT_ENCODING, "gzip");
+            response.setContainerResponseWriter( new GZipResponseWriter(response.getContainerResponseWriter()));
+        }
+
+        return response;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/writer/GZipResponseWriter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/writer/GZipResponseWriter.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.writer;
+
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GZipResponseWriter implements ContainerResponseWriter {
+    private final ContainerResponseWriter crw;
+
+    private GZIPOutputStream gos;
+
+    public GZipResponseWriter(ContainerResponseWriter crw) {
+        this.crw = crw;
+    }
+
+    public OutputStream writeStatusAndHeaders(long contentLength, ContainerResponse response) throws IOException {
+        gos = new GZIPOutputStream(crw.writeStatusAndHeaders(-1, response));
+        return gos;
+    }
+
+    public void finish() throws IOException {
+        gos.finish();
+        crw.finish();
+    }
+}


### PR DESCRIPTION
Adding a filter to support response compression. This will ensure less bandwidth usage for field officer apps
Related Jira issue [FINERACT-426](https://issues.apache.org/jira/browse/FINERACT-426?jql=reporter%20in%20(avikganguly%2C%20avikganguly010))