### PR TITLE
remove Instructions to download gradle wrapper from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@ Requirements
 * Java >= 1.8 (Oracle JVMs have been tested)
 * MySQL 5.5
 
-Instructions to download gradle wrapper
-============
-If the file fineract-provider/gradle/wrapper/gradle-wrapper.jar doesn't already exist in your copy of the Fineract codebase, the same needs to be downloaded using the commands below
-
-wget --no-check-certificate -P fineract-provider/gradle/wrapper https://github.com/apache/fineract/raw/develop/fineract-provider/gradle/wrapper/gradle-wrapper.jar
-
-(or)
-
-curl --insecure -L https://github.com/apache/fineract/raw/develop/fineract-provider/gradle/wrapper/gradle-wrapper.jar > fineract-provider/gradle/wrapper/gradle-wrapper.jar
-
 Instructions to run Apache RAT (Release Audit Tool)
 ============
 1. Extract the archive file to your local directory.


### PR DESCRIPTION
because the Gradle Wrapper is available in fineract-provider/gradle/wrapper and therefore not a pre-requisite to contribute

> as already removed from Requirements in previous commit 2f80674a2c08a91faf45ce25ba435cfcb2211da8

BTW sorry I force commited that, I meant to raise a PR but clicked wrong)