### PR TITLE
upgrade Apache Tomcat from 7.0.54 to 7.0.94

### DIFF
--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 dependencies {
-        def tomcatVersion = '7.0.54'
+        def tomcatVersion = '7.0.94'
         tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
                "org.apache.tomcat.embed:tomcat-embed-logging-log4j:${tomcatVersion}" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
         tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {


### PR DESCRIPTION
This fixes the following weird problem I ran into during the Gradle & Spring Boot / OpenJPA Gradle plugins upgrades; it's likely some Tomcat bug that got fixed between .54 and .94:

    Unable to process resource element [jndi:/localhost/fineract-provider/WEB-INF/classes/org/apache/fineract/.../*.class] for annotations