### PR TITLE
FINERACT-830: Configuring Dockerfile to use Google Distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,31 +17,30 @@
 #
 FROM openjdk:11 AS builder
 
-COPY . fineract
-WORKDIR fineract
-RUN ./gradlew --no-daemon -x rat -x test war
-
-# =========================================
-
-FROM bitnami/tomcat:9.0 as fineract
-
-USER root
 RUN apt-get update -qq && apt-get install -y wget
 
-COPY --from=builder /fineract/build/libs/fineract-provider.war /opt/bitnami/tomcat/webapps
+COPY . fineract
+WORKDIR /fineract
 
-RUN keytool -genkey -keyalg RSA -alias tomcat -keystore /opt/bitnami/tomcat/tomcat.keystore -keypass xyz123 -storepass xyz123 -noprompt -dname "CN=Fineract, OU=Fineract, O=Fineract, L=Unknown, ST=Unknown, C=Unknown"
-COPY ./docker/server.xml /opt/bitnami/tomcat/conf
-RUN chmod 664 /opt/bitnami/tomcat/conf/server.xml
+RUN ./gradlew --no-daemon -x rat -x test bootJar
 
-WORKDIR /opt/bitnami/tomcat/lib
-# org.drizzle.jdbc.DrizzleDriver is used by default for both the all tenants and demo tenant DB DataSource
-RUN wget https://repo1.maven.org/maven2/org/drizzle/jdbc/drizzle-jdbc/1.4/drizzle-jdbc-1.4.jar
+WORKDIR /fineract/target
+RUN jar -xf /fineract/build/libs/fineract-provider.jar
 
 # https://issues.apache.org/jira/browse/LEGAL-462
 # https://issues.apache.org/jira/browse/FINERACT-762
 # We include an alternative JDBC driver (which is faster, but not allowed to be default in Apache distribution)
 # allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
 # The commented out lines in the docker-compose.yml illustrate how to do this.
-# To be sure that this instead of Drizlle is used, comment out wget above.
-RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar
+WORKDIR /fineract/target/BOOT-INF/lib
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.20/mysql-connector-java-8.0.20.jar 
+
+# =========================================
+
+FROM gcr.io/distroless/java:11 as fineract
+
+COPY --from=builder /fineract/target/BOOT-INF/lib /app/lib
+COPY --from=builder /fineract/target/META-INF /app/META-INF
+COPY --from=builder /fineract/target/BOOT-INF/classes /app
+
+ENTRYPOINT ["java", "-cp", "app:app/lib/*", "org.apache.fineract.ServerApplication"]


### PR DESCRIPTION
Using Google Distroless with OpenJDK 11 as base image for Fineract Docker build

FINERACT-830