### PR TITLE
FINERACT-1008-flyway-migration-fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TenantDatabaseUpgradeService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TenantDatabaseUpgradeService.java
@@ -33,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Service;
 
 /**
@@ -75,6 +77,9 @@ public class TenantDatabaseUpgradeService {
                                 "flyway.table", "schema_version")) // FINERACT-979
                         .load();
 
+                //Should be removed later when all instances are stabilized :FINERACT-1008
+                repairFlywayVersionSkip(flyway.getConfiguration().getDataSource());
+
                 try {
                     flyway.repair();
                     flyway.migrate();
@@ -98,6 +103,8 @@ public class TenantDatabaseUpgradeService {
         String dbPwd = getEnvVar("FINERACT_DEFAULT_TENANTDB_PWD", "mysql");
         LOG.info("upgradeTenantDB: FINERACT_DEFAULT_TENANTDB_HOSTNAME = {}, FINERACT_DEFAULT_TENANTDB_PORT = {}", dbHostname, dbPort);
 
+
+
         final Flyway flyway = Flyway.configure()
                 .dataSource(tenantDataSource)
                 .locations("sql/migrations/list_db")
@@ -111,9 +118,14 @@ public class TenantDatabaseUpgradeService {
                         "flyway.table", "schema_version")) // FINERACT-979
                 .load();
 
+        //Should be removed later when all instances are stabilized :FINERACT-1008
+        repairFlywayVersionSkip(flyway.getConfiguration().getDataSource());
+
         flyway.repair();
         flyway.migrate();
     }
+
+
 
     private String getEnvVar(String name, String defaultValue) {
         String value = System.getenv(name);
@@ -121,5 +133,42 @@ public class TenantDatabaseUpgradeService {
             return defaultValue;
         }
         return value;
+    }
+
+
+    private void repairFlywayVersionSkip(DataSource source) {
+        JdbcTemplate template = new JdbcTemplate(source);
+        LOG.info("repairFlywayVersionSkip: Check whether the version table is in old format ");
+        SqlRowSet ts = template.queryForRowSet("SHOW TABLES LIKE 'schema_version';");
+        if(ts.next()){
+        SqlRowSet rs = template.queryForRowSet("SHOW  COLUMNS FROM `schema_version` LIKE 'version_rank';");
+            if(rs.next()) {
+                LOG.info("repairFlywayVersionSkip: The schema_version table is in old format, executing repair ");
+                template.execute("CREATE TABLE `schema_version_history` (  `version_rank` int(11) NOT NULL, " +
+                        " `installed_rank` int(11) NOT NULL,  `version` varchar(50) NOT NULL,  `description` varchar(200) NOT NULL,  " +
+                        "`type` varchar(20) NOT NULL,  `script` varchar(1000) NOT NULL,  `checksum` int(11) DEFAULT NULL, " +
+                        " `installed_by` varchar(100) NOT NULL,  `installed_on` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
+                        " `execution_time` int(11) NOT NULL,  `success` tinyint(1) NOT NULL,  PRIMARY KEY (`version`), " +
+                        " KEY `schema_version_vr_idx` (`version_rank`),  KEY `schema_version_ir_idx` (`installed_rank`), " +
+                        " KEY `schema_version_s_idx` (`success`));");
+                template.execute("INSERT INTO schema_version_history select * from schema_version;");
+                template.execute("DROP TABLE schema_version;");
+                template.execute("CREATE TABLE `schema_version` ( `installed_rank` int(11) NOT NULL, " +
+                        "  `version` varchar(50) DEFAULT NULL,   `description` varchar(200) NOT NULL,   `type` varchar(20) NOT NULL,  " +
+                        " `script` varchar(1000) NOT NULL,   `checksum` int(11) DEFAULT NULL,   `installed_by` varchar(100) NOT NULL,  " +
+                        " `installed_on` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,   `execution_time` int(11) NOT NULL, " +
+                        "  `success` tinyint(1) NOT NULL,   PRIMARY KEY (`installed_rank`),   KEY `flyway_schema_history_s_idx` (`success`) );");
+                template.execute("INSERT INTO schema_version (installed_rank, version, description, type, script, checksum, " +
+                        "installed_by, installed_on, execution_time, success) SELECT installed_rank, version, description, type, " +
+                        "script, checksum, installed_by, installed_on, execution_time, success FROM schema_version_history;");
+                template.execute("DROP TABLE schema_version_history;");
+
+                LOG.info("repairFlywayVersionSkip: The schema_version repair completed.");
+            }else{
+                LOG.info("repairFlywayVersionSkip: The schema_version table format is new, aborting repair");
+            }
+        }else{
+            LOG.info("repairFlywayVersionSkip: The schema_version table does not exist, aborting repair");
+        }
     }
 }


### PR DESCRIPTION
## Description
Fix for  FINERACT-1008 : Field 'version_rank' doesn't have a default value 

Fix added by migrating the schema_version table to the latest flyway version format manually.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
