### PR TITLE
FINERACT-821 Added and Enforced HideUtilityClassConstructor checkstyle

### DIFF
--- a/fineract-provider/config/checkstyle/checkstyle.xml
+++ b/fineract-provider/config/checkstyle/checkstyle.xml
@@ -161,6 +161,7 @@
              <message key="ws.notPreceded"
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
+        <module name="HideUtilityClassConstructor"/>
           <module name="OneTopLevelClass"/>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
@@ -203,7 +204,6 @@
             <property name="setterCanReturnItsClass" value="true" />
         </module>
 
-        <module name="HideUtilityClassConstructor"/>
 
         < ! - - TODO Checks for Exception Handling Anti-Patterns - - >
         <module name="IllegalCatch"/>

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientStatusChecker.java
@@ -24,9 +24,13 @@ import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ClientStatusChecker {
+public final class ClientStatusChecker {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientStatusChecker.class);
+
+    private ClientStatusChecker() {
+
+    }
 
     public static void verifyClientIsActive(final HashMap<String, Object> clientStatusHashMap) {
         assertEquals(300, (int) clientStatusHashMap.get("id"));

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CalendarHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CalendarHelper.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CalendarHelper {
+public final class CalendarHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(CalendarHelper.class);
     private static final String BASE_URL = "/fineract-provider/api/v1/";
@@ -36,6 +36,10 @@ public class CalendarHelper {
     private static final String ENITY_NAME = "/calendars";
     private static final String CENTER_ENTITY = "centers/";
     private static final String EDIT_CALENDAR = "editcalendarbasedonmeetingdates/";
+
+    private CalendarHelper() {
+
+    }
 
     public static Integer createMeetingCalendarForGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer groupId, final String startDate, final String frequency, final String interval, final String repeatsOnDay) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
@@ -31,13 +31,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class CenterHelper {
+public final class CenterHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(CenterHelper.class);
     private static final String CENTERS_URL = "/fineract-provider/api/v1/centers";
 
     public static final String CREATED_DATE = "29 December 2014";
     private static final String CREATE_CENTER_URL = "/fineract-provider/api/v1/centers?" + Utils.TENANT_IDENTIFIER;
+
+    private CenterHelper() {
+
+    }
 
     public static CenterDomain retrieveByID(int id, final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
         final String GET_CENTER_BY_ID_URL = CENTERS_URL + "/" + id + "?associations=groupMembers&" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CurrenciesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CurrenciesHelper.java
@@ -28,7 +28,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({ "unused", "rawtypes", "unchecked" })
-public class CurrenciesHelper {
+public final class CurrenciesHelper {
+
+    private CurrenciesHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(CurrenciesHelper.class);
     private static final String CURRENCIES_URL = "/fineract-provider/api/v1/currencies";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ImageHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ImageHelper.java
@@ -24,7 +24,11 @@ import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ImageHelper {
+public final class ImageHelper {
+
+    private ImageHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(ImageHelper.class);
     private static final String STAFF_IMAGE_URL = "/fineract-provider/api/v1/staff/";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
@@ -23,7 +23,11 @@ import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
 
-public class PasswordPreferencesHelper {
+public final class PasswordPreferencesHelper {
+
+    private PasswordPreferencesHelper() {
+
+    }
 
     private static final String PASSWORD_PREFERENCES_URL = "/fineract-provider/api/v1/passwordpreferences";
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PaymentTypeHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PaymentTypeHelper.java
@@ -27,7 +27,11 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class PaymentTypeHelper {
+public final class PaymentTypeHelper {
+
+    private PaymentTypeHelper() {
+
+    }
 
     private static final String CREATE_PAYMENTTYPE_URL = "/fineract-provider/api/v1/paymenttypes?" + Utils.TENANT_IDENTIFIER;
     private static final String PAYMENTTYPE_URL = "/fineract-provider/api/v1/paymenttypes";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SurveyHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SurveyHelper.java
@@ -27,7 +27,11 @@ import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SurveyHelper {
+public final class SurveyHelper {
+
+    private SurveyHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(SurveyHelper.class);
     private static final String FULFIL_SURVEY_URL = "/fineract-provider/api/v1/survey/ppi_kenya_2009/clientId?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/TaxComponentHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/TaxComponentHelper.java
@@ -26,7 +26,11 @@ import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TaxComponentHelper {
+public final class TaxComponentHelper {
+
+    private TaxComponentHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(TaxComponentHelper.class);
     private static final String CREATE_TAX_COMPONENT_URL = "/fineract-provider/api/v1/taxes/component?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/TaxGroupHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/TaxGroupHelper.java
@@ -28,7 +28,11 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TaxGroupHelper {
+public final class TaxGroupHelper {
+
+    private TaxGroupHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(TaxGroupHelper.class);
     private static final String CREATE_TAX_COMPONENT_URL = "/fineract-provider/api/v1/taxes/group?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/Utils.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/Utils.java
@@ -49,7 +49,11 @@ import org.slf4j.LoggerFactory;
  * sync.
  */
 @SuppressWarnings("unchecked")
-public class Utils {
+public final class Utils {
+
+    private Utils() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/WorkingDaysHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/WorkingDaysHelper.java
@@ -26,7 +26,11 @@ import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkingDaysHelper {
+public final class WorkingDaysHelper {
+
+    private WorkingDaysHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkingDaysHelper.class);
     private static final String WORKINGDAYS_URL = "/fineract-provider/api/v1/workingdays";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/accounting/FinancialActivityAccountsMappingBuilder.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/accounting/FinancialActivityAccountsMappingBuilder.java
@@ -21,7 +21,11 @@ package org.apache.fineract.integrationtests.common.accounting;
 import com.google.gson.Gson;
 import java.util.HashMap;
 
-public class FinancialActivityAccountsMappingBuilder {
+public final class FinancialActivityAccountsMappingBuilder {
+
+    private FinancialActivityAccountsMappingBuilder() {
+
+    }
 
     public static String build(Integer financialActivityId, Integer glAccountId) {
         final HashMap<String, Object> map = new HashMap<>();

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
@@ -30,7 +30,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class ChargesHelper {
+public final class ChargesHelper {
+
+    private ChargesHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(ChargesHelper.class);
     private static final String CHARGES_URL = "/fineract-provider/api/v1/charges";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountStatusChecker.java
@@ -29,7 +29,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
-public class FixedDepositAccountStatusChecker {
+public final class FixedDepositAccountStatusChecker {
+
+    private FixedDepositAccountStatusChecker() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(FixedDepositAccountStatusChecker.class);
     private static final String FIXED_DEPOSIT_ACCOUNT_URL = "/fineract-provider/api/v1/fixeddepositaccounts";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/funds/FundsResourceHandler.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/funds/FundsResourceHandler.java
@@ -26,7 +26,11 @@ import java.util.HashMap;
 import java.util.List;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class FundsResourceHandler {
+public final class FundsResourceHandler {
+
+    private FundsResourceHandler() {
+
+    }
 
     private static final String FUNDS_URL = "/fineract-provider/api/v1/funds";
     private static final String CREATE_FUNDS_URL = FUNDS_URL + "?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/loans/LoanStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/loans/LoanStatusChecker.java
@@ -28,7 +28,11 @@ import java.util.HashMap;
 import org.apache.fineract.integrationtests.common.Utils;
 
 @SuppressWarnings("rawtypes")
-public class LoanStatusChecker {
+public final class LoanStatusChecker {
+
+    private LoanStatusChecker() {
+
+    }
 
     public static void verifyLoanIsApproved(final HashMap loanStatusHashMap) {
         assertFalse(getStatus(loanStatusHashMap, "pendingApproval"));

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/organisation/StaffHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/organisation/StaffHelper.java
@@ -29,7 +29,11 @@ import org.apache.fineract.integrationtests.common.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StaffHelper {
+public final class StaffHelper {
+
+    private StaffHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(StaffHelper.class);
     private static final String TRANSFER_STAFF_URL = "/fineract-provider/api/v1/groups";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/provisioning/ProvisioningHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/provisioning/ProvisioningHelper.java
@@ -28,7 +28,11 @@ import java.util.Random;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 
-public class ProvisioningHelper {
+public final class ProvisioningHelper {
+
+    private ProvisioningHelper() {
+
+    }
 
     public static final Map createProvisioingCriteriaJson(ArrayList<Integer> loanProducts, ArrayList categories, Account liability,
             Account expense) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/rates/RatesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/rates/RatesHelper.java
@@ -27,7 +27,11 @@ import org.apache.fineract.integrationtests.common.CommonConstants;
 import org.apache.fineract.integrationtests.common.Utils;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class RatesHelper {
+public final class RatesHelper {
+
+    private RatesHelper() {
+
+    }
 
     private static final String RATES_URL = "/fineract-provider/api/v1/rates";
     private static final String CREATE_RATES_URL = RATES_URL + "?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountStatusChecker.java
@@ -29,7 +29,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
-public class RecurringDepositAccountStatusChecker {
+public final class RecurringDepositAccountStatusChecker {
+
+    private RecurringDepositAccountStatusChecker() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(RecurringDepositAccountStatusChecker.class);
     private static final String RECURRING_DEPOSIT_ACCOUNT_URL = "/fineract-provider/api/v1/recurringdepositaccounts";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/savings/SavingsStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/savings/SavingsStatusChecker.java
@@ -28,7 +28,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
-public class SavingsStatusChecker {
+public final class SavingsStatusChecker {
+
+    private SavingsStatusChecker() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(SavingsStatusChecker.class);
     private static final String SAVINGS_ACCOUNT_URL = "/fineract-provider/api/v1/savingsaccounts";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareAccountTransactionHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareAccountTransactionHelper.java
@@ -23,7 +23,11 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.Map;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class ShareAccountTransactionHelper {
+public final class ShareAccountTransactionHelper {
+
+    private ShareAccountTransactionHelper() {
+
+    }
 
     private static final String SHARE_ACCOUNT_URL = "/fineract-provider/api/v1/accounts/share";
     private static final String CREATE_SHARE_ACCOUNT_URL = SHARE_ACCOUNT_URL + "?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareDividendsTransactionHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareDividendsTransactionHelper.java
@@ -23,7 +23,11 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.Map;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class ShareDividendsTransactionHelper {
+public final class ShareDividendsTransactionHelper {
+
+    private ShareDividendsTransactionHelper() {
+
+    }
 
     private static final String SHARE_PRODUCT_URL = "/fineract-provider/api/v1/shareproduct";
     private static final String DIVIDEND = "dividend";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareProductTransactionHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/shares/ShareProductTransactionHelper.java
@@ -23,7 +23,11 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.Map;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class ShareProductTransactionHelper {
+public final class ShareProductTransactionHelper {
+
+    private ShareProductTransactionHelper() {
+
+    }
 
     private static final String SHARE_PRODUCT_URL = "/fineract-provider/api/v1/products/share";
     private static final String CREATE_SHARE_PRODUCT_URL = SHARE_PRODUCT_URL + "?" + Utils.TENANT_IDENTIFIER;

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/system/CodeHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/system/CodeHelper.java
@@ -29,7 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class CodeHelper {
+public final class CodeHelper {
+
+    private CodeHelper() {
+
+    }
 
     public static final String CODE_ID_ATTRIBUTE_NAME = "id";
     public static final String RESPONSE_ID_ATTRIBUTE_NAME = "resourceId";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/roles/RolesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/roles/RolesHelper.java
@@ -24,7 +24,11 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
 import org.apache.fineract.integrationtests.common.Utils;
 
-public class RolesHelper {
+public final class RolesHelper {
+
+    private RolesHelper() {
+
+    }
 
     private static final String CREATE_ROLE_URL = "/fineract-provider/api/v1/roles?" + Utils.TENANT_IDENTIFIER;
     private static final String ROLE_URL = "/fineract-provider/api/v1/roles";

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/useradministration/users/UserHelper.java
@@ -26,7 +26,11 @@ import java.util.List;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.Assertions;
 
-public class UserHelper {
+public final class UserHelper {
+
+    private UserHelper() {
+
+    }
 
     private static final String CREATE_USER_URL = "/fineract-provider/api/v1/users?" + Utils.TENANT_IDENTIFIER;
     private static final String USER_URL = "/fineract-provider/api/v1/users";

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/accrual/api/AccrualAccountingConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/accrual/api/AccrualAccountingConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.accounting.accrual.api;
 
-public class AccrualAccountingConstants {
+public final class AccrualAccountingConstants {
+
+    private AccrualAccountingConstants() {
+
+    }
 
     public static final String accrueTillParamName = "tillDate";
     public static final String localeParamName = "locale";

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/common/AccountingConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/common/AccountingConstants.java
@@ -25,7 +25,11 @@ import java.util.Map;
 import org.apache.fineract.accounting.financialactivityaccount.data.FinancialActivityData;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
 
-public class AccountingConstants {
+public final class AccountingConstants {
+
+    private AccountingConstants() {
+
+    }
 
     /***
      * Accounting placeholders for cash based accounting for loan products

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/common/AccountingEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/common/AccountingEnumerations.java
@@ -26,7 +26,11 @@ import org.apache.fineract.accounting.journalentry.domain.JournalEntryType;
 import org.apache.fineract.accounting.producttoaccountmapping.domain.PortfolioProductType;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class AccountingEnumerations {
+public final class AccountingEnumerations {
+
+    private AccountingEnumerations() {
+
+    }
 
     public static EnumOptionData gLAccountType(final int id) {
         return gLAccountType(GLAccountType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/financialactivityaccount/api/FinancialActivityAccountsConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/financialactivityaccount/api/FinancialActivityAccountsConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class FinancialActivityAccountsConstants {
+public final class FinancialActivityAccountsConstants {
+
+    private FinancialActivityAccountsConstants() {
+
+    }
 
     private static final String idParamName = "id";
     private static final String factivityDataParamName = "financialActivityData";
@@ -30,6 +34,6 @@ public class FinancialActivityAccountsConstants {
     private static final String glAccountOptionsParamName = "glAccountOptions";
     private static final String financialActivityOptionsParamName = "financialActivityOptions";
     public static final String resourceNameForPermission = "FINANCIALACTIVITYACCOUNT";
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, factivityDataParamName,
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, factivityDataParamName,
             glAccountDataParamName, glAccountOptionsParamName, financialActivityOptionsParamName));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/domain/AccountNumberFormatEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/domain/AccountNumberFormatEnumerations.java
@@ -28,7 +28,11 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class AccountNumberFormatEnumerations {
+public final class AccountNumberFormatEnumerations {
+
+    private AccountNumberFormatEnumerations() {
+
+    }
 
     public static final Set<AccountNumberPrefixType> accountNumberPrefixesForClientAccounts = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(AccountNumberPrefixType.OFFICE_NAME, AccountNumberPrefixType.CLIENT_TYPE)));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/service/AccountNumberFormatConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/service/AccountNumberFormatConstants.java
@@ -20,7 +20,11 @@ package org.apache.fineract.infrastructure.accountnumberformat.service;
 
 import org.apache.fineract.infrastructure.accountnumberformat.data.AccountNumberFormatData;
 
-public class AccountNumberFormatConstants {
+public final class AccountNumberFormatConstants {
+
+    private AccountNumberFormatConstants() {
+
+    }
 
     // resource name for validation
     public static final String ENTITY_NAME = "accountNumberFormat";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/CenterConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/CenterConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class CenterConstants {
+public final class CenterConstants {
+
+    private CenterConstants() {
+
+    }
 
     // Column indices
     public static final int CENTER_NAME_COL = 0;// A

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ChartOfAcountsConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ChartOfAcountsConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class ChartOfAcountsConstants {
+public final class ChartOfAcountsConstants {
+
+    private ChartOfAcountsConstants() {
+
+    }
 
     public static final int ACCOUNT_TYPE_COL = 0;// A
     public static final int ACCOUNT_NAME_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ClientEntityConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ClientEntityConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class ClientEntityConstants {
+public final class ClientEntityConstants {
+
+    private ClientEntityConstants() {
+
+    }
 
     public static final int NAME_COL = 0;// A
     public static final int OFFICE_NAME_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ClientPersonConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/ClientPersonConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class ClientPersonConstants {
+public final class ClientPersonConstants {
+
+    private ClientPersonConstants() {
+
+    }
 
     public static final int FIRST_NAME_COL = 0;// A
     public static final int LAST_NAME_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/FixedDepositConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/FixedDepositConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class FixedDepositConstants {
+public final class FixedDepositConstants {
+
+    private FixedDepositConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int CLIENT_NAME_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/GroupConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/GroupConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class GroupConstants {
+public final class GroupConstants {
+
+    private GroupConstants() {
+
+    }
 
     public static final int NAME_COL = 0; // A
     public static final int OFFICE_NAME_COL = 1; // B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/GuarantorConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/GuarantorConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class GuarantorConstants {
+public final class GuarantorConstants {
+
+    private GuarantorConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int CLIENT_NAME_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/JournalEntryConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/JournalEntryConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class JournalEntryConstants {
+public final class JournalEntryConstants {
+
+    private JournalEntryConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/LoanConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/LoanConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class LoanConstants {
+public final class LoanConstants {
+
+    private LoanConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;// A
     public static final int LOAN_TYPE_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/LoanRepaymentConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/LoanRepaymentConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class LoanRepaymentConstants {
+public final class LoanRepaymentConstants {
+
+    private LoanRepaymentConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;// A
     public static final int CLIENT_NAME_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/OfficeConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/OfficeConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class OfficeConstants {
+public final class OfficeConstants {
+
+    private OfficeConstants() {
+
+    }
 
     // Column indices
     public static final int OFFICE_NAME_COL = 0;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/RecurringDepositConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/RecurringDepositConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class RecurringDepositConstants {
+public final class RecurringDepositConstants {
+
+    private RecurringDepositConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int CLIENT_NAME_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/SavingsConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/SavingsConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class SavingsConstants {
+public final class SavingsConstants {
+
+    private SavingsConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int SAVINGS_TYPE_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/SharedAccountsConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/SharedAccountsConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class SharedAccountsConstants {
+public final class SharedAccountsConstants {
+
+    private SharedAccountsConstants() {
+
+    }
 
     public static final int CLIENT_NAME_COL = 0;
     public static final int PRODUCT_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/StaffConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/StaffConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class StaffConstants {
+public final class StaffConstants {
+
+    private StaffConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;// A
     public static final int FIRST_NAME_COL = 1;// B

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TemplatePopulateImportConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TemplatePopulateImportConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class TemplatePopulateImportConstants {
+public final class TemplatePopulateImportConstants {
+
+    private TemplatePopulateImportConstants() {
+
+    }
 
     // columns sizes
     public static final int SMALL_COL_SIZE = 4000;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TransactionConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TransactionConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class TransactionConstants {
+public final class TransactionConstants {
+
+    private TransactionConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int CLIENT_NAME_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/UserConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/UserConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.constants;
 
-public class UserConstants {
+public final class UserConstants {
+
+    private UserConstants() {
+
+    }
 
     public static final int OFFICE_NAME_COL = 0;
     public static final int STAFF_NAME_COL = 1;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/ImportHandlerUtils.java
@@ -39,7 +39,11 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellReference;
 import org.joda.time.LocalDate;
 
-public class ImportHandlerUtils {
+public final class ImportHandlerUtils {
+
+    private ImportHandlerUtils() {
+
+    }
 
     public static Integer getNumberOfRows(Sheet sheet, int primaryColumn) {
         Integer noOfEntries = 0;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/cache/CacheApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/cache/CacheApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.cache;
 
-public class CacheApiConstants {
+public final class CacheApiConstants {
+
+    private CacheApiConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "CACHE";
     public static final String cacheTypeParameter = "cacheType";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/cache/CacheEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/cache/CacheEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.cache;
 import org.apache.fineract.infrastructure.cache.domain.CacheType;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class CacheEnumerations {
+public final class CacheEnumerations {
+
+    private CacheEnumerations() {
+
+    }
 
     public static EnumOptionData cacheType(final int id) {
         return cacheType(CacheType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/EmailApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/EmailApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class EmailApiConstants {
+public final class EmailApiConstants {
+
+    private EmailApiConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "email";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/ScheduledEmailConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/ScheduledEmailConstants.java
@@ -23,7 +23,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ScheduledEmailConstants {
+public final class ScheduledEmailConstants {
+
+    private ScheduledEmailConstants() {
+
+    }
 
     // define the API resource entity name
     public static final String SCHEDULED_EMAIL_ENTITY_NAME = "SCHEDULEDEMAIL";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/data/ScheduledEmailEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/data/ScheduledEmailEnumerations.java
@@ -22,7 +22,11 @@ import org.apache.fineract.infrastructure.campaigns.email.domain.ScheduledEmailA
 import org.apache.fineract.infrastructure.campaigns.email.domain.ScheduledEmailStretchyReportParamDateOption;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class ScheduledEmailEnumerations {
+public final class ScheduledEmailEnumerations {
+
+    private ScheduledEmailEnumerations() {
+
+    }
 
     public static EnumOptionData emailAttachementFileFormat(final Integer emailAttachementFileFormatId) {
         return emailAttachementFileFormat(ScheduledEmailAttachmentFileFormat.instance(emailAttachementFileFormatId));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailCampaignStatusEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailCampaignStatusEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.infrastructure.campaigns.email.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class EmailCampaignStatusEnumerations {
+public final class EmailCampaignStatusEnumerations {
+
+    private EmailCampaignStatusEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(EmailCampaignStatus.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailMessageEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailMessageEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.infrastructure.campaigns.email.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class EmailMessageEnumerations {
+public final class EmailMessageEnumerations {
+
+    private EmailMessageEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(EmailMessageStatusType.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/constants/SmsCampaignEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/constants/SmsCampaignEnumerations.java
@@ -25,7 +25,11 @@ import org.apache.fineract.infrastructure.campaigns.constants.CampaignType;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 
-public class SmsCampaignEnumerations {
+public final class SmsCampaignEnumerations {
+
+    private SmsCampaignEnumerations() {
+
+    }
 
     public static EnumOptionData smscampaignTriggerType(final SmsCampaignTriggerType type) {
         EnumOptionData optionData = new EnumOptionData(SmsCampaignTriggerType.INVALID.getValue().longValue(),

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/domain/SmsCampaignStatusEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/domain/SmsCampaignStatusEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.campaigns.sms.domain;
 import org.apache.fineract.infrastructure.campaigns.sms.constants.SmsCampaignStatus;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class SmsCampaignStatusEnumerations {
+public final class SmsCampaignStatusEnumerations {
+
+    private SmsCampaignStatusEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(SmsCampaignStatus.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/ExternalServiceConfigurationApiConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/ExternalServiceConfigurationApiConstant.java
@@ -22,11 +22,15 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ExternalServiceConfigurationApiConstant {
+public final class ExternalServiceConfigurationApiConstant {
+
+    private ExternalServiceConfigurationApiConstant() {
+
+    }
 
     public static final String NAME = "name";
     public static final String VALUE = "value";
     public static final String EXTERNAL_SERVICE_RESOURCE_NAME = "externalServiceConfiguration";
 
-    protected static final Set<String> EXTERNAL_SERVICE_CONFIGURATION_DATA_PARAMETERS = new HashSet<>(Arrays.asList(NAME, VALUE));
+    static final Set<String> EXTERNAL_SERVICE_CONFIGURATION_DATA_PARAMETERS = new HashSet<>(Arrays.asList(NAME, VALUE));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationApiConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationApiConstant.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.configuration.api;
 
-public class GlobalConfigurationApiConstant {
+public final class GlobalConfigurationApiConstant {
+
+    private GlobalConfigurationApiConstant() {
+
+    }
 
     public static final String ENABLED = "enabled";
     public static final String VALUE = "value";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesConstants.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.configuration.service;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ExternalServicesConstants {
+public final class ExternalServicesConstants {
+
+    private ExternalServicesConstants() {
+
+    }
 
     public static final String S3_SERVICE_NAME = "S3";
     public static final String S3_BUCKET_NAME = "s3_bucket_name";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/api/ApiParameterHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/api/ApiParameterHelper.java
@@ -30,7 +30,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.serialization.JsonParserHelper;
 import org.apache.fineract.infrastructure.security.utils.SQLInjectionValidator;
 
-public class ApiParameterHelper {
+public final class ApiParameterHelper {
+
+    private ApiParameterHelper() {
+
+    }
 
     public static Long commandId(final MultivaluedMap<String, String> queryParams) {
         Long id = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/JdbcSupport.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/JdbcSupport.java
@@ -34,7 +34,11 @@ import org.springframework.jdbc.support.JdbcUtils;
  * Support for retrieving possibly null values from jdbc recordset delegating to springs {@link JdbcUtils} where
  * possible.
  */
-public class JdbcSupport {
+public final class JdbcSupport {
+
+    private JdbcSupport() {
+
+    }
 
     public static DateTime getDateTime(final ResultSet rs, final String columnName) throws SQLException {
         DateTime dateTime = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
@@ -34,7 +34,11 @@ import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class DateUtils {
+public final class DateUtils {
+
+    private DateUtils() {
+
+    }
 
     public static DateTimeZone getDateTimeZoneOfTenant() {
         final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/ThreadLocalContextUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/ThreadLocalContextUtil.java
@@ -24,7 +24,11 @@ import org.springframework.util.Assert;
 /**
  *
  */
-public class ThreadLocalContextUtil {
+public final class ThreadLocalContextUtil {
+
+    private ThreadLocalContextUtil() {
+
+    }
 
     public static final String CONTEXT_TENANTS = "tenants";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DataTableApiConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DataTableApiConstant.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.dataqueries.api;
 /**
  * Created by Cieyou on 2/26/14.
  */
-public class DataTableApiConstant {
+public final class DataTableApiConstant {
+
+    private DataTableApiConstant() {
+
+    }
 
     public static final Integer CATEGORY_PPI = 200;
     public static final Integer CATEGORY_DEFAULT = 100;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/contentrepository/ContentRepositoryUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/contentrepository/ContentRepositoryUtils.java
@@ -29,7 +29,11 @@ import org.apache.fineract.infrastructure.core.exception.ImageUploadException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.documentmanagement.exception.ContentManagementException;
 
-public class ContentRepositoryUtils {
+public final class ContentRepositoryUtils {
+
+    private ContentRepositoryUtils() {
+
+    }
 
     private static final Random random = new Random();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/FineractEntityAccessConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/FineractEntityAccessConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.entityaccess;
 
-public class FineractEntityAccessConstants {
+public final class FineractEntityAccessConstants {
+
+    private FineractEntityAccessConstants() {
+
+    }
 
     public static final String GLOBAL_CONFIG_FOR_OFFICE_SPECIFIC_PRODUCTS = "office-specific-products-enabled";
     public static final String GLOBAL_CONFIG_FOR_RESTRICT_PRODUCTS_TO_USER_OFFICE = "restrict-products-to-user-office";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/api/FineractEntityApiResourceConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/api/FineractEntityApiResourceConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class FineractEntityApiResourceConstants {
+public final class FineractEntityApiResourceConstants {
+
+    private FineractEntityApiResourceConstants() {
+
+    }
 
     public static final String FINERACT_ENTITY_RESOURCE_NAME = "FineractEntity";
     public static final String mappingTypes = "mappingTypes";
@@ -41,9 +45,8 @@ public class FineractEntityApiResourceConstants {
     public static final String ROLE_ACCESS_TO_LOAN_PRODUCTS = " role_access_to_loan_products ";
     public static final String ROLE_ACCESS_TO_SAVINGS_PRODUCTS = " role_access_to_savings_products ";
 
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(mappingTypes));
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(mappingTypes));
 
-    protected static final Set<String> FETCH_ENTITY_TO_ENTITY_MAPPINGS = new HashSet<>(
-            Arrays.asList(mapId, relId, fromEnityType, toEntityType));
+    static final Set<String> FETCH_ENTITY_TO_ENTITY_MAPPINGS = new HashSet<>(Arrays.asList(mapId, relId, fromEnityType, toEntityType));
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/gcm/api/DeviceRegistrationApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/gcm/api/DeviceRegistrationApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.gcm.api;
 
-public class DeviceRegistrationApiConstants {
+public final class DeviceRegistrationApiConstants {
+
+    private DeviceRegistrationApiConstants() {
+
+    }
 
     public static final String clientIdParamName = "clientId";
     public static final String registrationIdParamName = "registrationId";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/api/HookApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/api/HookApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class HookApiConstants {
+public final class HookApiConstants {
+
+    private HookApiConstants() {
+
+    }
 
     public static final String HOOK_RESOURCE_NAME = "HOOK";
 
@@ -62,10 +66,10 @@ public class HookApiConstants {
 
     public static final String templateNameParamName = "templateName";
 
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(nameParamName, displayNameParamName,
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(nameParamName, displayNameParamName,
             templateIdParamName, isActiveParamName, configParamName, eventsParamName, templateNameParamName));
 
-    protected static final Set<String> UPDATE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(nameParamName, displayNameParamName,
+    static final Set<String> UPDATE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(nameParamName, displayNameParamName,
             templateIdParamName, isActiveParamName, configParamName, eventsParamName, templateNameParamName));
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/ProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/ProcessorHelper.java
@@ -38,7 +38,11 @@ import retrofit.client.OkClient;
 import retrofit.client.Response;
 
 @SuppressWarnings("unused")
-public class ProcessorHelper {
+public final class ProcessorHelper {
+
+    private ProcessorHelper() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessorHelper.class);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/annotation/CronMethodParser.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/annotation/CronMethodParser.java
@@ -37,7 +37,11 @@ import org.springframework.util.ClassUtils;
 /**
  * Parser to find method which is marked with CronTargetMethod annotation
  */
-public class CronMethodParser {
+public final class CronMethodParser {
+
+    private CronMethodParser() {
+
+    }
 
     public static class ClassMethodNamesPair {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/SchedulerJobApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/SchedulerJobApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class SchedulerJobApiConstants {
+public final class SchedulerJobApiConstants {
+
+    private SchedulerJobApiConstants() {
+
+    }
 
     public static final String JOB_RESOURCE_NAME = "schedulerjob";
     public static final String SCHEDULER_RESOURCE_NAME = "SCHEDULER";
@@ -53,13 +57,12 @@ public class SchedulerJobApiConstants {
     public static final String JOB_RUN_HISTORY = "runhistory";
     public static final String SCHEDULER_STATUS_PATH = "scheduler";
 
-    protected static final Set<String> JOB_DETAIL_RESPONSE_DATA_PARAMETERS = new HashSet<>(
+    static final Set<String> JOB_DETAIL_RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(jobIdentifierParamName, displayNameParamName, nextRunTimeParamName, initializingErrorParamName,
                     cronExpressionParamName, jobActiveStatusParamName, currentlyRunningParamName, lastRunHistoryObjParamName));
 
-    protected static final Set<String> JOB_HISTORY_RESPONSE_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(versionParamName, jobRunStartTimeParamName, jobRunEndTimeParamName, statusParamName, jobRunErrorMessageParamName,
-                    triggerTypeParamName, jobRunErrorLogParamName));
+    static final Set<String> JOB_HISTORY_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(versionParamName, jobRunStartTimeParamName,
+            jobRunEndTimeParamName, statusParamName, jobRunErrorMessageParamName, triggerTypeParamName, jobRunErrorLogParamName));
 
-    protected static final Set<String> SCHEDULER_DETAIL_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(schedulerStatusParamName));
+    static final Set<String> SCHEDULER_DETAIL_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(schedulerStatusParamName));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/ReportMailingJobConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/ReportMailingJobConstants.java
@@ -24,7 +24,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ReportMailingJobConstants implements Serializable {
+public final class ReportMailingJobConstants implements Serializable {
+
+    private ReportMailingJobConstants() {
+
+    }
 
     // define the API resource entity name
     public static final String REPORT_MAILING_JOB_ENTITY_NAME = "REPORTMAILINGJOB";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/helper/IPv4Helper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/helper/IPv4Helper.java
@@ -30,7 +30,11 @@ import org.slf4j.LoggerFactory;
  *
  * @see http://hawkee.com/snippet/9731/
  */
-public class IPv4Helper {
+public final class IPv4Helper {
+
+    private IPv4Helper() {
+
+    }
 
     /**
      * Returns the long format of the provided IP address.

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/util/ReportMailingJobDateUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/reportmailingjob/util/ReportMailingJobDateUtil.java
@@ -23,7 +23,11 @@ import java.util.Calendar;
 import java.util.Date;
 import org.apache.fineract.infrastructure.reportmailingjob.data.ReportMailingJobStretchyReportParamDateOption;
 
-public class ReportMailingJobDateUtil {
+public final class ReportMailingJobDateUtil {
+
+    private ReportMailingJobDateUtil() {
+
+    }
 
     public static final String MYSQL_DATE_FORMAT = "yyyy-MM-dd";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/constants/TwoFactorConfigurationConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/constants/TwoFactorConfigurationConstants.java
@@ -24,7 +24,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class TwoFactorConfigurationConstants {
+public final class TwoFactorConfigurationConstants {
+
+    private TwoFactorConfigurationConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "TWOFACTOR_CONFIGURATION";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/constants/TwoFactorConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/constants/TwoFactorConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.security.constants;
 
-public class TwoFactorConstants {
+public final class TwoFactorConstants {
+
+    private TwoFactorConstants() {
+
+    }
 
     public static final String ACCESSTOKEN_RESOURCE_NAME = "TWOFACTOR_ACCESSTOKEN";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/SQLInjectionValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/SQLInjectionValidator.java
@@ -23,7 +23,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
-public class SQLInjectionValidator {
+public final class SQLInjectionValidator {
+
+    private SQLInjectionValidator() {
+
+    }
 
     private static final String[] DDL_COMMANDS = { "create", "drop", "alter", "truncate", "comment", "sleep" };
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/SmsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/SmsApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.sms;
 
-public class SmsApiConstants {
+public final class SmsApiConstants {
+
+    private SmsApiConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "sms";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/domain/SmsMessageEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/domain/SmsMessageEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.infrastructure.sms.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class SmsMessageEnumerations {
+public final class SmsMessageEnumerations {
+
+    private SmsMessageEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(SmsMessageStatusType.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/LikelihoodApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/LikelihoodApiConstants.java
@@ -23,12 +23,16 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.infrastructure.survey.data.LikelihoodStatus;
 
-public class LikelihoodApiConstants {
+public final class LikelihoodApiConstants {
+
+    private LikelihoodApiConstants() {
+
+    }
 
     public static final String ACTIVE = "active";
 
     public static final String LIKELIHOOD_RESOURCE_NAME = "likelihood";
 
-    protected static final Set<Long> VALID_LIKELIHOOD_ENABLED_VALUES = new HashSet<>(
+    static final Set<Long> VALID_LIKELIHOOD_ENABLED_VALUES = new HashSet<>(
             Arrays.asList(LikelihoodStatus.DISABLED, LikelihoodStatus.ENABLED));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/PovertyLineApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/PovertyLineApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.infrastructure.survey.api;
 
-public class PovertyLineApiConstants {
+public final class PovertyLineApiConstants {
+
+    private PovertyLineApiConstants() {
+
+    }
 
     static final String POVERTY_LINE_RESOURCE_NAME = "PovertyLine";
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiConstants.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.survey.api;
 /**
  * Created by Cieyou on 2/27/14.
  */
-public class SurveyApiConstants {
+public final class SurveyApiConstants {
+
+    private SurveyApiConstants() {
+
+    }
 
     static final String SURVEY_RESOURCE_NAME = "Survey";
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/data/LikelihoodStatus.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/data/LikelihoodStatus.java
@@ -21,7 +21,11 @@ package org.apache.fineract.infrastructure.survey.data;
 /**
  * Created by Cieyou on 3/12/14.
  */
-public class LikelihoodStatus {
+public final class LikelihoodStatus {
+
+    private LikelihoodStatus() {
+
+    }
 
     public static final long ENABLED = 200;
     public static final long DISABLED = 100;

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/util/InteropUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/util/InteropUtil.java
@@ -20,7 +20,11 @@ package org.apache.fineract.interoperation.util;
 
 import java.util.Locale;
 
-public class InteropUtil {
+public final class InteropUtil {
+
+    private InteropUtil() {
+
+    }
 
     public static final String ISO8601_DATE_TIME_FORMAT = "yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]";
     public static final String ISO8601_DATE_FORMAT = "yyyy-MM-dd";

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/util/MathUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/util/MathUtil.java
@@ -25,7 +25,11 @@ import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 
-public class MathUtil {
+public final class MathUtil {
+
+    private MathUtil() {
+
+    }
 
     public static Long nullToZero(Long value) {
         return nullToDefault(value, 0L);

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/api/HolidayApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/api/HolidayApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class HolidayApiConstants {
+public final class HolidayApiConstants {
+
+    private HolidayApiConstants() {
+
+    }
 
     public static final String HOLIDAY_RESOURCE_NAME = "holiday";
 
@@ -43,7 +47,6 @@ public class HolidayApiConstants {
     public static final String status = "status";
     public static final String reschedulingType = "reschedulingType";
 
-    protected static final Set<String> HOLIDAY_RESPONSE_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(idParamName, nameParamName, fromDateParamName, descriptionParamName, toDateParamName,
-                    repaymentsRescheduledToParamName, localeParamName, dateFormatParamName, status));
+    static final Set<String> HOLIDAY_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, nameParamName, fromDateParamName,
+            descriptionParamName, toDateParamName, repaymentsRescheduledToParamName, localeParamName, dateFormatParamName, status));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayEnumerations.java
@@ -22,7 +22,11 @@ import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.organisation.holiday.domain.HolidayStatusType;
 import org.apache.fineract.organisation.holiday.domain.RescheduleType;
 
-public class HolidayEnumerations {
+public final class HolidayEnumerations {
+
+    private HolidayEnumerations() {
+
+    }
 
     public static EnumOptionData holidayStatusType(final int id) {
         return holidayStatusType(HolidayStatusType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayUtil.java
@@ -23,7 +23,11 @@ import org.apache.fineract.organisation.holiday.domain.Holiday;
 import org.apache.fineract.organisation.workingdays.data.AdjustedDateDetailsDTO;
 import org.joda.time.LocalDate;
 
-public class HolidayUtil {
+public final class HolidayUtil {
+
+    private HolidayUtil() {
+
+    }
 
     public static LocalDate getRepaymentRescheduleDateToIfHoliday(LocalDate repaymentDate, final List<Holiday> holidays) {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/domain/StaffEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/domain/StaffEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.organisation.staff.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class StaffEnumerations {
+public final class StaffEnumerations {
+
+    private StaffEnumerations() {
+
+    }
 
     public static EnumOptionData organisationalRole(final Integer id) {
         return organisationalRole(StaffOrganisationalRoleType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/api/WorkingDaysApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/api/WorkingDaysApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class WorkingDaysApiConstants {
+public final class WorkingDaysApiConstants {
+
+    private WorkingDaysApiConstants() {
+
+    }
 
     public static final String WORKING_DAYS_RESOURCE_NAME = "workingdays";
 
@@ -38,8 +42,8 @@ public class WorkingDaysApiConstants {
     public static final String extendTermForDailyRepayments = "extendTermForDailyRepayments";
     public static final String extendTermForRepaymentsOnHolidays = "extendTermForRepaymentsOnHolidays";
 
-    protected static final Set<String> WORKING_DAYS_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, recurrence,
+    static final Set<String> WORKING_DAYS_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, recurrence,
             repayment_rescheduling_enum, extendTermForDailyRepayments, extendTermForRepaymentsOnHolidays));
 
-    protected static final Set<String> WORKING_DAYS_TEMPLATE_PARAMETERS = new HashSet<>(Arrays.asList(rescheduleRepaymentTemplate));
+    static final Set<String> WORKING_DAYS_TEMPLATE_PARAMETERS = new HashSet<>(Arrays.asList(rescheduleRepaymentTemplate));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/domain/WorkingDaysEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/domain/WorkingDaysEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.organisation.workingdays.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class WorkingDaysEnumerations {
+public final class WorkingDaysEnumerations {
+
+    private WorkingDaysEnumerations() {
+
+    }
 
     public static EnumOptionData workingDaysStatusType(final int id) {
         return repaymentRescheduleType(RepaymentRescheduleType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/service/WorkingDaysUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/service/WorkingDaysUtil.java
@@ -24,7 +24,11 @@ import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
 import org.apache.fineract.portfolio.calendar.service.CalendarUtils;
 import org.joda.time.LocalDate;
 
-public class WorkingDaysUtil {
+public final class WorkingDaysUtil {
+
+    private WorkingDaysUtil() {
+
+    }
 
     public static LocalDate getOffSetDateIfNonWorkingDay(final LocalDate date, final LocalDate nextMeetingDate,
             final WorkingDays workingDays) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/AccountDetailConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/AccountDetailConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.account;
 
-public class AccountDetailConstants {
+public final class AccountDetailConstants {
+
+    private AccountDetailConstants() {
+
+    }
 
     // general
     public static final String localeParamName = "locale";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/AccountTransfersApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/AccountTransfersApiConstants.java
@@ -24,7 +24,11 @@ import java.util.Set;
 import org.apache.fineract.portfolio.account.AccountDetailConstants;
 import org.apache.fineract.portfolio.account.data.AccountTransferData;
 
-public class AccountTransfersApiConstants {
+public final class AccountTransfersApiConstants {
+
+    private AccountTransfersApiConstants() {
+
+    }
 
     public static final String ACCOUNT_TRANSFER_RESOURCE_NAME = "accounttransfer";
 
@@ -38,6 +42,6 @@ public class AccountTransfersApiConstants {
      * These parameters will match the class level parameters of {@link AccountTransferData}. Where possible, we try to
      * get response parameters to match those of request parameters.
      */
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(AccountDetailConstants.idParamName, transferDescriptionParamName, currencyParamName));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionApiConstants.java
@@ -23,7 +23,11 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.portfolio.account.AccountDetailConstants;
 
-public class StandingInstructionApiConstants {
+public final class StandingInstructionApiConstants {
+
+    private StandingInstructionApiConstants() {
+
+    }
 
     public static final String STANDING_INSTRUCTION_RESOURCE_NAME = "standinginstruction";
 
@@ -40,7 +44,7 @@ public class StandingInstructionApiConstants {
     public static final String recurrenceOnMonthDayParamName = "recurrenceOnMonthDay";
     public static final String monthDayFormatParamName = "monthDayFormat";
 
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(AccountDetailConstants.idParamName, nameParamName, priorityParamName, instructionTypeParamName, statusParamName,
                     AccountDetailConstants.transferTypeParamName, validFromParamName, validTillParamName));
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransferEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransferEnumerations.java
@@ -26,7 +26,11 @@ import org.apache.fineract.portfolio.account.domain.StandingInstructionPriority;
 import org.apache.fineract.portfolio.account.domain.StandingInstructionStatus;
 import org.apache.fineract.portfolio.account.domain.StandingInstructionType;
 
-public class AccountTransferEnumerations {
+public final class AccountTransferEnumerations {
+
+    private AccountTransferEnumerations() {
+
+    }
 
     public static EnumOptionData accountType(final Integer type) {
         return accountType(PortfolioAccountType.fromInt(type));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.accountdetails.service;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.accountdetails.domain.AccountType;
 
-public class AccountEnumerations {
+public final class AccountEnumerations {
+
+    private AccountEnumerations() {
+
+    }
 
     public static EnumOptionData loanType(final Integer loanTypeId) {
         return loanType(AccountType.fromInt(loanTypeId));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/CalendarConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/CalendarConstants.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.calendar;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CalendarConstants {
+public final class CalendarConstants {
+
+    private CalendarConstants() {
+
+    }
 
     public static final String CALENDAR_RESOURCE_NAME = "calendar";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarEnumerations.java
@@ -29,7 +29,11 @@ import org.apache.fineract.portfolio.calendar.domain.CalendarType;
 import org.apache.fineract.portfolio.calendar.domain.CalendarWeekDaysType;
 import org.apache.fineract.portfolio.common.domain.NthDayType;
 
-public class CalendarEnumerations {
+public final class CalendarEnumerations {
+
+    private CalendarEnumerations() {
+
+    }
 
     public static EnumOptionData calendarEntityType(final int id) {
         return calendarEntityType(CalendarEntityType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
@@ -54,7 +54,11 @@ import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CalendarUtils {
+public final class CalendarUtils {
+
+    private CalendarUtils() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(CalendarUtils.class);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.charge.api;
 
-public class ChargesApiConstants {
+public final class ChargesApiConstants {
+
+    private ChargesApiConstants() {
+
+    }
 
     public static final String glAccountIdParamName = "incomeAccountId";
     public static final String taxGroupIdParamName = "taxGroupId";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
@@ -24,7 +24,11 @@ import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 
-public class ChargeEnumerations {
+public final class ChargeEnumerations {
+
+    private ChargeEnumerations() {
+
+    }
 
     public static EnumOptionData chargeTimeType(final int id) {
         return chargeTimeType(ChargeTimeType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientApiConstants.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.portfolio.client.data.ClientData;
 
+@SuppressWarnings({ "HideUtilityClassConstructor" })
 public class ClientApiConstants {
 
     public static final String CLIENT_RESOURCE_NAME = "client";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientEnumerations.java
@@ -22,7 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class ClientEnumerations {
+public final class ClientEnumerations {
+
+    private ClientEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(ClientStatus.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/api/CollateralApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/api/CollateralApiConstants.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.collateral.api;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CollateralApiConstants {
+public final class CollateralApiConstants {
+
+    private CollateralApiConstants() {
+
+    }
 
     public static final String COLLATERAL_CODE_NAME = "LoanCollateral";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collectionsheet/CollectionSheetConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collectionsheet/CollectionSheetConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.collectionsheet;
 
-public class CollectionSheetConstants {
+public final class CollectionSheetConstants {
+
+    private CollectionSheetConstants() {
+
+    }
 
     public static final String COLLECTIONSHEET_RESOURCE_NAME = "collectionsheet";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/service/CommonEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/service/CommonEnumerations.java
@@ -26,7 +26,11 @@ import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 
-public class CommonEnumerations {
+public final class CommonEnumerations {
+
+    private CommonEnumerations() {
+
+    }
 
     public static final String DAYS_IN_MONTH_TYPE = "daysInMonthType";
     public static final String DAYS_IN_YEAR_TYPE = "daysInYearType";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupingTypesApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupingTypesApiConstants.java
@@ -23,7 +23,11 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.portfolio.group.data.CenterData;
 
-public class GroupingTypesApiConstants {
+public final class GroupingTypesApiConstants {
+
+    private GroupingTypesApiConstants() {
+
+    }
 
     public static final String CENTER_RESOURCE_NAME = "center";
     public static final String GROUP_RESOURCE_NAME = "group";
@@ -92,22 +96,22 @@ public class GroupingTypesApiConstants {
      * These parameters will match the class level parameters of {@link CenterData}. Where possible, we try to get
      * response parameters to match those of request parameters.
      */
-    protected static final Set<String> CENTER_RESPONSE_DATA_PARAMETERS = new HashSet<>(
+    static final Set<String> CENTER_RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(idParamName, nameParamName, externalIdParamName, officeIdParamName, officeNameParamName, staffIdParamName,
                     staffNameParamName, hierarchyParamName, officeOptionsParamName, staffOptionsParamName, statusParamName, activeParamName,
                     activationDateParamName, timeLine, groupMembersParamName, collectionMeetingCalendar, closureReasons, datatables));
 
-    protected static final Set<String> CENTER_GROUP_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, nameParamName,
+    static final Set<String> CENTER_GROUP_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(idParamName, nameParamName,
             externalIdParamName, officeIdParamName, officeNameParamName, staffIdParamName, staffNameParamName, hierarchyParamName,
             officeOptionsParamName, staffOptionsParamName, clientOptionsParamName, datatables));
 
-    protected static final Set<String> GROUP_RESPONSE_DATA_PARAMETERS = new HashSet<>(
+    static final Set<String> GROUP_RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(idParamName, nameParamName, externalIdParamName, officeIdParamName, officeNameParamName, "parentId", "parentName",
                     staffIdParamName, staffNameParamName, hierarchyParamName, officeOptionsParamName, statusParamName, activeParamName,
                     activationDateParamName, staffOptionsParamName, clientOptionsParamName, timeLine, datatables));
 
-    protected static final Set<String> COLLECTIONSHEET_DATA_PARAMETERS = new HashSet<>(Arrays.asList("dueDate", "loanProducts", "groups"));
+    static final Set<String> COLLECTIONSHEET_DATA_PARAMETERS = new HashSet<>(Arrays.asList("dueDate", "loanProducts", "groups"));
 
-    protected static final Set<String> STAFF_CENTER_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(staffIdParamName,
-            staffNameParamName, meetingFallCenters, totalCollected, totalOverdue, totaldue, installmentDue));
+    static final Set<String> STAFF_CENTER_RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(staffIdParamName, staffNameParamName,
+            meetingFallCenters, totalCollected, totalOverdue, totaldue, installmentDue));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/GroupingTypeEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/domain/GroupingTypeEnumerations.java
@@ -20,7 +20,11 @@ package org.apache.fineract.portfolio.group.domain;
 
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 
-public class GroupingTypeEnumerations {
+public final class GroupingTypeEnumerations {
+
+    private GroupingTypeEnumerations() {
+
+    }
 
     public static EnumOptionData status(final Integer statusId) {
         return status(GroupingTypeStatus.fromInt(statusId));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupTypeEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupTypeEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.group.service;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.group.domain.GroupTypes;
 
-public class GroupTypeEnumerations {
+public final class GroupTypeEnumerations {
+
+    private GroupTypeEnumerations() {
+
+    }
 
     public static EnumOptionData groupType(final Integer id) {
         return groupType(GroupTypes.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/InterestRateChartApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/InterestRateChartApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.interestratechart;
 
-public class InterestRateChartApiConstants {
+public final class InterestRateChartApiConstants {
+
+    private InterestRateChartApiConstants() {
+
+    }
 
     public static final String INTERESTRATE_CHART_RESOURCE_NAME = "interestchart";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/InterestRateChartSlabApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/InterestRateChartSlabApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.interestratechart;
 
-public class InterestRateChartSlabApiConstants {
+public final class InterestRateChartSlabApiConstants {
+
+    private InterestRateChartSlabApiConstants() {
+
+    }
 
     public static final String INTERESTRATE_CHART_SLAB_RESOURCE_NAME = "chartslab";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/incentive/AttributeIncentiveCalculationFactory.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/incentive/AttributeIncentiveCalculationFactory.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.interestratechart.incentive;
 
-public class AttributeIncentiveCalculationFactory {
+public final class AttributeIncentiveCalculationFactory {
+
+    private AttributeIncentiveCalculationFactory() {
+
+    }
 
     public static AttributeIncentiveCalculation findAttributeIncentiveCalculation(InterestIncentiveEntityType entityType) {
         AttributeIncentiveCalculation attributeIncentiveCalculation = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestIncentivesEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestIncentivesEnumerations.java
@@ -25,7 +25,11 @@ import org.apache.fineract.portfolio.interestratechart.incentive.InterestIncenti
 import org.apache.fineract.portfolio.interestratechart.incentive.InterestIncentiveEntityType;
 import org.apache.fineract.portfolio.interestratechart.incentive.InterestIncentiveType;
 
-public class InterestIncentivesEnumerations {
+public final class InterestIncentivesEnumerations {
+
+    private InterestIncentivesEnumerations() {
+
+    }
 
     public static EnumOptionData attributeName(final Integer attributeName) {
         return attributeName(InterestIncentiveAttributeName.fromInt(attributeName));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestRateChartEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestRateChartEnumerations.java
@@ -25,7 +25,11 @@ import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class InterestRateChartEnumerations {
+public final class InterestRateChartEnumerations {
+
+    private InterestRateChartEnumerations() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(InterestRateChartEnumerations.class);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/GuarantorConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/GuarantorConstants.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.loanaccount.guarantor;
 import java.util.HashSet;
 import java.util.Set;
 
-public class GuarantorConstants {
+public final class GuarantorConstants {
+
+    private GuarantorConstants() {
+
+    }
 
     public static final String GUARANTOR_RELATIONSHIP_CODE_NAME = "GuarantorRelationship";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/service/GuarantorEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/service/GuarantorEnumerations.java
@@ -24,7 +24,11 @@ import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.loanaccount.guarantor.domain.GuarantorFundStatusType;
 import org.apache.fineract.portfolio.loanaccount.guarantor.domain.GuarantorType;
 
-public class GuarantorEnumerations {
+public final class GuarantorEnumerations {
+
+    private GuarantorEnumerations() {
+
+    }
 
     public static EnumOptionData guarantorType(final int id) {
         return guarantorType(GuarantorType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/FinanicalFunctions.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/FinanicalFunctions.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.loanaccount.loanschedule.domain;
 
-public class FinanicalFunctions {
+public final class FinanicalFunctions {
+
+    private FinanicalFunctions() {
+
+    }
 
     /**
      * PMT calculates a fixed monthly payment to be paid by borrower every 'period' to ensure loan is paid off in full

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/RescheduleLoansApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/RescheduleLoansApiConstants.java
@@ -23,7 +23,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class RescheduleLoansApiConstants {
+public final class RescheduleLoansApiConstants {
+
+    private RescheduleLoansApiConstants() {
+
+    }
 
     public static final String ENTITY_NAME = "RESCHEDULELOAN";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.loanaccount.rescheduleloan.data;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 
-public class LoanRescheduleRequestEnumerations {
+public final class LoanRescheduleRequestEnumerations {
+
+    private LoanRescheduleRequestEnumerations() {
+
+    }
 
     public static EnumOptionData status(final LoanRescheduleRequestStatusEnumData status) {
         Long id = status.id();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LendingStrategyEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LendingStrategyEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.loanproduct.service;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.loanproduct.domain.LendingStrategy;
 
-public class LendingStrategyEnumerations {
+public final class LendingStrategyEnumerations {
+
+    private LendingStrategyEnumerations() {
+
+    }
 
     public static EnumOptionData lendingStrategy(final Integer id) {
         return lendingStrategy(LendingStrategy.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
@@ -39,7 +39,11 @@ import org.apache.fineract.portfolio.loanproduct.domain.LoanProductValueConditio
 import org.apache.fineract.portfolio.loanproduct.domain.LoanRescheduleStrategyMethod;
 import org.apache.fineract.portfolio.loanproduct.domain.RecalculationFrequencyType;
 
-public class LoanEnumerations {
+public final class LoanEnumerations {
+
+    private LoanEnumerations() {
+
+    }
 
     public static final String LOAN_TERM_FREQUENCY_TYPE = "loanTermFrequencyType";
     public static final String TERM_FREQUENCY_TYPE = "termFrequencyType";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/meeting/MeetingApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/meeting/MeetingApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.meeting;
 
-public class MeetingApiConstants {
+public final class MeetingApiConstants {
+
+    private MeetingApiConstants() {
+
+    }
 
     public static final String MEETING_RESOURCE_NAME = "meeting";
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/meeting/attendance/service/AttendanceEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/meeting/attendance/service/AttendanceEnumerations.java
@@ -23,7 +23,11 @@ import java.util.List;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.meeting.attendance.AttendanceType;
 
-public class AttendanceEnumerations {
+public final class AttendanceEnumerations {
+
+    private AttendanceEnumerations() {
+
+    }
 
     public static EnumOptionData attendanceType(final int attendanceType) {
         return attendanceType(AttendanceType.fromInt(attendanceType));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/service/NoteEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/service/NoteEnumerations.java
@@ -21,7 +21,11 @@ package org.apache.fineract.portfolio.note.service;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.note.domain.NoteType;
 
-public class NoteEnumerations {
+public final class NoteEnumerations {
+
+    private NoteEnumerations() {
+
+    }
 
     public static EnumOptionData noteType(final Integer id) {
         return noteType(NoteType.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/PaymentDetailConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/PaymentDetailConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.paymentdetail;
 
-public class PaymentDetailConstants {
+public final class PaymentDetailConstants {
+
+    private PaymentDetailConstants() {
+
+    }
 
     // Code representing Payment Details
     public static final String paymentTypeCodeName = "PaymentType";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymenttype/api/PaymentTypeApiResourceConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymenttype/api/PaymentTypeApiResourceConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class PaymentTypeApiResourceConstants {
+public final class PaymentTypeApiResourceConstants {
+
+    private PaymentTypeApiResourceConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "paymenttype";
     public static final String ENTITY_NAME = "PAYMENTTYPE";
@@ -34,5 +38,5 @@ public class PaymentTypeApiResourceConstants {
     public static final String ISCASHPAYMENT = "isCashPayment";
     public static final String POSITION = "position";
 
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(ID, NAME, DESCRIPTION, ISCASHPAYMENT));
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(ID, NAME, DESCRIPTION, ISCASHPAYMENT));
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/rate/api/RateApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/rate/api/RateApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.rate.api;
 
-public class RateApiConstants {
+public final class RateApiConstants {
+
+    private RateApiConstants() {
+
+    }
 
     public static final String approveUserIdParamName = "approveUserId";
     public static final String rate = "rate";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/rate/service/RateEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/rate/service/RateEnumerations.java
@@ -22,7 +22,11 @@ package org.apache.fineract.portfolio.rate.service;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.portfolio.rate.domain.RateAppliesTo;
 
-public class RateEnumerations {
+public final class RateEnumerations {
+
+    private RateEnumerations() {
+
+    }
 
     public static EnumOptionData rateAppliesTo(final int id) {
         return rateAppliesTo(RateAppliesTo.fromInt(id));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositAccountUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositAccountUtils.java
@@ -25,7 +25,11 @@ import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DepositAccountUtils {
+public final class DepositAccountUtils {
+
+    private DepositAccountUtils() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(DepositAccountUtils.class);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
@@ -23,7 +23,11 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.accounting.common.AccountingConstants.SavingProductAccountingParams;
 
-public class DepositsApiConstants {
+public final class DepositsApiConstants {
+
+    private DepositsApiConstants() {
+
+    }
 
     // Deposit products
     public static final String FIXED_DEPOSIT_PRODUCT_RESOURCE_NAME = "fixeddeposit";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.savings;
 
+@SuppressWarnings({ "HideUtilityClassConstructor" })
 public class SavingsApiConstants {
 
     public static final String SAVINGS_PRODUCT_RESOURCE_NAME = "savingsproduct";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsEnumerations.java
@@ -40,7 +40,11 @@ import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionEnumD
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountStatusType;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountSubStatusEnum;
 
-public class SavingsEnumerations {
+public final class SavingsEnumerations {
+
+    private SavingsEnumerations() {
+
+    }
 
     public static final String INTEREST_COMPOUNDING_PERIOD_TYPE = "interestCompoundingPeriodType";
     public static final String INTEREST_POSTING_PERIOD_TYPE = "interestPostingPeriodType";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/registration/SelfServiceApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/registration/SelfServiceApiConstants.java
@@ -24,7 +24,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class SelfServiceApiConstants {
+public final class SelfServiceApiConstants {
+
+    private SelfServiceApiConstants() {
+
+    }
 
     public static final String accountNumberParamName = "accountNumber";
     public static final String passwordParamName = "password";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/savings/data/SelfSavingsAccountConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/savings/data/SelfSavingsAccountConstants.java
@@ -19,7 +19,11 @@
 
 package org.apache.fineract.portfolio.self.savings.data;
 
-public class SelfSavingsAccountConstants {
+public final class SelfSavingsAccountConstants {
+
+    private SelfSavingsAccountConstants() {
+
+    }
 
     public static final String savingsAccountResource = "savings";
     public static final String clientIdParameterName = "clientId";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/SharesEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/SharesEnumerations.java
@@ -26,7 +26,11 @@ import org.apache.fineract.portfolio.shareaccounts.domain.ShareAccountStatusType
 import org.apache.fineract.portfolio.shareproducts.SharePeriodFrequencyType;
 import org.apache.fineract.portfolio.shareproducts.domain.ShareProductDividendStatusType;
 
-public class SharesEnumerations {
+public final class SharesEnumerations {
+
+    private SharesEnumerations() {
+
+    }
 
     public static ShareAccountStatusEnumData status(final Integer statusEnum) {
         return status(ShareAccountStatusType.fromInt(statusEnum));

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxUtils.java
@@ -28,7 +28,11 @@ import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupMappings;
 import org.joda.time.LocalDate;
 
-public class TaxUtils {
+public final class TaxUtils {
+
+    private TaxUtils() {
+
+    }
 
     public static Map<TaxComponent, BigDecimal> splitTax(final BigDecimal amount, final LocalDate date,
             final Set<TaxGroupMappings> taxGroupMappings, final int scale) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/transfer/api/TransferApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/transfer/api/TransferApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.portfolio.transfer.api;
 
-public class TransferApiConstants {
+public final class TransferApiConstants {
+
+    private TransferApiConstants() {
+
+    }
 
     // general
     public static final String localeParamName = "locale";

--- a/fineract-provider/src/main/java/org/apache/fineract/spm/util/SurveyApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/spm/util/SurveyApiConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.spm.util;
 
-public class SurveyApiConstants {
+public final class SurveyApiConstants {
+
+    private SurveyApiConstants() {
+
+    }
 
     public static final String SURVEY_RESOURCE_NAME = "survey";
     public static final String keyParamName = "key";

--- a/fineract-provider/src/main/java/org/apache/fineract/template/domain/TemplateFunctions.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/domain/TemplateFunctions.java
@@ -22,6 +22,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+@SuppressWarnings({ "HideUtilityClassConstructor" })
 public class TemplateFunctions {
 
     public static String now() {

--- a/fineract-provider/src/main/java/org/apache/fineract/template/service/TrustModifier.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/service/TrustModifier.java
@@ -33,7 +33,11 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 @SuppressWarnings("unused")
-public class TrustModifier {
+public final class TrustModifier {
+
+    private TrustModifier() {
+
+    }
 
     private static final TrustingHostnameVerifier TRUSTING_HOSTNAME_VERIFIER = new TrustingHostnameVerifier();
     private static SSLSocketFactory factory;

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/AppUserApiConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/AppUserApiConstant.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.useradministration.api;
 
-public class AppUserApiConstant {
+public final class AppUserApiConstant {
+
+    private AppUserApiConstant() {
+
+    }
 
     public static final int numberOfPreviousPasswords = 3;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PasswordPreferencesApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PasswordPreferencesApiConstants.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class PasswordPreferencesApiConstants {
+public final class PasswordPreferencesApiConstants {
+
+    private PasswordPreferencesApiConstants() {
+
+    }
 
     public static final String RESOURCE_NAME = "passwordpreferences";
     public static final String ENTITY_NAME = "PASSWORD_PREFERENCES";
@@ -37,6 +41,6 @@ public class PasswordPreferencesApiConstants {
     // request parameters
     public static final String VALIDATION_POLICY_ID = "validationPolicyId";
 
-    protected static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(ID_PARAM_NAME, ACTIVE, DESCRIPTION));
+    static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(Arrays.asList(ID_PARAM_NAME, ACTIVE, DESCRIPTION));
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserConstants.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.useradministration.service;
 
-public class AppUserConstants {
+public final class AppUserConstants {
+
+    private AppUserConstants() {
+
+    }
 
     public static final String PASSWORD_NEVER_EXPIRES = "passwordNeverExpires";
     public static final String IS_SELF_SERVICE_USER = "isSelfServiceUser";

--- a/fineract-provider/src/test/java/org/apache/fineract/common/Utils.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/common/Utils.java
@@ -38,7 +38,11 @@ import org.slf4j.LoggerFactory;
  * eventually do completely away with src/integrationTest and have only src/test.. can you help? ;)
  */
 @SuppressWarnings("unchecked")
-public class Utils {
+public final class Utils {
+
+    private Utils() {
+
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
     public static final String TENANT_IDENTIFIER = "tenantIdentifier=default";

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/LoanProductRelatedDetailTestHelper.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/LoanProductRelatedDetailTestHelper.java
@@ -33,7 +33,11 @@ import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail
  * This class is used to keep in one place configurations for setting up {@link LoanProductRelatedDetail} object used in
  * {@link LoanScheduleGenerator} 's
  */
-public class LoanProductRelatedDetailTestHelper {
+public final class LoanProductRelatedDetailTestHelper {
+
+    private LoanProductRelatedDetailTestHelper() {
+
+    }
 
     public static LoanProductRelatedDetail createSettingsForEqualPrincipalAmortizationQuarterly() {
 

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/LoanScheduleTestDataHelper.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/LoanScheduleTestDataHelper.java
@@ -27,7 +27,11 @@ import org.joda.time.LocalDate;
 /**
  * Helper class for creating loan schedule data suitable for testing.
  */
-public class LoanScheduleTestDataHelper {
+public final class LoanScheduleTestDataHelper {
+
+    private LoanScheduleTestDataHelper() {
+
+    }
 
     /**
      * Creates brand new three installment loan:


### PR DESCRIPTION
FINERACT-821

HideUtilityClassConstructor  ->
Utility Classes like Helperand Constants are forced to have all methods static, and constructor non-public and non-default
If we keep constructor protected we cannot create an object of that class but support inheritance if required.  The other option was to use a private constructor(which won't support inheritance). I have decided to go with protected constructor any contradicting views?

The problems-> 
1. Some Utility classes don't have all the methods static and also use "this" keyword inside methods.
Solution-> remove this keywords and make the method static.
2. The constructor is used to set values in a utility class
Solution -> Make another method to set values and make constructor protected. 
3. Some methods return "this" 
Solution-> Very suspicious on this, why is a utility class returning its instance? Still looking into how to fix this.

There are about 150-200 changes so can anyone please verify this approach? Do you see any unintended side effects? 
@vorburger @awasum @ptuomola @xurror @percyashu 
