### PR TITLE
improve ClasspathHellDuplicatesCheckRuleTest (req. by FINERACT-953)

### DIFF
--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/classdupes/ClasspathHellDuplicatesChecker.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/classdupes/ClasspathHellDuplicatesChecker.java
@@ -129,7 +129,7 @@ public class ClasspathHellDuplicatesChecker {
                 || resourcePath.startsWith("META-INF/additional-spring")
                 || resourcePath.startsWith("META-INF/terracotta")
                 // Groovy is groovy
-                || resourcePath.startsWith("META-INF/groovy-release-info.properties")
+                || resourcePath.startsWith("META-INF/groovy")
                 // Something doesn't to be a perfectly clean in Maven Surefire:
                 || resourcePath.startsWith("META-INF/maven/")
                 || resourcePath.contains("surefire")


### PR DESCRIPTION
to ignore all `META-INF/groovy**` such as `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule` which is part of both `groovy-xml-3.0.3.jar` as well as e.g. `ical4j-3.0.18.jar`.

Required by FINERACT-953.