### PR TITLE
FINERACT-972: Ensure Tomcat is started after compiling integration tests

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -467,6 +467,8 @@ cargo {
 
 cargoRunLocal.dependsOn bootWar
 cargoStartLocal.dependsOn bootWar
+cargoStartLocal.mustRunAfter "integrationTestClasses"
+cargoStartLocal.mustRunAfter "enhance"
 
 /* http://stackoverflow.com/questions/19653311/jpa-repository-works-in-idea-and-production-but-not-in-gradle */
 sourceSets.main.output.resourcesDir = sourceSets.main.java.outputDir


### PR DESCRIPTION
## Description
Tomcat was being started before compiling integration tests, meaning that if the integration test compilation failed then it was left running. After adding the dependencies, it now is started only after successful compilation of integration tests. 

FINERACT-972