### PR TITLE
FINERACT-807  -  Use underscore instead of dash in tenants and default tenant database names

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,6 +37,6 @@ tasks:
       # NB MySQL on GitPod.io is currently quite slow.
       # similar to .travis.yml, but using authentication_string= instead of password= due to mysql major version difference
       mysql -e "USE mysql;\nUPDATE user SET authentication_string=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n"
-      ./gradlew createDB -PdbName=mifosplatform-tenants
-      ./gradlew createDB -PdbName=mifostenant-default
+      ./gradlew createDB -PdbName=fineract_tenants
+      ./gradlew createDB -PdbName=fineract_default
       ./gradlew build -x test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ addons:
 
 before_install:
   - echo "USE mysql;\nUPDATE user SET password=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
-  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifosplatform-tenants`;'
-  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `mifostenant-default`;'
+  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_tenants`;'
+  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_default`;'
 # Hardcoding the time zone is a temporary fix for https://issues.apache.org/jira/browse/FINERACT-723
   - export TZ=Asia/Kolkata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ COPY ./docker/server.xml /opt/bitnami/tomcat/conf
 RUN chmod 664 /opt/bitnami/tomcat/conf/server.xml
 
 WORKDIR /opt/bitnami/tomcat/lib
-# org.drizzle.jdbc.DrizzleDriver is used in docker/server.xml for jdbc/mifosplatform-tenants DataSource
+# org.drizzle.jdbc.DrizzleDriver is used in docker/server.xml for jdbc/fineract_tenants DataSource
 # (But note that connections to individual tenant DBs may use another driver...)
 RUN wget https://repo1.maven.org/maven2/org/drizzle/jdbc/drizzle-jdbc/1.4/drizzle-jdbc-1.4.jar

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Instructions how to run for local development
 ============
 
 Run the following commands:
-1. `./gradlew createDB -PdbName=mifosplatform-tenants`
-1. `./gradlew createDB -PdbName=mifostenant-default`
+1. `./gradlew createDB -PdbName=fineract_tenants`
+1. `./gradlew createDB -PdbName=fineract_default`
 1. `./gradlew tomcatRunWAR`
 
 
@@ -71,8 +71,8 @@ Instructions to execute Integration tests
 > Note that if this is the first time to access MySQL DB, then you may need to reset your password.
 
 Run the following commands, very similarly to how [.travis.yml](.travis.yml) does:
-1. `./gradlew createDB -PdbName=mifosplatform-tenants`
-1. `./gradlew createDB -PdbName=mifostenant-default`
+1. `./gradlew createDB -PdbName=fineract_tenants`
+1. `./gradlew createDB -PdbName=fineract_default`
 1. `./gradlew clean integrationTest`
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     depends_on:
       - fineractmysql
     environment:
-      - JAVA_OPTS=-Dfineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/mifosplatform-tenants -Dfineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver -Dfineract_tenants_uid=root -Dfineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca -Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
+      - JAVA_OPTS=-Dfineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants -Dfineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver -Dfineract_tenants_uid=root -Dfineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca -Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
       - FINERACT_DEFAULT_TENANTDB_HOSTNAME=fineractmysql
       - FINERACT_DEFAULT_TENANTDB_PORT=3306
       - FINERACT_DEFAULT_TENANTDB_UID=root

--- a/docker/server.xml
+++ b/docker/server.xml
@@ -39,7 +39,7 @@
          UserDatabaseRealm to authenticate users
     -->
      <Resource type="javax.sql.DataSource"
-        name="jdbc/mifosplatform-tenants"
+        name="jdbc/fineract_tenants"
         factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
         driverClassName="${fineract_tenants_driver}"
         url="${fineract_tenants_url}"

--- a/fineract-db/docker/01-databases.sql
+++ b/fineract-db/docker/01-databases.sql
@@ -18,8 +18,8 @@
 --
 
 # create databases
-CREATE DATABASE IF NOT EXISTS `mifosplatform-tenants`;
-CREATE DATABASE IF NOT EXISTS `mifostenant-default`;
+CREATE DATABASE IF NOT EXISTS `fineract_tenants`;
+CREATE DATABASE IF NOT EXISTS `fineract_default`;
 
 # create root user and grant rights
 GRANT ALL ON *.* TO 'root'@'%';

--- a/fineract-db/mifospltaform-tenants-first-time-install.sql
+++ b/fineract-db/mifospltaform-tenants-first-time-install.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifosplatform-tenants
+-- Host: localhost    Database: fineract_tenants
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 
@@ -117,7 +117,7 @@ CREATE TABLE `tenants` (
 LOCK TABLES `tenants` WRITE;
 /*!40000 ALTER TABLE `tenants` DISABLE KEYS */;
 INSERT INTO `tenants` VALUES 
-(1,'default','default','mifostenant-default','Asia/Kolkata',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1,5,30000,1,60,1,50,1,40,20,10,60,34000,60000);
+(1,'default','default','fineract_default','Asia/Kolkata',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1,5,30000,1,60,1,50,1,40,20,10,60,34000,60000);
 /*!40000 ALTER TABLE `tenants` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/fineract-db/multi-tenant-demo-backups/0001-mifos-platform-shared-tenants.sql
+++ b/fineract-db/multi-tenant-demo-backups/0001-mifos-platform-shared-tenants.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifosplatform-tenants
+-- Host: localhost    Database: fineract_tenants
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 
@@ -66,7 +66,7 @@ CREATE TABLE `tenants` (
 
 LOCK TABLES `tenants` WRITE;
 /*!40000 ALTER TABLE `tenants` DISABLE KEYS */;
-INSERT INTO `tenants` VALUES (1,'default','Default Demo Tenant','mifostenant-default','Asia/Kolkata',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1);
+INSERT INTO `tenants` VALUES (1,'default','Default Demo Tenant','fineract_default','Asia/Kolkata',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1);
 /*!40000 ALTER TABLE `tenants` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/fineract-db/multi-tenant-demo-backups/bare-bones-demo/bk_bare_bones_demo.sql
+++ b/fineract-db/multi-tenant-demo-backups/bare-bones-demo/bk_bare_bones_demo.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifostenant-default
+-- Host: localhost    Database: fineract_default
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 

--- a/fineract-db/multi-tenant-demo-backups/bk_mifostenant_default.sql
+++ b/fineract-db/multi-tenant-demo-backups/bk_mifostenant_default.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifostenant-default
+-- Host: localhost    Database: fineract_default
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 

--- a/fineract-db/multi-tenant-demo-backups/default-demo/bk_mifostenant-default.sql
+++ b/fineract-db/multi-tenant-demo-backups/default-demo/bk_mifostenant-default.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifostenant-default
+-- Host: localhost    Database: fineract_default
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 

--- a/fineract-db/multi-tenant-demo-backups/latam-demo/bk_latam.sql
+++ b/fineract-db/multi-tenant-demo-backups/latam-demo/bk_latam.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifostenant-default
+-- Host: localhost    Database: fineract_default
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -495,8 +495,8 @@ task dropDB {
 task setBlankPassword {
     doLast {
         def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
-        sql.execute('USE `mifosplatform-tenants`')
-        sql.execute('UPDATE mifosplatform-tenants.tenants SET schema_server = \'localhost\', schema_server_port = \'3306\', schema_username = \'mifos\', schema_password = \'mysql\' WHERE id=1;')
+        sql.execute('USE `fineract_tenants`')
+        sql.execute('UPDATE fineract_tenants.tenants SET schema_server = \'localhost\', schema_server_port = \'3306\', schema_username = \'mifos\', schema_password = \'mysql\' WHERE id=1;')
     }
 }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/DataSourceProperties.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/DataSourceProperties.java
@@ -47,7 +47,7 @@ public class DataSourceProperties extends PoolProperties {
     @Value("${" + HOST + ":localhost}")
     private volatile @NotNull String hostname;
 
-    @Value("${" + DB + ":mifosplatform-tenants}")
+    @Value("${" + DB + ":fineract_tenants}")
     private volatile @NotNull String dbName;
 
     @Value("${" + UID + ":root}")

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/MariaDB4jSetupService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/MariaDB4jSetupService.java
@@ -38,13 +38,13 @@ public class MariaDB4jSetupService {
     @PostConstruct
     protected void setUpDBs() throws ManagedProcessException {
         db.createDB(getTenantDBName());
-        db.createDB("mifostenant-default");
+        db.createDB("fineract_default");
         // Note that we don't need to initialize the DBs, because
         // the TenantDatabaseUpgradeService will do this in just a moment.
     }
 
     public String getTenantDBName() {
-        return "mifosplatform-tenants";
+        return "fineract_tenants";
     }
 
     @PreDestroy

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/TenantDataSourcePortFixService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/db/TenantDataSourcePortFixService.java
@@ -29,13 +29,13 @@ import org.springframework.stereotype.Service;
 
 /**
  * Service which "fixes up" the schemaServerPort in the tenants table of the
- * mifosplatform-tenants schema. It sets it to the actual current port of
+ * fineract_tenants schema. It sets it to the actual current port of
  * MariaDB4j, instead of the default 3306 which is hard-coded in the initial
  * set-up SQL script (V1__mifos-platform-shared-tenants.sql).
  *
  * This service is called by the TenantDatabaseUpgradeService
  * "just at the right time" during start-up, that is AFTER the initialization of
- * the mifosplatform-tenants but BEFORE Flyway runs on all tenant schemas.
+ * the fineract_tenants but BEFORE Flyway runs on all tenant schemas.
  *
  * It's difficult to achieve the same goal elsewhere, because we cannot do this
  * e.g. in MariaDB4jSetupService, as that's too early
@@ -72,12 +72,12 @@ public class TenantDataSourcePortFixService {
 
     public void fixUpTenantsSchemaServerPort() {
     if (!enabled)  {
-        logger.info("No schema_server_port UPDATE made to tenant_server_connections table of the mifosplatform-tenants schema, because " + ENABLED + " = false");
+        logger.info("No schema_server_port UPDATE made to tenant_server_connections table of the fineract_tenants schema, because " + ENABLED + " = false");
         return;
     }
     if (dsp == null) {
         // we don't have any generic mechanism to know the DB port, given just a tenant DataSource
-        logger.debug("No schema_server_port UPDATE made to tenant_server_connections table of the mifosplatform-tenants schema (because neither MariaDB4j nor our own Spring Boot DataSourceConfiguration is used in a traditional WAR)");
+        logger.debug("No schema_server_port UPDATE made to tenant_server_connections table of the fineract_tenants schema (because neither MariaDB4j nor our own Spring Boot DataSourceConfiguration is used in a traditional WAR)");
         return;
     }
         int r = jdbcTemplate
@@ -88,7 +88,7 @@ public class TenantDataSourcePortFixService {
     else
             logger.info("Upated "
                     + r
-                    + " rows in the tenant_server_connections table of the mifosplatform-tenants schema to the real current host: "
+                    + " rows in the tenant_server_connections table of the fineract_tenants schema to the real current host: "
                     + dsp.getHost() + ", port: " + dsp.getPort());
     }
 

--- a/fineract-provider/src/main/resources/META-INF/spring/jndi.xml
+++ b/fineract-provider/src/main/resources/META-INF/spring/jndi.xml
@@ -29,6 +29,6 @@
     	http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd">
 
 	<!-- name here must match TestDataSourceConfiguration -->
-	<jee:jndi-lookup jndi-name="java:comp/env/jdbc/mifosplatform-tenants"
+	<jee:jndi-lookup jndi-name="java:comp/env/jdbc/fineract_tenants"
 		id="tenantDataSourceJndi" />
 </beans>

--- a/fineract-provider/src/main/resources/sql/migrations/list_db/V1__mifos-platform-shared-tenants.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/list_db/V1__mifos-platform-shared-tenants.sql
@@ -19,7 +19,7 @@
 
 -- MySQL dump 10.13  Distrib 5.1.60, for Win32 (ia32)
 --
--- Host: localhost    Database: mifosplatform-tenants
+-- Host: localhost    Database: fineract_tenants
 -- ------------------------------------------------------
 -- Server version	5.1.60-community
 
@@ -66,7 +66,7 @@ CREATE TABLE `tenants` (
 
 LOCK TABLES `tenants` WRITE;
 /*!40000 ALTER TABLE `tenants` DISABLE KEYS */;
-INSERT INTO `tenants` VALUES (1,'default','Default Demo Tenant','mifostenant-default','Asia/Kolkata',NULL,NULL,NULL,NULL,'${fineract_default_tenantdb_hostname}','${fineract_default_tenantdb_port}','${fineract_default_tenantdb_uid}','${fineract_default_tenantdb_pwd}',1);
+INSERT INTO `tenants` VALUES (1,'default','Default Demo Tenant','fineract_default','Asia/Kolkata',NULL,NULL,NULL,NULL,'${fineract_default_tenantdb_hostname}','${fineract_default_tenantdb_port}','${fineract_default_tenantdb_uid}','${fineract_default_tenantdb_pwd}',1);
 -- Add tenants to support interoperation multi-tenancy
 -- INSERT INTO `tenants` VALUES (2,'tn01','Buffalo','tn01','Africa/Bujumbura',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1);
 -- INSERT INTO `tenants` VALUES (3,'tn02','Lion','tn02','Africa/Bujumbura',NULL,NULL,NULL,NULL,'localhost','3306','root','mysql',1);

--- a/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
@@ -29,7 +29,7 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
--- Dumping structure for table mifostenant-default.acc_accounting_rule
+-- Dumping structure for table fineract_default.acc_accounting_rule
 DROP TABLE IF EXISTS `acc_accounting_rule`;
 CREATE TABLE IF NOT EXISTS `acc_accounting_rule` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -51,12 +51,12 @@ CREATE TABLE IF NOT EXISTS `acc_accounting_rule` (
   CONSTRAINT `FK_acc_accounting_rule_m_office` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_accounting_rule: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_accounting_rule: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_accounting_rule` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_accounting_rule` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_gl_account
+-- Dumping structure for table fineract_default.acc_gl_account
 DROP TABLE IF EXISTS `acc_gl_account`;
 CREATE TABLE IF NOT EXISTS `acc_gl_account` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -78,12 +78,12 @@ CREATE TABLE IF NOT EXISTS `acc_gl_account` (
   CONSTRAINT `FK_ACC_0000000001` FOREIGN KEY (`parent_id`) REFERENCES `acc_gl_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_gl_account: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_gl_account: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_gl_account` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_gl_account` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_gl_closure
