### PR TITLE
FINERACT-802-restrict-client-to-have-single-self-service-user

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
@@ -27,6 +27,7 @@ import com.jayway.restassured.specification.ResponseSpecification;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
 import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
@@ -35,6 +36,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 
 public class UserAdministrationTest {
 
@@ -64,6 +66,7 @@ public class UserAdministrationTest {
 
     @Test
     public void testCreateNewUserBlocksDuplicateUsername() {
+
         final Integer roleId = RolesHelper.createRole(this.requestSpec, this.responseSpec);
         Assert.assertNotNull(roleId);
 
@@ -121,6 +124,26 @@ public class UserAdministrationTest {
         Map reason = (Map) errors.get(0);
         Assert.assertEquals("User with username alphabet already exists.", reason.get("defaultUserMessage"));
         Assert.assertEquals("error.msg.user.duplicate.username", reason.get("userMessageGlobalisationCode"));
+    }
+    @Test
+    public void testCreateNewUserBlocksDuplicateClientId() {
+        final Integer roleId = RolesHelper.createRole(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(roleId);
+
+        final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(staffId);
+
+        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(clientId);
+
+        final Integer userId = (Integer) UserHelper.createUserForSelfService(this.requestSpec, this.responseSpec, roleId, staffId, clientId, "resourceId");
+        Assert.assertNotNull(userId);
+        this.transientUsers.add(userId);
+
+        final List errors = (List) UserHelper.createUserForSelfService(this.requestSpec, expectStatusCode(403), roleId, staffId, clientId, "errors");
+        Map reason = (Map) errors.get(0);
+        
+        Assert.assertEquals("Self Service User Id is already created. Go to Admin->Users to edit or delete the self-service user.", reason.get("defaultUserMessage"));
     }
 
 }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
@@ -35,6 +35,9 @@ public class UserHelper {
     public static Object createUser(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, int roleId, int staffId, String username, String attribute) {
         return Utils.performServerPost(requestSpec, responseSpec, CREATE_USER_URL, getTestCreateUserAsJSON(roleId, staffId, username), attribute);
     }
+    public static Object createUserForSelfService(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, int roleId, int staffId, int clientId, String attribute) {
+        return Utils.performServerPost(requestSpec, responseSpec, CREATE_USER_URL, getTestCreateUserAsJSONForSelfService(roleId, staffId, clientId), attribute);
+    }
 
     public static String getTestCreateUserAsJSON(int roleId, int staffId) {
         return "{ \"username\": \"" + Utils.randomNameGenerator("User_Name_", 3)
@@ -56,6 +59,15 @@ public class UserHelper {
         return "{ \"username\": \"" + username
             + "\", \"firstname\": \"Test\", \"lastname\": \"User\", \"email\": \"whatever@mifos.org\","
             + " \"officeId\": \"1\"}";
+    }
+    public static String getTestCreateUserAsJSONForSelfService(int roleId, int staffId, int clientId) {
+        return "{ \"username\": \"" + Utils.randomNameGenerator("User_Name_", 3)
+                + "\", \"firstname\": \"Test\", \"lastname\": \"User\", \"email\": \"whatever@mifos.org\","
+                + " \"officeId\": \"1\", \"staffId\": " + "\""
+                + staffId +"\",\"roles\": [\""
+                + roleId + "\"], \"sendPasswordToEmail\": false,"
+                +"\"isSelfServiceUser\" : true,"
+                +"\"clients\" : [\""+clientId+"\"]}";
     }
 
     public static Integer deleteUser(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final Integer userId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -349,6 +349,10 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
                     username);
         }
 
+        if (realCause.getMessage().contains("'unique_self_client'")) {
+            throw new PlatformDataIntegrityException("error.msg.user.self.service.user.already.exist", "Self Service User Id is already created. Go to Admin->Users to edit or delete the self-service user.");
+        }
+
         logger.error(dve.getMessage(), dve);
         throw new PlatformDataIntegrityException("error.msg.unknown.data.integrity.issue", "Unknown data integrity issue with resource.");
     }

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V354__self_service_user_unique_for_client.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V354__self_service_user_unique_for_client.sql
@@ -1,0 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+ALTER TABLE `m_selfservice_user_client_mapping` ADD CONSTRAINT `unique_self_client` UNIQUE (`client_id`);


### PR DESCRIPTION
## Description
The client can have two or more different usernames to login as self service user : FINERACT-802

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
