### PR TITLE
add Fedora prereq install doc to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,17 @@ Fineract is a mature platform with open APIs that provides a reliable, robust, a
 Requirements
 ============
 * Java >= 1.8 (Oracle JVMs have been tested)
-* MySQL 5.5
+* MySQL 5.5 or MariaDB
+
+On Fedora:
+
+    sudo dnf install java-1.8.0-openjdk-devel
+    sudo dnf install mariadb-server
+    sudo systemctl enable mariadb
+    sudo systemctl start mariadb
+
+Now set the database password for the development environment which is hard-coded in build scripts like fineract-provider/build.gradle by [looking at how .travis.yml does it](https://github.com/apache/fineract/blob/develop/.travis.yml).
+
 
 Instructions to download gradle wrapper
 ============


### PR DESCRIPTION
WIP, do not merge - using mariadb-server currently fails due to below.

Once we're done with the upcoming upgrades, this hopefully will work though.

```
vorburger@toby ~/M/fineract> ./gradlew migrateTenantListDB -PdbName=mifosplatform-tenants --stacktrace
Listening for transport dt_socket at address: 8005
:migrateTenantListDB FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/home/vorburger/Mifos/fineract/fineract-provider/build.gradle' line: 497

* What went wrong:
Execution failed for task ':flywayMigrate'.
> Error occurred while executing flywayMigrate
  Unsupported Database: MariaDB 10.3

```