### PR TITLE
FINERACT-546 disassociate group from center

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/Group.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/Group.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,10 +45,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.security.service.RandomPasswordGenerator;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.organisation.staff.domain.Staff;
@@ -108,9 +107,9 @@ public final class Group extends AbstractPersistableCustom<Long> {
 
     @OneToMany(fetch = FetchType.EAGER)
     @JoinColumn(name = "parent_id")
-    private final List<Group> groupMembers = new LinkedList<>();
-
-    @ManyToMany
+    private Set<Group> groupMembers = new HashSet<>();
+    
+	@ManyToMany
     @JoinTable(name = "m_group_client", joinColumns = @JoinColumn(name = "group_id"), inverseJoinColumns = @JoinColumn(name = "client_id"))
     private Set<Client> clientMembers = new HashSet<>();
 
@@ -577,7 +576,7 @@ public final class Group extends AbstractPersistableCustom<Long> {
     }
 
     public List<String> disassociateGroups(Set<Group> groupMembersSet) {
-
+    	
         final List<String> differences = new ArrayList<>();
         for (final Group group : groupMembersSet) {
             if (hasGroupAsMember(group)) {
@@ -744,4 +743,13 @@ public final class Group extends AbstractPersistableCustom<Long> {
         this.accountNumber = accountIdentifier;
         this.accountNumberRequiresAutoGeneration = false;
     }
+
+	public Set<Group> getGroupMembers() {
+		return groupMembers;
+	}
+
+	public void setGroupMembers(Set<Group> groupMembers) {
+		this.groupMembers = groupMembers;
+	}
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/GroupRepositoryWrapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/GroupRepositoryWrapper.java
@@ -66,4 +66,13 @@ public class GroupRepositoryWrapper {
     public void flush() {
         this.repository.flush();
     }
+    
+    public Group findOneAndLoadAssociatedMembers(final Long id) {
+        final Group entity = this.repository.findOne(id);
+        if (entity == null) { throw new GroupNotFoundException(id); }
+        else{
+        	entity.getGroupMembers().size();
+        }
+        return entity;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
@@ -877,14 +877,14 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
     public CommandProcessingResult disassociateGroupsToCenter(final Long centerId, final JsonCommand command) {
         this.fromApiJsonDeserializer.validateForDisassociateGroups(command.json());
 
-        final Group centerForUpdate = this.groupRepository.findOneWithNotFoundDetection(centerId);
+        final Group centerForUpdate = this.groupRepository.findOneAndLoadAssociatedMembers(centerId);
         final Set<Group> groupMembers = assembleSetOfChildGroups(centerForUpdate.officeId(), command);
 
         final Map<String, Object> actualChanges = new HashMap<>();
 
         final List<String> changes = centerForUpdate.disassociateGroups(groupMembers);
         if (!changes.isEmpty()) {
-            actualChanges.put(GroupingTypesApiConstants.clientMembersParamName, changes);
+            actualChanges.put(GroupingTypesApiConstants.groupMembersParamName, changes);
         }
 
         this.groupRepository.saveAndFlush(centerForUpdate);


### PR DESCRIPTION
Unable to remove group from center fixed. Since OpenJPA annotation failed to load the eager entities, application was unable to load the entities mapped to it. The fix initializes entities mapped to it.