### PR TITLE
FINERACT-938: Upgrading nekohtml and removing direct reference to Xerces

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -112,10 +112,11 @@ dependencyManagement {
         dependency 'org.mockito:mockito-core:+'
         dependency 'org.slf4j:slf4j-simple:1.8.0-beta4'
         dependency 'org.slf4j:slf4j-api:1.8.0-beta4'
-        dependency 'com.mockrunner:mockrunner-jms:2.0.1'
-	dependency 'dom4j:dom4j:1.6.1'
-        dependency 'xerces:xercesImpl:2.12.0'
+        dependency 'com.mockrunner:mockrunner-jms:2.0.4'
         dependency 'io.github.classgraph:classgraph:4.8.43'
+        dependency 'org.dom4j:dom4j:2.1.0'
+        dependency 'nekohtml:nekohtml:1.9.6.2'
+
 
         dependencySet(group: 'com.sun.jersey', version: jerseyVersion) {
             entry 'jersey-core'

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -83,7 +83,6 @@ dependencies {
             'org.apache.poi:poi',
             'org.apache.poi:poi-ooxml',
             'org.apache.poi:poi-ooxml-schemas',
-            'dom4j:dom4j',
 
             'com.lowagie:itext',
 
@@ -100,7 +99,10 @@ dependencies {
             'org.apache.bval:org.apache.bval.bundle',
 
              // JAX-B dependencies for JDK 9+
-             "jakarta.xml.bind:jakarta.xml.bind-api"
+             "jakarta.xml.bind:jakarta.xml.bind-api",
+             "org.dom4j:dom4j"
+
+
     )
     implementation ('io.swagger:swagger-jersey-jaxrs') {
 		exclude group: 'javax.validation'
@@ -110,7 +112,6 @@ dependencies {
     }
 
     testCompile 'junit:junit',
-            'xerces:xercesImpl',
             'org.mockito:mockito-core',
             'io.github.classgraph:classgraph',
             'com.google.code.gson:gson',


### PR DESCRIPTION
## Description
Version of nekohtml pulled in by Mockrunner uses an old version of Xerces, leading to problems with JDK11. This was first fixed by explicitly pulling in a new version of Xerces. However, this pull request fixes it by upgrading nekohtml to a newer version instead. Also upgrading dom4j to the newest version. 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
