### PR TITLE
Fineract-725 Added Jacoco to measure current code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ This project enforces [its code conventions](fineract-provider/config/checkstyle
 We recommend that you configure your favourite Java IDE to match those conventions.  For Eclipse, you can
 File > Import > General > Preferences our [config/fineractdev-eclipse-preferences.epf](config/fineractdev-eclipse-preferences.epf).
 
+Code Coverage Reports
+============
+
+The project uses Jacoco to measure unit tests code coverage, to generate a report run the following command: 
+
+    `./gradlew clean build jacocoTestReport`
+
+Generated reports can be found in build/code-coverage directory.
 
 Version
 ============

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -26,6 +26,7 @@ project.ext.jerseyVersion = '1.17'
 buildscript {
   ext {
     openJPAVersion = '3.1.0'
+    jacocoVersion = '0.8.5'
   }
   repositories {
   	 jcenter()
@@ -66,6 +67,7 @@ apply plugin: 'openjpa'
 apply plugin: "com.github.spotbugs"
 apply plugin: 'checkstyle'
 apply plugin: 'com.github.andygoossens.gradle-modernizer-plugin'
+apply plugin: 'jacoco'
 // apply plugin: 'pmd'
 
 dependencyManagement {
@@ -155,6 +157,19 @@ openjpa {
     includes = ['**/AbstractPersistableCustom.class', '**/domain/*.class']
     enhance {
         enforcePropertyRestrictions true
+    }
+}
+
+jacoco {
+    toolVersion = jacocoVersion
+    reportsDir = file("$buildDir/reports/jacoco")
+}
+
+jacocoTestReport{
+    reports{
+        html.enabled=true
+        xml.enabled=true
+        html.destination file("${buildDir}/code-coverage")
     }
 }
 


### PR DESCRIPTION
## Description
please refer: https://issues.apache.org/jira/browse/FINERACT-725
A report like this is being generated currently:
![image](https://user-images.githubusercontent.com/42006277/77576522-5cbda300-6efb-11ea-8f8a-3980d1cebba2.png)

To generate run:  sudo ./gradlew clean build jacocoTestReport
If these changes are correct, I suggest we also add this to read me :) 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
