### PR TITLE
remove only use of Apache BVal @NotEmpty annotation (in InteropIdentifierRequest/Response)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/data/InteropIdentifierRequestData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/data/InteropIdentifierRequestData.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.interoperation.data;
 
 import com.google.gson.JsonObject;
-import org.apache.bval.constraints.NotEmpty;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.interoperation.domain.InteropIdentifierType;
@@ -36,14 +35,9 @@ public class InteropIdentifierRequestData {
 
     static final String[] PARAMS = {PARAM_ACCOUNT_ID};
 
-    @NotEmpty
     private final InteropIdentifierType idType;
-    @NotEmpty
     private final String idValue;
-
     private final String subIdOrType;
-
-    @NotEmpty
     private final String accountId;
 
     public InteropIdentifierRequestData(@NotNull InteropIdentifierType idType, @NotNull String idValue, String subIdOrType, String accountId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/data/InteropIdentifierResponseData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/data/InteropIdentifierResponseData.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.interoperation.data;
 
-import org.apache.bval.constraints.NotEmpty;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 
 import javax.validation.constraints.NotNull;
@@ -26,9 +25,7 @@ import java.util.Map;
 
 public class InteropIdentifierResponseData extends CommandProcessingResult {
 
-    @NotEmpty
     private String accountId;
-
 
     protected InteropIdentifierResponseData(Long resourceId, Long officeId, Long commandId, Map<String, Object> changesOnly, @NotNull String accountId) {
         super(resourceId, officeId, commandId, changesOnly);


### PR DESCRIPTION
I'm not sure if this even worked?  There's no test coverage for it.

This is required to be able to (easily) switch from openjpa-all to openjpa in upcoming #607

The alternative would be to add an explicit dependency to BVal; but that seems unnecessary, and avoiding it will likely reduce other dependency issues.