### PR TITLE
use Ubuntu Trusty instead of Xenial on Travis CI (fixes FINERACT-763)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# https://issues.apache.org/jira/browse/FINERACT-763
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/FINERACT-763

re. https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476