### PR TITLE
improve SchedulerJobsTest.testDateFormat() by introducing Awaitility

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -114,7 +114,7 @@ dependencyManagement {
         dependency 'io.github.classgraph:classgraph:4.8.43'
         dependency 'org.dom4j:dom4j:2.1.0'
         dependency 'nekohtml:nekohtml:1.9.6.2'
-
+		dependency 'org.awaitility:awaitility:4.0.2'
 
         dependencySet(group: 'com.sun.jersey', version: jerseyVersion) {
             entry 'jersey-core'

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -78,7 +78,7 @@ dependencies {
 		exclude group: 'javax.validation'
     }
     implementation ('org.apache.activemq:activemq-broker') {
-    	exclude group: 'org.apache.geronimo.specs'
+        exclude group: 'org.apache.geronimo.specs'
     }
     implementation ('org.springframework.boot:spring-boot-starter-data-jpa') {
 		exclude group: 'org.hibernate'
@@ -111,9 +111,10 @@ dependencies {
 	// Do NOT repeat dependencies which are ALREADY in implementation or runtimeOnly!
 	//
     testImplementation( 'junit:junit',
-    		'org.junit.platform:junit-platform-runner', // FINERACT-943
+            'org.junit.platform:junit-platform-runner', // FINERACT-943
             'org.mockito:mockito-core',
             'io.github.classgraph:classgraph',
+            'org.awaitility:awaitility'
 	)
     testImplementation ('io.rest-assured:rest-assured') {
         exclude group: 'commons-logging'

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
@@ -67,6 +67,7 @@ public class SchedulerJobHelper {
         final String GET_SCHEDULER_JOB_BY_ID_URL = "/fineract-provider/api/v1/jobs/" + jobId + "?" + Utils.TENANT_IDENTIFIER;
         System.out.println("------------------------ RETRIEVING SCHEDULER JOB BY ID -------------------------");
         final Map<String, Object> response = Utils.performServerGet(requestSpec, response200Spec, GET_SCHEDULER_JOB_BY_ID_URL, "");
+        System.out.println(response);
         assertNotNull(response);
         return response;
     }
@@ -78,7 +79,8 @@ public class SchedulerJobHelper {
         return (Boolean) response.get("active");
     }
 
-    public void updateSchedulerStatus(final String command) {
+    public void updateSchedulerStatus(final boolean on) {
+        String command = on ? "start" : "stop";
         final String UPDATE_SCHEDULER_STATUS_URL = "/fineract-provider/api/v1/scheduler?command=" + command + "&" + Utils.TENANT_IDENTIFIER;
         System.out.println("------------------------ UPDATING SCHEDULER STATUS -------------------------");
         Utils.performServerPost(requestSpec, response202Spec, UPDATE_SCHEDULER_STATUS_URL, runSchedulerJobAsJSON(), null);


### PR DESCRIPTION
This recently introduced new test (FINERACT-926) would locally pass, but
then fail on the next run, because another test in the same class would
modify job state to be inactive.  It now sets the first jobs state as it
requires it to be, and properly awaits the expected outcome.

Related to FINERACT-922.