### PR TITLE
FINERACT-803 fix exception handling for username duplication

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/UserAdministrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.integrationtests;
+
+import com.jayway.restassured.builder.RequestSpecBuilder;
+import com.jayway.restassured.builder.ResponseSpecBuilder;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.specification.RequestSpecification;
+import com.jayway.restassured.specification.ResponseSpecification;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
+import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
+import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UserAdministrationTest {
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private List<Integer> transientUsers = new ArrayList<>();
+
+    private ResponseSpecification expectStatusCode(int code) {
+        return new ResponseSpecBuilder().expectStatusCode(code).build();
+    }
+
+    @Before
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.responseSpec = expectStatusCode(200);
+    }
+
+    @After
+    public void tearDown() {
+        for(Integer userId : this.transientUsers) {
+            UserHelper.deleteUser(this.requestSpec, this.responseSpec, userId);
+        }
+        this.transientUsers.clear();
+    }
+
+    @Test
+    public void testCreateNewUserBlocksDuplicateUsername() {
+        final Integer roleId = RolesHelper.createRole(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(roleId);
+
+        final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(staffId);
+
+        final Integer userId = (Integer) UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, "alphabet", "resourceId");
+        Assert.assertNotNull(userId);
+        this.transientUsers.add(userId);
+
+        final List errors = (List) UserHelper.createUser(this.requestSpec, expectStatusCode(403), roleId, staffId, "alphabet", "errors");
+        Map reason = (Map) errors.get(0);
+        System.out.println("Reason: " + reason.get("defaultUserMessage"));
+        System.out.println("Code: " + reason.get("userMessageGlobalisationCode"));
+        Assert.assertEquals("User with username alphabet already exists.", reason.get("defaultUserMessage"));
+        Assert.assertEquals("error.msg.user.duplicate.username", reason.get("userMessageGlobalisationCode"));
+    }
+
+    @Test
+    public void testUpdateUserAcceptsNewOrSameUsername() {
+        final Integer roleId = RolesHelper.createRole(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(roleId);
+
+        final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(staffId);
+
+        final Integer userId = (Integer) UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, "alphabet", "resourceId");
+        Assert.assertNotNull(userId);
+        this.transientUsers.add(userId);
+
+        final Integer userId2 = (Integer) UserHelper.updateUser(this.requestSpec, this.responseSpec, userId, "renegade", "resourceId");
+        Assert.assertNotNull(userId2);
+
+        final Integer userId3 = (Integer) UserHelper.updateUser(this.requestSpec, this.responseSpec, userId, "renegade", "resourceId");
+        Assert.assertNotNull(userId3);
+    }
+
+    @Test
+    public void testUpdateUserBlockDuplicateUsername() {
+        final Integer roleId = RolesHelper.createRole(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(roleId);
+
+        final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+        Assert.assertNotNull(staffId);
+
+        final Integer userId = (Integer) UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, "alphabet", "resourceId");
+        Assert.assertNotNull(userId);
+        this.transientUsers.add(userId);
+
+        final Integer userId2 = (Integer) UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, "bilingual", "resourceId");
+        Assert.assertNotNull(userId2);
+        this.transientUsers.add(userId2);
+
+        final List errors = (List) UserHelper.updateUser(this.requestSpec, expectStatusCode(403), userId2, "alphabet", "errors");
+        Map reason = (Map) errors.get(0);
+        Assert.assertEquals("User with username alphabet already exists.", reason.get("defaultUserMessage"));
+        Assert.assertEquals("error.msg.user.duplicate.username", reason.get("userMessageGlobalisationCode"));
+    }
+
+}

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -32,19 +32,38 @@ public class UserHelper {
         return Utils.performServerPost(requestSpec, responseSpec, CREATE_USER_URL, getTestCreateUserAsJSON(roleId, staffId), "resourceId");
     }
 
