### PR TITLE
remove line in AbstractLoanScheduleGenerator [FINERACT-977]

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractLoanScheduleGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractLoanScheduleGenerator.java
@@ -641,9 +641,8 @@ public abstract class AbstractLoanScheduleGenerator implements LoanScheduleGener
             && fixedEmiAmount != null
             && fixedEmiAmount.compareTo(loanApplicationTerms.getFixedEmiAmount()) != 0) {
             currentPeriodParams.setEmiAmountChanged(true);
-            currentPeriodParams.plusPrincipalForThisPeriod(currentPeriodParams.getEarlyPaidAmount());
           }
-            currentPeriodParams.plusPrincipalForThisPeriod(currentPeriodParams.getEarlyPaidAmount());
+          currentPeriodParams.plusPrincipalForThisPeriod(currentPeriodParams.getEarlyPaidAmount());
         }
 
         // update outstandingLoanBlance using current period


### PR DESCRIPTION
This line was wrongly added in #960 re. fix possible NPE in AbstractLoanScheduleGenerator for FINERACT-977.

This has absolutely nothing to do with FINERACT-855/FINERACT-1016 (I initially confused 2 unrelated things).