### PR TITLE
change community-app port in docker compose from 80 to 9090 (FINERACT-845)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ Now to run a new Fineract instance you can simply:
 1. `git clone https://github.com/apache/fineract.git ; cd fineract`
 1. `docker-compose build`
 1. `docker-compose up -d`
-1. Fineract will run at https://localhost:8443/fineract-provider/ now!
-1. community-app + Fineract will run at http://localhost/?baseApiUrl=https://localhost:8443/fineract-provider/
+1. fineract (back-end) is running at https://localhost:8443/fineract-provider/
+1. wait for https://localhost:8443/fineract-provider/actuator/health to return `{"status":"UP"}`
+1. community-app (UI) is running at http://localhost:9090/?baseApiUrl=https://localhost:8443/fineract-provider&tenantIdentifier=default
+1. login using default _username_ `mifos` and _password_ `password`
 
 The [`docker-compose.yml`](docker-compose.yml) will build the `fineract` container from the source based on the [`Dockerfile`](Dockerfile).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     container_name: mifos-ui
     restart: always
     ports:
-      - 80:80
+      - 9090:80
 
 
 # https://issues.apache.org/jira/browse/FINERACT-762


### PR DESCRIPTION
This makes it much easier and more secure to use it "rootless",
e.g. with https://podman.io's podman-compose instead (Moby) Docker.

Also includes minor README improvements useful for beginners.

re. FINERACT-845