### PR TITLE
remove bad 'default:' in SavingsEnumerations switch

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsEnumerations.java
@@ -199,7 +199,6 @@ public class SavingsEnumerations {
                 optionData = new SavingsAccountTransactionEnumData(SavingsAccountTransactionType.AMOUNT_RELEASE.getValue().longValue(),
                         SavingsAccountTransactionType.AMOUNT_RELEASE.getCode(), "Release Amount");
                 break;
-            default:
         }
         return optionData;
     }


### PR DESCRIPTION
This default: is "wrong", because it's not required - the switch, in this particular case, *IS* actually already handling all cases.

But if in the future someone were to add an additional new SavingsAccountTransactionType, then we would want Error Prone to fail to signal that it needs to be handled here - but the "default:" would "hide" that.

This is a follow-up to https://github.com/apache/fineract/pull/983/ for FINERACT-822, and also related to the discussion started on https://github.com/apache/fineract/pull/989.

There originally used to be a "default:" in the middle of the switch, that obviously WAS completely wrong and an old copy-paste bug.