### PR TITLE
add new Dependency Upgrades section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,15 @@ them in different commits. This helps review to review your code faster.
 
 We have an automated Bot which marks pull requests as "stale" after a while, and ultimately automatically closes them.
 
+Dependency Upgrades
+-------------------
+
+This project uses a number of 3rd-party libraries, and this section provides some guidance for their updates. We have set-up [Renovate's bot](https://renovate.whitesourcesoftware.com) to automatically raise Pull Requests for our review when new dependencies are available [FINERACT-962](https://issues.apache.org/jira/browse/FINERACT-962).
+
+Upgrades sometimes require package name changes.  Changed code should ideally have test coverage.
+
+Our `ClasspathHellDuplicatesCheckRuleTest` detects classes that appear in more than 1 JAR.  If a version bump in [`build.gradle`](https://github.com/search?q=repo%3Aapache%2Ffineract+filename%3Abuild.gradle&type=Code&ref=advsearch&l=&l=) causes changes in transitives dependencies, then you may have to add related `exclude` to our [`dependencies.gradle`](https://github.com/apache/fineract/search?q=dependencies.gradle).  Running `./gradlew dependencies` helps to understand what is required.
+
 
 Releasing
 ---------


### PR DESCRIPTION
motivated by wanting to clarify for @nnatarajan how #907 can be tackled.

@ptuomola @xurror @awasum @thesmallstar do you think there is any way to write this more helpfully?

related to FINERACT-963 and for (future, not yet activated) FINERACT-962