### PR TITLE
make javac fail, not just warn, for (Xlint) unchecked (FINERACT-959)

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -284,7 +284,7 @@ configurations {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << '-Xlint:unchecked'
+    options.compilerArgs += ["-Xlint:unchecked", "-Werror"] // TODO FINERACT-959 (gradually) enable -Xlint:all (see "javac -help -X")
     options.deprecation = true
 }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
@@ -108,7 +108,7 @@ public class SchedulerJobsTest {
             Map<String, Object> schedulerJob = schedulerJobHelper.getSchedulerJobById(jobId);
 
             // Executing Scheduler Job
-            schedulerJobHelper.runSchedulerJob(requestSpec, jobId.toString());
+            SchedulerJobHelper.runSchedulerJob(requestSpec, jobId.toString());
 
             // Retrieving Scheduler Job by ID
             schedulerJob = schedulerJobHelper.getSchedulerJobById(jobId);
@@ -121,6 +121,7 @@ public class SchedulerJobsTest {
                 assertNotNull(schedulerJob);
                 System.out.println("Job " + jobId +" is Still Running");
             }
+            @SuppressWarnings({ "unchecked", "rawtypes" })
             List<Map> jobHistoryData = schedulerJobHelper.getSchedulerJobHistory(jobId);
 
             // Verifying the Status of the Recently executed Scheduler Job


### PR DESCRIPTION
This is just a first step - we should aim for -Xlint:all! ;)

see FINERACT-959