### PR TITLE
improve ClientSavingsIntegrationTest error reporting (FINERACT-852)

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
@@ -1909,7 +1909,7 @@ public class ClientSavingsIntegrationTest {
     }
 
     @Test
-    public void testSavingsAccount_DormancyTracking() {
+    public void testSavingsAccount_DormancyTracking() throws InterruptedException {
         this.savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1973,11 +1973,7 @@ public class ClientSavingsIntegrationTest {
         }
 
         SchedulerJobHelper jobHelper = new SchedulerJobHelper(this.requestSpec, this.responseSpec);
-        try {
-            jobHelper.executeJob("Update Savings Dormant Accounts");
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        jobHelper.executeJob("Update Savings Dormant Accounts");
 
         //VERIFY WITHIN PROVIDED RANGE DOESN'T INACTIVATE
         savingsStatusHashMap = SavingsStatusChecker.getStatusOfSavings(this.requestSpec, this.responseSpec, savingsList.get(0));

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
@@ -24,6 +24,7 @@ import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Assert;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -104,12 +105,12 @@ public class SchedulerJobHelper {
         return runSchedulerJob;
     }
 
-    public void executeJob(String JobName) throws InterruptedException {
+    public void executeJob(String jobName) throws InterruptedException {
         ArrayList<HashMap> allSchedulerJobsData = getAllSchedulerJobs(this.requestSpec, this.responseSpec);
         Assert.assertNotNull(allSchedulerJobsData);
 
         for (Integer jobIndex = 0; jobIndex < allSchedulerJobsData.size(); jobIndex++) {
-            if (allSchedulerJobsData.get(jobIndex).get("displayName").equals(JobName)) {
+            if (allSchedulerJobsData.get(jobIndex).get("displayName").equals(jobName)) {
                 Integer jobId = (Integer) allSchedulerJobsData.get(jobIndex).get("jobId");
 
                 // Executing Scheduler Job
@@ -127,7 +128,9 @@ public class SchedulerJobHelper {
                     System.out.println("Job is Still Running");
                 }
 
-                ArrayList<HashMap> jobHistoryData = getSchedulerJobHistory(this.requestSpec, this.responseSpec, jobId.toString());
+                List<HashMap> jobHistoryData = getSchedulerJobHistory(this.requestSpec, this.responseSpec, jobId.toString());
+
+                Assert.assertFalse("Job History is empty :(  Was it too slow? Failures in background job?", jobHistoryData.isEmpty());
 
                 // print error associated with recent job failure (if any)
                 System.out.println("Job run error message (printed only if the job fails: "


### PR DESCRIPTION
Adds a new assertion for a hopefully clearer failure message than the
confusing low-level technical ArrayIndexOutOfBoundsException we
regularly hit on Travis CI.

Similar to https://github.com/apache/fineract/pull/764