### PR TITLE
Fix bug in generating notification.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationDomainServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationDomainServiceImpl.java
@@ -51,7 +51,9 @@ import javax.jms.Queue;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 
 @Service
@@ -583,7 +585,7 @@ public class NotificationDomainServiceImpl implements NotificationDomainService 
 	
 	private List<Long> retrieveSubscribers(Long officeId, String permission) {
 		
-		Collection<TopicSubscriberData> topicSubscribers = new ArrayList<>();
+		Set<TopicSubscriberData> topicSubscribers = new HashSet<>();
 		List<Long> subscriberIds = new ArrayList<>();
 		Long entityId = officeId;
 		String entityType= "";
@@ -596,7 +598,7 @@ public class NotificationDomainServiceImpl implements NotificationDomainService 
 		for (Role curRole : allRoles) {
 			if (curRole.hasPermissionTo(permission) || curRole.hasPermissionTo("ALL_FUNCTIONS")) {
 				String memberType = curRole.getName();
-				topicSubscribers = topicSubscriberReadPlatformService.getSubscribers(entityId, entityType, memberType);
+				topicSubscribers.addAll(topicSubscriberReadPlatformService.getSubscribers(entityId, entityType, memberType));
 			}
 		}
 		


### PR DESCRIPTION
When querying the users required to get a notification, add new topic subscribers
to the current set of subscribers, instead of replacing the currents set of subscribers
with the new topic subscribers.