### PR TITLE
make ApiParameterError (almost) immutable [FINERACT-1064]

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/data/AccountNumberFormatDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/data/AccountNumberFormatDataValidator.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Component;
 public class AccountNumberFormatDataValidator {
 
     private final FromJsonHelper fromApiJsonHelper;
+
     private static final Set<String> ACCOUNT_NUMBER_FORMAT_CREATE_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(AccountNumberFormatConstants.accountTypeParamName, AccountNumberFormatConstants.prefixTypeParamName));
 
@@ -56,7 +57,6 @@ public class AccountNumberFormatDataValidator {
     }
 
     public void validateForCreate(final String json) {
-
         if (StringUtils.isBlank(json)) {
             throw new InvalidJsonException();
         }
@@ -136,7 +136,6 @@ public class AccountNumberFormatDataValidator {
     }
 
     public void validateForUpdate(final String json, EntityAccountType entityAccountType) {
-
         if (StringUtils.isBlank(json)) {
             throw new InvalidJsonException();
         }
@@ -166,12 +165,10 @@ public class AccountNumberFormatDataValidator {
         }
 
         throwExceptionIfValidationWarningsExist(dataValidationErrors);
-
     }
 
     private void throwExceptionIfValidationWarningsExist(final List<ApiParameterError> dataValidationErrors) {
         if (!dataValidationErrors.isEmpty()) {
-            //
             throw new PlatformApiDataValidationException(dataValidationErrors);
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/ApiErrorMessageArg.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/ApiErrorMessageArg.java
@@ -29,10 +29,6 @@ public class ApiErrorMessageArg {
         return new ApiErrorMessageArg(object);
     }
 
-    protected ApiErrorMessageArg() {
-        //
-    }
-
     public ApiErrorMessageArg(final Object object) {
         this.value = object;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/ApiParameterError.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/ApiParameterError.java
@@ -23,23 +23,23 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class ApiParameterError {
+public final class ApiParameterError {
 
     /**
      * A developer friendly plain English description of why the HTTP error response was returned from the API.
      */
-    private String developerMessage;
+    private final String developerMessage;
 
     /**
      * A user friendly plain English description of why the HTTP error response was returned from the API that can be
      * presented to end users.
      */
-    private String defaultUserMessage;
+    private final String defaultUserMessage;
 
     /**
      * A code that can be used for globalisation support by client applications of the API.
      */
-    private String userMessageGlobalisationCode;
+    private final String userMessageGlobalisationCode;
 
     /**
      * The name of the field or parameter passed to the API that this error relates to.
@@ -49,41 +49,46 @@ public class ApiParameterError {
     /**
      * The actual value of the parameter (if any) as passed to API.
      */
-    private Object value;
+    private final Object value;
 
     /**
      * Arguments related to the user error message.
      */
-    private List<ApiErrorMessageArg> args = new ArrayList<>();
+    private final List<ApiErrorMessageArg> args;
 
     private final transient SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
 
     public static ApiParameterError generalError(final String globalisationMessageCode, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
-        return new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs);
+        return new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs, "id", null);
     }
 
     public static ApiParameterError resourceIdentifierNotFound(final String globalisationMessageCode, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
-        return new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs);
+        return new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs, "id", null);
     }
 
     public static ApiParameterError parameterError(final String globalisationMessageCode, final String defaultUserMessage,
             final String parameterName, final Object... defaultUserMessageArgs) {
-        final ApiParameterError error = new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs);
-        error.setParameterName(parameterName);
+        final ApiParameterError error = new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs,
+                parameterName, null);
         return error;
     }
 
-    protected ApiParameterError() {
-        //
+    public static ApiParameterError parameterErrorWithValue(final String globalisationMessageCode, final String defaultUserMessage,
+            final String parameterName, final String value, final Object... defaultUserMessageArgs) {
+        final ApiParameterError error = new ApiParameterError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs,
+                parameterName, value);
+        return error;
     }
 
