### PR TITLE
fix broken docker-compose set up (re. FINERACT-773)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,5 @@ script:
 # using "&&" instead of several "-" means that integrationTest does not run if test fails,
 # and Docker test does not run if integration test fails, which makes PR failure easier to understand.
 # @see https://docs.travis-ci.com/user/job-lifecycle/#customizing-the-build-phase
-  - ./gradlew --console=plain licenseMain licenseTest licenseIntegrationTest check  &&  ./gradlew --console=plain integrationTest  &&  sudo service mysql stop  &&  docker-compose build  &&  docker-compose up -d  &&  sleep 30s  &&  http --verify=no --timeout 240 --check-status get https://localhost:8443/fineract-provider/actuator/health || docker logs fineract_fineract-server_1
+  - ./gradlew --console=plain licenseMain licenseTest licenseIntegrationTest check  &&  ./gradlew --console=plain integrationTest  &&  sudo service mysql stop  &&  docker-compose build  &&  docker-compose up -d  &&  sleep 30s  &&  http --verify=no --timeout 240 --check-status get https://localhost:8443/fineract-provider/actuator/health
 # We stop the mysql system service when running the Docker test to avoid port 3306 conflicts (unless we run the mysql in docker-compose on another port; req. FINERACT-773)
-# The || docker logs lets use see the root cause in case of failures


### PR DESCRIPTION
This fixed bugs introduced in edc9e030e10b9f7f6c394ab35c307c7fa28939a0
(in https://github.com/apache/fineract/pull/648) which for FINERACT-773
actually broke things more instead of adding the intended feature, cauz:

1. FINERACT_DEFAULT_TENANTDB_HOSTNAME and FINERACT_DEFAULT_TENANTDB_PORT
   were meant to be OS Environment Variables, not Java System properties
   and so need to be read via System.getenv() not System.getProperty(),
   duh!

2. The Travis CI test which was meant to ensure non-regression for this
   broke in that same change, because the "|| docker logs" introduced at
   the same time would always pass (EITHER because "http" passed OR
   if not then "docker logs" would return 0), duh again!

Both were dumb, not sure what I was thinking when I had hacked this.. ;)