### PR TITLE
FINERACT-902 EagerFetchMode_SubclassFetchMode in persistence.xml

### DIFF
--- a/fineract-provider/src/main/resources/META-INF/persistence.xml
+++ b/fineract-provider/src/main/resources/META-INF/persistence.xml
@@ -28,6 +28,8 @@
 	<persistence-unit name="jpa-pu" transaction-type="RESOURCE_LOCAL">
 		<provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
 	<properties>
+        <property name="openjpa.jdbc.EagerFetchMode" value="none"/>
+        <property name="openjpa.jdbc.SubclassFetchMode" value="none"/>
         <property name="openjpa.Compatibility" value="QuotedNumbersInQueries=true"/>
         <property name="openjpa.jdbc.DBDictionary" value="org.apache.fineract.infrastructure.core.domain.MySQLDictionaryCustom"/>
         <!--<property name="openjpa.InverseManager" value="true(Action=warn)"/> -->


### PR DESCRIPTION
## Description
This PR is created for future reference and also addressing comment by @vorburger in PR: https://github.com/apache/fineract/pull/738.
The changes were made in the persistence.xml file to resolve the error saying "MySQL can only use 61 tables in a join hibernate".

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://jira.apache.org/jira/browse/FINERACT-902

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
