### PR TITLE
Reduce AWS SDK Dependency Updating to monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,10 @@
   "ignorePaths": [
     "docs/**"
   ],
-  "labels": ["renovate"]
+  "labels": ["renovate"],
+  "packageRules": [{
+    "description": "Limit the aws sdk to monthly updates because otherwise it PRs every day",
+    "packageNames": ["com.amazonaws:aws-java-sdk-s3"],
+    "schedule": ["monthly"]
+  }]
 }


### PR DESCRIPTION
## Description

This Renovate Bot configuration change will mean that PRs for `com.amazonaws:aws-java-sdk-s3` will be created only on the first day of each month. Existing (open) PRs will continue to get rebased (if conflicted) or updated (if a newer version gets released), but once the PR is merged or closed then another one won't be created again until the next month.

Discussion: https://github.com/apache/fineract/pull/1071#issuecomment-644957795

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
