### PR TITLE
FINERACT-1066 Fixes: NullPointerException at SQLInjectionValidator.va…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/ColumnValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/ColumnValidator.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.service.RoutingDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,6 +92,9 @@ public class ColumnValidator {
 
     public void validateSqlInjection(String schema, String... conditions) {
         for (String condition : conditions) {
+            if (StringUtils.isBlank(condition)) {
+                continue;
+            }
             SQLInjectionValidator.validateSQLInput(condition);
             List<String> operator = new ArrayList<>(Arrays.asList("=", ">", "<", "> =", "< =", "! =", "!=", ">=", "<="));
             condition = condition.trim().replace("( ", "(").replace(" )", ")").toLowerCase();

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/SQLInjectionValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/utils/SQLInjectionValidator.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.security.utils;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 
 public class SQLInjectionValidator {
 
@@ -33,6 +34,9 @@ public class SQLInjectionValidator {
     private static final String SQL_PATTERN = "[a-zA-Z_=,\\-'!><.?\"`% ()0-9*\n\r]*";
 
     public static final void validateSQLInput(final String sqlSearch) {
+        if (StringUtils.isBlank(sqlSearch)) {
+            return;
+        }
         String lowerCaseSQL = sqlSearch.toLowerCase();
         for (String ddl : DDL_COMMANDS) {
             if (lowerCaseSQL.contains(ddl)) {
@@ -118,6 +122,9 @@ public class SQLInjectionValidator {
     }
 
     public static final void validateAdhocQuery(final String sqlSearch) {
+        if (StringUtils.isBlank(sqlSearch)) {
+            return;
+        }
         String lowerCaseSQL = sqlSearch.toLowerCase().trim();
         for (String ddl : DDL_COMMANDS) {
             if (lowerCaseSQL.startsWith(ddl)) {


### PR DESCRIPTION
This happened due to 
```
  if (searchParameters.isOrderByRequested()) {
                sqlBuilder.append(" order by ").append(searchParameters.getOrderBy()).append(' ').append(searchParameters.getSortOrder());
                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getOrderBy(),
                        searchParameters.getSortOrder());
            }
```
-> here, we checked if OrderBY was not null but did not check if sortorder was "not null".

Instead of fixing it here, it is better to fix it in the called function (IMO).
Since the function SQLvalidateinput can be called either from columnValidator or independently, I have added check for not null at both the places.
