### PR TITLE
FINERACT-797: Use Spring Boot BOM to avoid maintaining version numbers in dependencies.gradle

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -21,11 +21,7 @@ Run as:
 gradle clean tomcatrunwar
 '''
 
-// project.ext.springBootVersion = '2.1.9.RELEASE'
-// project.ext.springVersion = '5.1.10.RELEASE'
-// project.ext.springOauthVersion = '2.3.6.RELEASE'
-// project.ext.jerseyVersion = '1.17'
-// project.ext.springDataJpaVersion = '2.2.0.RELEASE' // also change spring-boot-gradle-plugin version below
+project.ext.jerseyVersion = '1.17'
 
 buildscript {
   ext {
@@ -111,13 +107,13 @@ dependencyManagement {
         entry 'spring-boot-starter-actuator'
         entry 'spring-boot-starter-tomcat'
      }
-     dependencySet(group: 'com.sun.jersey', version: '1.17') {
+     dependencySet(group: 'com.sun.jersey', version: jerseyVersion) {
          entry 'jersey-core'
          entry 'jersey-servlet'
          entry 'jersey-server'
          entry 'jersey-json'
      }
-     dependencySet(group: 'com.sun.jersey.contribs', version: '1.17') {
+     dependencySet(group: 'com.sun.jersey.contribs', version: jerseyVersion) {
          entry 'jersey-spring'
          entry 'jersey-multipart'
      }

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -21,11 +21,11 @@ Run as:
 gradle clean tomcatrunwar
 '''
 
