### PR TITLE
FINERACT-930 re-use excel styles so that the 4k row limit isn't excee…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
@@ -222,10 +222,26 @@ public class ImportHandlerUtils {
     }
 
     public static CellStyle getCellStyle(Workbook workbook, IndexedColors color) {
+        CellReference cellReference = new CellReference("A1");
+        Sheet predefined = workbook.getSheet(color.toString());
+        // if we have already defined this style, return it and don't create another one
+        if (predefined != null) {
+            Row row = predefined.getRow(cellReference.getRow());
+            Cell cell = row.getCell(cellReference.getCol());
+            return cell.getCellStyle();
+        }
         CellStyle style = workbook.createCellStyle();
         style.setFillForegroundColor(color.getIndex());
         style.setFillPattern(CellStyle.SOLID_FOREGROUND);
+
+        Sheet cache = workbook.createSheet(color.toString());
+        workbook.setSheetHidden(workbook.getSheetIndex(cache), HSSFWorkbook.SHEET_STATE_VERY_HIDDEN);
+        Row row = cache.createRow(cellReference.getRow());
+        Cell cell = row.createCell(cellReference.getCol());
+        cell.setCellStyle(style);
+
         return style;
+
     }
 
     public static String getDefaultUserMessages(List<ApiParameterError> ApiParameterErrorList){

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
@@ -27,6 +27,8 @@ import org.apache.fineract.infrastructure.core.exception.AbstractPlatformService
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.hssf.util.CellReference;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellValue;


### PR DESCRIPTION
## Description
When doing a bulk import that contains more than 4000 entries, the import stalls and doesn't complete. Excel doesn't support more than 4000 styles in a work book yet the current code creates a new style every time we mark a record in the output report as successful or failed. Only two styles are actually needed.

This proposes that the styles are stored in extra [hidden] sheets and referenced when requesting for a new style. If the style already exists, use that instead of generating a new one.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
