### PR TITLE
Thread.run()->Thread.start()

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerStopListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerStopListener.java
@@ -72,7 +72,7 @@ public class SchedulerStopListener implements JobListener {
                     SchedulerStopListener.this.jobRegisterService.stopScheduler(schedulerName);
                 }
             });
-            newThread.run();
+            newThread.start();
         }
     }
 


### PR DESCRIPTION
Hello,
To utilize the multiple-thread of Java, is it good to use Thread.start() instead of Thread.run()?