-project.ext.springBootVersion = '2.1.9.RELEASE'
-project.ext.springVersion = '5.1.10.RELEASE'
-project.ext.springOauthVersion = '2.3.6.RELEASE'
-project.ext.jerseyVersion = '1.17'
-project.ext.springDataJpaVersion = '2.2.0.RELEASE' // also change spring-boot-gradle-plugin version below
+// project.ext.springBootVersion = '2.1.9.RELEASE'
+// project.ext.springVersion = '5.1.10.RELEASE'
+// project.ext.springOauthVersion = '2.3.6.RELEASE'
+// project.ext.jerseyVersion = '1.17'
+// project.ext.springDataJpaVersion = '2.2.0.RELEASE' // also change spring-boot-gradle-plugin version below
 
 buildscript {
   ext {
@@ -38,6 +38,7 @@ buildscript {
   }
 
   dependencies {
+     classpath 'io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE'
      classpath 'com.bmuschko:gradle-tomcat-plugin:2.5',
                'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0',
                'org.zeroturnaround:gradle-jrebel-plugin:1.1.2',
@@ -48,6 +49,7 @@ buildscript {
   }
 }
 
+apply plugin: 'io.spring.dependency-management'
 apply plugin: "org.nosphere.apache.rat"
 apply plugin: 'rebel'
 apply plugin: 'license'
@@ -59,8 +61,82 @@ apply plugin: 'com.bmuschko.tomcat'
 apply plugin: 'project-report'
 apply plugin: 'java-library'
 apply plugin: 'openjpa'
+
 // apply plugin: 'pmd'
 // apply plugin: 'findbugs'
+
+dependencyManagement {
+  imports {
+    mavenBom 'org.springframework:spring-framework-bom:5.1.10.RELEASE'
+  }
+  dependencies {
+     dependency 'org.springframework.security.oauth:spring-security-oauth2:2.3.6.RELEASE'
+     dependency 'org.apache.openjpa:openjpa:3.1.0'
+     dependency 'com.squareup.retrofit:retrofit:1.6.1'
+     dependency 'com.squareup.okhttp:okhttp:2.0.0'
+     dependency 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
+     dependency 'com.google.code.gson:gson:2.2.4'
+     dependency 'com.google.guava:guava:15.0'
+     dependency 'joda-time:joda-time:2.4'
+     dependency 'org.apache.commons:commons-email:1.3.3'
+     dependency 'org.apache.commons:commons-lang3:3.3.2'
+     dependency 'org.drizzle.jdbc:drizzle-jdbc:1.4'
+     dependency 'com.lowagie:itext:2.1.7'
+     dependency 'com.lowagie:itext-rtf:2.1.7'
+     dependency 'org.mnode.ical4j:ical4j:1.0.4'
+     dependency 'com.googlecode.flyway:flyway-core:2.1.1'
+     dependency 'org.quartz-scheduler:quartz:2.1.7'
+     dependency 'com.amazonaws:aws-java-sdk-s3:1.11.80'
+     dependency 'net.sf.ehcache:ehcache:2.7.2'
+     dependency 'com.github.spullara.mustache.java:compiler:0.8.12'
+     dependency 'com.jayway.jsonpath:json-path:0.9.1'
+     dependency 'org.apache.tika:tika-core:1.9'
+     dependency 'org.apache.httpcomponents:httpclient:4.3.5'
+     dependency 'io.swagger:swagger-jersey-jaxrs:1.5.15'
+     dependency 'org.springframework:spring-jms:4.0.7.RELEASE'
+     dependency 'org.apache.activemq:activemq-broker:5.9.1'
+     dependency 'javax.validation:validation-api:2.0.0.Final'
+     dependency 'org.apache.bval:org.apache.bval.bundle:2.0.2'
+     dependency 'junit:junit:4.12'
+     dependency 'junit:junit-dep:4.11'
+     dependency 'org.mockito:mockito-core:+'
+     dependency 'com.jayway.restassured:rest-assured:2.3.3'
+     dependency 'com.mockrunner:mockrunner-jms:2.0.1'
+     dependency 'com.mockrunner:mockrunner-jdbc:2.0.1'
+
+     dependencySet(group:'org.springframework.boot', version: '2.1.9.RELEASE') {
+        entry 'spring-boot-starter-web'
+        entry 'spring-boot-starter-data-jpa'
+        entry 'spring-boot-starter-security'
+        entry 'spring-boot-starter-actuator'
+        entry 'spring-boot-starter-tomcat'
+     }
+     dependencySet(group: 'com.sun.jersey', version: '1.17') {
+         entry 'jersey-core'
+         entry 'jersey-servlet'
+         entry 'jersey-server'
+         entry 'jersey-json'
+     }
+     dependencySet(group: 'com.sun.jersey.contribs', version: '1.17') {
+         entry 'jersey-spring'
+         entry 'jersey-multipart'
+     }
+     dependencySet(group: 'org.apache.poi', version: '3.9') {
+         entry 'poi'
+         entry 'poi-ooxml'
+         entry 'poi-ooxml-schemas'
+     }
+     dependencySet(group: 'org.apache.tomcat.embed', version: '7.0.94') {
+         entry 'tomcat-embed-core'
+         entry 'tomcat-embed-jasper'
+         entry 'tomcat-embed-logging-log4j'
+     }
+     dependencySet(group: 'org.apache.tomcat', version: '7.0.94') {
+         entry 'tomcat-dbcp'
+         entry 'tomcat-jdbc'
+     }
+  }
+}
 
 /* define the valid syntax level for source files */
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -65,6 +65,7 @@ dependencyManagement {
   imports {
     mavenBom 'org.springframework:spring-framework-bom:5.1.10.RELEASE'
   }
+  
   dependencies {
      dependency 'org.springframework.security.oauth:spring-security-oauth2:2.3.6.RELEASE'
      dependency 'org.apache.openjpa:openjpa:3.1.0'
@@ -100,13 +101,6 @@ dependencyManagement {
      dependency 'com.mockrunner:mockrunner-jms:2.0.1'
      dependency 'com.mockrunner:mockrunner-jdbc:2.0.1'
 
-     dependencySet(group:'org.springframework.boot', version: '2.1.9.RELEASE') {
-        entry 'spring-boot-starter-web'
-        entry 'spring-boot-starter-data-jpa'
-        entry 'spring-boot-starter-security'
-        entry 'spring-boot-starter-actuator'
-        entry 'spring-boot-starter-tomcat'
-     }
      dependencySet(group: 'com.sun.jersey', version: jerseyVersion) {
          entry 'jersey-core'
          entry 'jersey-servlet'

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -17,17 +17,16 @@
  * under the License.
  */
 dependencies {
-        def tomcatVersion = '7.0.94'
-        tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
-               "org.apache.tomcat.embed:tomcat-embed-logging-log4j:${tomcatVersion}" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
-        tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
+        tomcat "org.apache.tomcat.embed:tomcat-embed-core",
+               "org.apache.tomcat.embed:tomcat-embed-logging-log4j" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
+        tomcat("org.apache.tomcat.embed:tomcat-embed-jasper") {
             exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
         }
-        tomcat "org.apache.tomcat:tomcat-dbcp:${tomcatVersion}"
+        tomcat "org.apache.tomcat:tomcat-dbcp"
 
-    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat:${springBootVersion}")
+    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 
-    compile ("org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion") {
+    compile ("org.springframework.boot:spring-boot-starter-data-jpa") {
         exclude group: 'com.zaxxer', module: 'HikariCP'
     }
 
@@ -120,7 +119,7 @@ dependencies {
             [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
             [group: 'org.springframework', name:'spring-jms', version: '4.0.7.RELEASE'],
             [group: 'joda-time', name: 'joda-time', version: '2.4'],
-            [  group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
+            [group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
             [group: 'com.google.guava', name: 'guava', version: '15.0'],
             [group: 'org.apache.poi',name: 'poi-ooxml', version: '3.9'],
             [group: 'org.springframework', name: 'spring-context-support', version: springVersion],

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -31,102 +31,97 @@ dependencies {
     }
 
      api(
-            [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
-            [group: 'org.quartz-scheduler', name: 'quartz', version: '2.1.7'],
-            [group: 'org.apache.openjpa', name:'openjpa', version: openJPAVersion],
-            [group: 'org.springframework', name:'spring-jms', version: '4.0.7.RELEASE'],
-            [group: 'joda-time', name: 'joda-time', version: '2.4'],
-            [group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
-            [group: 'com.google.guava', name: 'guava', version: '15.0'],
-            [group: 'org.springframework', name: 'spring-context-support', version: springVersion],
-            [group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: springOauthVersion],
-            [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion],
-            [group: 'com.squareup.retrofit', name: 'retrofit', version: '1.6.1']
+            'com.google.code.gson:gson',
+            'org.quartz-scheduler:quartz',
+            'org.apache.openjpa:openjpa',
+            'org.springframework:spring-jms',
+            'joda-time:joda-time',
+            'org.mnode.ical4j:ical4j',
+            'com.google.guava:guava',
+            'org.springframework:spring-context-support',
+            'org.springframework.security.oauth:spring-security-oauth2',
+            'com.sun.jersey:jersey-core',
+            'com.squareup.retrofit:retrofit'
     )
     implementation(
-            // [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.3'],
+            // 'ch.vorburger.mariaDB4j:mariaDB4j'
 
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion],
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: springBootVersion],
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion],
+            'org.springframework.boot:spring-boot-starter-web',
+            'org.springframework.boot:spring-boot-starter-security',
+            'org.springframework.boot:spring-boot-starter-actuator',
 
-            //[group: 'org.eclipse.persistence', name: 'javax.persistence', version: '2.0.0'],
-
-
-            [group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: springOauthVersion],
+            //'org.eclipse.persistence:javax.persistence',
 
 
-            //[group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1'],
-
-            [group: 'com.sun.jersey', name: 'jersey-servlet', version: jerseyVersion],
-            [group: 'com.sun.jersey', name: 'jersey-server', version: jerseyVersion],
-            [group: 'com.sun.jersey', name: 'jersey-json', version: jerseyVersion],
-            [group: 'com.sun.jersey.contribs', name: 'jersey-spring', version: jerseyVersion],
-            [group: 'com.sun.jersey.contribs', name: 'jersey-multipart', version: jerseyVersion],
+            'org.springframework.security.oauth:spring-security-oauth2',
 
 
-            [group: 'com.squareup.okhttp', name: 'okhttp', version: '2.0.0'],
-            [group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.0.0'],
+            //'javax.ws.rs:jsr311-api',
+
+            'com.sun.jersey:jersey-servlet',
+            'com.sun.jersey:jersey-server',
+            'com.sun.jersey:jersey-json',
+            'com.sun.jersey.contribs:jersey-spring',
+            'com.sun.jersey.contribs:jersey-multipart',
 
 
+            'com.squareup.okhttp:okhttp',
+            'com.squareup.okhttp:okhttp-urlconnection',
 
-
-
-
-            //[group: 'net.sourceforge.javacsv', name: 'javacsv', version: '2.0'],
-            [group: 'org.apache.commons', name: 'commons-email', version: '1.3.3'],
-            [group: 'org.apache.commons', name: 'commons-lang3', version: '3.3.2'],
+            //'net.sourceforge.javacsvjavacsv',
+            'org.apache.commons:commons-email',
+            'org.apache.commons:commons-lang3',
 
             // no slf4j & logback here (anymore), as spring-boot-starter-logging already brings this now, better assembled (log4j-over-slf4j was originally forgotten here)
 
-            //[group: 'mysql', name: 'mysql-connector-java', version: '5.1.27'],
-            [group: 'org.drizzle.jdbc', name: 'drizzle-jdbc', version: '1.4'],
-            [group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: tomcatVersion],
+            //'mysql:mysql-connector-java',
+            'org.drizzle.jdbc:drizzle-jdbc',
+            'org.apache.tomcat:tomcat-jdbc',
 
 
-            [group: 'org.apache.poi',name: 'poi', version: '3.9'],
-            [group: 'org.apache.poi',name: 'poi-ooxml', version: '3.9'],
-            [group: 'org.apache.poi',name: 'poi-ooxml-schemas', version: '3.9'],
+            'org.apache.poi:poi',
+            'org.apache.poi:poi-ooxml',
+            'org.apache.poi:poi-ooxml-schemas',
 
-            [group: 'com.lowagie', name: 'itext', version: '2.1.7'],
-            //[group: 'com.lowagie', name: 'itext-rtf', version: '2.1.7'],
+            'com.lowagie:itext',
+            //'com.lowagie:itext-rtf',
 
-            [group: 'com.googlecode.flyway', name: 'flyway-core', version: '2.1.1'],
+            'com.googlecode.flyway:flyway-core',
 
-            [group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.80'],
-            [group: 'net.sf.ehcache', name: 'ehcache', version: '2.7.2'],
-            [group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.12'],
-            [group: 'com.jayway.jsonpath', name: 'json-path', version: '0.9.1'],
-            [group: 'org.apache.tika', name: 'tika-core', version :'1.9'],
+            'com.amazonaws:aws-java-sdk-s3',
+            'net.sf.ehcache:ehcache',
+            'com.github.spullara.mustache.java:compiler',
+            'com.jayway.jsonpath:json-path',
+            'org.apache.tika:tika-core',
             // Although fineract (at the time of writing) doesn't have any compile time dep. on this,
             // it's useful to have this for the Spring Boot TestRestTemplate http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-rest-templates-test-utility
-            [group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.5'],
+            'org.apache.httpcomponents:httpclient',
             // Once we've switched to Java 8 this dep can be removed.
-            //[group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0']
+            //'com.google.code.findbugs:jsr305',
 
-            [group: 'io.swagger', name: 'swagger-jersey-jaxrs', version: '1.5.15'],
-            [group: 'org.apache.activemq', name: 'activemq-broker', version: '5.9.1'],
-            [group: 'javax.validation', name: 'validation-api', version: '2.0.0.Final']
+            'io.swagger:swagger-jersey-jaxrs',
+            'org.apache.activemq:activemq-broker',
+            'javax.validation:validation-api',
     )
 
-    implementation 'org.apache.bval:org.apache.bval.bundle:2.0.2'
+    implementation 'org.apache.bval:org.apache.bval.bundle'
 
-    testCompile 'junit:junit:4.11',
-            'junit:junit-dep:4.11',
-            'org.mockito:mockito-core:1.9.5',
-            'com.jayway.restassured:rest-assured:2.3.3',
-            [group: 'com.mockrunner', name: 'mockrunner-jms', version: '1.0.6'],
-            [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
-            [group: 'org.springframework', name:'spring-jms', version: '4.0.7.RELEASE'],
-            [group: 'joda-time', name: 'joda-time', version: '2.4'],
-            [group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
-            [group: 'com.google.guava', name: 'guava', version: '15.0'],
-            [group: 'org.apache.poi',name: 'poi-ooxml', version: '3.9'],
-            [group: 'org.springframework', name: 'spring-context-support', version: springVersion],
-            [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion],
-            [group: 'com.mockrunner', name: 'mockrunner-jdbc', version: '1.0.6']
+    testCompile 'junit:junit',
+            'junit:junit-dep',
+            'org.mockito:mockito-core',
+            'com.jayway.restassured:rest-assured',
+            'com.mockrunner:mockrunner-jms',
+            'com.google.code.gson:gson',
+            'org.springframework:spring-jms',
+            'joda-time:joda-time',
+            'org.mnode.ical4j:ical4j',
+            'com.google.guava:guava',
+            'org.apache.poi:poi-ooxml',
+            'org.springframework:spring-context-support',
+            'com.sun.jersey:jersey-core',
+            'com.mockrunner:mockrunner-jdbc'
 
-    testCompile ("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
+    testCompile ("org.springframework.boot:spring-boot-starter-test") {
          exclude group: 'com.jayway.jsonpath', module: 'json-path'
      }
 }

--- a/fineract-provider/dev-dependencies.gradle
+++ b/fineract-provider/dev-dependencies.gradle
@@ -17,15 +17,14 @@
  * under the License.
  */
 dependencies {
-        def tomcatVersion = '7.0.94'
-        tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
-               "org.apache.tomcat.embed:tomcat-embed-logging-log4j:${tomcatVersion}" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
-        tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
+        tomcat "org.apache.tomcat.embed:tomcat-embed-core",
+               "org.apache.tomcat.embed:tomcat-embed-logging-log4j" // NOT tomcat-embed-logging-juli (http://stackoverflow.com/questions/23963049/classcircularityerror-java-util-logging-logrecord-running-gradle-webapp-with-ja)
+        tomcat("org.apache.tomcat.embed:tomcat-embed-jasper") {
             exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
         }
-        tomcat "org.apache.tomcat:tomcat-dbcp:${tomcatVersion}"
+        tomcat "org.apache.tomcat:tomcat-dbcp"
 
-    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat:${springBootVersion}")
+    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 
      api(
             [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
@@ -123,7 +122,7 @@ dependencies {
             [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion],
             [group: 'com.mockrunner', name: 'mockrunner-jdbc', version: '1.0.6']
 
-    testCompile ("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
-        exclude group: 'com.jayway.jsonpath', module: 'json-path'
-    }
+     testCompile ("org.springframework.boot:spring-boot-starter-test") {
+         exclude group: 'com.jayway.jsonpath', module: 'json-path'
+     }
 }

--- a/fineract-provider/dev-dependencies.gradle
+++ b/fineract-provider/dev-dependencies.gradle
@@ -27,100 +27,100 @@ dependencies {
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 
      api(
-            [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
-            [group: 'org.quartz-scheduler', name: 'quartz', version: '2.1.7'],
-            [group: 'joda-time', name: 'joda-time', version: '2.4'],
-            [group: 'org.apache.openjpa', name:'openjpa-all', version:'2.4.1'],
-            [group: 'org.springframework', name:'spring-jms'],
-            [group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
-            [group: 'com.google.guava', name: 'guava', version: '15.0'],
-            [group: 'org.springframework', name: 'spring-context-support', version: springVersion],
-            [group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: springOauthVersion],
-            [group: 'com.squareup.retrofit', name: 'retrofit', version: '1.6.1'],
-            [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion]
+            'com.google.code.gson:gson',
+            'org.quartz-scheduler:quartz',
+            'joda-time:joda-time',
+            'org.apache.openjpa:openjpa-all',
+            'org.springframework:spring-jms',
+            'org.mnode.ical4j:ical4j',
+            'com.google.guava:guava',
+            'org.springframework:spring-context-support',
+            'org.springframework.security.oauth:spring-security-oauth2',
+            'com.squareup.retrofit:retrofit',
+            'com.sun.jersey:jersey-core',
     )
 
     implementation(
-            [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.3'],
+            'ch.vorburger.mariaDB4j:mariaDB4j',
 
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion],
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: springBootVersion],
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: springBootVersion],
-            [group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion],
-            //[group: 'org.eclipse.persistence', name: 'javax.persistence', version: '2.0.0'],
-
-
-
-
-            [group: 'org.apache.openjpa', name:'openjpa-maven-plugin', version:openJPAVersion],
-            [group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1'],
-
-            [group: 'com.sun.jersey', name: 'jersey-servlet', version: jerseyVersion],
-            [group: 'com.sun.jersey', name: 'jersey-server', version: jerseyVersion],
-            [group: 'com.sun.jersey', name: 'jersey-json', version: jerseyVersion],
-            [group: 'com.sun.jersey.contribs', name: 'jersey-spring', version: jerseyVersion],
-            [group: 'com.sun.jersey.contribs', name: 'jersey-multipart', version: jerseyVersion],
-
-
-            [group: 'com.squareup.okhttp', name: 'okhttp', version: '2.0.0'],
-            [group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.0.0'],
+            'org.springframework.boot:spring-boot-starter-web',
+            'org.springframework.boot:spring-boot-starter-data-jpa',
+            'org.springframework.boot:spring-boot-starter-security',
+            'org.springframework.boot:spring-boot-starter-actuator',
+            //'org.eclipse.persistence:javax.persistence',
 
 
 
 
+            'org.apache.openjpa:openjpa-maven-plugin'
+            'javax.ws.rs:jsr311-api',
 
-            //[group: 'net.sourceforge.javacsv', name: 'javacsv', version: '2.0'],
-            [group: 'org.apache.commons', name: 'commons-email', version: '1.3.3'],
-            [group: 'org.apache.commons', name: 'commons-lang3', version: '3.3.2'],
+            'com.sun.jersey:jersey-servlet',
+            'com.sun.jersey:jersey-server',
+            'com.sun.jersey:jersey-json',
+            'com.sun.jersey.contribs:jersey-spring',
+            'com.sun.jersey.contribs:jersey-multipart',
+
+
+            'com.squareup.okhttp:okhttp',
+            'com.squareup.okhttp:okhttp-urlconnection',
+
+
+
+
+
+            //'net.sourceforge.javacsv:javacsv',
+            'org.apache.commons:commons-email',
+            'org.apache.commons:commons-lang3',
 
             // no slf4j & logback here (anymore), as spring-boot-starter-logging already brings this now, better assembled (log4j-over-slf4j was originally forgotten here)
 
-            //[group: 'mysql', name: 'mysql-connector-java', version: '5.1.27'],
-            [group: 'org.drizzle.jdbc', name: 'drizzle-jdbc', version: '1.4'],
-            [group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: tomcatVersion],
+            //'mysql:mysql-connector-java',
+            'org.drizzle.jdbc:drizzle-jdbc',
+            'org.apache.tomcat:tomcat-jdbc',
 
 
-            [group: 'org.apache.poi',name: 'poi', version: '3.9'],
-            [group: 'org.apache.poi',name: 'poi-ooxml', version: '3.9'],
-            [group: 'org.apache.poi',name: 'poi-ooxml-schemas', version: '3.9'],
+            'org.apache.poi:poi',
+            'org.apache.poi:poi-ooxml',
+            'org.apache.poi:poi-ooxml-schemas',
 
-            [group: 'com.lowagie', name: 'itext', version: '2.1.7'],
-            [group: 'com.lowagie', name: 'itext-rtf', version: '2.1.7'],
+            'com.lowagie:itext',
+            'com.lowagie:itext-rtf',
 
-            [group: 'com.googlecode.flyway', name: 'flyway-core', version: '2.1.1'],
+            'com.googlecode.flyway:flyway-core',
 
-            [group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.80'],
-            [group: 'net.sf.ehcache', name: 'ehcache', version: '2.7.2'],
-            [group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.12'],
-            [group: 'com.jayway.jsonpath', name: 'json-path', version: '0.9.1'],
-            [group: 'org.apache.tika', name: 'tika-core', version :'1.9'],
+            'com.amazonaws:aws-java-sdk-s3',
+            'net.sf.ehcache:ehcache',
+            'com.github.spullara.mustache.java:compiler',
+            'com.jayway.jsonpath:json-path',
+            'org.apache.tika:tika-core',
             // Although fineract (at the time of writing) doesn't have any compile time dep. on this,
             // it's useful to have this for the Spring Boot TestRestTemplate http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-rest-templates-test-utility
-            [group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.5'],
+            'org.apache.httpcomponents:httpclient',
             // Once we've switched to Java 8 this dep can be removed.
-            //[group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0']
+            //'com.google.code.findbugs:jsr305',
 
-            [group: 'io.swagger', name: 'swagger-jersey-jaxrs', version: '1.5.15'],
+            'io.swagger:swagger-jersey-jaxrs',
 
-            [group: 'org.apache.activemq', name: 'activemq-broker', version: '5.9.1'],
-            [group: 'javax.validation', name: 'validation-api', version: '2.0.0.Final']
+            'org.apache.activemq:activemq-broker',
+            'javax.validation:validation-api',
     )
 
     testCompile 'junit:junit:4.11',
             'junit:junit-dep:4.11',
             'org.mockito:mockito-core:1.9.5',
             'com.jayway.restassured:rest-assured:2.3.3',
-            [group: 'com.mockrunner', name: 'mockrunner-jms', version: '1.0.6'],
-            [group: 'com.google.code.gson', name: 'gson', version: '2.2.4'],
-            [group: 'org.springframework', name:'spring-jms', version: '4.0.7.RELEASE'],
-            [group: 'joda-time', name: 'joda-time', version: '2.4'],
-            [  group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
-            [group: 'com.google.guava', name: 'guava', version: '15.0'],
-            [group: 'org.apache.poi',name: 'poi-ooxml', version: '3.9'],
-            [group: 'org.springframework', name: 'spring-context-support', version: springVersion],
+            'com.mockrunner:mockrunner-jms',
+            'com.google.code.gson:gson',
+            'org.springframework:spring-jms',
+            'joda-time:joda-time',
+            'org.mnode.ical4j:ical4j',
+            'com.google.guava:guava',
+            'org.apache.poi:poi-ooxml',
+            'org.springframework:spring-context-support',
 
-            [group: 'com.sun.jersey', name: 'jersey-core', version: jerseyVersion],
-            [group: 'com.mockrunner', name: 'mockrunner-jdbc', version: '1.0.6']
+            'com.sun.jersey:jersey-core',
+            'com.mockrunner:mockrunner-jdbc',
 
      testCompile ("org.springframework.boot:spring-boot-starter-test") {
          exclude group: 'com.jayway.jsonpath', module: 'json-path'

--- a/fineract-provider/src/test/java/org/apache/fineract/mix/report/service/XBRLBuilderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/mix/report/service/XBRLBuilderTest.java
@@ -79,10 +79,13 @@ public class XBRLBuilderTest {
             nodes = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(result.getBytes()))
                     .getElementsByTagName("Assets");
         } catch (final SAXException e) {
+            // TODO Auto-generated catch block
             e.printStackTrace();
         } catch (final IOException e) {
+            // TODO Auto-generated catch block
             e.printStackTrace();
         } catch (final ParserConfigurationException e) {
+            // TODO Auto-generated catch block
             e.printStackTrace();
         }
         assertNotNull(nodes);

--- a/fineract-provider/src/test/java/org/apache/fineract/mix/report/service/XBRLBuilderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/mix/report/service/XBRLBuilderTest.java
@@ -79,13 +79,10 @@ public class XBRLBuilderTest {
             nodes = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(result.getBytes()))
                     .getElementsByTagName("Assets");
         } catch (final SAXException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
         } catch (final IOException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
         } catch (final ParserConfigurationException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
         }
         assertNotNull(nodes);


### PR DESCRIPTION
FINERACT-797 - Spring Dependency Management
 - Update mockito to latest version
 - Move dependencies from dependencies.gradle to build.gradle
 - Removed implemented TODOs from XBRBuilderTest.java
https://issues.apache.org/jira/browse/FINERACT-797

## Description
In an ideal world, in a future PR, it would be really really cool if we could just avoid having to repeat using fixed version, and could use the implicit versions via Spring BOM dependency management, see https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#managing-dependencies ...

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
