### PR TITLE
FINERACT-1079: Run spotlessApply before compileJava task

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -578,7 +578,7 @@ modernizer {
 
 compileJava{
     dependsOn rat
-    dependsOn spotlessCheck
+    dependsOn spotlessApply
     finalizedBy resolve
 }
 


### PR DESCRIPTION
## Description
Developers consistently have problems manually running the spotlessApply task after coding changes... See: https://github.com/apache/fineract/pull/1151 and https://github.com/apache/fineract/pull/1148

maybe we should just run spotlessApply just before compilation and skip the tasks to check for spotless failures? Or we run both of them: Run spotlessApply before spotlessCheck (seems wasteful). Is this a good idea? I wonder?

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
