### PR TITLE
Activate and Enforce Checkstyle EqualsHashCode check.

### DIFF
--- a/fineract-provider/config/checkstyle/checkstyle.xml
+++ b/fineract-provider/config/checkstyle/checkstyle.xml
@@ -48,8 +48,8 @@
     </module>
   -->
     <module name="TreeWalker">
-<!-- TODO Enable many more checks (go about this one by one, step by step, raise separate PRs fixing and then enforcing):
         <module name="EqualsHashCode"/>
+<!-- TODO Enable many more checks (go about this one by one, step by step, raise separate PRs fixing and then enforcing):
 
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>


### PR DESCRIPTION
Thanks to prior work for SpotBugs, this passes without requiring any
code adjustments.  (Fineract had a nubmer of problems in this space
before the SpotBugs work.)

Enabling this helps to ensure non-regression so that no new equals() and
hashCode() related bugs creep in.  (This does overlap a little bit with
SpotBugs, but the build time overhead to run the extra check is
completely negligible, so it seems worth having this.  If only just in
case SpotBugs for whatever reason in the future would get deactivated
again.)