### PR TITLE
add MySQL JDBC Driver (LGPL) to Dockerfile + doc (fixes FINERACT-762)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,13 @@ COPY ./docker/server.xml /opt/bitnami/tomcat/conf
 RUN chmod 664 /opt/bitnami/tomcat/conf/server.xml
 
 WORKDIR /opt/bitnami/tomcat/lib
-# org.drizzle.jdbc.DrizzleDriver is used in docker/server.xml for jdbc/fineract_tenants DataSource
-# (But note that connections to individual tenant DBs may use another driver...)
+# org.drizzle.jdbc.DrizzleDriver is used by default for both the all tenants and demo tenant DB DataSource
 RUN wget https://repo1.maven.org/maven2/org/drizzle/jdbc/drizzle-jdbc/1.4/drizzle-jdbc-1.4.jar
+
+# https://issues.apache.org/jira/browse/LEGAL-462
+# https://issues.apache.org/jira/browse/FINERACT-762
+# We include an alternative JDBC driver (which is faster, but not allowed to be default in Apache distribution)
+# allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
+# The commented out lines in the docker-compose.yml illustrate how to do this.
+# To be sure that this instead of Drizlle is used, comment out wget above.
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,3 +55,9 @@ services:
       - FINERACT_DEFAULT_TENANTDB_PORT=3306
       - FINERACT_DEFAULT_TENANTDB_UID=root
       - FINERACT_DEFAULT_TENANTDB_PWD=skdcnwauicn2ucnaecasdsajdnizucawencascdca
+
+# https://issues.apache.org/jira/browse/FINERACT-762
+# To use an altnerative JDBC driver (which is faster, but not allowed to be default in Apache distribution)
+# replace org.drizzle.jdbc.DrizzleDriver with com.mysql.jdbc.Driver in DRIVERCLASS_NAME and fineract_tenants_driver,
+# and remove ":thin:" from PROTOCOL and fineract_tenants_url.  Note that the mysql-connector-java-*.jar is already
+# bundled in the container by the Dockerfile, but just not used by default.

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TomcatJdbcDataSourcePerTenantService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TomcatJdbcDataSourcePerTenantService.java
@@ -109,7 +109,7 @@ public class TomcatJdbcDataSourcePerTenantService implements RoutingDataSourceSe
         config.addDataSourceProperty("maintainTimeStats", "false");
 
         // https://github.com/brettwooldridge/HikariCP/wiki/JDBC-Logging#mysql-connectorj
-        config.addDataSourceProperty("logger", "com.mysql.jdbc.log.StandardLogger");
+        // TODO FINERACT-890: config.addDataSourceProperty("logger", "com.mysql.cj.log.Slf4JLogger");
         config.addDataSourceProperty("logSlowQueries", "true");
         config.addDataSourceProperty("dumpQueriesOnException", "true");
 

--- a/fineract-provider/src/main/resources/META-INF/spring/hikariDataSource.xml
+++ b/fineract-provider/src/main/resources/META-INF/spring/hikariDataSource.xml
@@ -60,7 +60,7 @@
                 <prop key="maintainTimeStats">false</prop>
 
                 <!-- https://github.com/brettwooldridge/HikariCP/wiki/JDBC-Logging#mysql-connectorj -->
-                <prop key="logger">com.mysql.jdbc.log.StandardLogger</prop>
+                <!-- TODO FINERACT-890: <prop key="logger">com.mysql.cj.log.Slf4JLogger</prop>  -->
                 <prop key="logSlowQueries">true</prop>
                 <prop key="dumpQueriesOnException">true</prop>
             </props>


### PR DESCRIPTION
Note that it is NOT enabled by default, which should be OK for the ASF.

The main point here is just to clearly document it for end-users.

I've obviously tried out what's documented, and can confirm it works.