### PR TITLE
Fix Addresses Path

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientAddressApiResources.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientAddressApiResources.java
@@ -49,7 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-@Path("/client")
+@Path("/clients")
 @Component
 @Scope("singleton")
 public class ClientAddressApiResources {


### PR DESCRIPTION
Path for addresses resource is inconsistent
/client/{clientId}/addresses

Other resources are plurals:
/clients/{clientId}/charges
/clients/{clientId}/identifiers
/clients/{clientId}/accounts

Change addresses path to:
/clients/{clientId}/addresses