-    private ApiParameterError(final String globalisationMessageCode, final String defaultUserMessage,
-            final Object[] defaultUserMessageArgs) {
+    private ApiParameterError(final String globalisationMessageCode, final String defaultUserMessage, final Object[] defaultUserMessageArgs,
+            String parameterName, String value) {
         this.userMessageGlobalisationCode = globalisationMessageCode;
         this.developerMessage = defaultUserMessage;
         this.defaultUserMessage = defaultUserMessage;
+        this.parameterName = parameterName;
+        this.value = value;
 
         final List<ApiErrorMessageArg> messageArgs = new ArrayList<>();
         if (defaultUserMessageArgs != null) {
@@ -97,32 +102,18 @@ public class ApiParameterError {
             }
         }
         this.args = messageArgs;
-
-        this.parameterName = "id";
     }
 
     public String getDeveloperMessage() {
         return this.developerMessage;
     }
 
-    public void setDeveloperMessage(final String developerMessage) {
-        this.developerMessage = developerMessage;
-    }
-
     public String getDefaultUserMessage() {
         return this.defaultUserMessage;
     }
 
-    public void setDefaultUserMessage(final String defaultUserMessage) {
-        this.defaultUserMessage = defaultUserMessage;
-    }
-
     public String getUserMessageGlobalisationCode() {
         return this.userMessageGlobalisationCode;
-    }
-
-    public void setUserMessageGlobalisationCode(final String userMessageGlobalisationCode) {
-        this.userMessageGlobalisationCode = userMessageGlobalisationCode;
     }
 
     public String getParameterName() {
@@ -137,15 +128,7 @@ public class ApiParameterError {
         return this.value;
     }
 
-    public void setValue(final Object value) {
-        this.value = value;
-    }
-
     public List<ApiErrorMessageArg> getArgs() {
         return this.args;
-    }
-
-    public void setArgs(final List<ApiErrorMessageArg> args) {
-        this.args = args;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelper.java
@@ -560,11 +560,10 @@ public class JsonParserHelper {
         } catch (final ParseException e) {
 
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-            final ApiParameterError error = ApiParameterError.parameterError("validation.msg.invalid.integer.format",
+            final ApiParameterError error = ApiParameterError.parameterErrorWithValue("validation.msg.invalid.integer.format",
                     "The parameter " + parameterName + " has value: " + numericalValueFormatted
                             + " which is invalid integer value for provided locale of [" + clientApplicationLocale.toString() + "].",
-                    parameterName, numericalValueFormatted, clientApplicationLocale);
-            error.setValue(numericalValueFormatted);
+                    parameterName, numericalValueFormatted, numericalValueFormatted, clientApplicationLocale);
             dataValidationErrors.add(error);
 
             throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.",
@@ -585,10 +584,9 @@ public class JsonParserHelper {
         } catch (final NumberFormatException e) {
 
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-            final ApiParameterError error = ApiParameterError.parameterError("validation.msg.invalid.integer",
+            final ApiParameterError error = ApiParameterError.parameterErrorWithValue("validation.msg.invalid.integer",
                     "The parameter " + parameterName + " has value: " + numericalValueFormatted + " which is invalid integer.",
-                    parameterName, numericalValueFormatted);
-            error.setValue(numericalValueFormatted);
+                    parameterName, numericalValueFormatted, numericalValueFormatted);
             dataValidationErrors.add(error);
 
             throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.",
@@ -632,7 +630,7 @@ public class JsonParserHelper {
                 if (parsedNumber instanceof BigDecimal) {
                     number = (BigDecimal) parsedNumber;
                 } else {
-                    number = BigDecimal.valueOf(Double.valueOf(parsedNumber.doubleValue()));
+                    number = BigDecimal.valueOf(parsedNumber.doubleValue());
                 }
             }
 
@@ -640,11 +638,10 @@ public class JsonParserHelper {
         } catch (final ParseException e) {
 
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-            final ApiParameterError error = ApiParameterError.parameterError("validation.msg.invalid.decimal.format",
+            final ApiParameterError error = ApiParameterError.parameterErrorWithValue("validation.msg.invalid.decimal.format",
                     "The parameter " + parameterName + " has value: " + numericalValueFormatted
                             + " which is invalid decimal value for provided locale of [" + clientApplicationLocale.toString() + "].",
-                    parameterName, numericalValueFormatted, clientApplicationLocale);
-            error.setValue(numericalValueFormatted);
+                    parameterName, numericalValueFormatted, numericalValueFormatted, clientApplicationLocale);
             dataValidationErrors.add(error);
 
             throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.",

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/EntityDatatableChecksWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/EntityDatatableChecksWritePlatformServiceImpl.java
@@ -107,7 +107,7 @@ public class EntityDatatableChecksWritePlatformServiceImpl implements EntityData
             final String foreignKeyColumnName = EntityTables.getForeignKeyColumnNameOnDatatable(entity);
             final boolean columnExist = datatableData.hasColumn(foreignKeyColumnName);
 
-            LOG.info("{} has column {} ? {}", new Object[] { datatableData.getRegisteredTableName(), foreignKeyColumnName, columnExist });
+            LOG.info("{} has column {} ? {}", datatableData.getRegisteredTableName(), foreignKeyColumnName, columnExist);
 
             if (!columnExist) {
                 throw new EntityDatatableCheckNotSupportedException(datatableData.getRegisteredTableName(), entity);
@@ -237,7 +237,6 @@ public class EntityDatatableChecksWritePlatformServiceImpl implements EntityData
                 try {
                     this.readWriteNonCoreDataService.createNewDatatableEntry(datatableName, entityId, datatableData.toString());
                 } catch (PlatformApiDataValidationException e) {
-                    List<ApiParameterError> errors = e.getErrors();
                     for (ApiParameterError error : e.getErrors()) {
                         error.setParameterName("datatables." + datatableName + "." + error.getParameterName());
                     }


### PR DESCRIPTION
FINERACT-1064

by making (most of) its fields final, because Immutable is Good

Only "almost" / "most" because of the of the remaining use of setParameterName() in
EntityDatatableChecksWritePlatformServiceImpl.saveDatatables() which unfortunately looks
a lot less trivial to get rid of, so that's for another time/someone else, later (or never).