### PR TITLE
rm hardcoded system time from .travis.yml (fixes FINERACT-788)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,10 @@ jdk:
 services:
   - mysql
 
-# Hardcoding system time as a temporary fix for running buggy test cases
 before_install:
   - echo "USE mysql;\nUPDATE user SET password=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifosplatform-tenants`;'
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifostenant-default`;'
-  - export TZ=Asia/Kolkata
-  - sudo service ntp stop
-  - sudo date --set="23 February 2019 01:02:03"
 
 # https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
   - echo "USE mysql;\nUPDATE user SET password=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifosplatform-tenants`;'
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifostenant-default`;'
+# Hardcoding the time zone is a temporary fix for https://issues.apache.org/jira/browse/FINERACT-723
+  - export TZ=Asia/Kolkata
 
 # https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/FINERACT-788