### PR TITLE
bump OpenJPA version from 2.4.1 to 2.4.3 for Java 11 compliance

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -29,7 +29,7 @@ project.ext.springDataJpaVersion = '1.7.0.RELEASE' // also change spring-boot-gr
 
 buildscript {
   ext {
-    openJPAVersion = '2.4.1'
+    openJPAVersion = '2.4.3'
   }
   repositories {
   	 jcenter()


### PR DESCRIPTION
This will require # (which in turn first requires a few other minor PRs to be merged).

The upgrade is because 2.4.1 was not yet Java 11 compatible (due to an old ASM)
    
In the context of the Gradle upgrade work, I'd like to upgrade to Java 11 soon-ish, and am starting to experiment with it.

This first requires #604, #605, #606.