### PR TITLE
Update openjpa to v3.1.2 also in dependencyManagement not just buildscript

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -91,7 +91,7 @@ dependencyManagement {
         // We use the Renovate Bot to automatically propose Pull Requests (PRs) when upgrades for all of these versions are available.
 
         dependency 'org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE'
-        dependency 'org.apache.openjpa:openjpa:3.1.1' // when upgrading, also change OpenJPA version repeated above in buildscript!
+        dependency 'org.apache.openjpa:openjpa:3.1.2' // when upgrading, also change OpenJPA version repeated above in buildscript!
         dependency 'com.squareup.retrofit:retrofit:1.9.0'
         dependency 'com.squareup.okhttp:okhttp:2.7.5'
         dependency 'com.squareup.okhttp:okhttp-urlconnection:2.7.5'


### PR DESCRIPTION
This is a follow-up to #1170 which upgrade only one but not the other occurrence of the OpenJPA version.