### PR TITLE
remove hard-coded versions of Spring Security OAuth2 & JMS (use BOM)

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -77,7 +77,7 @@ dependencyManagement {
     }
 
     dependencies {
-        dependency 'org.springframework.security.oauth:spring-security-oauth2:2.3.6.RELEASE'
+        dependency 'org.springframework.security.oauth:spring-security-oauth2:+'
         dependency "org.apache.openjpa:openjpa:3.1.1" // when upgrading, also change OpenJPA version repeated above in buildscript!
         dependency 'com.squareup.retrofit:retrofit:1.6.1'
         dependency 'com.squareup.okhttp:okhttp:2.0.0'
@@ -100,7 +100,7 @@ dependencyManagement {
         dependency 'org.apache.tika:tika-core:1.9'
         dependency 'org.apache.httpcomponents:httpclient:+'
         dependency 'io.swagger:swagger-jersey-jaxrs:1.5.15'
-        dependency 'org.springframework:spring-jms:4.0.7.RELEASE'
+        dependency 'org.springframework:spring-jms:+'
         dependency 'org.apache.activemq:activemq-broker:+'
         dependency 'javax.validation:validation-api:+'
         dependency 'org.apache.bval:org.apache.bval.bundle:2.0.2'


### PR DESCRIPTION
**TODO** `./gradlew tomcatRunWAR` fails due to `Caused by: java.lang.ClassNotFoundException: javax.jms.JMSContext` ...