### PR TITLE
FINERACT-757: Client list retrieval returns emtpy result when using search parameter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -251,7 +251,7 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
         }
 
         if (externalId != null) {
-        	paramList.add(ApiParameterHelper.sqlEncodeString(externalId));
+        	paramList.add(externalId);
             extraCriteria += " and c.external_id like ? " ;
         }
 
@@ -262,17 +262,17 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
         }
 
         if (firstname != null) {
-        	paramList.add(ApiParameterHelper.sqlEncodeString(firstname));
+        	paramList.add(firstname);
             extraCriteria += " and c.firstname like ? " ;
         }
 
         if (lastname != null) {
-        	paramList.add(ApiParameterHelper.sqlEncodeString(lastname));
+        	paramList.add(lastname);
             extraCriteria += " and c.lastname like ? ";
         }
 
         if (searchParameters.isScopedByOfficeHierarchy()) {
-        	paramList.add(ApiParameterHelper.sqlEncodeString(searchParameters.getHierarchy() + "%"));
+        	paramList.add(searchParameters.getHierarchy() + "%");
             extraCriteria += " and o.hierarchy like ? ";
         }
 


### PR DESCRIPTION
## Description
While testing /clients endpoint to search clients using search parameters such as firstName, secondName or externalId the search gave no results. 

Apparently in the past queries that required given paramaters were built concatenating strings and sqlInjection validation was needed and the function sqlEncodeString in the class ApiParametersHelper was used for this reason.

The function validated if parameters contained sqlInjection but also appended quotation marks to the the given parameter, however parameters are being passed as an object array instead of being appended to the query string so this validation isn't needed anymore as it's done by the sqlTemplate class used to run the query.  

For example: Calling the sqlEncodeString modified the searchParam "Joe" to "'Joe'" adding quotation marks and since there are no clients with quotation marks in their name no clients were found and the result was empty.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
