### PR TITLE
FINERACT-1061: Removing call to rs.beforeFirst()

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/productmix/service/ProductMixReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/productmix/service/ProductMixReadPlatformServiceImpl.java
@@ -111,9 +111,7 @@ public class ProductMixReadPlatformServiceImpl implements ProductMixReadPlatform
                 extractedData.put(this.productId, productMixData);
                 return extractedData;
             }
-            /* move the cursor to starting of resultset */
-            rs.beforeFirst();
-            while (rs.next()) {
+            do {
                 final Long productId = rs.getLong("productId");
                 final String name = rs.getString("name");
                 final Collection<LoanProductData> restrictedProducts = this.loanProductReadPlatformService
@@ -122,7 +120,7 @@ public class ProductMixReadPlatformServiceImpl implements ProductMixReadPlatform
                         .retrieveAllowedProductsForMix(productId);
                 final ProductMixData productMixData = ProductMixData.withDetails(productId, name, restrictedProducts, allowedProducts);
                 extractedData.put(productId, productMixData);
-            }
+            } while (rs.next());
             return extractedData;
         }
     }


### PR DESCRIPTION
FINERACT-1061

## Description
Call to rs.beforeFirst() is not supported by many JDBC drivers, so changing the logic flow to remove it

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
