### PR TITLE
add keystore.jks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 .idea
 gradle
 catalina.base_IS_UNDEFINED/
+keystore.jks


### PR DESCRIPTION
This file is created by the Tomcat embedded by Spring Boot
when running "java -jar build/libs/fineract-provider.jar",
having it on .gitignore avoids anyone commiting it by mistake.