### PR TITLE
set fineract_tenants_* more nicely in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,11 @@ services:
     depends_on:
       - fineractmysql
     environment:
-      - JAVA_OPTS=-Dfineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants -Dfineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver -Dfineract_tenants_uid=root -Dfineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca -Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
+      - JAVA_OPTS=-Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
+      - fineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver
+      - fineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+      - fineract_tenants_uid=root
+      - fineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca 
       - FINERACT_DEFAULT_TENANTDB_HOSTNAME=fineractmysql
       - FINERACT_DEFAULT_TENANTDB_PORT=3306
       - FINERACT_DEFAULT_TENANTDB_UID=root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       - fineractmysql
     environment:
       - JAVA_OPTS=-Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
+      - DRIVERCLASS_NAME=org.drizzle.jdbc.DrizzleDriver
+      - PROTOCOL=jdbc
+      - SUB_PROTOCOL=mysql:thin
       - fineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver
       - fineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
       - fineract_tenants_uid=root


### PR DESCRIPTION
We can use environment variables instead of system properties.

We originally had to use system properties and could not use environment variables, because these used to read by Tomcat, but since the switch to Hikari in FINERACT-796 these are read by Spring Boot instead of Tomcat, so we can now use system properties.

This both "looks nicer" and is useful e.g. for FINERACT-881.