### PR TITLE
FINERACT-1037: Adding persistent volume for Fineract imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
     build:
       context: .
       target: fineract
+    volumes:
+      - fineract-home:/root/.fineract
     ports: 
       - 8443:8443
     depends_on:
@@ -63,6 +65,8 @@ services:
     ports:
       - 9090:80
 
+volumes:
+  fineract-home:
 
 # https://issues.apache.org/jira/browse/FINERACT-762
 # To use an altnerative JDBC driver (which is faster, but not allowed to be default in Apache distribution)


### PR DESCRIPTION
FINERACT-1037

## Description
Currently any imported files are stored in the Fineract container itself. Once the container is recreated, these files are lost and the database is out of synch. To fix this, create a volume for storing the imported files and mount that to the container. 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
