### PR TITLE
Remove already added checkstyle from comments

### DIFF
--- a/fineract-provider/config/checkstyle/checkstyle.xml
+++ b/fineract-provider/config/checkstyle/checkstyle.xml
@@ -120,7 +120,7 @@
             <message key="forbid.certain.imports" value="Use ''java.nio.charset.StandardCharsets'' instead of ''{0}''" />
         </module>
       
-        <module name="SuppressWarningsHolder" />
+
         <module name="OuterTypeFilename"/>
         <module name="OneTopLevelClass"/>
        


### PR DESCRIPTION
SuppressWarningsHolder was added in #906 removing it from comments to keep a track of pending tasks :) 