### PR TITLE
FINERACT-942 Added and Enforced IllegalThrows checkstyle

### DIFF
--- a/fineract-provider/config/checkstyle/checkstyle.xml
+++ b/fineract-provider/config/checkstyle/checkstyle.xml
@@ -57,6 +57,7 @@
         </module>
         <module name="EqualsHashCode"/>
         <module name="FallThrough"/>
+        <module name="IllegalThrows" />
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
         <module name="AvoidStarImport"/>
@@ -119,7 +120,7 @@
 
         < ! - - TODO Checks for Exception Handling Anti-Patterns - - >
         <module name="IllegalCatch"/>
-        <module name="IllegalThrows" />
+
         <module name="MutableException"/>
         <module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseExceptionCheck" />
 

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
@@ -194,7 +194,7 @@ public class InteropApiResource {
     public String registerAccountIdentifier(@PathParam("idType") @ApiParam(value = "idType") InteropIdentifierType idType,
                                             @PathParam("idValue") @ApiParam(value = "idValue") String idValue,
                                             @ApiParam(hidden = true) String identifierJson, @Context UriInfo uriInfo)
-            throws Throwable {
+                        {
         CommandWrapper commandRequest = new InteropWrapperBuilder().registerAccountIdentifier(idType, idValue, null).withJson(identifierJson).build();
 
         InteropIdentifierAccountResponseData result = (InteropIdentifierAccountResponseData) commandsSourceService.logCommandSource(commandRequest);
@@ -215,7 +215,7 @@ public class InteropApiResource {
                                             @PathParam("idValue") @ApiParam(value = "idValue") String idValue,
                                             @PathParam("subIdOrType") @ApiParam(value = "subIdOrType") String subIdOrType,
                                             @ApiParam(hidden = true) String identifierJson, @Context UriInfo uriInfo)
-            throws Throwable {
+                         {
         CommandWrapper commandRequest = new InteropWrapperBuilder().registerAccountIdentifier(idType, idValue, subIdOrType).withJson(identifierJson).build();
 
         InteropIdentifierAccountResponseData result = (InteropIdentifierAccountResponseData) commandsSourceService.logCommandSource(commandRequest);
@@ -235,7 +235,7 @@ public class InteropApiResource {
     public String deleteAccountIdentifier(@PathParam("idType") @ApiParam(value = "idType") InteropIdentifierType idType,
                                           @PathParam("idValue") @ApiParam(value = "idValue") String idValue,
                                           @Context UriInfo uriInfo)
-            throws Throwable {
+                         {
         CommandWrapper commandRequest = new InteropWrapperBuilder().deleteAccountIdentifier(idType, idValue, null).build();
 
         InteropIdentifierAccountResponseData result = (InteropIdentifierAccountResponseData) commandsSourceService.logCommandSource(commandRequest);
@@ -256,7 +256,7 @@ public class InteropApiResource {
                                           @PathParam("idValue") @ApiParam(value = "idValue") String idValue,
                                           @PathParam("subIdOrType") @ApiParam(value = "subIdOrType") String subIdOrType,
                                           @Context UriInfo uriInfo)
-            throws Throwable {
+                           {
         CommandWrapper commandRequest = new InteropWrapperBuilder().deleteAccountIdentifier(idType, idValue, subIdOrType).build();
 
         InteropIdentifierAccountResponseData result = (InteropIdentifierAccountResponseData) commandsSourceService.logCommandSource(commandRequest);


### PR DESCRIPTION
Just curious on this change:
IllegalThrows:  Declaring that a method throws java.lang.Error or java.lang.RuntimeException is almost never acceptable.

I was doing a bit of research why this is not a good idea, I came across a contradicting statement on this on [link](https://stackabuse.com/exception-handling-in-java-a-complete-guide-with-best-and-worst-practices/ ) : 

> Since we're throwing a runtime exception, there's no need to include it in the method signature, like in the example above, but it's often considered good practice to do so, at least for the sake of documentation. 

Any comments on this @vorburger @xurror @ptuomola ?

