### PR TITLE
FINERACT-933 Fixed ArrayIndexOutOfBoundsException at ClientPersonImportHandler

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/client/ClientPersonImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/client/ClientPersonImportHandler.java
@@ -105,7 +105,7 @@ public class ClientPersonImportHandler implements ImportHandler {
         Long clientTypeId = null;
         if (clientType!=null) {
             String[] clientTypeAr = clientType.split("-");
-            if (clientTypeAr[1] != null) {
+            if (clientTypeAr.length > 1 && clientTypeAr[1] != null) {
                 clientTypeId = Long.parseLong(clientTypeAr[1]);
             }
         }
@@ -113,16 +113,16 @@ public class ClientPersonImportHandler implements ImportHandler {
         Long genderId = null;
         if (gender!=null) {
             String[] genderAr = gender.split("-");
-            if (genderAr[1] != null) {
+            if (genderAr.length > 1 && genderAr[1] != null) {
                 genderId = Long.parseLong(genderAr[1]);
             }
         }
         String clientClassification= ImportHandlerUtils.readAsString(ClientPersonConstants.CLIENT_CLASSIFICATION_COL, row);
-        Long clientClassicationId = null;
+        Long clientClassificationId = null;
         if (clientClassification!=null) {
             String[] clientClassificationAr = clientClassification.split("-");
-            if (clientClassificationAr[1] != null) {
-                clientClassicationId = Long.parseLong(clientClassificationAr[1]);
+            if (clientClassificationAr.length > 1 && clientClassificationAr[1] != null) {
+                clientClassificationId = Long.parseLong(clientClassificationAr[1]);
             }
         }
         Boolean isStaff = ImportHandlerUtils.readAsBoolean(ClientPersonConstants.IS_STAFF_COL, row);
@@ -135,7 +135,7 @@ public class ClientPersonImportHandler implements ImportHandler {
             if (addressType!=null) {
                 String[] addressTypeAr = addressType.split("-");
 
-                if (addressTypeAr[1] != null) {
+                if (addressTypeAr.length > 1 && addressTypeAr[1] != null) {
                     addressTypeId = Long.parseLong(addressTypeAr[1]);
                 }
             }
@@ -150,11 +150,11 @@ public class ClientPersonImportHandler implements ImportHandler {
 
             String stateProvince=ImportHandlerUtils.readAsString(ClientPersonConstants.STATE_PROVINCE_COL, row);
             Long stateProvinceId = null;
-            if (stateProvince!=null && stateProvince.isBlank()) {
+            if (stateProvince != null) {
                 String[] stateProvinceAr = stateProvince.split("-");
                 // Arkansas-AL <-- expected format of the cell
                 // but probably it's either an empty cell or it is missing a hyphen
-                if (stateProvinceAr[1] != null) {
+                if (stateProvinceAr.length > 1 && stateProvinceAr[1] != null) {
                     stateProvinceId = Long.parseLong(stateProvinceAr[1]);
                 }
             }
@@ -162,7 +162,7 @@ public class ClientPersonImportHandler implements ImportHandler {
             Long countryId=null;
             if (country!=null) {
                 String[] countryAr = country.split("-");
-                if (countryAr[1] != null) {
+                if (countryAr.length > 1 && countryAr[1] != null) {
                     countryId = Long.parseLong(countryAr[1]);
                 }
             }
@@ -171,7 +171,7 @@ public class ClientPersonImportHandler implements ImportHandler {
              addressList = new ArrayList<AddressData>(Arrays.asList(addressDataObj));
         }
         return ClientData.importClientPersonInstance(legalFormId,row.getRowNum(),firstName,lastName,middleName,submittedOn,activationDate,active,externalId,
-                officeId, staffId, mobileNo, dob, clientTypeId, genderId, clientClassicationId, isStaff,
+                officeId, staffId, mobileNo, dob, clientTypeId, genderId, clientClassificationId, isStaff,
                 addressList, locale, dateFormat);
 
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/client/ClientPersonImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/client/ClientPersonImportHandler.java
@@ -150,8 +150,10 @@ public class ClientPersonImportHandler implements ImportHandler {
 
             String stateProvince=ImportHandlerUtils.readAsString(ClientPersonConstants.STATE_PROVINCE_COL, row);
             Long stateProvinceId = null;
-            if (stateProvince!=null) {
+            if (stateProvince!=null && stateProvince.isBlank()) {
                 String[] stateProvinceAr = stateProvince.split("-");
+                // Arkansas-AL <-- expected format of the cell
+                // but probably it's either an empty cell or it is missing a hyphen
                 if (stateProvinceAr[1] != null) {
                     stateProvinceId = Long.parseLong(stateProvinceAr[1]);
                 }


### PR DESCRIPTION
## Description
It appears that the exception may have been caused by the formatting of dashes in which the code expects a dash, but the input doesn't contain dashes or the possibility that the spreadsheet has an empty cell. If so, then there would be a similar or the same exception for the logic directly below it.

FYI -- Due to recent changes in the file, the exception moved down a few lines from 149 to 154.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
