### PR TITLE
FINERACT-609 Group Topup Loan Bug Fix.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformService.java
@@ -34,4 +34,6 @@ public interface AccountDetailsReadPlatformService {
     public Collection<LoanAccountSummaryData> retrieveGroupLoanAccountsByLoanOfficerId(final Long groupId, final Long loanOfficerId);
 
     public Collection<LoanAccountSummaryData> retrieveClientActiveLoanAccountSummary(final Long clientId);
+
+    public Collection<LoanAccountSummaryData> retrieveGroupActiveLoanAccountSummary(final Long groupId);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
@@ -127,9 +127,16 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
         return retrieveLoanAccountDetails(loanWhereClause, new Object[] { groupId, loanOfficerId });
     }
 
-    @Override public Collection<LoanAccountSummaryData> retrieveClientActiveLoanAccountSummary(final Long clientId) {
+    @Override
+    public Collection<LoanAccountSummaryData> retrieveClientActiveLoanAccountSummary(final Long clientId) {
         final String loanWhereClause = " where l.client_id = ? and l.loan_status_id = 300 ";
         return retrieveLoanAccountDetails(loanWhereClause, new Object[] { clientId });
+    }
+
+    @Override
+    public Collection<LoanAccountSummaryData> retrieveGroupActiveLoanAccountSummary(final Long groupId) {
+        final String loanWhereClause = " where l.group_id = ? and l.loan_status_id = 300 ";
+        return retrieveLoanAccountDetails(loanWhereClause, new Object[] { groupId });
     }
 
     private List<LoanAccountSummaryData> retrieveLoanAccountDetails(final String loanwhereClause, final Object[] inputs) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1411,15 +1411,17 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
             }
         }
 
-        Collection<LoanAccountSummaryData> clientActiveLoanOptions = null;
-        if(loanProduct.canUseForTopup() && clientId != null){
-            clientActiveLoanOptions = this.accountDetailsReadPlatformService.retrieveClientActiveLoanAccountSummary(clientId);
+        Collection<LoanAccountSummaryData> activeLoanOptions = null;
+        if(loanProduct.canUseForTopup() && clientId != null) {
+            activeLoanOptions = this.accountDetailsReadPlatformService.retrieveClientActiveLoanAccountSummary(clientId);
+        } else if (loanProduct.canUseForTopup() && groupId != null) {
+            activeLoanOptions = this.accountDetailsReadPlatformService.retrieveGroupActiveLoanAccountSummary(groupId);
         }
 
         return LoanAccountData.loanProductWithTemplateDefaults(loanProduct, loanTermFrequencyTypeOptions, repaymentFrequencyTypeOptions,
                 repaymentFrequencyNthDayTypeOptions, repaymentFrequencyDaysOfWeekTypeOptions, repaymentStrategyOptions,
                 interestRateFrequencyTypeOptions, amortizationTypeOptions, interestTypeOptions, interestCalculationPeriodTypeOptions,
-                fundOptions, chargeOptions, loanPurposeOptions, loanCollateralOptions, loanCycleCounter, clientActiveLoanOptions);
+                fundOptions, chargeOptions, loanPurposeOptions, loanCollateralOptions, loanCycleCounter, activeLoanOptions);
     }
 
     @Override


### PR DESCRIPTION
Fix FINERACT-609 issue where topup loan wasn't working for group loan accounts. This was because the server wasn't sending the JSON array (named activeClientLoanOptions) which contained the IDs of active group loan accounts that could be closed in order to create the topup group loan account.
Now when creating a group topup loan, the server correctly replies with active group loans (named activeClientLoanOptions) so that an account to close can be selected in order to create the new group topup loan account.

## Description
Describe the changes made and why they were made. Ignore if these details are present on the associated Jira ticket
Added query: retrieveGroupActiveLoanAccountSummary(Long groupId) to get the active group loans (that can be closed) in order to complete the group topup loan application.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.
I don't think any update is required.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.
I'm creating this PR as advised by my GSoC mentors to see whether the integration tests on Travis-CI succeed. Even my local upstream/develop branch has failing integration tests - possibly due to https://issues.apache.org/jira/browse/FINERACT-707

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