+    public static Object createUser(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, int roleId, int staffId, String username, String attribute) {
+        return Utils.performServerPost(requestSpec, responseSpec, CREATE_USER_URL, getTestCreateUserAsJSON(roleId, staffId, username), attribute);
+    }
+
     public static String getTestCreateUserAsJSON(int roleId, int staffId) {
-        String json = "{ \"username\": \"" + Utils.randomNameGenerator("User_Name_", 3)
+        return "{ \"username\": \"" + Utils.randomNameGenerator("User_Name_", 3)
                 + "\", \"firstname\": \"Test\", \"lastname\": \"User\", \"email\": \"whatever@mifos.org\","
                 + " \"officeId\": \"1\", \"staffId\": " + "\""
-                + Integer.toString(staffId)+"\",\"roles\": [\""
-                + Integer.toString(roleId) + "\"], \"sendPasswordToEmail\": false}";
-        System.out.println(json);
-        return json;
+                + staffId +"\",\"roles\": [\""
+                + roleId + "\"], \"sendPasswordToEmail\": false}";
+    }
 
+    private static String getTestCreateUserAsJSON(int roleId, int staffId, String username) {
+        return "{ \"username\": \"" + username
+            + "\", \"firstname\": \"Test\", \"lastname\": \"User\", \"email\": \"whatever@mifos.org\","
+            + " \"officeId\": \"1\", \"staffId\": " + "\""
+            + staffId +"\",\"roles\": [\""
+            + roleId + "\"], \"sendPasswordToEmail\": false}";
+    }
+
+    private static String getTestUpdateUserAsJSON(String username) {
+        return "{ \"username\": \"" + username
+            + "\", \"firstname\": \"Test\", \"lastname\": \"User\", \"email\": \"whatever@mifos.org\","
+            + " \"officeId\": \"1\"}";
     }
 
     public static Integer deleteUser(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final Integer userId) {
         return Utils.performServerDelete(requestSpec, responseSpec, createRoleOperationURL(userId), "resourceId");
+    }
+
+    public static Object updateUser(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, int userId, String username, String attribute) {
+        return Utils.performServerPut(requestSpec, responseSpec, createRoleOperationURL(userId), getTestUpdateUserAsJSON(username), attribute);
     }
 
     private static String createRoleOperationURL(final Integer userId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -65,6 +64,7 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -164,13 +164,13 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
         } catch (final DataIntegrityViolationException dve) {
             handleDataIntegrityIssues(command, dve.getMostSpecificCause(), dve);
             return CommandProcessingResult.empty();
-        }catch (final PersistenceException | AuthenticationServiceException dve) {
-        	Throwable throwable = ExceptionUtils.getRootCause(dve.getCause()) ;
+        } catch (final JpaSystemException | PersistenceException | AuthenticationServiceException dve) {
+        	  Throwable throwable = ExceptionUtils.getRootCause(dve.getCause()) ;
             handleDataIntegrityIssues(command, throwable, dve);
             return new CommandProcessingResultBuilder() //
                     .withCommandId(command.commandId()) //
                     .build();
-        }catch (final PlatformEmailSendException e) {
+        } catch (final PlatformEmailSendException e) {
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
 
             final String email = command.stringValueOfParameterNamed("email");
@@ -257,8 +257,8 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
         } catch (final DataIntegrityViolationException dve) {
             handleDataIntegrityIssues(command, dve.getMostSpecificCause(), dve);
             return CommandProcessingResult.empty();
-        }catch (final PersistenceException | AuthenticationServiceException dve) {
-        	Throwable throwable = ExceptionUtils.getRootCause(dve.getCause()) ;
+        } catch (final JpaSystemException | PersistenceException | AuthenticationServiceException dve) {
+        	  Throwable throwable = ExceptionUtils.getRootCause(dve.getCause()) ;
             handleDataIntegrityIssues(command, throwable, dve);
             return new CommandProcessingResultBuilder() //
                     .withCommandId(command.commandId()) //


### PR DESCRIPTION
## Description
There was already error handling in place for username duplication. It wasn't working because the actual exception being thrown `JpaSystemException` didn't match what was being caught.

This adds integration tests to verify the behaviour and adds `JpaSystemException` to the catch block.

Fixes #665 #660 