### PR TITLE
Fineract-723

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientUndoRejectAndWithdrawalIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientUndoRejectAndWithdrawalIntegrationTest.java
@@ -173,9 +173,11 @@ public class ClientUndoRejectAndWithdrawalIntegrationTest {
 		ClientStatusChecker.verifyClientRejected(status);
 		DateFormat dateFormat = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
 		Calendar todaysDate = Calendar.getInstance();
+		todaysDate.setTime(Utils.getDateOfTenant());
 		todaysDate.add(Calendar.DATE, 1);
 		final String undoRejectDate = dateFormat.format(todaysDate.getTime());
-		ArrayList<HashMap> clientErrorData = (ArrayList<HashMap>) validationErrorHelper.undoWithdrawclient(clientId,
+
+		ArrayList<HashMap> clientErrorData = (ArrayList<HashMap>) validationErrorHelper.undoRejectedclient(clientId,
 				CommonConstants.RESPONSE_ERROR, undoRejectDate);
 		assertEquals("validation.msg.client.reopenedDate.is.greater.than.date",
 				((HashMap<String, Object>) clientErrorData.get(0)).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
@@ -286,8 +288,10 @@ public class ClientUndoRejectAndWithdrawalIntegrationTest {
 		ClientStatusChecker.verifyClientWithdrawn(status);
 		DateFormat dateFormat = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
 		Calendar todaysDate = Calendar.getInstance();
+		todaysDate.setTime(Utils.getDateOfTenant());
 		todaysDate.add(Calendar.DATE, 1);
 		final String undoWithdrawDate = dateFormat.format(todaysDate.getTime());
+
 		ArrayList<HashMap> clientErrorData = (ArrayList<HashMap>) validationErrorHelper.undoWithdrawclient(clientId,
 				CommonConstants.RESPONSE_ERROR, undoWithdrawDate);
 		assertEquals("validation.msg.client.reopenedDate.is.greater.than.date",

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/GroupSavingsIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/GroupSavingsIntegrationTest.java
@@ -530,9 +530,9 @@ public class GroupSavingsIntegrationTest {
                 .plusWeeks((Integer) paidCharge.get("feeInterval"));
         assertEquals(expectedNextDueDate, nextDueDate);
         cal = Calendar.getInstance();
-        
-        this.savingsAccountHelper.closeSavingsAccountAndGetBackRequiredField(savingsId, "true", null, sdf.format(cal.getTime()));
-        
+
+        this.savingsAccountHelper.closeSavingsAccountAndGetBackRequiredField(savingsId, "true", null, sdf.format(Utils.getDateOfTenant()));
+
     }
 
     public static Integer createSavingsProduct(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/Utils.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/Utils.java
@@ -177,6 +177,10 @@ public class Utils {
         return today;
     }
 
+    public static Date getDateOfTenant() {
+        return getLocalDateOfTenant().toDateTimeAtStartOfDay().toDate();
+    }
+
     public static TimeZone getTimeZoneOfTenant() {
         return TimeZone.getTimeZone(TENANT_TIME_ZONE);
     }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareAccountIntegrationTests.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareAccountIntegrationTests.java
@@ -27,14 +27,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -162,7 +160,7 @@ public class ShareAccountIntegrationTests {
         Map<String, Object> shareAccountData = ShareAccountTransactionHelper
                 .retrieveShareAccount(shareAccountId, requestSpec, responseSpec);
         Assert.assertNotNull(shareAccountData);
-        
+
      // Approve share Account
         Map<String, Object> approveMap = new HashMap<>();
         approveMap.put("note", "Share Account Approval Note");
@@ -202,7 +200,7 @@ public class ShareAccountIntegrationTests {
             } else if (transactionType.equals("charge.payment")) {
                 Assert.assertEquals("2.0", String.valueOf(transaction.get("amount")));
                 Assert.assertEquals("0", String.valueOf(transaction.get("amountPaid")));
-                Date transactionDate = DateUtils.getDateOfTenant() ;
+                Date transactionDate = Utils.getDateOfTenant();
                 Assert.assertEquals(simple.format(transactionDate), simple.format(date));
             }
         }
@@ -211,7 +209,7 @@ public class ShareAccountIntegrationTests {
         Assert.assertEquals("25", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void rejectShareAccount() {
@@ -237,7 +235,7 @@ public class ShareAccountIntegrationTests {
         Map<String, Object> shareAccountData = ShareAccountTransactionHelper
                 .retrieveShareAccount(shareAccountId, requestSpec, responseSpec);
         Assert.assertNotNull(shareAccountData);
-        
+
         // Reject share Account
         Map<String, Object> rejectMap = new HashMap<>();
         rejectMap.put("note", "Share Account Rejection Note");
@@ -253,9 +251,9 @@ public class ShareAccountIntegrationTests {
         Calendar cal = Calendar.getInstance();
         cal.set(dateList.get(0), dateList.get(1) - 1, dateList.get(2));
         Date rejectedDate = cal.getTime();
-        Date currentTenantDate = DateUtils.getDateOfTenant() ;
+        Date currentTenantDate = Utils.getDateOfTenant();
         Assert.assertEquals(simple.format(currentTenantDate), simple.format(rejectedDate));
-        
+
         List<Map<String, Object>> transactions = (List<Map<String, Object>>) shareAccountData.get("purchasedShares");
         Assert.assertNotNull(transactions);
         Assert.assertEquals(2, transactions.size());
@@ -277,7 +275,7 @@ public class ShareAccountIntegrationTests {
             } else if (transactionType.equals("charge.payment")) {
                 Assert.assertEquals("2.0", String.valueOf(transaction.get("amount")));
                 Assert.assertEquals("0", String.valueOf(transaction.get("amountPaid")));
-                Date transactionDate = DateUtils.getDateOfTenant() ;
+                Date transactionDate = Utils.getDateOfTenant() ;
                 Assert.assertEquals(simple.format(transactionDate), simple.format(date));
             }
         }
@@ -286,7 +284,7 @@ public class ShareAccountIntegrationTests {
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void testShareAccountUndoApproval() {
@@ -313,7 +311,7 @@ public class ShareAccountIntegrationTests {
         Map<String, Object> shareAccountData = ShareAccountTransactionHelper
                 .retrieveShareAccount(shareAccountId, requestSpec, responseSpec);
         Assert.assertNotNull(shareAccountData);
-        
+
      // Approve share Account
         Map<String, Object> approveMap = new HashMap<>();
         approveMap.put("note", "Share Account Approval Note");
@@ -332,18 +330,18 @@ public class ShareAccountIntegrationTests {
         cal.set(dateList.get(0), dateList.get(1) - 1, dateList.get(2));
         Date approvedDate = cal.getTime();
         Assert.assertEquals("01 Jan 2016", simple.format(approvedDate));
-        
+
         // Undo Approval share Account
         Map<String, Object> undoApprovalMap = new HashMap<>();
         String undoApprovalJson = new Gson().toJson(undoApprovalMap);
         ShareAccountTransactionHelper.postCommand("undoapproval", shareAccountId, undoApprovalJson, requestSpec, responseSpec);
-        
+
         shareAccountData = ShareAccountTransactionHelper
                 .retrieveShareAccount(shareAccountId, requestSpec, responseSpec);
-        
+
         statusMap = (Map<String, Object>) shareAccountData.get("status");
         Assert.assertEquals("shareAccountStatusType.submitted.and.pending.approval", String.valueOf(statusMap.get("code")));
-        
+
         List<Map<String, Object>> transactions = (List<Map<String, Object>>) shareAccountData.get("purchasedShares");
         Assert.assertNotNull(transactions);
         Assert.assertEquals(2, transactions.size());
@@ -365,7 +363,7 @@ public class ShareAccountIntegrationTests {
             } else if (transactionType.equals("charge.payment")) {
                 Assert.assertEquals("2.0", String.valueOf(transaction.get("amount")));
                 Assert.assertEquals("0", String.valueOf(transaction.get("amountPaid")));
-                Date transactionDate = DateUtils.getDateOfTenant() ;
+                Date transactionDate = Utils.getDateOfTenant();
                 Assert.assertEquals(simple.format(transactionDate), simple.format(date));
             }
         }
@@ -374,7 +372,7 @@ public class ShareAccountIntegrationTests {
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("25", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test
     public void testCreateShareAccountWithCharges() {
@@ -459,7 +457,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         // Approve share Account
         Map<String, Object> approveMap = new HashMap<>();
         approveMap.put("note", "Share Account Approval Note");
@@ -501,7 +499,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         Map<String, Object> activateMap = new HashMap<>();
         activateMap.put("dateFormat", "dd MMMM yyyy");
         activateMap.put("activatedDate", "01 Jan 2016");
@@ -566,7 +564,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         Map<String, Object> summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("30", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
@@ -640,7 +638,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("30", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("15", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
@@ -714,7 +712,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("45", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
@@ -776,7 +774,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("45", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("20", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
@@ -838,7 +836,7 @@ public class ShareAccountIntegrationTests {
                 Assert.fail("Other Charge defintion found");
             }
         }
-        
+
         summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("45", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
@@ -918,7 +916,7 @@ public class ShareAccountIntegrationTests {
         summaryMap = (Map<String, Object>) shareAccountData.get("summary");
         Assert.assertEquals("30", String.valueOf(summaryMap.get("totalApprovedShares")));
         Assert.assertEquals("0", String.valueOf(summaryMap.get("totalPendingForApprovalShares")));
-        
+
         //Close Share Account
         Map<String, Object> closeAccountMap = new HashMap<>();
         closeAccountMap.put("note", "Share Account Close Note");


### PR DESCRIPTION
## Description
Fixes issue where certain integration tests would fail when run on a system with a different time zone than the tenant's time zone (IST). This was caused by some tests mistakenly using the DateUtils class instead of the test-specific Utils class. The Utils class hardcodes the tenant's TZ, whereas DateUtils reads it from the database. This caused these test failures. 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
