### PR TITLE
clean-up rm WebContent/META-INF/MANIFEST.MF

### DIFF
--- a/fineract-provider/WebContent/META-INF/MANIFEST.MF
+++ b/fineract-provider/WebContent/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-


### PR DESCRIPTION
This is ancient, and should normally not be required anymore, now.

Gradle would add it, if required.