### PR TITLE
FINERACT-951: Upgrading Travis distro and MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 #
 
 # https://issues.apache.org/jira/browse/FINERACT-763
-dist: trusty
+dist: bionic
 
 language: java
 
@@ -35,7 +35,7 @@ addons:
     - httpie
 
 before_install:
-  - echo "USE mysql;\nUPDATE user SET password=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
+  - echo "USE mysql;\nALTER USER 'root'@'localhost' IDENTIFIED BY 'mysql';\n" | mysql -u root
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_tenants`;'
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_default`;'
 # Hardcoding the time zone is a temporary fix for https://issues.apache.org/jira/browse/FINERACT-723

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ If you are interested in contributing to this project, but perhaps don't quite k
 Requirements
 ============
 * Java >= 11 (OpenJDK JVM is tested by our CI on Travis)
-* MySQL 5.5
+* MySQL 5.7
 
 You can run the required version of the database server in a container, instead of having to install it, like this:
 
-    docker run --name mysql-5.5 -p 3306:3306 -e MYSQL_ROOT_PASSWORD=mysql -d mysql:5.5
+    docker run --name mysql-5.7 -p 3306:3306 -e MYSQL_ROOT_PASSWORD=mysql -d mysql:5.7
 
 and stop and destroy it like this:
 
-    docker rm -f mysql-5.5
+    docker rm -f mysql-5.7
 
 Beware that this database container database keeps its state inside the container and not on the host filesystem.  It is lost when you destroy (rm) this container.  This is typically fine for development.  See [Caveats: Where to Store Data on the database container documentation](https://hub.docker.com/_/mysql) re. how to make it persistent instead of ephemeral.
 


### PR DESCRIPTION
FINERACT-951

## Description
Upgraded Travis distro to latest available. Changed MySQL password setting script to be compatible with MySQL 5.7.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at https://github.com/apache/fineract/blob/develop/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
