### PR TITLE
Add Z,ro flags to Docker Compose Volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   fineractmysql:
     image: mysql:5.7
     volumes:
-      - ./fineract-db/docker:/docker-entrypoint-initdb.d
+      - ./fineract-db/docker:/docker-entrypoint-initdb.d:Z,ro
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: mysql


### PR DESCRIPTION
This is required on secure Linux distributions such as Fedora/CentOS/RHEL where SELinux is enabled, where without this the mysql container fails to start due to:

    ls: cannot open directory '/docker-entrypoint-initdb.d/': Permission denied

These Z,ro volume mount flags are (should be..) harmless and ignored by Docker on other platforms, such as insecure ;) Linux distributions without SELinux, or Windows and Mac.

PS: I personally don't actually use real Docker, but instead I use Podman (see https://github.com/containers/libpod; install via `dnf install podman-docker`) and https://github.com/containers/podman-compose/) via `pip3 install podman-compose`; it's more secure (because it doesn't need a daemon and root to run containers).