### PR TITLE
remove Tomcat Jasper JSP Engine, as we don't use JSP

### DIFF
--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -20,9 +20,6 @@ dependencies {
         def tomcatVersion = '7.0.54'
         tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
                "org.apache.tomcat.embed:tomcat-embed-logging-log4j:${tomcatVersion}" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
-        tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
-            exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
-        }
         tomcat "org.apache.tomcat:tomcat-dbcp:${tomcatVersion}"
 
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat:${springBootVersion}")


### PR DESCRIPTION
This probably also makes integration test start-up a (little) bit faster.