### PR TITLE
Prevent Apache rat task from failing subsequently after building project: FINERACT-731

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build
 *.ipr
 *.iws
 *.DS_Store
+.idea
+gradle

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -158,7 +158,9 @@ rat {
 	'**/assets/html5shiv.js',
 
 	//BSD License
-	'**/assets/uglify.js'
+	'**/assets/uglify.js',
+         //Ignore out folder
+         '**/out/**'
 	]
 }
 


### PR DESCRIPTION
## Description
Building project subsequently after the first build task make the rat task to fail: FINERACT-731

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commit.

- [x] PR contains a single commit (If you have multiple commits, please squash them into a single commit).

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
