### PR TITLE
Minor: Remove comment in build.gradle re. springDataJpaVersion

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -38,7 +38,7 @@ buildscript {
      classpath 'com.bmuschko:gradle-tomcat-plugin:2.5',
                'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0',
                'org.zeroturnaround:gradle-jrebel-plugin:1.1.2',
-               'org.springframework.boot:spring-boot-gradle-plugin:2.2.4.RELEASE' // also change springDataJpaVersion
+               'org.springframework.boot:spring-boot-gradle-plugin:2.2.4.RELEASE'
       // below
      classpath "org.apache.openjpa:openjpa:$openJPAVersion"
      classpath 'com.radcortez.gradle:openjpa-gradle-plugin:3.1.0'


### PR DESCRIPTION
This has been removed in a20f76d68612aae3a4384a43d99afbdaecd41404, and it's confusing to look for what that means, e.g. while code reviewing proposed "bump" changes to the used versions of `spring.gradle:dependency-management-plugin` and `springframework.boot:spring-boot-gradle-plugin` such as in https://github.com/apache/fineract/pull/701.