### PR TITLE
add new testNumberOfJobs() to SchedulerJobsTest (re. FINERACT-922)

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
@@ -28,6 +28,7 @@ import io.restassured.specification.RequestSpecification;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import org.apache.fineract.infrastructure.jobs.service.JobName;
 import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.Before;
@@ -72,6 +73,12 @@ public class SchedulerJobsTest {
             // Verifying Status of the Scheduler after starting
             assertEquals("Verifying Scheduler Job Status", true, schedulerStatus);
         }
+    }
+
+    @Test
+    public void testNumberOfJobs() {
+        List<Integer> jobIds = schedulerJobHelper.getAllSchedulerJobIds();
+        assertEquals("Number of jobs in database and code do not match: " + jobIds, JobName.values().length, jobIds.size());
     }
 
     @Test

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobName.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobName.java
@@ -47,7 +47,6 @@ public enum JobName {
     SEND_MESSAGES_TO_SMS_GATEWAY("Send Messages to SMS Gateway"),
     GET_DELIVERY_REPORTS_FROM_SMS_GATEWAY("Get Delivery Reports from SMS Gateway"),
     GENERATE_ADHOCCLIENT_SCEHDULE("Generate AdhocClient Schedule"),
-    SEND_MESSAGES_TO_EMAIL_GATEWAY("Send messages to Email gateway"),
     UPDATE_EMAIL_OUTBOUND_WITH_CAMPAIGN_MESSAGE("Update Email Outbound with campaign message"),
     EXECUTE_EMAIL("Execute Email"),
     UPDATE_TRAIL_BALANCE_DETAILS("Update Trial Balance Details");


### PR DESCRIPTION
This will catch problems such as the integration tests running "too early" (before Flyway has fully initialized the database), which I have a suspicion could be one of (many) causes of the unstable scheduler tests, notably because of the IllegalArgumentException at SchedulerJobsTest.java:90 in #817.

see FINERACT-922 and FINERACT-952 re. removed JobName