### PR TITLE
One-touch deploy: Set host to fineractmysql when running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY . fineract
 
 WORKDIR fineract
 RUN sed -i 's/localhost/fineractmysql/' ./fineract-provider/build.gradle
+RUN sed -i 's/localhost/fineractmysql/' ./fineract-provider/src/main/resources/sql/migrations/list_db/V1__mifos-platform-shared-tenants.sql
 RUN ./gradlew clean war
 RUN mv build/libs/fineract-provider.war /opt/bitnami/tomcat/webapps
 


### PR DESCRIPTION
## Description
This is a quick update to the One-touch deploy process. When we seed the tenant database, we want to default the hostname to fineractmysql rather than localhost. Eventually, this will be all that we need to do, rather than updating the build.gradle file. 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
