### PR TITLE
Adding vnd.ms-excel support

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -99,8 +99,12 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                 final String fileExtension = Files.getFileExtension(fileDetail.getFileName()).toLowerCase();
                 ImportFormatType format = ImportFormatType.of(fileExtension);
                 if (!fileType.contains("msoffice")) {
-                    throw new GeneralPlatformDomainRuleException("error.msg.invalid.file.extension",
-                            "Uploaded file extension is not recognized.");
+                    // We had a problem where we tried to upload the downloaded file from the import options, it was somehow changed the
+                    // extension we use this fix.
+                    if (!fileType.contains("application/vnd.ms-excel")) {
+                        throw new GeneralPlatformDomainRuleException("error.msg.invalid.file.extension",
+                                "Uploaded file extension is not recognized.");
+                    }
                 }
                 Workbook workbook = new HSSFWorkbook(clonedInputStreamWorkbook);
                 GlobalEntityType entityType=null;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -98,13 +98,12 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                 final String fileType = tika.detect(tikaInputStream);
                 final String fileExtension = Files.getFileExtension(fileDetail.getFileName()).toLowerCase();
                 ImportFormatType format = ImportFormatType.of(fileExtension);
-                if (!fileType.contains("msoffice")) {
+                if (!fileType.contains("msoffice") && !fileType.contains("application/vnd.ms-excel")) {
                     // We had a problem where we tried to upload the downloaded file from the import options, it was somehow changed the
                     // extension we use this fix.
-                    if (!fileType.contains("application/vnd.ms-excel")) {
                         throw new GeneralPlatformDomainRuleException("error.msg.invalid.file.extension",
                                 "Uploaded file extension is not recognized.");
-                    }
+                    
                 }
                 Workbook workbook = new HSSFWorkbook(clonedInputStreamWorkbook);
                 GlobalEntityType entityType=null;


### PR DESCRIPTION
## Description
When using an importer to download the template file for any specific Domain and while uploading the same template with filled data , it seems to fail. Debugging the problem made me realise that it had changed the file extension some how, No idea why it was happening maybe from the UI side. But I checked it was not the case.

So I managed to put a condition which makes sure that we have this condition fulfilled also.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
