### PR TITLE
use openjpa (with real dependencies) instead of shaded openjpa-all

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -42,7 +42,7 @@ buildscript {
                'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0',
                'org.zeroturnaround:gradle-jrebel-plugin:1.1.2',
                'org.springframework.boot:spring-boot-gradle-plugin:1.1.6.RELEASE' // also change springDataJpaVersion above
-     classpath "org.apache.openjpa:openjpa-all:$openJPAVersion"
+     classpath "org.apache.openjpa:openjpa:$openJPAVersion"
      classpath 'at.schmutterer.oss.gradle:gradle-openjpa:0.2.0'
      classpath 'gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.2.2'
   }
@@ -178,9 +178,6 @@ configurations {
 		exclude module: 'bcmail-jdk14'
 		exclude module: 'bcprov-jdk14'
 		exclude module: 'bctsp-jdk14'
-		exclude module: 'bval-core'
-		exclude module: 'org.apache.bval.bundle'
-		exclude module: 'bval-jsr303'
 		exclude module: 'c3p0'
 		exclude module: 'stax-api'
 		exclude module: 'jaxb-api'
@@ -188,9 +185,6 @@ configurations {
 		exclude module: 'jboss-logging'
 		exclude module: 'itext-rtf'
 		exclude module: 'classworlds'
-		exclude module: 'jcl-over-slf4j'
-		exclude module: 'jul-to-slf4j'
-		exclude module: 'serp'
 	}
 	runtime
 	all*.exclude group: 'commons-logging'

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -42,7 +42,7 @@ dependencies {
 				
 	       		[group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: springOauthVersion],
 
-                [group: 'org.apache.openjpa', name:'openjpa-all', version: openJPAVersion],
+                [group: 'org.apache.openjpa', name:'openjpa', version: openJPAVersion],
                 //[group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1'],
                 [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion],
                 [group: 'com.sun.jersey', name: 'jersey-servlet', version: jerseyVersion],
@@ -96,6 +96,9 @@ dependencies {
                 [group: 'org.apache.activemq', name: 'activemq-broker'],
                 [group: 'javax.validation', name: 'validation-api', version: '2.0.0.Final']
     )
+
+     // TODO FINERACT-777 use "implementation" instead of "compile" once we have upgraded Gradle (FINERACT-700)
+     compile 'org.apache.bval:org.apache.bval.bundle:2.0.2'
 
      testCompile 'junit:junit:4.11',
                  'junit:junit-dep:4.11',


### PR DESCRIPTION
Because the openjpa-all.jar is "shaded" and that causes classpath duplicate problems.