### PR TITLE
remove direct explicit Guava dependency (FINERACT-963)

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -45,9 +45,6 @@ buildscript {
         classpath 'com.radcortez.gradle:openjpa-gradle-plugin:3.1.0'
         classpath 'gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.3.1'
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.8"
-        // Use Guava version 23+ as a workaround to spotbug intergration.
-        // See: https://github.com/spotbugs/spotbugs-gradle-plugin/issues/128#issuecomment-535864882
-        classpath 'com.google.guava:guava:28.1-jre'
         classpath "gradle.plugin.com.github.andygoossens:gradle-modernizer-plugin:1.3.0"
         classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.2"
     }
@@ -87,7 +84,6 @@ dependencyManagement {
         dependency 'com.squareup.okhttp:okhttp:2.0.0'
         dependency 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
         dependency 'com.google.code.gson:gson:+'
-        dependency 'com.google.guava:guava:28.1-jre'
         dependency 'org.apache.commons:commons-email:1.5'
         dependency 'org.apache.commons:commons-io:+'
         dependency 'org.drizzle.jdbc:drizzle-jdbc:1.4'

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -44,7 +44,6 @@ dependencies {
             'com.sun.jersey.contribs:jersey-multipart',
 
             'joda-time:joda-time',
-            'com.google.guava:guava',
             'com.google.code.gson:gson',
             'com.sun.jersey:jersey-core',
             'com.squareup.retrofit:retrofit',


### PR DESCRIPTION
We *ARE* using Guava, but, unless we have a real need for a more recent
specific version, it seems "safer" (and less hassle to maintain bumping)
just using whatever version we transitively inherit from other libraries
we use that themselves depend on Guava (currently Swagger, Mustache and
activemq-broker).

Currently that "whatever version" is a 28.2 (we used 28.1 before).

This removes two fairly different kinds of Guava dependencies we have:
One for run-time (above), and one for build time which seems to have
been added due to some SpotBugs related issue (but it now works without
that, so that must have been some issue in SpotBugs that meanwhile go
fixed).