+-- Dumping structure for table fineract_default.acc_gl_closure
 DROP TABLE IF EXISTS `acc_gl_closure`;
 CREATE TABLE IF NOT EXISTS `acc_gl_closure` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -105,12 +105,12 @@ CREATE TABLE IF NOT EXISTS `acc_gl_closure` (
   CONSTRAINT `FK_acc_gl_closure_m_office` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_gl_closure: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_gl_closure: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_gl_closure` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_gl_closure` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_gl_financial_activity_account
+-- Dumping structure for table fineract_default.acc_gl_financial_activity_account
 DROP TABLE IF EXISTS `acc_gl_financial_activity_account`;
 CREATE TABLE IF NOT EXISTS `acc_gl_financial_activity_account` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -122,12 +122,12 @@ CREATE TABLE IF NOT EXISTS `acc_gl_financial_activity_account` (
   CONSTRAINT `FK_office_mapping_acc_gl_account` FOREIGN KEY (`gl_account_id`) REFERENCES `acc_gl_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_gl_financial_activity_account: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_gl_financial_activity_account: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_gl_financial_activity_account` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_gl_financial_activity_account` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_gl_journal_entry
+-- Dumping structure for table fineract_default.acc_gl_journal_entry
 DROP TABLE IF EXISTS `acc_gl_journal_entry`;
 CREATE TABLE IF NOT EXISTS `acc_gl_journal_entry` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -180,12 +180,12 @@ CREATE TABLE IF NOT EXISTS `acc_gl_journal_entry` (
   CONSTRAINT `FK_acc_gl_journal_entry_m_share_account_transaction` FOREIGN KEY (`share_transaction_id`) REFERENCES `m_share_account_transactions` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_gl_journal_entry: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_gl_journal_entry: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_gl_journal_entry` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_gl_journal_entry` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_product_mapping
+-- Dumping structure for table fineract_default.acc_product_mapping
 DROP TABLE IF EXISTS `acc_product_mapping`;
 CREATE TABLE IF NOT EXISTS `acc_product_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -202,12 +202,12 @@ CREATE TABLE IF NOT EXISTS `acc_product_mapping` (
   CONSTRAINT `FK_acc_product_mapping_m_payment_type` FOREIGN KEY (`payment_type`) REFERENCES `m_payment_type` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_product_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_product_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_product_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_product_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.acc_rule_tags
+-- Dumping structure for table fineract_default.acc_rule_tags
 DROP TABLE IF EXISTS `acc_rule_tags`;
 CREATE TABLE IF NOT EXISTS `acc_rule_tags` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -222,12 +222,12 @@ CREATE TABLE IF NOT EXISTS `acc_rule_tags` (
   CONSTRAINT `FK_m_code_value_id` FOREIGN KEY (`tag_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.acc_rule_tags: ~0 rows (approximately)
+-- Dumping data for table fineract_default.acc_rule_tags: ~0 rows (approximately)
 /*!40000 ALTER TABLE `acc_rule_tags` DISABLE KEYS */;
 /*!40000 ALTER TABLE `acc_rule_tags` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.c_account_number_format
+-- Dumping structure for table fineract_default.c_account_number_format
 DROP TABLE IF EXISTS `c_account_number_format`;
 CREATE TABLE IF NOT EXISTS `c_account_number_format` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -237,12 +237,12 @@ CREATE TABLE IF NOT EXISTS `c_account_number_format` (
   UNIQUE KEY `account_type_enum` (`account_type_enum`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.c_account_number_format: ~0 rows (approximately)
+-- Dumping data for table fineract_default.c_account_number_format: ~0 rows (approximately)
 /*!40000 ALTER TABLE `c_account_number_format` DISABLE KEYS */;
 /*!40000 ALTER TABLE `c_account_number_format` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.c_cache
+-- Dumping structure for table fineract_default.c_cache
 DROP TABLE IF EXISTS `c_cache`;
 CREATE TABLE IF NOT EXISTS `c_cache` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -250,14 +250,14 @@ CREATE TABLE IF NOT EXISTS `c_cache` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.c_cache: ~0 rows (approximately)
+-- Dumping data for table fineract_default.c_cache: ~0 rows (approximately)
 /*!40000 ALTER TABLE `c_cache` DISABLE KEYS */;
 INSERT INTO `c_cache` (`id`, `cache_type_enum`) VALUES
 	(1, 1);
 /*!40000 ALTER TABLE `c_cache` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.c_configuration
+-- Dumping structure for table fineract_default.c_configuration
 DROP TABLE IF EXISTS `c_configuration`;
 CREATE TABLE IF NOT EXISTS `c_configuration` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -271,7 +271,7 @@ CREATE TABLE IF NOT EXISTS `c_configuration` (
   UNIQUE KEY `name_UNIQUE` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=33 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.c_configuration: ~27 rows (approximately)
+-- Dumping data for table fineract_default.c_configuration: ~27 rows (approximately)
 /*!40000 ALTER TABLE `c_configuration` DISABLE KEYS */;
 INSERT INTO `c_configuration` (`id`, `name`, `value`, `date_value`, `enabled`, `is_trap_door`, `description`) VALUES
 	(1, 'maker-checker', NULL, NULL, 0, 0, NULL),
@@ -304,7 +304,7 @@ INSERT INTO `c_configuration` (`id`, `name`, `value`, `date_value`, `enabled`, `
 /*!40000 ALTER TABLE `c_configuration` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.c_external_service
+-- Dumping structure for table fineract_default.c_external_service
 DROP TABLE IF EXISTS `c_external_service`;
 CREATE TABLE IF NOT EXISTS `c_external_service` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -313,7 +313,7 @@ CREATE TABLE IF NOT EXISTS `c_external_service` (
   UNIQUE KEY `name_UNIQUE` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.c_external_service: ~3 rows (approximately)
+-- Dumping data for table fineract_default.c_external_service: ~3 rows (approximately)
 /*!40000 ALTER TABLE `c_external_service` DISABLE KEYS */;
 INSERT INTO `c_external_service` (`id`, `name`) VALUES
 	(3, 'MESSAGE_GATEWAY'),
@@ -322,7 +322,7 @@ INSERT INTO `c_external_service` (`id`, `name`) VALUES
 /*!40000 ALTER TABLE `c_external_service` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.c_external_service_properties
+-- Dumping structure for table fineract_default.c_external_service_properties
 DROP TABLE IF EXISTS `c_external_service_properties`;
 CREATE TABLE IF NOT EXISTS `c_external_service_properties` (
   `name` varchar(150) NOT NULL,
@@ -332,7 +332,7 @@ CREATE TABLE IF NOT EXISTS `c_external_service_properties` (
   CONSTRAINT `FK_c_external_service_properties_c_external_service` FOREIGN KEY (`external_service_id`) REFERENCES `c_external_service` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.c_external_service_properties: ~12 rows (approximately)
+-- Dumping data for table fineract_default.c_external_service_properties: ~12 rows (approximately)
 /*!40000 ALTER TABLE `c_external_service_properties` DISABLE KEYS */;
 INSERT INTO `c_external_service_properties` (`name`, `value`, `external_service_id`) VALUES
 	('s3_access_key', NULL, 1),
@@ -350,7 +350,7 @@ INSERT INTO `c_external_service_properties` (`name`, `value`, `external_service_
 /*!40000 ALTER TABLE `c_external_service_properties` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.job
+-- Dumping structure for table fineract_default.job
 DROP TABLE IF EXISTS `job`;
 CREATE TABLE IF NOT EXISTS `job` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -372,7 +372,7 @@ CREATE TABLE IF NOT EXISTS `job` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.job: ~26 rows (approximately)
+-- Dumping data for table fineract_default.job: ~26 rows (approximately)
 /*!40000 ALTER TABLE `job` DISABLE KEYS */;
 INSERT INTO `job` (`id`, `name`, `display_name`, `cron_expression`, `create_time`, `task_priority`, `group_name`, `previous_run_start_time`, `next_run_time`, `job_key`, `initializing_errorlog`, `is_active`, `currently_running`, `updates_allowed`, `scheduler_group`, `is_misfired`) VALUES
 	(1, 'Update loan Summary', 'Update loan Summary', '0 0 22 1/1 * ? *', '2015-06-03 02:56:57', 5, NULL, NULL, '2017-02-24 22:00:00', 'Update loan SummaryJobDetail1 _ DEFAULT', NULL, 1, 0, 1, 0, 0),
@@ -404,7 +404,7 @@ INSERT INTO `job` (`id`, `name`, `display_name`, `cron_expression`, `create_time
 /*!40000 ALTER TABLE `job` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.job_run_history
+-- Dumping structure for table fineract_default.job_run_history
 DROP TABLE IF EXISTS `job_run_history`;
 CREATE TABLE IF NOT EXISTS `job_run_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -421,12 +421,12 @@ CREATE TABLE IF NOT EXISTS `job_run_history` (
   CONSTRAINT `scheduledjobsFK` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.job_run_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.job_run_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `job_run_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `job_run_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.mix_taxonomy
+-- Dumping structure for table fineract_default.mix_taxonomy
 DROP TABLE IF EXISTS `mix_taxonomy`;
 CREATE TABLE IF NOT EXISTS `mix_taxonomy` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -439,7 +439,7 @@ CREATE TABLE IF NOT EXISTS `mix_taxonomy` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=49 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.mix_taxonomy: ~48 rows (approximately)
+-- Dumping data for table fineract_default.mix_taxonomy: ~48 rows (approximately)
 /*!40000 ALTER TABLE `mix_taxonomy` DISABLE KEYS */;
 INSERT INTO `mix_taxonomy` (`id`, `name`, `namespace_id`, `dimension`, `type`, `description`, `need_mapping`) VALUES
 	(1, 'AdministrativeExpense', 1, NULL, 3, NULL, 1),
@@ -493,7 +493,7 @@ INSERT INTO `mix_taxonomy` (`id`, `name`, `namespace_id`, `dimension`, `type`, `
 /*!40000 ALTER TABLE `mix_taxonomy` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.mix_taxonomy_mapping
+-- Dumping structure for table fineract_default.mix_taxonomy_mapping
 DROP TABLE IF EXISTS `mix_taxonomy_mapping`;
 CREATE TABLE IF NOT EXISTS `mix_taxonomy_mapping` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -504,14 +504,14 @@ CREATE TABLE IF NOT EXISTS `mix_taxonomy_mapping` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.mix_taxonomy_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.mix_taxonomy_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `mix_taxonomy_mapping` DISABLE KEYS */;
 INSERT INTO `mix_taxonomy_mapping` (`id`, `identifier`, `config`, `last_update_date`, `currency`) VALUES
 	(1, 'default', NULL, NULL, '');
 /*!40000 ALTER TABLE `mix_taxonomy_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.mix_xbrl_namespace
+-- Dumping structure for table fineract_default.mix_xbrl_namespace
 DROP TABLE IF EXISTS `mix_xbrl_namespace`;
 CREATE TABLE IF NOT EXISTS `mix_xbrl_namespace` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -521,7 +521,7 @@ CREATE TABLE IF NOT EXISTS `mix_xbrl_namespace` (
   UNIQUE KEY `UNQUE` (`prefix`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.mix_xbrl_namespace: ~7 rows (approximately)
+-- Dumping data for table fineract_default.mix_xbrl_namespace: ~7 rows (approximately)
 /*!40000 ALTER TABLE `mix_xbrl_namespace` DISABLE KEYS */;
 INSERT INTO `mix_xbrl_namespace` (`id`, `prefix`, `url`) VALUES
 	(1, 'ifrs', 'http://xbrl.iasb.org/taxonomy/2009-04-01/ifrs'),
@@ -534,7 +534,7 @@ INSERT INTO `mix_xbrl_namespace` (`id`, `prefix`, `url`) VALUES
 /*!40000 ALTER TABLE `mix_xbrl_namespace` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_account_transfer_details
+-- Dumping structure for table fineract_default.m_account_transfer_details
 DROP TABLE IF EXISTS `m_account_transfer_details`;
 CREATE TABLE IF NOT EXISTS `m_account_transfer_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -566,12 +566,12 @@ CREATE TABLE IF NOT EXISTS `m_account_transfer_details` (
   CONSTRAINT `FK_m_account_transfer_details_to_savings_account` FOREIGN KEY (`to_savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_account_transfer_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_account_transfer_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_account_transfer_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_account_transfer_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_account_transfer_standing_instructions
+-- Dumping structure for table fineract_default.m_account_transfer_standing_instructions
 DROP TABLE IF EXISTS `m_account_transfer_standing_instructions`;
 CREATE TABLE IF NOT EXISTS `m_account_transfer_standing_instructions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -595,12 +595,12 @@ CREATE TABLE IF NOT EXISTS `m_account_transfer_standing_instructions` (
   CONSTRAINT `FK_m_standing_instructions_account_transfer_details` FOREIGN KEY (`account_transfer_details_id`) REFERENCES `m_account_transfer_details` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_account_transfer_standing_instructions: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_account_transfer_standing_instructions: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_account_transfer_standing_instructions` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_account_transfer_standing_instructions` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_account_transfer_standing_instructions_history
+-- Dumping structure for table fineract_default.m_account_transfer_standing_instructions_history
 DROP TABLE IF EXISTS `m_account_transfer_standing_instructions_history`;
 CREATE TABLE IF NOT EXISTS `m_account_transfer_standing_instructions_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -614,12 +614,12 @@ CREATE TABLE IF NOT EXISTS `m_account_transfer_standing_instructions_history` (
   CONSTRAINT `FK_m_account_transfer_standing_instructions_m_history` FOREIGN KEY (`standing_instruction_id`) REFERENCES `m_account_transfer_standing_instructions` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_account_transfer_standing_instructions_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_account_transfer_standing_instructions_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_account_transfer_standing_instructions_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_account_transfer_standing_instructions_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_account_transfer_transaction
+-- Dumping structure for table fineract_default.m_account_transfer_transaction
 DROP TABLE IF EXISTS `m_account_transfer_transaction`;
 CREATE TABLE IF NOT EXISTS `m_account_transfer_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -648,12 +648,12 @@ CREATE TABLE IF NOT EXISTS `m_account_transfer_transaction` (
   CONSTRAINT `FK_m_account_transfer_transaction_to_m_savings_transaction` FOREIGN KEY (`to_savings_transaction_id`) REFERENCES `m_savings_account_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_account_transfer_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_account_transfer_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_account_transfer_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_account_transfer_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_address
+-- Dumping structure for table fineract_default.m_address
 DROP TABLE IF EXISTS `m_address`;
 CREATE TABLE IF NOT EXISTS `m_address` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -680,12 +680,12 @@ CREATE TABLE IF NOT EXISTS `m_address` (
   CONSTRAINT `address_fields_codefk2` FOREIGN KEY (`country_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_address: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_address: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_address` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_address` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_appuser
+-- Dumping structure for table fineract_default.m_appuser
 DROP TABLE IF EXISTS `m_appuser`;
 CREATE TABLE IF NOT EXISTS `m_appuser` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -714,7 +714,7 @@ CREATE TABLE IF NOT EXISTS `m_appuser` (
   CONSTRAINT `fk_m_appuser_002` FOREIGN KEY (`staff_id`) REFERENCES `m_staff` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_appuser: ~2 rows (approximately)
+-- Dumping data for table fineract_default.m_appuser: ~2 rows (approximately)
 /*!40000 ALTER TABLE `m_appuser` DISABLE KEYS */;
 INSERT INTO `m_appuser` (`id`, `is_deleted`, `office_id`, `staff_id`, `username`, `firstname`, `lastname`, `password`, `email`, `firsttime_login_remaining`, `nonexpired`, `nonlocked`, `nonexpired_credentials`, `enabled`, `last_time_password_updated`, `password_never_expires`, `is_self_service_user`) VALUES
 	(1, 0, 1, NULL, 'mifos', 'App', 'Administrator', '5787039480429368bf94732aacc771cd0a3ea02bcf504ffe1185ab94213bc63a', 'demomfi@mifos.org', b'0', b'1', b'1', b'1', b'1', '2015-06-03', 0, b'0'),
@@ -722,7 +722,7 @@ INSERT INTO `m_appuser` (`id`, `is_deleted`, `office_id`, `staff_id`, `username`
 /*!40000 ALTER TABLE `m_appuser` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_appuser_previous_password
+-- Dumping structure for table fineract_default.m_appuser_previous_password
 DROP TABLE IF EXISTS `m_appuser_previous_password`;
 CREATE TABLE IF NOT EXISTS `m_appuser_previous_password` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -734,12 +734,12 @@ CREATE TABLE IF NOT EXISTS `m_appuser_previous_password` (
   CONSTRAINT `m_appuser_previous_password_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
--- Dumping data for table mifostenant-default.m_appuser_previous_password: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_appuser_previous_password: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_appuser_previous_password` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_appuser_previous_password` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_appuser_role
+-- Dumping structure for table fineract_default.m_appuser_role
 DROP TABLE IF EXISTS `m_appuser_role`;
 CREATE TABLE IF NOT EXISTS `m_appuser_role` (
   `appuser_id` bigint(20) NOT NULL,
@@ -751,14 +751,14 @@ CREATE TABLE IF NOT EXISTS `m_appuser_role` (
   CONSTRAINT `FK7662CE59B4100309` FOREIGN KEY (`appuser_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_appuser_role: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_appuser_role: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_appuser_role` DISABLE KEYS */;
 INSERT INTO `m_appuser_role` (`appuser_id`, `role_id`) VALUES
 	(1, 1);
 /*!40000 ALTER TABLE `m_appuser_role` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_calendar
+-- Dumping structure for table fineract_default.m_calendar
 DROP TABLE IF EXISTS `m_calendar`;
 CREATE TABLE IF NOT EXISTS `m_calendar` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -782,12 +782,12 @@ CREATE TABLE IF NOT EXISTS `m_calendar` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_calendar: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_calendar: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_calendar` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_calendar` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_calendar_history
+-- Dumping structure for table fineract_default.m_calendar_history
 DROP TABLE IF EXISTS `m_calendar_history`;
 CREATE TABLE IF NOT EXISTS `m_calendar_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -809,12 +809,12 @@ CREATE TABLE IF NOT EXISTS `m_calendar_history` (
   CONSTRAINT `FK_m_calendar_m_calendar_history` FOREIGN KEY (`calendar_id`) REFERENCES `m_calendar` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_calendar_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_calendar_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_calendar_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_calendar_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_calendar_instance
+-- Dumping structure for table fineract_default.m_calendar_instance
 DROP TABLE IF EXISTS `m_calendar_instance`;
 CREATE TABLE IF NOT EXISTS `m_calendar_instance` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -826,12 +826,12 @@ CREATE TABLE IF NOT EXISTS `m_calendar_instance` (
   CONSTRAINT `FK_m_calendar_m_calendar_instance` FOREIGN KEY (`calendar_id`) REFERENCES `m_calendar` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_calendar_instance: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_calendar_instance: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_calendar_instance` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_calendar_instance` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_cashiers
+-- Dumping structure for table fineract_default.m_cashiers
 DROP TABLE IF EXISTS `m_cashiers`;
 CREATE TABLE IF NOT EXISTS `m_cashiers` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -850,12 +850,12 @@ CREATE TABLE IF NOT EXISTS `m_cashiers` (
   CONSTRAINT `FK_m_cashiers_m_teller` FOREIGN KEY (`teller_id`) REFERENCES `m_tellers` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_cashiers: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_cashiers: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_cashiers` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_cashiers` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_cashier_transactions
+-- Dumping structure for table fineract_default.m_cashier_transactions
 DROP TABLE IF EXISTS `m_cashier_transactions`;
 CREATE TABLE IF NOT EXISTS `m_cashier_transactions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -873,12 +873,12 @@ CREATE TABLE IF NOT EXISTS `m_cashier_transactions` (
   CONSTRAINT `FK_m_teller_transactions_m_cashiers` FOREIGN KEY (`cashier_id`) REFERENCES `m_cashiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_cashier_transactions: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_cashier_transactions: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_cashier_transactions` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_cashier_transactions` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_charge
+-- Dumping structure for table fineract_default.m_charge
 DROP TABLE IF EXISTS `m_charge`;
 CREATE TABLE IF NOT EXISTS `m_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -908,12 +908,12 @@ CREATE TABLE IF NOT EXISTS `m_charge` (
   CONSTRAINT `FK_m_charge_m_tax_group` FOREIGN KEY (`tax_group_id`) REFERENCES `m_tax_group` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client
+-- Dumping structure for table fineract_default.m_client
 DROP TABLE IF EXISTS `m_client`;
 CREATE TABLE IF NOT EXISTS `m_client` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -990,12 +990,12 @@ CREATE TABLE IF NOT EXISTS `m_client` (
   CONSTRAINT `FK_m_client_type_mcode_value_reject` FOREIGN KEY (`reject_reason_cv_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_address
+-- Dumping structure for table fineract_default.m_client_address
 DROP TABLE IF EXISTS `m_client_address`;
 CREATE TABLE IF NOT EXISTS `m_client_address` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1011,12 +1011,12 @@ CREATE TABLE IF NOT EXISTS `m_client_address` (
   CONSTRAINT `clientaddressfk` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_address: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_address: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_address` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_address` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_attendance
+-- Dumping structure for table fineract_default.m_client_attendance
 DROP TABLE IF EXISTS `m_client_attendance`;
 CREATE TABLE IF NOT EXISTS `m_client_attendance` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1030,12 +1030,12 @@ CREATE TABLE IF NOT EXISTS `m_client_attendance` (
   CONSTRAINT `FK_m_meeting_m_client_attendance` FOREIGN KEY (`meeting_id`) REFERENCES `m_meeting` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_attendance: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_attendance: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_attendance` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_attendance` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_charge
+-- Dumping structure for table fineract_default.m_client_charge
 DROP TABLE IF EXISTS `m_client_charge`;
 CREATE TABLE IF NOT EXISTS `m_client_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1061,12 +1061,12 @@ CREATE TABLE IF NOT EXISTS `m_client_charge` (
   CONSTRAINT `FK_m_client_charge_m_client` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_charge_paid_by
+-- Dumping structure for table fineract_default.m_client_charge_paid_by
 DROP TABLE IF EXISTS `m_client_charge_paid_by`;
 CREATE TABLE IF NOT EXISTS `m_client_charge_paid_by` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1080,12 +1080,12 @@ CREATE TABLE IF NOT EXISTS `m_client_charge_paid_by` (
   CONSTRAINT `FK_m_client_charge_paid_by_m_client_transaction` FOREIGN KEY (`client_transaction_id`) REFERENCES `m_client_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_charge_paid_by: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_charge_paid_by: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_charge_paid_by` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_charge_paid_by` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_identifier
+-- Dumping structure for table fineract_default.m_client_identifier
 DROP TABLE IF EXISTS `m_client_identifier`;
 CREATE TABLE IF NOT EXISTS `m_client_identifier` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1108,12 +1108,12 @@ CREATE TABLE IF NOT EXISTS `m_client_identifier` (
   CONSTRAINT `FK_m_client_document_m_code_value` FOREIGN KEY (`document_type_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_identifier: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_identifier: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_identifier` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_identifier` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_non_person
+-- Dumping structure for table fineract_default.m_client_non_person
 DROP TABLE IF EXISTS `m_client_non_person`;
 CREATE TABLE IF NOT EXISTS `m_client_non_person` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1129,12 +1129,12 @@ CREATE TABLE IF NOT EXISTS `m_client_non_person` (
   CONSTRAINT `FK_client_id` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_non_person: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_non_person: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_non_person` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_non_person` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_client_transaction
+-- Dumping structure for table fineract_default.m_client_transaction
 DROP TABLE IF EXISTS `m_client_transaction`;
 CREATE TABLE IF NOT EXISTS `m_client_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1157,12 +1157,12 @@ CREATE TABLE IF NOT EXISTS `m_client_transaction` (
   CONSTRAINT `FK_m_client_transaction_m_client` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_client_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_client_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_client_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_client_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_code
+-- Dumping structure for table fineract_default.m_code
 DROP TABLE IF EXISTS `m_code`;
 CREATE TABLE IF NOT EXISTS `m_code` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1172,7 +1172,7 @@ CREATE TABLE IF NOT EXISTS `m_code` (
   UNIQUE KEY `code_name` (`code_name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_code: ~28 rows (approximately)
+-- Dumping data for table fineract_default.m_code: ~28 rows (approximately)
 /*!40000 ALTER TABLE `m_code` DISABLE KEYS */;
 INSERT INTO `m_code` (`id`, `code_name`, `is_system_defined`) VALUES
 	(1, 'Customer Identifier', 1),
@@ -1206,7 +1206,7 @@ INSERT INTO `m_code` (`id`, `code_name`, `is_system_defined`) VALUES
 /*!40000 ALTER TABLE `m_code` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_code_value
+-- Dumping structure for table fineract_default.m_code_value
 DROP TABLE IF EXISTS `m_code_value`;
 CREATE TABLE IF NOT EXISTS `m_code_value` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1223,7 +1223,7 @@ CREATE TABLE IF NOT EXISTS `m_code_value` (
   CONSTRAINT `FKCFCEA42640BE071Z` FOREIGN KEY (`code_id`) REFERENCES `m_code` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_code_value: ~13 rows (approximately)
+-- Dumping data for table fineract_default.m_code_value: ~13 rows (approximately)
 /*!40000 ALTER TABLE `m_code_value` DISABLE KEYS */;
 INSERT INTO `m_code_value` (`id`, `code_id`, `code_value`, `code_description`, `order_position`, `code_score`, `is_active`, `is_mandatory`) VALUES
 	(1, 1, 'Passport', NULL, 1, NULL, 1, 0),
@@ -1242,7 +1242,7 @@ INSERT INTO `m_code_value` (`id`, `code_id`, `code_value`, `code_description`, `
 /*!40000 ALTER TABLE `m_code_value` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_currency
+-- Dumping structure for table fineract_default.m_currency
 DROP TABLE IF EXISTS `m_currency`;
 CREATE TABLE IF NOT EXISTS `m_currency` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1256,7 +1256,7 @@ CREATE TABLE IF NOT EXISTS `m_currency` (
   UNIQUE KEY `code` (`code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=164 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_currency: ~163 rows (approximately)
+-- Dumping data for table fineract_default.m_currency: ~163 rows (approximately)
 /*!40000 ALTER TABLE `m_currency` DISABLE KEYS */;
 INSERT INTO `m_currency` (`id`, `code`, `decimal_places`, `currency_multiplesof`, `display_symbol`, `name`, `internationalized_name_code`) VALUES
 	(1, 'AED', 2, NULL, NULL, 'UAE Dirham', 'currency.AED'),
@@ -1425,7 +1425,7 @@ INSERT INTO `m_currency` (`id`, `code`, `decimal_places`, `currency_multiplesof`
 /*!40000 ALTER TABLE `m_currency` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_account_on_hold_transaction
+-- Dumping structure for table fineract_default.m_deposit_account_on_hold_transaction
 DROP TABLE IF EXISTS `m_deposit_account_on_hold_transaction`;
 CREATE TABLE IF NOT EXISTS `m_deposit_account_on_hold_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1440,12 +1440,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_account_on_hold_transaction` (
   CONSTRAINT `FK_deposit_on_hold_transaction_m_savings_account` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_account_on_hold_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_account_on_hold_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_account_on_hold_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_account_on_hold_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_account_recurring_detail
+-- Dumping structure for table fineract_default.m_deposit_account_recurring_detail
 DROP TABLE IF EXISTS `m_deposit_account_recurring_detail`;
 CREATE TABLE IF NOT EXISTS `m_deposit_account_recurring_detail` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1462,12 +1462,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_account_recurring_detail` (
   CONSTRAINT `FKDARD00000000000001` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_account_recurring_detail: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_account_recurring_detail: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_account_recurring_detail` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_account_recurring_detail` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_account_term_and_preclosure
+-- Dumping structure for table fineract_default.m_deposit_account_term_and_preclosure
 DROP TABLE IF EXISTS `m_deposit_account_term_and_preclosure`;
 CREATE TABLE IF NOT EXISTS `m_deposit_account_term_and_preclosure` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1494,12 +1494,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_account_term_and_preclosure` (
   CONSTRAINT `FKDATP00000000000001` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_account_term_and_preclosure: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_account_term_and_preclosure: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_account_term_and_preclosure` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_account_term_and_preclosure` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_product_interest_rate_chart
+-- Dumping structure for table fineract_default.m_deposit_product_interest_rate_chart
 DROP TABLE IF EXISTS `m_deposit_product_interest_rate_chart`;
 CREATE TABLE IF NOT EXISTS `m_deposit_product_interest_rate_chart` (
   `deposit_product_id` bigint(20) NOT NULL,
@@ -1510,12 +1510,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_product_interest_rate_chart` (
   CONSTRAINT `FKDPIRC00000000000002` FOREIGN KEY (`interest_rate_chart_id`) REFERENCES `m_interest_rate_chart` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_product_interest_rate_chart: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_product_interest_rate_chart: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_product_interest_rate_chart` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_product_interest_rate_chart` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_product_recurring_detail
+-- Dumping structure for table fineract_default.m_deposit_product_recurring_detail
 DROP TABLE IF EXISTS `m_deposit_product_recurring_detail`;
 CREATE TABLE IF NOT EXISTS `m_deposit_product_recurring_detail` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1528,12 +1528,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_product_recurring_detail` (
   CONSTRAINT `FKDPRD00000000000001` FOREIGN KEY (`savings_product_id`) REFERENCES `m_savings_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_product_recurring_detail: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_product_recurring_detail: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_product_recurring_detail` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_product_recurring_detail` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_deposit_product_term_and_preclosure
+-- Dumping structure for table fineract_default.m_deposit_product_term_and_preclosure
 DROP TABLE IF EXISTS `m_deposit_product_term_and_preclosure`;
 CREATE TABLE IF NOT EXISTS `m_deposit_product_term_and_preclosure` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1555,12 +1555,12 @@ CREATE TABLE IF NOT EXISTS `m_deposit_product_term_and_preclosure` (
   CONSTRAINT `FKDPTP00000000000001` FOREIGN KEY (`savings_product_id`) REFERENCES `m_savings_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_deposit_product_term_and_preclosure: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_deposit_product_term_and_preclosure: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_deposit_product_term_and_preclosure` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_deposit_product_term_and_preclosure` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_document
+-- Dumping structure for table fineract_default.m_document
 DROP TABLE IF EXISTS `m_document`;
 CREATE TABLE IF NOT EXISTS `m_document` (
   `id` int(20) NOT NULL AUTO_INCREMENT,
@@ -1576,12 +1576,12 @@ CREATE TABLE IF NOT EXISTS `m_document` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_document: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_document: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_document` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_document` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_entity_datatable_check
+-- Dumping structure for table fineract_default.m_entity_datatable_check
 DROP TABLE IF EXISTS `m_entity_datatable_check`;
 CREATE TABLE IF NOT EXISTS `m_entity_datatable_check` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1597,12 +1597,12 @@ CREATE TABLE IF NOT EXISTS `m_entity_datatable_check` (
   CONSTRAINT `m_entity_datatable_check_ibfk_1` FOREIGN KEY (`x_registered_table_name`) REFERENCES `x_registered_table` (`registered_table_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_entity_datatable_check: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_entity_datatable_check: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_entity_datatable_check` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_entity_datatable_check` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_entity_relation
+-- Dumping structure for table fineract_default.m_entity_relation
 DROP TABLE IF EXISTS `m_entity_relation`;
 CREATE TABLE IF NOT EXISTS `m_entity_relation` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1613,7 +1613,7 @@ CREATE TABLE IF NOT EXISTS `m_entity_relation` (
   UNIQUE KEY `from_entity_type_to_entity_type_code_name` (`from_entity_type`,`to_entity_type`,`code_name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_entity_relation: ~5 rows (approximately)
+-- Dumping data for table fineract_default.m_entity_relation: ~5 rows (approximately)
 /*!40000 ALTER TABLE `m_entity_relation` DISABLE KEYS */;
 INSERT INTO `m_entity_relation` (`id`, `from_entity_type`, `to_entity_type`, `code_name`) VALUES
 	(1, 1, 2, 'office_access_to_loan_products'),
@@ -1624,7 +1624,7 @@ INSERT INTO `m_entity_relation` (`id`, `from_entity_type`, `to_entity_type`, `co
 /*!40000 ALTER TABLE `m_entity_relation` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_entity_to_entity_access
+-- Dumping structure for table fineract_default.m_entity_to_entity_access
 DROP TABLE IF EXISTS `m_entity_to_entity_access`;
 CREATE TABLE IF NOT EXISTS `m_entity_to_entity_access` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1640,12 +1640,12 @@ CREATE TABLE IF NOT EXISTS `m_entity_to_entity_access` (
   CONSTRAINT `FK_access_type_code_m_code_value` FOREIGN KEY (`access_type_code_value_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_entity_to_entity_access: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_entity_to_entity_access: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_entity_to_entity_access` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_entity_to_entity_access` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_entity_to_entity_mapping
+-- Dumping structure for table fineract_default.m_entity_to_entity_mapping
 DROP TABLE IF EXISTS `m_entity_to_entity_mapping`;
 CREATE TABLE IF NOT EXISTS `m_entity_to_entity_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1659,12 +1659,12 @@ CREATE TABLE IF NOT EXISTS `m_entity_to_entity_mapping` (
   CONSTRAINT `FK__rel_id_m_entity_relation_id` FOREIGN KEY (`rel_id`) REFERENCES `m_entity_relation` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_entity_to_entity_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_entity_to_entity_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_entity_to_entity_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_entity_to_entity_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_field_configuration
+-- Dumping structure for table fineract_default.m_field_configuration
 DROP TABLE IF EXISTS `m_field_configuration`;
 CREATE TABLE IF NOT EXISTS `m_field_configuration` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1677,7 +1677,7 @@ CREATE TABLE IF NOT EXISTS `m_field_configuration` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_field_configuration: ~18 rows (approximately)
+-- Dumping data for table fineract_default.m_field_configuration: ~18 rows (approximately)
 /*!40000 ALTER TABLE `m_field_configuration` DISABLE KEYS */;
 INSERT INTO `m_field_configuration` (`id`, `entity`, `subentity`, `field`, `is_enabled`, `is_mandatory`, `validation_regex`) VALUES
 	(1, 'ADDRESS', 'CLIENT', 'addressType', 1, 0, ''),
@@ -1701,7 +1701,7 @@ INSERT INTO `m_field_configuration` (`id`, `entity`, `subentity`, `field`, `is_e
 /*!40000 ALTER TABLE `m_field_configuration` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_floating_rates
+-- Dumping structure for table fineract_default.m_floating_rates
 DROP TABLE IF EXISTS `m_floating_rates`;
 CREATE TABLE IF NOT EXISTS `m_floating_rates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1716,12 +1716,12 @@ CREATE TABLE IF NOT EXISTS `m_floating_rates` (
   UNIQUE KEY `unq_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_floating_rates: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_floating_rates: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_floating_rates` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_floating_rates` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_floating_rates_periods
+-- Dumping structure for table fineract_default.m_floating_rates_periods
 DROP TABLE IF EXISTS `m_floating_rates_periods`;
 CREATE TABLE IF NOT EXISTS `m_floating_rates_periods` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1739,12 +1739,12 @@ CREATE TABLE IF NOT EXISTS `m_floating_rates_periods` (
   CONSTRAINT `FK_mappings_m_floating_rates` FOREIGN KEY (`floating_rates_id`) REFERENCES `m_floating_rates` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_floating_rates_periods: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_floating_rates_periods: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_floating_rates_periods` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_floating_rates_periods` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_fund
+-- Dumping structure for table fineract_default.m_fund
 DROP TABLE IF EXISTS `m_fund`;
 CREATE TABLE IF NOT EXISTS `m_fund` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1755,12 +1755,12 @@ CREATE TABLE IF NOT EXISTS `m_fund` (
   UNIQUE KEY `fund_externalid_org` (`external_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_fund: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_fund: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_fund` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_fund` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_group
+-- Dumping structure for table fineract_default.m_group
 DROP TABLE IF EXISTS `m_group`;
 CREATE TABLE IF NOT EXISTS `m_group` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1796,12 +1796,12 @@ CREATE TABLE IF NOT EXISTS `m_group` (
   CONSTRAINT `m_group_ibfk_1` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_group: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_group: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_group` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_group` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_group_client
+-- Dumping structure for table fineract_default.m_group_client
 DROP TABLE IF EXISTS `m_group_client`;
 CREATE TABLE IF NOT EXISTS `m_group_client` (
   `group_id` bigint(20) NOT NULL,
@@ -1812,12 +1812,12 @@ CREATE TABLE IF NOT EXISTS `m_group_client` (
   CONSTRAINT `m_group_client_ibfk_2` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_group_client: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_group_client: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_group_client` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_group_client` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_group_level
+-- Dumping structure for table fineract_default.m_group_level
 DROP TABLE IF EXISTS `m_group_level`;
 CREATE TABLE IF NOT EXISTS `m_group_level` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1831,7 +1831,7 @@ CREATE TABLE IF NOT EXISTS `m_group_level` (
   CONSTRAINT `Parent_levelId_reference` FOREIGN KEY (`parent_id`) REFERENCES `m_group_level` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_group_level: ~2 rows (approximately)
+-- Dumping data for table fineract_default.m_group_level: ~2 rows (approximately)
 /*!40000 ALTER TABLE `m_group_level` DISABLE KEYS */;
 INSERT INTO `m_group_level` (`id`, `parent_id`, `super_parent`, `level_name`, `recursable`, `can_have_clients`) VALUES
 	(1, NULL, 1, 'Center', 1, 0),
@@ -1839,7 +1839,7 @@ INSERT INTO `m_group_level` (`id`, `parent_id`, `super_parent`, `level_name`, `r
 /*!40000 ALTER TABLE `m_group_level` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_group_roles
+-- Dumping structure for table fineract_default.m_group_roles
 DROP TABLE IF EXISTS `m_group_roles`;
 CREATE TABLE IF NOT EXISTS `m_group_roles` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1856,12 +1856,12 @@ CREATE TABLE IF NOT EXISTS `m_group_roles` (
   CONSTRAINT `FK_grouprole_m_codevalue` FOREIGN KEY (`role_cv_id`) REFERENCES `m_code_value` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_group_roles: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_group_roles: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_group_roles` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_group_roles` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_guarantor
+-- Dumping structure for table fineract_default.m_guarantor
 DROP TABLE IF EXISTS `m_guarantor`;
 CREATE TABLE IF NOT EXISTS `m_guarantor` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1889,12 +1889,12 @@ CREATE TABLE IF NOT EXISTS `m_guarantor` (
   CONSTRAINT `FK_m_guarantor_m_loan` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_guarantor: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_guarantor: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_guarantor` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_guarantor` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_guarantor_funding_details
+-- Dumping structure for table fineract_default.m_guarantor_funding_details
 DROP TABLE IF EXISTS `m_guarantor_funding_details`;
 CREATE TABLE IF NOT EXISTS `m_guarantor_funding_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1912,12 +1912,12 @@ CREATE TABLE IF NOT EXISTS `m_guarantor_funding_details` (
   CONSTRAINT `FK_m_guarantor_fund_details_m_guarantor` FOREIGN KEY (`guarantor_id`) REFERENCES `m_guarantor` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_guarantor_funding_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_guarantor_funding_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_guarantor_funding_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_guarantor_funding_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_guarantor_transaction
+-- Dumping structure for table fineract_default.m_guarantor_transaction
 DROP TABLE IF EXISTS `m_guarantor_transaction`;
 CREATE TABLE IF NOT EXISTS `m_guarantor_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1934,12 +1934,12 @@ CREATE TABLE IF NOT EXISTS `m_guarantor_transaction` (
   CONSTRAINT `FK_guarantor_transaction_m_loan_transaction` FOREIGN KEY (`loan_transaction_id`) REFERENCES `m_loan_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_guarantor_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_guarantor_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_guarantor_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_guarantor_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_holiday
+-- Dumping structure for table fineract_default.m_holiday
 DROP TABLE IF EXISTS `m_holiday`;
 CREATE TABLE IF NOT EXISTS `m_holiday` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1954,12 +1954,12 @@ CREATE TABLE IF NOT EXISTS `m_holiday` (
   UNIQUE KEY `holiday_name` (`name`,`from_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_holiday: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_holiday: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_holiday` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_holiday` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_holiday_office
+-- Dumping structure for table fineract_default.m_holiday_office
 DROP TABLE IF EXISTS `m_holiday_office`;
 CREATE TABLE IF NOT EXISTS `m_holiday_office` (
   `holiday_id` bigint(20) NOT NULL,
@@ -1971,12 +1971,12 @@ CREATE TABLE IF NOT EXISTS `m_holiday_office` (
   CONSTRAINT `m_office_id_ibfk_2` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_holiday_office: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_holiday_office: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_holiday_office` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_holiday_office` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_hook
+-- Dumping structure for table fineract_default.m_hook
 DROP TABLE IF EXISTS `m_hook`;
 CREATE TABLE IF NOT EXISTS `m_hook` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1995,12 +1995,12 @@ CREATE TABLE IF NOT EXISTS `m_hook` (
   CONSTRAINT `fk_ugd_template_id` FOREIGN KEY (`ugd_template_id`) REFERENCES `m_template` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_hook: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_hook: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_hook` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_hook` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_hook_configuration
+-- Dumping structure for table fineract_default.m_hook_configuration
 DROP TABLE IF EXISTS `m_hook_configuration`;
 CREATE TABLE IF NOT EXISTS `m_hook_configuration` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2013,12 +2013,12 @@ CREATE TABLE IF NOT EXISTS `m_hook_configuration` (
   CONSTRAINT `fk_hook_id_cfg` FOREIGN KEY (`hook_id`) REFERENCES `m_hook` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_hook_configuration: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_hook_configuration: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_hook_configuration` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_hook_configuration` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_hook_registered_events
+-- Dumping structure for table fineract_default.m_hook_registered_events
 DROP TABLE IF EXISTS `m_hook_registered_events`;
 CREATE TABLE IF NOT EXISTS `m_hook_registered_events` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2030,12 +2030,12 @@ CREATE TABLE IF NOT EXISTS `m_hook_registered_events` (
   CONSTRAINT `fk_hook_idc` FOREIGN KEY (`hook_id`) REFERENCES `m_hook` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_hook_registered_events: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_hook_registered_events: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_hook_registered_events` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_hook_registered_events` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_hook_schema
+-- Dumping structure for table fineract_default.m_hook_schema
 DROP TABLE IF EXISTS `m_hook_schema`;
 CREATE TABLE IF NOT EXISTS `m_hook_schema` (
   `id` smallint(6) NOT NULL AUTO_INCREMENT,
@@ -2049,7 +2049,7 @@ CREATE TABLE IF NOT EXISTS `m_hook_schema` (
   CONSTRAINT `fk_hook_template_id` FOREIGN KEY (`hook_template_id`) REFERENCES `m_hook_templates` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_hook_schema: ~7 rows (approximately)
+-- Dumping data for table fineract_default.m_hook_schema: ~7 rows (approximately)
 /*!40000 ALTER TABLE `m_hook_schema` DISABLE KEYS */;
 INSERT INTO `m_hook_schema` (`id`, `hook_template_id`, `field_type`, `field_name`, `placeholder`, `optional`) VALUES
 	(1, 1, 'string', 'Payload URL', NULL, 0),
@@ -2062,7 +2062,7 @@ INSERT INTO `m_hook_schema` (`id`, `hook_template_id`, `field_type`, `field_name
 /*!40000 ALTER TABLE `m_hook_schema` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_hook_templates
+-- Dumping structure for table fineract_default.m_hook_templates
 DROP TABLE IF EXISTS `m_hook_templates`;
 CREATE TABLE IF NOT EXISTS `m_hook_templates` (
   `id` smallint(6) NOT NULL AUTO_INCREMENT,
@@ -2070,7 +2070,7 @@ CREATE TABLE IF NOT EXISTS `m_hook_templates` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_hook_templates: ~2 rows (approximately)
+-- Dumping data for table fineract_default.m_hook_templates: ~2 rows (approximately)
 /*!40000 ALTER TABLE `m_hook_templates` DISABLE KEYS */;
 INSERT INTO `m_hook_templates` (`id`, `name`) VALUES
 	(1, 'Web'),
@@ -2078,7 +2078,7 @@ INSERT INTO `m_hook_templates` (`id`, `name`) VALUES
 /*!40000 ALTER TABLE `m_hook_templates` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_image
+-- Dumping structure for table fineract_default.m_image
 DROP TABLE IF EXISTS `m_image`;
 CREATE TABLE IF NOT EXISTS `m_image` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2087,12 +2087,12 @@ CREATE TABLE IF NOT EXISTS `m_image` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_image: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_image: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_image` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_image` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_interest_incentives
+-- Dumping structure for table fineract_default.m_interest_incentives
 DROP TABLE IF EXISTS `m_interest_incentives`;
 CREATE TABLE IF NOT EXISTS `m_interest_incentives` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2108,12 +2108,12 @@ CREATE TABLE IF NOT EXISTS `m_interest_incentives` (
   CONSTRAINT `FK_m_interest_incentives_m_interest_rate_slab` FOREIGN KEY (`interest_rate_slab_id`) REFERENCES `m_interest_rate_slab` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_interest_incentives: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_interest_incentives: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_interest_incentives` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_interest_incentives` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_interest_rate_chart
+-- Dumping structure for table fineract_default.m_interest_rate_chart
 DROP TABLE IF EXISTS `m_interest_rate_chart`;
 CREATE TABLE IF NOT EXISTS `m_interest_rate_chart` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2125,12 +2125,12 @@ CREATE TABLE IF NOT EXISTS `m_interest_rate_chart` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_interest_rate_chart: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_interest_rate_chart: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_interest_rate_chart` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_interest_rate_chart` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_interest_rate_slab
+-- Dumping structure for table fineract_default.m_interest_rate_slab
 DROP TABLE IF EXISTS `m_interest_rate_slab`;
 CREATE TABLE IF NOT EXISTS `m_interest_rate_slab` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2148,12 +2148,12 @@ CREATE TABLE IF NOT EXISTS `m_interest_rate_slab` (
   CONSTRAINT `FKIRS00000000000001` FOREIGN KEY (`interest_rate_chart_id`) REFERENCES `m_interest_rate_chart` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_interest_rate_slab: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_interest_rate_slab: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_interest_rate_slab` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_interest_rate_slab` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan
+-- Dumping structure for table fineract_default.m_loan
 DROP TABLE IF EXISTS `m_loan`;
 CREATE TABLE IF NOT EXISTS `m_loan` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2294,12 +2294,12 @@ CREATE TABLE IF NOT EXISTS `m_loan` (
   CONSTRAINT `m_loan_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `m_group` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loanproduct_provisioning_entry
+-- Dumping structure for table fineract_default.m_loanproduct_provisioning_entry
 DROP TABLE IF EXISTS `m_loanproduct_provisioning_entry`;
 CREATE TABLE IF NOT EXISTS `m_loanproduct_provisioning_entry` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2332,12 +2332,12 @@ CREATE TABLE IF NOT EXISTS `m_loanproduct_provisioning_entry` (
   CONSTRAINT `m_loanproduct_provisioning_entry_ibfk_8` FOREIGN KEY (`expense_account`) REFERENCES `acc_gl_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loanproduct_provisioning_entry: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loanproduct_provisioning_entry: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loanproduct_provisioning_entry` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loanproduct_provisioning_entry` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loanproduct_provisioning_mapping
+-- Dumping structure for table fineract_default.m_loanproduct_provisioning_mapping
 DROP TABLE IF EXISTS `m_loanproduct_provisioning_mapping`;
 CREATE TABLE IF NOT EXISTS `m_loanproduct_provisioning_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2350,12 +2350,12 @@ CREATE TABLE IF NOT EXISTS `m_loanproduct_provisioning_mapping` (
   CONSTRAINT `m_loanproduct_provisioning_mapping_ibfk_2` FOREIGN KEY (`criteria_id`) REFERENCES `m_provisioning_criteria` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loanproduct_provisioning_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loanproduct_provisioning_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loanproduct_provisioning_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loanproduct_provisioning_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_arrears_aging
+-- Dumping structure for table fineract_default.m_loan_arrears_aging
 DROP TABLE IF EXISTS `m_loan_arrears_aging`;
 CREATE TABLE IF NOT EXISTS `m_loan_arrears_aging` (
   `loan_id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2369,12 +2369,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_arrears_aging` (
   CONSTRAINT `m_loan_arrears_aging_ibfk_1` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_arrears_aging: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_arrears_aging: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_arrears_aging` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_arrears_aging` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_charge
+-- Dumping structure for table fineract_default.m_loan_charge
 DROP TABLE IF EXISTS `m_loan_charge`;
 CREATE TABLE IF NOT EXISTS `m_loan_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2405,12 +2405,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_charge` (
   CONSTRAINT `m_loan_charge_ibfk_2` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_charge_paid_by
+-- Dumping structure for table fineract_default.m_loan_charge_paid_by
 DROP TABLE IF EXISTS `m_loan_charge_paid_by`;
 CREATE TABLE IF NOT EXISTS `m_loan_charge_paid_by` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2425,12 +2425,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_charge_paid_by` (
   CONSTRAINT `FK__m_loan_transaction` FOREIGN KEY (`loan_transaction_id`) REFERENCES `m_loan_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_charge_paid_by: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_charge_paid_by: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_charge_paid_by` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_charge_paid_by` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_collateral
+-- Dumping structure for table fineract_default.m_loan_collateral
 DROP TABLE IF EXISTS `m_loan_collateral`;
 CREATE TABLE IF NOT EXISTS `m_loan_collateral` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2445,12 +2445,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_collateral` (
   CONSTRAINT `FK_collateral_m_loan` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_collateral: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_collateral: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_collateral` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_collateral` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_disbursement_detail
+-- Dumping structure for table fineract_default.m_loan_disbursement_detail
 DROP TABLE IF EXISTS `m_loan_disbursement_detail`;
 CREATE TABLE IF NOT EXISTS `m_loan_disbursement_detail` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2463,12 +2463,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_disbursement_detail` (
   CONSTRAINT `FK_loan_disbursement_detail_loan_id` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_disbursement_detail: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_disbursement_detail: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_disbursement_detail` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_disbursement_detail` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_installment_charge
+-- Dumping structure for table fineract_default.m_loan_installment_charge
 DROP TABLE IF EXISTS `m_loan_installment_charge`;
 CREATE TABLE IF NOT EXISTS `m_loan_installment_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2490,12 +2490,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_installment_charge` (
   CONSTRAINT `FK_loan_schedule_id_charge_schedule` FOREIGN KEY (`loan_schedule_id`) REFERENCES `m_loan_repayment_schedule` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_installment_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_installment_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_installment_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_installment_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_interest_recalculation_additional_details
+-- Dumping structure for table fineract_default.m_loan_interest_recalculation_additional_details
 DROP TABLE IF EXISTS `m_loan_interest_recalculation_additional_details`;
 CREATE TABLE IF NOT EXISTS `m_loan_interest_recalculation_additional_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2507,12 +2507,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_interest_recalculation_additional_details` (
   CONSTRAINT `FK_additional_details_repayment_schedule_id` FOREIGN KEY (`loan_repayment_schedule_id`) REFERENCES `m_loan_repayment_schedule` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_interest_recalculation_additional_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_interest_recalculation_additional_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_interest_recalculation_additional_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_interest_recalculation_additional_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_officer_assignment_history
+-- Dumping structure for table fineract_default.m_loan_officer_assignment_history
 DROP TABLE IF EXISTS `m_loan_officer_assignment_history`;
 CREATE TABLE IF NOT EXISTS `m_loan_officer_assignment_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2531,12 +2531,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_officer_assignment_history` (
   CONSTRAINT `fk_m_loan_officer_assignment_history_0002` FOREIGN KEY (`loan_officer_id`) REFERENCES `m_staff` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_officer_assignment_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_officer_assignment_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_officer_assignment_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_officer_assignment_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_overdue_installment_charge
+-- Dumping structure for table fineract_default.m_loan_overdue_installment_charge
 DROP TABLE IF EXISTS `m_loan_overdue_installment_charge`;
 CREATE TABLE IF NOT EXISTS `m_loan_overdue_installment_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2550,12 +2550,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_overdue_installment_charge` (
   CONSTRAINT `FK_m_loan_overdue_installment_charge_m_loan_repayment_schedule` FOREIGN KEY (`loan_schedule_id`) REFERENCES `m_loan_repayment_schedule` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_overdue_installment_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_overdue_installment_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_overdue_installment_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_overdue_installment_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_paid_in_advance
+-- Dumping structure for table fineract_default.m_loan_paid_in_advance
 DROP TABLE IF EXISTS `m_loan_paid_in_advance`;
 CREATE TABLE IF NOT EXISTS `m_loan_paid_in_advance` (
   `loan_id` bigint(20) NOT NULL,
@@ -2568,12 +2568,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_paid_in_advance` (
   CONSTRAINT `m_loan_paid_in_advance_ibfk_1` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_paid_in_advance: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_paid_in_advance: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_paid_in_advance` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_paid_in_advance` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_recalculation_details
+-- Dumping structure for table fineract_default.m_loan_recalculation_details
 DROP TABLE IF EXISTS `m_loan_recalculation_details`;
 CREATE TABLE IF NOT EXISTS `m_loan_recalculation_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2597,12 +2597,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_recalculation_details` (
   CONSTRAINT `FK_m_loan_m_loan_recalculation_details` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
--- Dumping data for table mifostenant-default.m_loan_recalculation_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_recalculation_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_recalculation_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_recalculation_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_repayment_schedule
+-- Dumping structure for table fineract_default.m_loan_repayment_schedule
 DROP TABLE IF EXISTS `m_loan_repayment_schedule`;
 CREATE TABLE IF NOT EXISTS `m_loan_repayment_schedule` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2642,12 +2642,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_repayment_schedule` (
   CONSTRAINT `FK488B92AA40BE0710` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_repayment_schedule: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_repayment_schedule: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_repayment_schedule` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_repayment_schedule` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_repayment_schedule_history
+-- Dumping structure for table fineract_default.m_loan_repayment_schedule_history
 DROP TABLE IF EXISTS `m_loan_repayment_schedule_history`;
 CREATE TABLE IF NOT EXISTS `m_loan_repayment_schedule_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2672,12 +2672,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_repayment_schedule_history` (
   CONSTRAINT `m_loan_repayment_schedule_history_ibfk_2` FOREIGN KEY (`loan_reschedule_request_id`) REFERENCES `m_loan_reschedule_request` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_repayment_schedule_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_repayment_schedule_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_repayment_schedule_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_repayment_schedule_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_reschedule_request
+-- Dumping structure for table fineract_default.m_loan_reschedule_request
 DROP TABLE IF EXISTS `m_loan_reschedule_request`;
 CREATE TABLE IF NOT EXISTS `m_loan_reschedule_request` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2707,12 +2707,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_reschedule_request` (
   CONSTRAINT `m_loan_reschedule_request_ibfk_5` FOREIGN KEY (`rejected_by_user_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_reschedule_request: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_reschedule_request: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_reschedule_request` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_reschedule_request` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_reschedule_request_term_variations_mapping
+-- Dumping structure for table fineract_default.m_loan_reschedule_request_term_variations_mapping
 DROP TABLE IF EXISTS `m_loan_reschedule_request_term_variations_mapping`;
 CREATE TABLE IF NOT EXISTS `m_loan_reschedule_request_term_variations_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2725,12 +2725,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_reschedule_request_term_variations_mapping` (
   CONSTRAINT `FK__m_loan_term_variations` FOREIGN KEY (`loan_term_variations_id`) REFERENCES `m_loan_term_variations` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_reschedule_request_term_variations_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_reschedule_request_term_variations_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_reschedule_request_term_variations_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_reschedule_request_term_variations_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_term_variations
+-- Dumping structure for table fineract_default.m_loan_term_variations
 DROP TABLE IF EXISTS `m_loan_term_variations`;
 CREATE TABLE IF NOT EXISTS `m_loan_term_variations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2748,12 +2748,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_term_variations` (
   CONSTRAINT `FK_loan_id_m_loan_id` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_term_variations: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_term_variations: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_term_variations` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_term_variations` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_topup
+-- Dumping structure for table fineract_default.m_loan_topup
 DROP TABLE IF EXISTS `m_loan_topup`;
 CREATE TABLE IF NOT EXISTS `m_loan_topup` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2770,12 +2770,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_topup` (
   CONSTRAINT `m_loan_topup_FK_loan_id` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_topup: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_topup: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_topup` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_topup` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_tranche_charges
+-- Dumping structure for table fineract_default.m_loan_tranche_charges
 DROP TABLE IF EXISTS `m_loan_tranche_charges`;
 CREATE TABLE IF NOT EXISTS `m_loan_tranche_charges` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2788,12 +2788,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_tranche_charges` (
   CONSTRAINT `FK_m_loan_tranche_charges_m_loan` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_tranche_charges: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_tranche_charges: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_tranche_charges` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_tranche_charges` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_tranche_disbursement_charge
+-- Dumping structure for table fineract_default.m_loan_tranche_disbursement_charge
 DROP TABLE IF EXISTS `m_loan_tranche_disbursement_charge`;
 CREATE TABLE IF NOT EXISTS `m_loan_tranche_disbursement_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2806,12 +2806,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_tranche_disbursement_charge` (
   CONSTRAINT `FK_m_loan_tranche_disbursement_charge_m_loan_disbursement_detail` FOREIGN KEY (`disbursement_detail_id`) REFERENCES `m_loan_disbursement_detail` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_tranche_disbursement_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_tranche_disbursement_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_tranche_disbursement_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_tranche_disbursement_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_transaction
+-- Dumping structure for table fineract_default.m_loan_transaction
 DROP TABLE IF EXISTS `m_loan_transaction`;
 CREATE TABLE IF NOT EXISTS `m_loan_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2844,12 +2844,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_transaction` (
   CONSTRAINT `FK_m_loan_transaction_m_payment_detail` FOREIGN KEY (`payment_detail_id`) REFERENCES `m_payment_detail` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_loan_transaction_repayment_schedule_mapping
+-- Dumping structure for table fineract_default.m_loan_transaction_repayment_schedule_mapping
 DROP TABLE IF EXISTS `m_loan_transaction_repayment_schedule_mapping`;
 CREATE TABLE IF NOT EXISTS `m_loan_transaction_repayment_schedule_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2867,12 +2867,12 @@ CREATE TABLE IF NOT EXISTS `m_loan_transaction_repayment_schedule_mapping` (
   CONSTRAINT `FK_mappings_m_loan_transaction` FOREIGN KEY (`loan_transaction_id`) REFERENCES `m_loan_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_loan_transaction_repayment_schedule_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_loan_transaction_repayment_schedule_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_loan_transaction_repayment_schedule_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_loan_transaction_repayment_schedule_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_mandatory_savings_schedule
+-- Dumping structure for table fineract_default.m_mandatory_savings_schedule
 DROP TABLE IF EXISTS `m_mandatory_savings_schedule`;
 CREATE TABLE IF NOT EXISTS `m_mandatory_savings_schedule` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2895,12 +2895,12 @@ CREATE TABLE IF NOT EXISTS `m_mandatory_savings_schedule` (
   CONSTRAINT `FKMSS0000000001` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_mandatory_savings_schedule: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_mandatory_savings_schedule: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_mandatory_savings_schedule` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_mandatory_savings_schedule` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_meeting
+-- Dumping structure for table fineract_default.m_meeting
 DROP TABLE IF EXISTS `m_meeting`;
 CREATE TABLE IF NOT EXISTS `m_meeting` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2911,12 +2911,12 @@ CREATE TABLE IF NOT EXISTS `m_meeting` (
   CONSTRAINT `FK_m_calendar_instance_m_meeting` FOREIGN KEY (`calendar_instance_id`) REFERENCES `m_calendar_instance` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
--- Dumping data for table mifostenant-default.m_meeting: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_meeting: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_meeting` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_meeting` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_note
+-- Dumping structure for table fineract_default.m_note
 DROP TABLE IF EXISTS `m_note`;
 CREATE TABLE IF NOT EXISTS `m_note` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2950,12 +2950,12 @@ CREATE TABLE IF NOT EXISTS `m_note` (
   CONSTRAINT `FK_savings_account_id` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_note: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_note: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_note` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_note` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_office
+-- Dumping structure for table fineract_default.m_office
 DROP TABLE IF EXISTS `m_office`;
 CREATE TABLE IF NOT EXISTS `m_office` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2971,14 +2971,14 @@ CREATE TABLE IF NOT EXISTS `m_office` (
   CONSTRAINT `FK2291C477E2551DCC` FOREIGN KEY (`parent_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_office: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_office: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_office` DISABLE KEYS */;
 INSERT INTO `m_office` (`id`, `parent_id`, `hierarchy`, `external_id`, `name`, `opening_date`) VALUES
 	(1, NULL, '.', '1', 'Head Office', '2009-01-01');
 /*!40000 ALTER TABLE `m_office` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_office_transaction
+-- Dumping structure for table fineract_default.m_office_transaction
 DROP TABLE IF EXISTS `m_office_transaction`;
 CREATE TABLE IF NOT EXISTS `m_office_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -2996,12 +2996,12 @@ CREATE TABLE IF NOT EXISTS `m_office_transaction` (
   CONSTRAINT `FK1E37728B93C6C1B6` FOREIGN KEY (`to_office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_office_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_office_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_office_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_office_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_organisation_currency
+-- Dumping structure for table fineract_default.m_organisation_currency
 DROP TABLE IF EXISTS `m_organisation_currency`;
 CREATE TABLE IF NOT EXISTS `m_organisation_currency` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3014,14 +3014,14 @@ CREATE TABLE IF NOT EXISTS `m_organisation_currency` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_organisation_currency: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_organisation_currency: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_organisation_currency` DISABLE KEYS */;
 INSERT INTO `m_organisation_currency` (`id`, `code`, `decimal_places`, `currency_multiplesof`, `name`, `display_symbol`, `internationalized_name_code`) VALUES
 	(21, 'USD', 2, NULL, 'US Dollar', '$', 'currency.USD');
 /*!40000 ALTER TABLE `m_organisation_currency` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_password_validation_policy
+-- Dumping structure for table fineract_default.m_password_validation_policy
 DROP TABLE IF EXISTS `m_password_validation_policy`;
 CREATE TABLE IF NOT EXISTS `m_password_validation_policy` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -3032,7 +3032,7 @@ CREATE TABLE IF NOT EXISTS `m_password_validation_policy` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_password_validation_policy: ~2 rows (approximately)
+-- Dumping data for table fineract_default.m_password_validation_policy: ~2 rows (approximately)
 /*!40000 ALTER TABLE `m_password_validation_policy` DISABLE KEYS */;
 INSERT INTO `m_password_validation_policy` (`id`, `regex`, `description`, `active`, `key`) VALUES
 	(1, '^.{1,50}$', 'Password most be at least 1 character and not more that 50 characters long', 1, 'simple'),
@@ -3040,7 +3040,7 @@ INSERT INTO `m_password_validation_policy` (`id`, `regex`, `description`, `activ
 /*!40000 ALTER TABLE `m_password_validation_policy` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_payment_detail
+-- Dumping structure for table fineract_default.m_payment_detail
 DROP TABLE IF EXISTS `m_payment_detail`;
 CREATE TABLE IF NOT EXISTS `m_payment_detail` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3055,12 +3055,12 @@ CREATE TABLE IF NOT EXISTS `m_payment_detail` (
   CONSTRAINT `FK_m_payment_detail_m_payment_type` FOREIGN KEY (`payment_type_id`) REFERENCES `m_payment_type` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_payment_detail: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_payment_detail: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_payment_detail` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_payment_detail` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_payment_type
+-- Dumping structure for table fineract_default.m_payment_type
 DROP TABLE IF EXISTS `m_payment_type`;
 CREATE TABLE IF NOT EXISTS `m_payment_type` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -3071,12 +3071,12 @@ CREATE TABLE IF NOT EXISTS `m_payment_type` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_payment_type: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_payment_type: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_payment_type` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_payment_type` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_permission
+-- Dumping structure for table fineract_default.m_permission
 DROP TABLE IF EXISTS `m_permission`;
 CREATE TABLE IF NOT EXISTS `m_permission` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3089,7 +3089,7 @@ CREATE TABLE IF NOT EXISTS `m_permission` (
   UNIQUE KEY `code` (`code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=767 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_permission: ~744 rows (approximately)
+-- Dumping data for table fineract_default.m_permission: ~744 rows (approximately)
 /*!40000 ALTER TABLE `m_permission` DISABLE KEYS */;
 INSERT INTO `m_permission` (`id`, `grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES
 	(1, 'special', 'ALL_FUNCTIONS', NULL, NULL, 0),
@@ -3839,7 +3839,7 @@ INSERT INTO `m_permission` (`id`, `grouping`, `code`, `entity_name`, `action_nam
 /*!40000 ALTER TABLE `m_permission` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_portfolio_account_associations
+-- Dumping structure for table fineract_default.m_portfolio_account_associations
 DROP TABLE IF EXISTS `m_portfolio_account_associations`;
 CREATE TABLE IF NOT EXISTS `m_portfolio_account_associations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3860,12 +3860,12 @@ CREATE TABLE IF NOT EXISTS `m_portfolio_account_associations` (
   CONSTRAINT `linked_savings_fk` FOREIGN KEY (`linked_savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_portfolio_account_associations: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_portfolio_account_associations: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_portfolio_account_associations` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_portfolio_account_associations` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_portfolio_command_source
+-- Dumping structure for table fineract_default.m_portfolio_command_source
 DROP TABLE IF EXISTS `m_portfolio_command_source`;
 CREATE TABLE IF NOT EXISTS `m_portfolio_command_source` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3903,12 +3903,12 @@ CREATE TABLE IF NOT EXISTS `m_portfolio_command_source` (
   CONSTRAINT `FK_m_maker_m_appuser` FOREIGN KEY (`maker_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_portfolio_command_source: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_portfolio_command_source: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_portfolio_command_source` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_portfolio_command_source` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan
+-- Dumping structure for table fineract_default.m_product_loan
 DROP TABLE IF EXISTS `m_product_loan`;
 CREATE TABLE IF NOT EXISTS `m_product_loan` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -3976,12 +3976,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan` (
   CONSTRAINT `FK_ltp_strategy` FOREIGN KEY (`loan_transaction_strategy_id`) REFERENCES `ref_loan_transaction_processing_strategy` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_charge
+-- Dumping structure for table fineract_default.m_product_loan_charge
 DROP TABLE IF EXISTS `m_product_loan_charge`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_charge` (
   `product_loan_id` bigint(20) NOT NULL,
@@ -3992,12 +3992,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_charge` (
   CONSTRAINT `m_product_loan_charge_ibfk_2` FOREIGN KEY (`product_loan_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_configurable_attributes
+-- Dumping structure for table fineract_default.m_product_loan_configurable_attributes
 DROP TABLE IF EXISTS `m_product_loan_configurable_attributes`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_configurable_attributes` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4015,12 +4015,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_configurable_attributes` (
   CONSTRAINT `fk_m_product_loan_configurable_attributes_0001` FOREIGN KEY (`loan_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_configurable_attributes: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_configurable_attributes: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_configurable_attributes` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_configurable_attributes` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_floating_rates
+-- Dumping structure for table fineract_default.m_product_loan_floating_rates
 DROP TABLE IF EXISTS `m_product_loan_floating_rates`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_floating_rates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4038,12 +4038,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_floating_rates` (
   CONSTRAINT `FK_mappings_m_product_loan_id` FOREIGN KEY (`loan_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_floating_rates: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_floating_rates: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_floating_rates` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_floating_rates` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_guarantee_details
+-- Dumping structure for table fineract_default.m_product_loan_guarantee_details
 DROP TABLE IF EXISTS `m_product_loan_guarantee_details`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_guarantee_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4056,12 +4056,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_guarantee_details` (
   CONSTRAINT `FK_guarantee_details_loan_product` FOREIGN KEY (`loan_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_guarantee_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_guarantee_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_guarantee_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_guarantee_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_recalculation_details
+-- Dumping structure for table fineract_default.m_product_loan_recalculation_details
 DROP TABLE IF EXISTS `m_product_loan_recalculation_details`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_recalculation_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4087,12 +4087,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_recalculation_details` (
   CONSTRAINT `FK_m_product_loan_m_product_loan_recalculation_details` FOREIGN KEY (`product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
--- Dumping data for table mifostenant-default.m_product_loan_recalculation_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_recalculation_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_recalculation_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_recalculation_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_variable_installment_config
+-- Dumping structure for table fineract_default.m_product_loan_variable_installment_config
 DROP TABLE IF EXISTS `m_product_loan_variable_installment_config`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_variable_installment_config` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4104,12 +4104,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_variable_installment_config` (
   CONSTRAINT `FK_mappings_m_variable_product_loan_id` FOREIGN KEY (`loan_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_variable_installment_config: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_variable_installment_config: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_variable_installment_config` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_variable_installment_config` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_loan_variations_borrower_cycle
+-- Dumping structure for table fineract_default.m_product_loan_variations_borrower_cycle
 DROP TABLE IF EXISTS `m_product_loan_variations_borrower_cycle`;
 CREATE TABLE IF NOT EXISTS `m_product_loan_variations_borrower_cycle` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4125,12 +4125,12 @@ CREATE TABLE IF NOT EXISTS `m_product_loan_variations_borrower_cycle` (
   CONSTRAINT `borrower_cycle_loan_product_FK` FOREIGN KEY (`loan_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_loan_variations_borrower_cycle: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_loan_variations_borrower_cycle: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_loan_variations_borrower_cycle` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_loan_variations_borrower_cycle` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_product_mix
+-- Dumping structure for table fineract_default.m_product_mix
 DROP TABLE IF EXISTS `m_product_mix`;
 CREATE TABLE IF NOT EXISTS `m_product_mix` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4143,12 +4143,12 @@ CREATE TABLE IF NOT EXISTS `m_product_mix` (
   CONSTRAINT `FK_m_product_mix_restricted_product_id_to_m_product_loan` FOREIGN KEY (`restricted_product_id`) REFERENCES `m_product_loan` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_product_mix: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_product_mix: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_product_mix` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_product_mix` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_provisioning_criteria
+-- Dumping structure for table fineract_default.m_provisioning_criteria
 DROP TABLE IF EXISTS `m_provisioning_criteria`;
 CREATE TABLE IF NOT EXISTS `m_provisioning_criteria` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4165,12 +4165,12 @@ CREATE TABLE IF NOT EXISTS `m_provisioning_criteria` (
   CONSTRAINT `m_provisioning_criteria_ibfk_2` FOREIGN KEY (`lastmodifiedby_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_provisioning_criteria: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_provisioning_criteria: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_provisioning_criteria` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_provisioning_criteria` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_provisioning_criteria_definition
+-- Dumping structure for table fineract_default.m_provisioning_criteria_definition
 DROP TABLE IF EXISTS `m_provisioning_criteria_definition`;
 CREATE TABLE IF NOT EXISTS `m_provisioning_criteria_definition` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4192,12 +4192,12 @@ CREATE TABLE IF NOT EXISTS `m_provisioning_criteria_definition` (
   CONSTRAINT `m_provisioning_criteria_definition_ibfk_4` FOREIGN KEY (`expense_account`) REFERENCES `acc_gl_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_provisioning_criteria_definition: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_provisioning_criteria_definition: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_provisioning_criteria_definition` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_provisioning_criteria_definition` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_provisioning_history
+-- Dumping structure for table fineract_default.m_provisioning_history
 DROP TABLE IF EXISTS `m_provisioning_history`;
 CREATE TABLE IF NOT EXISTS `m_provisioning_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4213,12 +4213,12 @@ CREATE TABLE IF NOT EXISTS `m_provisioning_history` (
   CONSTRAINT `m_provisioning_history_ibfk_2` FOREIGN KEY (`lastmodifiedby_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_provisioning_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_provisioning_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_provisioning_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_provisioning_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_provision_category
+-- Dumping structure for table fineract_default.m_provision_category
 DROP TABLE IF EXISTS `m_provision_category`;
 CREATE TABLE IF NOT EXISTS `m_provision_category` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4228,7 +4228,7 @@ CREATE TABLE IF NOT EXISTS `m_provision_category` (
   UNIQUE KEY `category_name` (`category_name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_provision_category: ~4 rows (approximately)
+-- Dumping data for table fineract_default.m_provision_category: ~4 rows (approximately)
 /*!40000 ALTER TABLE `m_provision_category` DISABLE KEYS */;
 INSERT INTO `m_provision_category` (`id`, `category_name`, `description`) VALUES
 	(1, 'STANDARD', 'Punctual Payment without any dues'),
@@ -4238,7 +4238,7 @@ INSERT INTO `m_provision_category` (`id`, `category_name`, `description`) VALUES
 /*!40000 ALTER TABLE `m_provision_category` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_report_mailing_job
+-- Dumping structure for table fineract_default.m_report_mailing_job
 DROP TABLE IF EXISTS `m_report_mailing_job`;
 CREATE TABLE IF NOT EXISTS `m_report_mailing_job` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4277,12 +4277,12 @@ CREATE TABLE IF NOT EXISTS `m_report_mailing_job` (
   CONSTRAINT `m_report_mailing_job_ibfk_4` FOREIGN KEY (`run_as_userid`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_report_mailing_job: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_report_mailing_job: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_report_mailing_job` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_report_mailing_job` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_report_mailing_job_configuration
+-- Dumping structure for table fineract_default.m_report_mailing_job_configuration
 DROP TABLE IF EXISTS `m_report_mailing_job_configuration`;
 CREATE TABLE IF NOT EXISTS `m_report_mailing_job_configuration` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -4292,7 +4292,7 @@ CREATE TABLE IF NOT EXISTS `m_report_mailing_job_configuration` (
   UNIQUE KEY `unique_name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_report_mailing_job_configuration: ~4 rows (approximately)
+-- Dumping data for table fineract_default.m_report_mailing_job_configuration: ~4 rows (approximately)
 /*!40000 ALTER TABLE `m_report_mailing_job_configuration` DISABLE KEYS */;
 INSERT INTO `m_report_mailing_job_configuration` (`id`, `name`, `value`) VALUES
 	(1, 'GMAIL_SMTP_SERVER', 'smtp.gmail.com'),
@@ -4302,7 +4302,7 @@ INSERT INTO `m_report_mailing_job_configuration` (`id`, `name`, `value`) VALUES
 /*!40000 ALTER TABLE `m_report_mailing_job_configuration` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_report_mailing_job_run_history
+-- Dumping structure for table fineract_default.m_report_mailing_job_run_history
 DROP TABLE IF EXISTS `m_report_mailing_job_run_history`;
 CREATE TABLE IF NOT EXISTS `m_report_mailing_job_run_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4317,12 +4317,12 @@ CREATE TABLE IF NOT EXISTS `m_report_mailing_job_run_history` (
   CONSTRAINT `m_report_mailing_job_run_history_ibfk_1` FOREIGN KEY (`job_id`) REFERENCES `m_report_mailing_job` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_report_mailing_job_run_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_report_mailing_job_run_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_report_mailing_job_run_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_report_mailing_job_run_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_role
+-- Dumping structure for table fineract_default.m_role
 DROP TABLE IF EXISTS `m_role`;
 CREATE TABLE IF NOT EXISTS `m_role` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4333,14 +4333,14 @@ CREATE TABLE IF NOT EXISTS `m_role` (
   UNIQUE KEY `unq_name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_role: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_role: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_role` DISABLE KEYS */;
 INSERT INTO `m_role` (`id`, `name`, `description`, `is_disabled`) VALUES
 	(1, 'Super user', 'This role provides all application permissions.', 0);
 /*!40000 ALTER TABLE `m_role` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_role_permission
+-- Dumping structure for table fineract_default.m_role_permission
 DROP TABLE IF EXISTS `m_role_permission`;
 CREATE TABLE IF NOT EXISTS `m_role_permission` (
   `role_id` bigint(20) NOT NULL,
@@ -4352,14 +4352,14 @@ CREATE TABLE IF NOT EXISTS `m_role_permission` (
   CONSTRAINT `FK8DEDB04815CEC7AB` FOREIGN KEY (`role_id`) REFERENCES `m_role` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_role_permission: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_role_permission: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_role_permission` DISABLE KEYS */;
 INSERT INTO `m_role_permission` (`role_id`, `permission_id`) VALUES
 	(1, 1);
 /*!40000 ALTER TABLE `m_role_permission` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account
+-- Dumping structure for table fineract_default.m_savings_account
 DROP TABLE IF EXISTS `m_savings_account`;
 CREATE TABLE IF NOT EXISTS `m_savings_account` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4435,12 +4435,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account` (
   CONSTRAINT `FK_savings_account_tax_group` FOREIGN KEY (`tax_group_id`) REFERENCES `m_tax_group` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_charge
+-- Dumping structure for table fineract_default.m_savings_account_charge
 DROP TABLE IF EXISTS `m_savings_account_charge`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4471,12 +4471,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_charge` (
   CONSTRAINT `m_savings_account_charge_ibfk_2` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_charge_paid_by
+-- Dumping structure for table fineract_default.m_savings_account_charge_paid_by
 DROP TABLE IF EXISTS `m_savings_account_charge_paid_by`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_charge_paid_by` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4490,12 +4490,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_charge_paid_by` (
   CONSTRAINT `FK__m_savings_account_transaction` FOREIGN KEY (`savings_account_transaction_id`) REFERENCES `m_savings_account_transaction` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_charge_paid_by: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_charge_paid_by: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_charge_paid_by` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_charge_paid_by` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_interest_rate_chart
+-- Dumping structure for table fineract_default.m_savings_account_interest_rate_chart
 DROP TABLE IF EXISTS `m_savings_account_interest_rate_chart`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_interest_rate_chart` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4510,12 +4510,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_interest_rate_chart` (
   CONSTRAINT `FKSAIRC00000000000001` FOREIGN KEY (`savings_account_id`) REFERENCES `m_savings_account` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_interest_rate_chart: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_interest_rate_chart: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_interest_rate_chart` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_interest_rate_chart` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_interest_rate_slab
+-- Dumping structure for table fineract_default.m_savings_account_interest_rate_slab
 DROP TABLE IF EXISTS `m_savings_account_interest_rate_slab`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_interest_rate_slab` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4533,12 +4533,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_interest_rate_slab` (
   CONSTRAINT `FKSAIRS00000000000001` FOREIGN KEY (`savings_account_interest_rate_chart_id`) REFERENCES `m_savings_account_interest_rate_chart` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_interest_rate_slab: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_interest_rate_slab: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_interest_rate_slab` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_interest_rate_slab` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_transaction
+-- Dumping structure for table fineract_default.m_savings_account_transaction
 DROP TABLE IF EXISTS `m_savings_account_transaction`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_transaction` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4566,12 +4566,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_transaction` (
   CONSTRAINT `FK_m_savings_account_transaction_m_payment_detail` FOREIGN KEY (`payment_detail_id`) REFERENCES `m_payment_detail` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_transaction: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_transaction: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_transaction` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_transaction` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_account_transaction_tax_details
+-- Dumping structure for table fineract_default.m_savings_account_transaction_tax_details
 DROP TABLE IF EXISTS `m_savings_account_transaction_tax_details`;
 CREATE TABLE IF NOT EXISTS `m_savings_account_transaction_tax_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4585,12 +4585,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_account_transaction_tax_details` (
   CONSTRAINT `FK_savings_account_transaction_tax_details_tax_component` FOREIGN KEY (`tax_component_id`) REFERENCES `m_tax_component` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_account_transaction_tax_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_account_transaction_tax_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_account_transaction_tax_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_account_transaction_tax_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_interest_incentives
+-- Dumping structure for table fineract_default.m_savings_interest_incentives
 DROP TABLE IF EXISTS `m_savings_interest_incentives`;
 CREATE TABLE IF NOT EXISTS `m_savings_interest_incentives` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4606,12 +4606,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_interest_incentives` (
   CONSTRAINT `FK_m_savings_interest_incentives_m_savings_interest_rate_slab` FOREIGN KEY (`deposit_account_interest_rate_slab_id`) REFERENCES `m_savings_account_interest_rate_slab` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_interest_incentives: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_interest_incentives: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_interest_incentives` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_interest_incentives` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_officer_assignment_history
+-- Dumping structure for table fineract_default.m_savings_officer_assignment_history
 DROP TABLE IF EXISTS `m_savings_officer_assignment_history`;
 CREATE TABLE IF NOT EXISTS `m_savings_officer_assignment_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4630,12 +4630,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_officer_assignment_history` (
   CONSTRAINT `fk_m_savings_officer_assignment_history_0002` FOREIGN KEY (`savings_officer_id`) REFERENCES `m_staff` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_officer_assignment_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_officer_assignment_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_officer_assignment_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_officer_assignment_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_product
+-- Dumping structure for table fineract_default.m_savings_product
 DROP TABLE IF EXISTS `m_savings_product`;
 CREATE TABLE IF NOT EXISTS `m_savings_product` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4678,12 +4678,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_product` (
   CONSTRAINT `FK_savings_product_tax_group` FOREIGN KEY (`tax_group_id`) REFERENCES `m_tax_group` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_product: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_product: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_product` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_product` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_savings_product_charge
+-- Dumping structure for table fineract_default.m_savings_product_charge
 DROP TABLE IF EXISTS `m_savings_product_charge`;
 CREATE TABLE IF NOT EXISTS `m_savings_product_charge` (
   `savings_product_id` bigint(20) NOT NULL,
@@ -4694,12 +4694,12 @@ CREATE TABLE IF NOT EXISTS `m_savings_product_charge` (
   CONSTRAINT `m_savings_product_charge_ibfk_2` FOREIGN KEY (`savings_product_id`) REFERENCES `m_savings_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_savings_product_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_savings_product_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_savings_product_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_savings_product_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_selfservice_beneficiaries_tpt
+-- Dumping structure for table fineract_default.m_selfservice_beneficiaries_tpt
 DROP TABLE IF EXISTS `m_selfservice_beneficiaries_tpt`;
 CREATE TABLE IF NOT EXISTS `m_selfservice_beneficiaries_tpt` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4715,12 +4715,12 @@ CREATE TABLE IF NOT EXISTS `m_selfservice_beneficiaries_tpt` (
   UNIQUE KEY `name` (`name`,`app_user_id`,`is_active`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_selfservice_beneficiaries_tpt: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_selfservice_beneficiaries_tpt: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_selfservice_beneficiaries_tpt` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_selfservice_beneficiaries_tpt` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_selfservice_user_client_mapping
+-- Dumping structure for table fineract_default.m_selfservice_user_client_mapping
 DROP TABLE IF EXISTS `m_selfservice_user_client_mapping`;
 CREATE TABLE IF NOT EXISTS `m_selfservice_user_client_mapping` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4733,12 +4733,12 @@ CREATE TABLE IF NOT EXISTS `m_selfservice_user_client_mapping` (
   CONSTRAINT `m_selfservice_client_id` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_selfservice_user_client_mapping: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_selfservice_user_client_mapping: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_selfservice_user_client_mapping` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_selfservice_user_client_mapping` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_account
+-- Dumping structure for table fineract_default.m_share_account
 DROP TABLE IF EXISTS `m_share_account`;
 CREATE TABLE IF NOT EXISTS `m_share_account` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4792,12 +4792,12 @@ CREATE TABLE IF NOT EXISTS `m_share_account` (
   CONSTRAINT `m_share_account_ibfk_9` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_account: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_account: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_account` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_account` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_account_charge
+-- Dumping structure for table fineract_default.m_share_account_charge
 DROP TABLE IF EXISTS `m_share_account_charge`;
 CREATE TABLE IF NOT EXISTS `m_share_account_charge` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4826,12 +4826,12 @@ CREATE TABLE IF NOT EXISTS `m_share_account_charge` (
   CONSTRAINT `m_share_account_charge_ibfk_2` FOREIGN KEY (`account_id`) REFERENCES `m_share_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_account_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_account_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_account_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_account_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_account_charge_paid_by
+-- Dumping structure for table fineract_default.m_share_account_charge_paid_by
 DROP TABLE IF EXISTS `m_share_account_charge_paid_by`;
 CREATE TABLE IF NOT EXISTS `m_share_account_charge_paid_by` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4845,12 +4845,12 @@ CREATE TABLE IF NOT EXISTS `m_share_account_charge_paid_by` (
   CONSTRAINT `m_share_account_transactions_charge_mapping_ibfk2` FOREIGN KEY (`charge_transaction_id`) REFERENCES `m_share_account_charge` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_account_charge_paid_by: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_account_charge_paid_by: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_account_charge_paid_by` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_account_charge_paid_by` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_account_dividend_details
+-- Dumping structure for table fineract_default.m_share_account_dividend_details
 DROP TABLE IF EXISTS `m_share_account_dividend_details`;
 CREATE TABLE IF NOT EXISTS `m_share_account_dividend_details` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4866,12 +4866,12 @@ CREATE TABLE IF NOT EXISTS `m_share_account_dividend_details` (
   CONSTRAINT `FK_m_share_account_dividend_details_dividend_pay_out_id` FOREIGN KEY (`dividend_pay_out_id`) REFERENCES `m_share_product_dividend_pay_out` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_account_dividend_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_account_dividend_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_account_dividend_details` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_account_dividend_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_account_transactions
+-- Dumping structure for table fineract_default.m_share_account_transactions
 DROP TABLE IF EXISTS `m_share_account_transactions`;
 CREATE TABLE IF NOT EXISTS `m_share_account_transactions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4890,12 +4890,12 @@ CREATE TABLE IF NOT EXISTS `m_share_account_transactions` (
   CONSTRAINT `m_share_account_purchased_shares_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `m_share_account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_account_transactions: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_account_transactions: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_account_transactions` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_account_transactions` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_product
+-- Dumping structure for table fineract_default.m_share_product
 DROP TABLE IF EXISTS `m_share_product`;
 CREATE TABLE IF NOT EXISTS `m_share_product` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4934,12 +4934,12 @@ CREATE TABLE IF NOT EXISTS `m_share_product` (
   CONSTRAINT `m_share_product_ibfk_2` FOREIGN KEY (`lastmodifiedby_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_product: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_product: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_product` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_product` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_product_charge
+-- Dumping structure for table fineract_default.m_share_product_charge
 DROP TABLE IF EXISTS `m_share_product_charge`;
 CREATE TABLE IF NOT EXISTS `m_share_product_charge` (
   `product_id` bigint(20) NOT NULL,
@@ -4950,12 +4950,12 @@ CREATE TABLE IF NOT EXISTS `m_share_product_charge` (
   CONSTRAINT `m_share_product_charge_ibfk_2` FOREIGN KEY (`product_id`) REFERENCES `m_share_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_product_charge: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_product_charge: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_product_charge` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_product_charge` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_product_dividend_pay_out
+-- Dumping structure for table fineract_default.m_share_product_dividend_pay_out
 DROP TABLE IF EXISTS `m_share_product_dividend_pay_out`;
 CREATE TABLE IF NOT EXISTS `m_share_product_dividend_pay_out` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4977,12 +4977,12 @@ CREATE TABLE IF NOT EXISTS `m_share_product_dividend_pay_out` (
   CONSTRAINT `FK_m_share_product_dividend_pay_out_product_id` FOREIGN KEY (`product_id`) REFERENCES `m_share_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_product_dividend_pay_out: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_product_dividend_pay_out: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_product_dividend_pay_out` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_product_dividend_pay_out` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_share_product_market_price
+-- Dumping structure for table fineract_default.m_share_product_market_price
 DROP TABLE IF EXISTS `m_share_product_market_price`;
 CREATE TABLE IF NOT EXISTS `m_share_product_market_price` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -4994,12 +4994,12 @@ CREATE TABLE IF NOT EXISTS `m_share_product_market_price` (
   CONSTRAINT `m_share_product_market_price_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `m_share_product` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_share_product_market_price: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_share_product_market_price: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_share_product_market_price` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_share_product_market_price` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_staff
+-- Dumping structure for table fineract_default.m_staff
 DROP TABLE IF EXISTS `m_staff`;
 CREATE TABLE IF NOT EXISTS `m_staff` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5025,12 +5025,12 @@ CREATE TABLE IF NOT EXISTS `m_staff` (
   CONSTRAINT `FK_m_staff_m_office` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_staff: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_staff: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_staff` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_staff` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_staff_assignment_history
+-- Dumping structure for table fineract_default.m_staff_assignment_history
 DROP TABLE IF EXISTS `m_staff_assignment_history`;
 CREATE TABLE IF NOT EXISTS `m_staff_assignment_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5049,12 +5049,12 @@ CREATE TABLE IF NOT EXISTS `m_staff_assignment_history` (
   CONSTRAINT `FK_m_staff_assignment_history_m_staff` FOREIGN KEY (`staff_id`) REFERENCES `m_staff` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_staff_assignment_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_staff_assignment_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_staff_assignment_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_staff_assignment_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_surveys
+-- Dumping structure for table fineract_default.m_surveys
 DROP TABLE IF EXISTS `m_surveys`;
 CREATE TABLE IF NOT EXISTS `m_surveys` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5067,12 +5067,12 @@ CREATE TABLE IF NOT EXISTS `m_surveys` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_surveys: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_surveys: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_surveys` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_surveys` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_survey_components
+-- Dumping structure for table fineract_default.m_survey_components
 DROP TABLE IF EXISTS `m_survey_components`;
 CREATE TABLE IF NOT EXISTS `m_survey_components` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5086,12 +5086,12 @@ CREATE TABLE IF NOT EXISTS `m_survey_components` (
   CONSTRAINT `m_survey_components_ibfk_1` FOREIGN KEY (`survey_id`) REFERENCES `m_surveys` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_survey_components: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_survey_components: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_survey_components` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_survey_components` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_survey_lookup_tables
+-- Dumping structure for table fineract_default.m_survey_lookup_tables
 DROP TABLE IF EXISTS `m_survey_lookup_tables`;
 CREATE TABLE IF NOT EXISTS `m_survey_lookup_tables` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5106,12 +5106,12 @@ CREATE TABLE IF NOT EXISTS `m_survey_lookup_tables` (
   CONSTRAINT `m_survey_lookup_tables_ibfk_1` FOREIGN KEY (`survey_id`) REFERENCES `m_surveys` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_survey_lookup_tables: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_survey_lookup_tables: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_survey_lookup_tables` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_survey_lookup_tables` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_survey_questions
+-- Dumping structure for table fineract_default.m_survey_questions
 DROP TABLE IF EXISTS `m_survey_questions`;
 CREATE TABLE IF NOT EXISTS `m_survey_questions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5126,12 +5126,12 @@ CREATE TABLE IF NOT EXISTS `m_survey_questions` (
   CONSTRAINT `m_survey_questions_ibfk_1` FOREIGN KEY (`survey_id`) REFERENCES `m_surveys` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_survey_questions: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_survey_questions: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_survey_questions` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_survey_questions` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_survey_responses
+-- Dumping structure for table fineract_default.m_survey_responses
 DROP TABLE IF EXISTS `m_survey_responses`;
 CREATE TABLE IF NOT EXISTS `m_survey_responses` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5144,12 +5144,12 @@ CREATE TABLE IF NOT EXISTS `m_survey_responses` (
   CONSTRAINT `m_survey_responses_ibfk_1` FOREIGN KEY (`question_id`) REFERENCES `m_survey_questions` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_survey_responses: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_survey_responses: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_survey_responses` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_survey_responses` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_survey_scorecards
+-- Dumping structure for table fineract_default.m_survey_scorecards
 DROP TABLE IF EXISTS `m_survey_scorecards`;
 CREATE TABLE IF NOT EXISTS `m_survey_scorecards` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5173,12 +5173,12 @@ CREATE TABLE IF NOT EXISTS `m_survey_scorecards` (
   CONSTRAINT `m_survey_scorecards_ibfk_5` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_survey_scorecards: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_survey_scorecards: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_survey_scorecards` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_survey_scorecards` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_tax_component
+-- Dumping structure for table fineract_default.m_tax_component
 DROP TABLE IF EXISTS `m_tax_component`;
 CREATE TABLE IF NOT EXISTS `m_tax_component` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5204,12 +5204,12 @@ CREATE TABLE IF NOT EXISTS `m_tax_component` (
   CONSTRAINT `FK_tax_component_lastmodifiedby` FOREIGN KEY (`lastmodifiedby_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_tax_component: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_tax_component: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_tax_component` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_tax_component` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_tax_component_history
+-- Dumping structure for table fineract_default.m_tax_component_history
 DROP TABLE IF EXISTS `m_tax_component_history`;
 CREATE TABLE IF NOT EXISTS `m_tax_component_history` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5230,12 +5230,12 @@ CREATE TABLE IF NOT EXISTS `m_tax_component_history` (
   CONSTRAINT `FK_tax_component_history_tax_component_id` FOREIGN KEY (`tax_component_id`) REFERENCES `m_tax_component` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_tax_component_history: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_tax_component_history: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_tax_component_history` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_tax_component_history` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_tax_group
+-- Dumping structure for table fineract_default.m_tax_group
 DROP TABLE IF EXISTS `m_tax_group`;
 CREATE TABLE IF NOT EXISTS `m_tax_group` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5251,12 +5251,12 @@ CREATE TABLE IF NOT EXISTS `m_tax_group` (
   CONSTRAINT `FK_tax_group_lastmodifiedby` FOREIGN KEY (`lastmodifiedby_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_tax_group: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_tax_group: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_tax_group` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_tax_group` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_tax_group_mappings
+-- Dumping structure for table fineract_default.m_tax_group_mappings
 DROP TABLE IF EXISTS `m_tax_group_mappings`;
 CREATE TABLE IF NOT EXISTS `m_tax_group_mappings` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5279,12 +5279,12 @@ CREATE TABLE IF NOT EXISTS `m_tax_group_mappings` (
   CONSTRAINT `FK_tax_group_mappings_tax_group` FOREIGN KEY (`tax_group_id`) REFERENCES `m_tax_group` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_tax_group_mappings: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_tax_group_mappings: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_tax_group_mappings` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_tax_group_mappings` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_tellers
+-- Dumping structure for table fineract_default.m_tellers
 DROP TABLE IF EXISTS `m_tellers`;
 CREATE TABLE IF NOT EXISTS `m_tellers` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5306,12 +5306,12 @@ CREATE TABLE IF NOT EXISTS `m_tellers` (
   CONSTRAINT `FK_m_tellers_m_office` FOREIGN KEY (`office_id`) REFERENCES `m_office` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_tellers: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_tellers: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_tellers` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_tellers` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_template
+-- Dumping structure for table fineract_default.m_template
 DROP TABLE IF EXISTS `m_template`;
 CREATE TABLE IF NOT EXISTS `m_template` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5323,12 +5323,12 @@ CREATE TABLE IF NOT EXISTS `m_template` (
   UNIQUE KEY `unq_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_template: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_template: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_template` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_template` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_templatemappers
+-- Dumping structure for table fineract_default.m_templatemappers
 DROP TABLE IF EXISTS `m_templatemappers`;
 CREATE TABLE IF NOT EXISTS `m_templatemappers` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5338,12 +5338,12 @@ CREATE TABLE IF NOT EXISTS `m_templatemappers` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_templatemappers: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_templatemappers: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_templatemappers` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_templatemappers` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_template_m_templatemappers
+-- Dumping structure for table fineract_default.m_template_m_templatemappers
 DROP TABLE IF EXISTS `m_template_m_templatemappers`;
 CREATE TABLE IF NOT EXISTS `m_template_m_templatemappers` (
   `m_template_id` bigint(20) NOT NULL,
@@ -5353,12 +5353,12 @@ CREATE TABLE IF NOT EXISTS `m_template_m_templatemappers` (
   KEY `m_template_id` (`m_template_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_template_m_templatemappers: ~0 rows (approximately)
+-- Dumping data for table fineract_default.m_template_m_templatemappers: ~0 rows (approximately)
 /*!40000 ALTER TABLE `m_template_m_templatemappers` DISABLE KEYS */;
 /*!40000 ALTER TABLE `m_template_m_templatemappers` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.m_working_days
+-- Dumping structure for table fineract_default.m_working_days
 DROP TABLE IF EXISTS `m_working_days`;
 CREATE TABLE IF NOT EXISTS `m_working_days` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5369,14 +5369,14 @@ CREATE TABLE IF NOT EXISTS `m_working_days` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.m_working_days: ~1 rows (approximately)
+-- Dumping data for table fineract_default.m_working_days: ~1 rows (approximately)
 /*!40000 ALTER TABLE `m_working_days` DISABLE KEYS */;
 INSERT INTO `m_working_days` (`id`, `recurrence`, `repayment_rescheduling_enum`, `extend_term_daily_repayments`, `extend_term_holiday_repayment`) VALUES
 	(1, 'FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU', 2, 0, 0);
 /*!40000 ALTER TABLE `m_working_days` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.oauth_access_token
+-- Dumping structure for table fineract_default.oauth_access_token
 DROP TABLE IF EXISTS `oauth_access_token`;
 CREATE TABLE IF NOT EXISTS `oauth_access_token` (
   `token_id` varchar(256) DEFAULT NULL,
@@ -5388,12 +5388,12 @@ CREATE TABLE IF NOT EXISTS `oauth_access_token` (
   `refresh_token` varchar(256) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.oauth_access_token: ~0 rows (approximately)
+-- Dumping data for table fineract_default.oauth_access_token: ~0 rows (approximately)
 /*!40000 ALTER TABLE `oauth_access_token` DISABLE KEYS */;
 /*!40000 ALTER TABLE `oauth_access_token` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.oauth_client_details
+-- Dumping structure for table fineract_default.oauth_client_details
 DROP TABLE IF EXISTS `oauth_client_details`;
 CREATE TABLE IF NOT EXISTS `oauth_client_details` (
   `client_id` varchar(128) NOT NULL,
@@ -5410,14 +5410,14 @@ CREATE TABLE IF NOT EXISTS `oauth_client_details` (
   PRIMARY KEY (`client_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.oauth_client_details: ~0 rows (approximately)
+-- Dumping data for table fineract_default.oauth_client_details: ~0 rows (approximately)
 /*!40000 ALTER TABLE `oauth_client_details` DISABLE KEYS */;
 INSERT INTO `oauth_client_details` (`client_id`, `resource_ids`, `client_secret`, `scope`, `authorized_grant_types`, `web_server_redirect_uri`, `authorities`, `access_token_validity`, `refresh_token_validity`, `additional_information`, `autoapprove`) VALUES
 	('community-app', NULL, '123', 'all', 'password,refresh_token', NULL, NULL, NULL, NULL, NULL, NULL);
 /*!40000 ALTER TABLE `oauth_client_details` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.oauth_refresh_token
+-- Dumping structure for table fineract_default.oauth_refresh_token
 DROP TABLE IF EXISTS `oauth_refresh_token`;
 CREATE TABLE IF NOT EXISTS `oauth_refresh_token` (
   `token_id` varchar(256) DEFAULT NULL,
@@ -5425,12 +5425,12 @@ CREATE TABLE IF NOT EXISTS `oauth_refresh_token` (
   `authentication` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.oauth_refresh_token: ~0 rows (approximately)
+-- Dumping data for table fineract_default.oauth_refresh_token: ~0 rows (approximately)
 /*!40000 ALTER TABLE `oauth_refresh_token` DISABLE KEYS */;
 /*!40000 ALTER TABLE `oauth_refresh_token` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.ppi_likelihoods
+-- Dumping structure for table fineract_default.ppi_likelihoods
 DROP TABLE IF EXISTS `ppi_likelihoods`;
 CREATE TABLE IF NOT EXISTS `ppi_likelihoods` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5439,12 +5439,12 @@ CREATE TABLE IF NOT EXISTS `ppi_likelihoods` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.ppi_likelihoods: ~0 rows (approximately)
+-- Dumping data for table fineract_default.ppi_likelihoods: ~0 rows (approximately)
 /*!40000 ALTER TABLE `ppi_likelihoods` DISABLE KEYS */;
 /*!40000 ALTER TABLE `ppi_likelihoods` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.ppi_likelihoods_ppi
+-- Dumping structure for table fineract_default.ppi_likelihoods_ppi
 DROP TABLE IF EXISTS `ppi_likelihoods_ppi`;
 CREATE TABLE IF NOT EXISTS `ppi_likelihoods_ppi` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5454,12 +5454,12 @@ CREATE TABLE IF NOT EXISTS `ppi_likelihoods_ppi` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.ppi_likelihoods_ppi: ~0 rows (approximately)
+-- Dumping data for table fineract_default.ppi_likelihoods_ppi: ~0 rows (approximately)
 /*!40000 ALTER TABLE `ppi_likelihoods_ppi` DISABLE KEYS */;
 /*!40000 ALTER TABLE `ppi_likelihoods_ppi` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.ppi_scores
+-- Dumping structure for table fineract_default.ppi_scores
 DROP TABLE IF EXISTS `ppi_scores`;
 CREATE TABLE IF NOT EXISTS `ppi_scores` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5468,7 +5468,7 @@ CREATE TABLE IF NOT EXISTS `ppi_scores` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.ppi_scores: ~20 rows (approximately)
+-- Dumping data for table fineract_default.ppi_scores: ~20 rows (approximately)
 /*!40000 ALTER TABLE `ppi_scores` DISABLE KEYS */;
 INSERT INTO `ppi_scores` (`id`, `score_from`, `score_to`) VALUES
 	(1, 0, 4),
@@ -5494,7 +5494,7 @@ INSERT INTO `ppi_scores` (`id`, `score_from`, `score_to`) VALUES
 /*!40000 ALTER TABLE `ppi_scores` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.ref_loan_transaction_processing_strategy
+-- Dumping structure for table fineract_default.ref_loan_transaction_processing_strategy
 DROP TABLE IF EXISTS `ref_loan_transaction_processing_strategy`;
 CREATE TABLE IF NOT EXISTS `ref_loan_transaction_processing_strategy` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -5505,7 +5505,7 @@ CREATE TABLE IF NOT EXISTS `ref_loan_transaction_processing_strategy` (
   UNIQUE KEY `ltp_strategy_code` (`code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.ref_loan_transaction_processing_strategy: ~7 rows (approximately)
+-- Dumping data for table fineract_default.ref_loan_transaction_processing_strategy: ~7 rows (approximately)
 /*!40000 ALTER TABLE `ref_loan_transaction_processing_strategy` DISABLE KEYS */;
 INSERT INTO `ref_loan_transaction_processing_strategy` (`id`, `code`, `name`, `sort_order`) VALUES
 	(1, 'mifos-standard-strategy', 'Penalties, Fees, Interest, Principal order', 1),
@@ -5518,19 +5518,19 @@ INSERT INTO `ref_loan_transaction_processing_strategy` (`id`, `code`, `name`, `s
 /*!40000 ALTER TABLE `ref_loan_transaction_processing_strategy` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.rpt_sequence
+-- Dumping structure for table fineract_default.rpt_sequence
 DROP TABLE IF EXISTS `rpt_sequence`;
 CREATE TABLE IF NOT EXISTS `rpt_sequence` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.rpt_sequence: ~0 rows (approximately)
+-- Dumping data for table fineract_default.rpt_sequence: ~0 rows (approximately)
 /*!40000 ALTER TABLE `rpt_sequence` DISABLE KEYS */;
 /*!40000 ALTER TABLE `rpt_sequence` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.r_enum_value
+-- Dumping structure for table fineract_default.r_enum_value
 DROP TABLE IF EXISTS `r_enum_value`;
 CREATE TABLE IF NOT EXISTS `r_enum_value` (
   `enum_name` varchar(100) NOT NULL,
@@ -5543,7 +5543,7 @@ CREATE TABLE IF NOT EXISTS `r_enum_value` (
   UNIQUE KEY `enum_value` (`enum_name`,`enum_value`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.r_enum_value: ~159 rows (approximately)
+-- Dumping data for table fineract_default.r_enum_value: ~159 rows (approximately)
 /*!40000 ALTER TABLE `r_enum_value` DISABLE KEYS */;
 INSERT INTO `r_enum_value` (`enum_name`, `enum_id`, `enum_message_property`, `enum_value`, `enum_type`) VALUES
 	('account_type_type_enum', 0, 'INVALID', 'INVALID', 0),
@@ -5708,7 +5708,7 @@ INSERT INTO `r_enum_value` (`enum_name`, `enum_id`, `enum_message_property`, `en
 /*!40000 ALTER TABLE `r_enum_value` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.scheduler_detail
+-- Dumping structure for table fineract_default.scheduler_detail
 DROP TABLE IF EXISTS `scheduler_detail`;
 CREATE TABLE IF NOT EXISTS `scheduler_detail` (
   `id` smallint(2) NOT NULL AUTO_INCREMENT,
@@ -5718,14 +5718,14 @@ CREATE TABLE IF NOT EXISTS `scheduler_detail` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.scheduler_detail: ~0 rows (approximately)
+-- Dumping data for table fineract_default.scheduler_detail: ~0 rows (approximately)
 /*!40000 ALTER TABLE `scheduler_detail` DISABLE KEYS */;
 INSERT INTO `scheduler_detail` (`id`, `is_suspended`, `execute_misfired_jobs`, `reset_scheduler_on_bootup`) VALUES
 	(1, 0, 1, 1);
 /*!40000 ALTER TABLE `scheduler_detail` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.schema_version
+-- Dumping structure for table fineract_default.schema_version
 DROP TABLE IF EXISTS `schema_version`;
 CREATE TABLE IF NOT EXISTS `schema_version` (
   `version_rank` int(11) NOT NULL,
@@ -5745,7 +5745,7 @@ CREATE TABLE IF NOT EXISTS `schema_version` (
   KEY `schema_version_s_idx` (`success`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.schema_version: ~337 rows (approximately)
+-- Dumping data for table fineract_default.schema_version: ~337 rows (approximately)
 /*!40000 ALTER TABLE `schema_version` DISABLE KEYS */;
 INSERT INTO `schema_version` (`version_rank`, `installed_rank`, `version`, `description`, `type`, `script`, `checksum`, `installed_by`, `installed_on`, `execution_time`, `success`) VALUES
 	(1, 1, '1', 'mifosplatform-core-ddl-latest', 'SQL', 'V1__mifosplatform-core-ddl-latest.sql', 1800446512, 'root', '2015-06-03 15:26:50', 919, 1),
@@ -6088,7 +6088,7 @@ INSERT INTO `schema_version` (`version_rank`, `installed_rank`, `version`, `desc
 /*!40000 ALTER TABLE `schema_version` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.sms_campaign
+-- Dumping structure for table fineract_default.sms_campaign
 DROP TABLE IF EXISTS `sms_campaign`;
 CREATE TABLE IF NOT EXISTS `sms_campaign` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -6116,12 +6116,12 @@ CREATE TABLE IF NOT EXISTS `sms_campaign` (
   CONSTRAINT `sms_campaign_ibfk_1` FOREIGN KEY (`report_id`) REFERENCES `stretchy_report` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.sms_campaign: ~0 rows (approximately)
+-- Dumping data for table fineract_default.sms_campaign: ~0 rows (approximately)
 /*!40000 ALTER TABLE `sms_campaign` DISABLE KEYS */;
 /*!40000 ALTER TABLE `sms_campaign` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.sms_messages_outbound
+-- Dumping structure for table fineract_default.sms_messages_outbound
 DROP TABLE IF EXISTS `sms_messages_outbound`;
 CREATE TABLE IF NOT EXISTS `sms_messages_outbound` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -6146,12 +6146,12 @@ CREATE TABLE IF NOT EXISTS `sms_messages_outbound` (
   CONSTRAINT `FKSTAFF000000001` FOREIGN KEY (`staff_id`) REFERENCES `m_staff` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.sms_messages_outbound: ~0 rows (approximately)
+-- Dumping data for table fineract_default.sms_messages_outbound: ~0 rows (approximately)
 /*!40000 ALTER TABLE `sms_messages_outbound` DISABLE KEYS */;
 /*!40000 ALTER TABLE `sms_messages_outbound` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.stretchy_parameter
+-- Dumping structure for table fineract_default.stretchy_parameter
 DROP TABLE IF EXISTS `stretchy_parameter`;
 CREATE TABLE IF NOT EXISTS `stretchy_parameter` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -6172,7 +6172,7 @@ CREATE TABLE IF NOT EXISTS `stretchy_parameter` (
   CONSTRAINT `fk_stretchy_parameter_001` FOREIGN KEY (`parent_id`) REFERENCES `stretchy_parameter` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1023 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.stretchy_parameter: ~32 rows (approximately)
+-- Dumping data for table fineract_default.stretchy_parameter: ~32 rows (approximately)
 /*!40000 ALTER TABLE `stretchy_parameter` DISABLE KEYS */;
 INSERT INTO `stretchy_parameter` (`id`, `parameter_name`, `parameter_variable`, `parameter_label`, `parameter_displayType`, `parameter_FormatType`, `parameter_default`, `special`, `selectOne`, `selectAll`, `parameter_sql`, `parent_id`) VALUES
 	(1, 'startDateSelect', 'startDate', 'startDate', 'date', 'date', 'today', NULL, NULL, NULL, NULL, NULL),
@@ -6210,7 +6210,7 @@ INSERT INTO `stretchy_parameter` (`id`, `parameter_name`, `parameter_variable`, 
 /*!40000 ALTER TABLE `stretchy_parameter` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.stretchy_report
+-- Dumping structure for table fineract_default.stretchy_report
 DROP TABLE IF EXISTS `stretchy_report`;
 CREATE TABLE IF NOT EXISTS `stretchy_report` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -6226,7 +6226,7 @@ CREATE TABLE IF NOT EXISTS `stretchy_report` (
   UNIQUE KEY `report_name_UNIQUE` (`report_name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=188 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.stretchy_report: ~115 rows (approximately)
+-- Dumping data for table fineract_default.stretchy_report: ~115 rows (approximately)
 /*!40000 ALTER TABLE `stretchy_report` DISABLE KEYS */;
 INSERT INTO `stretchy_report` (`id`, `report_name`, `report_type`, `report_subtype`, `report_category`, `report_sql`, `description`, `core_report`, `use_report`) VALUES
 	(1, 'Client Listing', 'Table', NULL, 'Client', 'select\nconcat(repeat("..",\n   ((LENGTH(ounder.`hierarchy`) - LENGTH(REPLACE(ounder.`hierarchy`, \'.\', \'\')) - 1))), ounder.`name`) as "Office/Branch",\n c.account_no as "Client Account No.",\nc.display_name as "Name",\nr.enum_message_property as "Status",\nc.activation_date as "Activation", c.external_id as "External Id"\nfrom m_office o\njoin m_office ounder on ounder.hierarchy like concat(o.hierarchy, \'%\')\nand ounder.hierarchy like concat(\'${currentUserHierarchy}\', \'%\')\njoin m_client c on c.office_id = ounder.id\nleft join r_enum_value r on r.enum_name = \'status_enum\' and r.enum_id = c.status_enum\nwhere o.id = ${officeId}\norder by ounder.hierarchy, c.account_no', 'Individual Client Report\r\n\r\nLists the small number of defined fields on the client table.  Would expect to copy this \n\nreport and add any \'one to one\' additional data for specific tenant needs.\r\n\r\nCan be run for any size MFI but you\'d expect it only to be run within a branch for \n\nlarger ones.  Depending on how many columns are displayed, there is probably is a limit of about 20/50k clients returned for html display (export to excel doesn\'t \n\nhave that client browser/memory impact).', 1, 1),
@@ -6347,7 +6347,7 @@ INSERT INTO `stretchy_report` (`id`, `report_name`, `report_type`, `report_subty
 /*!40000 ALTER TABLE `stretchy_report` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.stretchy_report_parameter
+-- Dumping structure for table fineract_default.stretchy_report_parameter
 DROP TABLE IF EXISTS `stretchy_report_parameter`;
 CREATE TABLE IF NOT EXISTS `stretchy_report_parameter` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -6362,7 +6362,7 @@ CREATE TABLE IF NOT EXISTS `stretchy_report_parameter` (
   CONSTRAINT `fk_report_parameter_002` FOREIGN KEY (`parameter_id`) REFERENCES `stretchy_parameter` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=522 DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.stretchy_report_parameter: ~415 rows (approximately)
+-- Dumping data for table fineract_default.stretchy_report_parameter: ~415 rows (approximately)
 /*!40000 ALTER TABLE `stretchy_report_parameter` DISABLE KEYS */;
 INSERT INTO `stretchy_report_parameter` (`id`, `report_id`, `parameter_id`, `report_parameter_name`) VALUES
 	(1, 1, 5, NULL),
@@ -6783,7 +6783,7 @@ INSERT INTO `stretchy_report_parameter` (`id`, `report_id`, `parameter_id`, `rep
 /*!40000 ALTER TABLE `stretchy_report_parameter` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.x_registered_table
+-- Dumping structure for table fineract_default.x_registered_table
 DROP TABLE IF EXISTS `x_registered_table`;
 CREATE TABLE IF NOT EXISTS `x_registered_table` (
   `registered_table_name` varchar(50) NOT NULL,
@@ -6792,12 +6792,12 @@ CREATE TABLE IF NOT EXISTS `x_registered_table` (
   PRIMARY KEY (`registered_table_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.x_registered_table: ~0 rows (approximately)
+-- Dumping data for table fineract_default.x_registered_table: ~0 rows (approximately)
 /*!40000 ALTER TABLE `x_registered_table` DISABLE KEYS */;
 /*!40000 ALTER TABLE `x_registered_table` ENABLE KEYS */;
 
 
--- Dumping structure for table mifostenant-default.x_table_column_code_mappings
+-- Dumping structure for table fineract_default.x_table_column_code_mappings
 DROP TABLE IF EXISTS `x_table_column_code_mappings`;
 CREATE TABLE IF NOT EXISTS `x_table_column_code_mappings` (
   `column_alias_name` varchar(50) NOT NULL,
@@ -6807,7 +6807,7 @@ CREATE TABLE IF NOT EXISTS `x_table_column_code_mappings` (
   CONSTRAINT `FK_x_code_id` FOREIGN KEY (`code_id`) REFERENCES `m_code` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table mifostenant-default.x_table_column_code_mappings: ~0 rows (approximately)
+-- Dumping data for table fineract_default.x_table_column_code_mappings: ~0 rows (approximately)
 /*!40000 ALTER TABLE `x_table_column_code_mappings` DISABLE KEYS */;
 /*!40000 ALTER TABLE `x_table_column_code_mappings` ENABLE KEYS */;
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;

--- a/fineract-provider/src/main/webapp/META-INF/context.xml
+++ b/fineract-provider/src/main/webapp/META-INF/context.xml
@@ -22,6 +22,6 @@
 
 
 <Context>
-	<ResourceLink name="jdbc/mifosplatform-tenants" global="jdbc/mifosplatform-tenants"
+	<ResourceLink name="jdbc/fineract_tenants" global="jdbc/fineract_tenants"
 		type="javax.sql.DataSource" />
 </Context>

--- a/fineract-provider/src/test/resources/META-INF/context.xml
+++ b/fineract-provider/src/test/resources/META-INF/context.xml
@@ -22,8 +22,8 @@
 
 
 <Context>
-	<Resource type="javax.sql.DataSource" name="jdbc/mifosplatform-tenants"
-		driverClassName="org.drizzle.jdbc.DrizzleDriver" url="jdbc:mysql:thin://localhost:3306/mifosplatform-tenants"
+	<Resource type="javax.sql.DataSource" name="jdbc/fineract_tenants"
+		driverClassName="org.drizzle.jdbc.DrizzleDriver" url="jdbc:mysql:thin://localhost:3306/fineract_tenants"
 		username="root" password="mysql" validationQuery="select 1" maxActive="10"
 		maxIdle="4" />
 </Context>


### PR DESCRIPTION
## Description
The Fineract tenants and tenant database names by default are currently mifosplatform-tenants and mifostenant-default respectively.

The Google Cloud Platform console for managed MySQL (Cloud SQL) prevents creating MySQL databases containing dashes; the UI says Database name: Needs to follow the MySQL identifier rules.

While this limitation appears to only be enforced in the Google Cloud UI (it's still possible to create databases containing '-' dashes using the gcloud CLI), the linked doc does seem to suggest to use only underscores.

To make this simpler, and comply with mySQL doc recommendation, let's change mifosplatform-tenants to fineract_tenants and mifostenant-default to fineract_default. (The change from mifosplatform to fineract is just because this seems a good opportunity to make that change, and because it's probably less and not more confusing to change the entire name, and not just a dash to and underscore.)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
