### PR TITLE
COPY only the minimal required files to build in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,22 @@
 #
 FROM openjdk:8 AS builder
 
-RUN mkdir fineract
-COPY . fineract
+# COPY . fineract is slow e.g. when using Podman instead of Docker (because it doesn't honor .dockerignore and copies all of .git/** into the container..), so let's explicitly list only what we need:
+COPY fineract-provider/src/main fineract/fineract-provider/src/main/
+COPY fineract-provider/config fineract/fineract-provider/config/
+COPY fineract-provider/gradle fineract/fineract-provider/gradle/
+COPY fineract-provider/properties fineract/fineract-provider/properties/
+COPY fineract-provider/[bd]*.gradle fineract/fineract-provider/
+COPY fineract-provider/gradle.properties fineract/fineract-provider/
+COPY fineract-provider/gradlew fineract/fineract-provider/
+COPY gradle* fineract/
+COPY settings.gradle fineract/
+COPY licenses fineract/licenses/
+COPY *LICENSE* fineract/
+COPY *NOTICE* fineract/
 
 WORKDIR fineract
+# RUN find .
 RUN ./gradlew clean -x rat -x test war
 
 # =========================================


### PR DESCRIPTION
This speeds up e.g. "podman-compose build" for me from 5m to 4m.

BEFORE:
real	5m29.884s
user	4m17.643s
sys	    2m57.567s

AFTER:
real	4m19.458s
user	3m13.815s
sys	    2m 3.095s