### PR TITLE
add suitable .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build/*
+.gradle/*


### PR DESCRIPTION
This reduces the `docker build` time spent in `STEP 6: COPY . fineract` from about 6m to 3m,
because it avoids copying locally built artifacts into the container (which we don't need there, we're just about to re-build them in the container anyway).

This also provides better isolation from the local dev environment and the should lead to more reproducible container builds.