### PR TITLE
add @Disabled to 2 old unit tests (which perhaps should be removed)

### DIFF
--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/AdhikarLoanRepaymentScheduleTransactionProcessorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/AdhikarLoanRepaymentScheduleTransactionProcessorTest.java
@@ -27,6 +27,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleIns
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.RBILoanRepaymentScheduleTransactionProcessor;
 import org.joda.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,14 +39,12 @@ public class AdhikarLoanRepaymentScheduleTransactionProcessorTest {
     // class under test
     private RBILoanRepaymentScheduleTransactionProcessor processor;
 
-    //
     private final LocalDate july2nd = new LocalDate(2012, 7, 2);
     private final MonetaryCurrency usDollars = new MonetaryCurrencyBuilder().withCode("USD").withDigitsAfterDecimal(2).build();
     private List<LoanRepaymentScheduleInstallment> installments;
 
     @BeforeEach
     public void setUpForEachTestCase() throws Exception {
-
         Field field = MoneyHelper.class.getDeclaredField("roundingMode");
         field.setAccessible(true);
         field.set(null, RoundingMode.HALF_EVEN);
@@ -58,6 +57,7 @@ public class AdhikarLoanRepaymentScheduleTransactionProcessorTest {
      * Scenario 1: Given no overdue installments, current interest due is paid before principal.
      */
     @Test
+    @Disabled
     public void givenNoOverdueInstallmentsOnTimeRepaymentPaysOffInterestDueFirst() {
 
         // // setup

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/HeavensFamilyLoanRepaymentScheduleTransactionProcessorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/HeavensFamilyLoanRepaymentScheduleTransactionProcessorTest.java
@@ -27,6 +27,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleIns
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.HeavensFamilyLoanRepaymentScheduleTransactionProcessor;
 import org.joda.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,14 +39,12 @@ public class HeavensFamilyLoanRepaymentScheduleTransactionProcessorTest {
     // class under test
     private HeavensFamilyLoanRepaymentScheduleTransactionProcessor processor;
 
-    //
     private final LocalDate july2nd = new LocalDate(2012, 7, 2);
     private final MonetaryCurrency usDollars = new MonetaryCurrencyBuilder().withCode("USD").withDigitsAfterDecimal(2).build();
     private List<LoanRepaymentScheduleInstallment> installments;
 
     @BeforeEach
     public void setUpForEachTestCase() throws Exception {
-
         Field field = MoneyHelper.class.getDeclaredField("roundingMode");
         field.setAccessible(true);
         field.set(null, RoundingMode.HALF_EVEN);
@@ -62,6 +61,7 @@ public class HeavensFamilyLoanRepaymentScheduleTransactionProcessorTest {
      * and zero principal portion
      */
     @Test
+    @Disabled
     public void givenSingleOnTimeLoanTransactionShouldPayoffInterestComponentFirst() {
 
         // // setup


### PR DESCRIPTION
This saves a few seconds ;) in the build, and (more importantly)
makes it easier to find all the project's @Disabled (formerly @Ignore) tests.