### PR TITLE
clean up dependencies.gradle and clarify scopes

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -495,7 +495,7 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testCompile
+    integrationTestCompile.extendsFrom testImplementation
     integrationTestRuntime.extendsFrom testRuntime
 }
 

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -21,47 +21,20 @@ dependencies {
 
     spotbugsPlugins "jp.skypencil.findbugs.slf4j:bug-pattern:1.4.2@jar"
 
-    compile ('org.springframework.boot:spring-boot-starter-data-jpa') {
-		exclude group: 'org.hibernate'
-    }
+	// Never use "compile" scope, but make all dependencies either 'implementation', 'runtimeOnly' or 'testCompile'.
+	// Note that we never use 'api', because Fineract at least currently is a simple monolithic application ("WAR"), not a library.
+	// We also (normally should have) no need to ever use 'compileOnly'.
 
-    compile ('com.amazonaws:aws-java-sdk-s3') {
-                exclude group: 'commons-logging'
-    }
-
-    compile ('org.mnode.ical4j:ical4j') {
-                exclude group: 'commons-logging'
-    }
-
-    api(
-            'com.google.code.gson:gson',
-            'org.springframework:spring-jms',
-            'joda-time:joda-time',
-            'com.google.guava:guava',
-            'org.springframework:spring-context-support',
-            'org.springframework.security.oauth:spring-security-oauth2',
-            'com.sun.jersey:jersey-core',
-            'com.squareup.retrofit:retrofit',
-            'jakarta.jms:jakarta.jms-api',
-            'jakarta.management.j2ee:jakarta.management.j2ee-api'
-    )
-
-	api ('org.apache.openjpa:openjpa') {
-		exclude group: 'org.eclipse.persistence'
-		exclude group: 'org.apache.geronimo.specs'
-	}
-
-    api('org.quartz-scheduler:quartz') {
-        exclude group: 'com.zaxxer', module: 'HikariCP-java7'
-    }
-
+	// implementation dependencies are directly used (compiled against) in src/main (and src/test)
+	//
     implementation(
             //'ch.vorburger.mariaDB4j:mariaDB4j:2.4.0',
 
             'org.springframework.boot:spring-boot-starter-web',
             'org.springframework.boot:spring-boot-starter-security',
-            'org.springframework.boot:spring-boot-starter-actuator',
 
+            'org.springframework:spring-jms',
+            'org.springframework:spring-context-support',
             'org.springframework.security.oauth:spring-security-oauth2',
 
             'com.sun.jersey:jersey-servlet',
@@ -70,6 +43,13 @@ dependencies {
             'com.sun.jersey.contribs:jersey-spring',
             'com.sun.jersey.contribs:jersey-multipart',
 
+            'joda-time:joda-time',
+            'com.google.guava:guava',
+            'com.google.code.gson:gson',
+            'com.sun.jersey:jersey-core',
+            'com.squareup.retrofit:retrofit',
+            'jakarta.jms:jakarta.jms-api',
+            'jakarta.management.j2ee:jakarta.management.j2ee-api',
 
             'com.squareup.okhttp:okhttp',
             'com.squareup.okhttp:okhttp-urlconnection',
@@ -77,32 +57,22 @@ dependencies {
             'org.apache.commons:commons-email',
             'org.apache.commons:commons-lang3',
             'org.apache.commons:commons-io',
-
-            'org.drizzle.jdbc:drizzle-jdbc',
-
             'org.apache.poi:poi',
             'org.apache.poi:poi-ooxml',
             'org.apache.poi:poi-ooxml-schemas',
+            'org.apache.tika:tika-core',
 
-            'com.lowagie:itext',
-
+            'org.drizzle.jdbc:drizzle-jdbc',
             'com.googlecode.flyway:flyway-core',
 
             'net.sf.ehcache:ehcache',
+            'com.lowagie:itext',
             'com.github.spullara.mustache.java:compiler',
             'com.jayway.jsonpath:json-path',
-            'org.apache.tika:tika-core',
-            // Although fineract (at the time of writing) doesn't have any compile time dep. on this,
-            // it's useful to have this for the Spring Boot TestRestTemplate http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-rest-templates-test-utility
-            'org.apache.httpcomponents:httpclient',
-
-            'org.apache.bval:org.apache.bval.bundle',
 
              // JAX-B dependencies for JDK 9+
              "jakarta.xml.bind:jakarta.xml.bind-api",
              "org.dom4j:dom4j"
-
-
     )
     implementation ('io.swagger:swagger-jersey-jaxrs') {
 		exclude group: 'javax.validation'
@@ -110,30 +80,49 @@ dependencies {
     implementation ('org.apache.activemq:activemq-broker') {
     	exclude group: 'org.apache.geronimo.specs'
     }
+    implementation ('org.springframework.boot:spring-boot-starter-data-jpa') {
+		exclude group: 'org.hibernate'
+    }
+	implementation ('org.apache.openjpa:openjpa') {
+		exclude group: 'org.eclipse.persistence'
+		exclude group: 'org.apache.geronimo.specs'
+	}
+    implementation ('org.quartz-scheduler:quartz') {
+        exclude group: 'com.zaxxer', module: 'HikariCP-java7'
+    }
+    implementation ('com.amazonaws:aws-java-sdk-s3') {
+		exclude group: 'commons-logging'
+    }
+    implementation ('org.mnode.ical4j:ical4j') {
+		exclude group: 'commons-logging'
+    }
 
-    testCompile 'junit:junit',
+	// runtimeOnly dependencies are things that Fineract code has no direct compile time dependency on, but which must be present at run-time
+	runtimeOnly(
+            'org.apache.bval:org.apache.bval.bundle',
+            'org.springframework.boot:spring-boot-starter-actuator',
+
+            // Although fineract (at the time of writing) doesn't have any compile time dep. on httpclient,
+            // it's useful to have this for the Spring Boot TestRestTemplate http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-rest-templates-test-utility
+            'org.apache.httpcomponents:httpclient',
+	)
+
+	// testCompile dependencies are ONLY used in src/test and/or src/integrationTest, not src/main.
+	// Do NOT repeat dependencies which are ALREADY in implementation or runtimeOnly!
+	//
+    testImplementation( 'junit:junit',
     		'org.junit.platform:junit-platform-runner', // FINERACT-943
             'org.mockito:mockito-core',
             'io.github.classgraph:classgraph',
-            'com.google.code.gson:gson',
-            'org.springframework:spring-jms',
-            'joda-time:joda-time',
-            'com.google.guava:guava',
-            'org.apache.poi:poi-ooxml',
-            'org.springframework:spring-context-support',
-            'com.sun.jersey:jersey-core'
-
-    testCompile ('io.rest-assured:rest-assured') {
+	)
+    testImplementation ('io.rest-assured:rest-assured') {
         exclude group: 'commons-logging'
         exclude group: 'org.apache.sling'
     }
-    testCompile ('com.mockrunner:mockrunner-jms') {
+    testImplementation ('com.mockrunner:mockrunner-jms') {
         exclude group: 'regexp'
     }
-    testCompile ('org.springframework.boot:spring-boot-starter-test') {
+    testImplementation ('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'com.jayway.jsonpath', module: 'json-path'
-    }
-    testCompile ('org.mnode.ical4j:ical4j') {
-        exclude group: 'commons-logging'
     }
 }


### PR DESCRIPTION
All of those are ALSO api and/or implementation, so there's no need to
duplicate them in testCompile.

Also adds a new comment inline hopefully clarifying this for future
users.