### PR TITLE
FINERACT-1095 Added status parameter in Clients API

### DIFF
--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -622,4 +623,12 @@ public class ClientHelper {
         return Utils.performServerTemplatePost(requestSpec, responseSpec, CLIENT_URL + "/uploadtemplate" + "?" + Utils.TENANT_IDENTIFIER,
                 legalFormType, file, locale, dateFormat);
     }
+
+    public List getClientWithStatus(final int limit, final String status) {
+        final String URL = "/fineract-provider/api/v1/clients?paged=true&status=" + status + "&limit=" + Integer.toString(limit) + "&"
+                + Utils.TENANT_IDENTIFIER;
+        LinkedHashMap responseClients = Utils.performServerGet(requestSpec, responseSpec, URL, "");
+        return (List) responseClients.get("pageItems");
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
@@ -29,6 +29,7 @@ public final class SearchParameters {
     private final String hierarchy;
     private final String firstname;
     private final String lastname;
+    private final String status;
     private final Integer offset;
     private final Integer limit;
     private final String orderBy;
@@ -62,8 +63,9 @@ public final class SearchParameters {
     }
 
     public static SearchParameters forClients(final String sqlSearch, final Long officeId, final String externalId,
-            final String displayName, final String firstname, final String lastname, final String hierarchy, final Integer offset,
-            final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly, final boolean isSelfUser) {
+            final String displayName, final String firstname, final String lastname, final String status, final String hierarchy,
+            final Integer offset, final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly,
+            final boolean isSelfUser) {
 
         final Integer maxLimitAllowed = getCheckedLimit(limit);
         final Long staffId = null;
@@ -71,8 +73,8 @@ public final class SearchParameters {
         final Long loanId = null;
         final Long savingsId = null;
 
-        return new SearchParameters(sqlSearch, officeId, externalId, displayName, hierarchy, firstname, lastname, offset, maxLimitAllowed,
-                orderBy, sortOrder, staffId, accountNo, loanId, savingsId, orphansOnly, isSelfUser);
+        return new SearchParameters(sqlSearch, officeId, externalId, displayName, hierarchy, firstname, lastname, status, offset,
+                maxLimitAllowed, orderBy, sortOrder, staffId, accountNo, loanId, savingsId, orphansOnly, isSelfUser);
     }
 
     public static SearchParameters forGroups(final String sqlSearch, final Long officeId, final Long staffId, final String externalId,
@@ -266,6 +268,36 @@ public final class SearchParameters {
         this.productId = null;
         this.categoryId = null;
         this.isSelfUser = isSelfUser;
+        this.status = null;
+
+    }
+
+    private SearchParameters(final String sqlSearch, final Long officeId, final String externalId, final String name,
+            final String hierarchy, final String firstname, final String lastname, final String status, final Integer offset,
+            final Integer limit, final String orderBy, final String sortOrder, final Long staffId, final String accountNo,
+            final Long loanId, final Long savingsId, final Boolean orphansOnly, boolean isSelfUser) {
+        this.sqlSearch = sqlSearch;
+        this.officeId = officeId;
+        this.externalId = externalId;
+        this.name = name;
+        this.hierarchy = hierarchy;
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.offset = offset;
+        this.limit = limit;
+        this.orderBy = orderBy;
+        this.sortOrder = sortOrder;
+        this.staffId = staffId;
+        this.accountNo = accountNo;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.orphansOnly = orphansOnly;
+        this.currencyCode = null;
+        this.provisioningEntryId = null;
+        this.productId = null;
+        this.categoryId = null;
+        this.isSelfUser = isSelfUser;
+        this.status = status;
 
     }
 
@@ -292,6 +324,7 @@ public final class SearchParameters {
         this.productId = productId;
         this.categoryId = categoryId;
         this.isSelfUser = false;
+        this.status = null;
 
     }
 
@@ -320,6 +353,8 @@ public final class SearchParameters {
         this.productId = null;
         this.categoryId = null;
         this.isSelfUser = false;
+        this.status = null;
+
     }
 
     public boolean isOrderByRequested() {
@@ -396,6 +431,10 @@ public final class SearchParameters {
 
     public String getLastname() {
         return this.lastname;
+    }
+
+    public String getStatus() {
+        return this.status;
     }
 
     public Integer getOffset() {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
@@ -166,6 +166,7 @@ public class ClientsApiResource {
             @QueryParam("displayName") @Parameter(description = "displayName") final String displayName,
             @QueryParam("firstName") @Parameter(description = "firstName") final String firstname,
             @QueryParam("lastName") @Parameter(description = "lastName") final String lastname,
+            @QueryParam("status") @Parameter(description = "status") final String status,
             @QueryParam("underHierarchy") @Parameter(description = "underHierarchy") final String hierarchy,
             @QueryParam("offset") @Parameter(description = "offset") final Integer offset,
             @QueryParam("limit") @Parameter(description = "limit") final Integer limit,
@@ -173,18 +174,19 @@ public class ClientsApiResource {
             @QueryParam("sortOrder") @Parameter(description = "sortOrder") final String sortOrder,
             @QueryParam("orphansOnly") @Parameter(description = "orphansOnly") final Boolean orphansOnly) {
 
-        return this.retrieveAll(uriInfo, sqlSearch, officeId, externalId, displayName, firstname, lastname, hierarchy, offset, limit,
-                orderBy, sortOrder, orphansOnly, false);
+        return this.retrieveAll(uriInfo, sqlSearch, officeId, externalId, displayName, firstname, lastname, status, hierarchy, offset,
+                limit, orderBy, sortOrder, orphansOnly, false);
     }
 
     public String retrieveAll(final UriInfo uriInfo, final String sqlSearch, final Long officeId, final String externalId,
-            final String displayName, final String firstname, final String lastname, final String hierarchy, final Integer offset,
-            final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly, final boolean isSelfUser) {
+            final String displayName, final String firstname, final String lastname, final String status, final String hierarchy,
+            final Integer offset, final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly,
+            final boolean isSelfUser) {
 
         this.context.authenticatedUser().validateHasReadPermission(ClientApiConstants.CLIENT_RESOURCE_NAME);
 
         final SearchParameters searchParameters = SearchParameters.forClients(sqlSearch, officeId, externalId, displayName, firstname,
-                lastname, hierarchy, offset, limit, orderBy, sortOrder, orphansOnly, isSelfUser);
+                lastname, status, hierarchy, offset, limit, orderBy, sortOrder, orphansOnly, isSelfUser);
 
         final Page<ClientData> clientData = this.clientReadPlatformService.retrieveAll(searchParameters);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientStatus.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientStatus.java
@@ -18,6 +18,8 @@
  */
 package org.apache.fineract.portfolio.client.domain;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Enum representation of client status states.
  */
@@ -61,6 +63,33 @@ public enum ClientStatus {
 
         }
         return enumeration;
+    }
+
+    public static ClientStatus fromString(final String clientString) {
+
+        ClientStatus clientStatus = ClientStatus.INVALID;
+
+        if (StringUtils.isEmpty(clientString)) {
+            return clientStatus;
+        }
+
+        if (clientString.equalsIgnoreCase(ClientStatus.PENDING.toString())) {
+            clientStatus = ClientStatus.PENDING;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.ACTIVE.toString())) {
+            clientStatus = ClientStatus.ACTIVE;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.TRANSFER_IN_PROGRESS.toString())) {
+            clientStatus = ClientStatus.TRANSFER_IN_PROGRESS;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.WITHDRAWN.toString())) {
+            clientStatus = ClientStatus.WITHDRAWN;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.CLOSED.toString())) {
+            clientStatus = ClientStatus.CLOSED;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.TRANSFER_ON_HOLD.toString())) {
+            clientStatus = ClientStatus.TRANSFER_ON_HOLD;
+        } else if (clientString.equalsIgnoreCase(ClientStatus.REJECTED.toString())) {
+            clientStatus = ClientStatus.REJECTED;
+        }
+
+        return clientStatus;
     }
 
     private ClientStatus(final Integer value, final String code) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -92,8 +92,6 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
     private final ConfigurationReadPlatformService configurationReadPlatformService;
     private final EntityDatatableChecksReadService entityDatatableChecksReadService;
     private final ColumnValidator columnValidator;
-    private final List<String> supportedStatusvalues = new ArrayList<String>(
-            Arrays.asList("pending", "active", "withdrawn", "closed", "rejected", "transfer_on_hold", "transfer_in_progreess"));
 
     @Autowired
     public ClientReadPlatformServiceImpl(final PlatformSecurityContext context, final RoutingDataSource dataSource,
@@ -181,12 +179,11 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
     public Page<ClientData> retrieveAll(final SearchParameters searchParameters) {
 
         if (searchParameters != null && searchParameters.getStatus() != null
-                && !supportedStatusvalues.contains(searchParameters.getStatus())) {
+                && ClientStatus.fromString(searchParameters.getStatus()) == ClientStatus.INVALID) {
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-            final String defaultUserMessage = "The Status value '" + searchParameters.getStatus()
-                    + "' is not supported. The supported status values are " + supportedStatusvalues.toString();
+            final String defaultUserMessage = "The Status value '" + searchParameters.getStatus() + "' is not supported.";
             final ApiParameterError error = ApiParameterError.parameterError("validation.msg.client.status.value.is.not.supported",
-                    defaultUserMessage, "status", searchParameters.getStatus(), supportedStatusvalues.toString());
+                    defaultUserMessage, "status", searchParameters.getStatus());
             dataValidationErrors.add(error);
             throw new PlatformApiDataValidationException(dataValidationErrors);
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/client/api/SelfClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/client/api/SelfClientsApiResource.java
@@ -99,6 +99,7 @@ public class SelfClientsApiResource {
             @QueryParam("firstName") @Parameter(description = "firstName") final String firstname,
             @QueryParam("lastName") @Parameter(description = "lastName") final String lastname,
             @QueryParam("offset") @Parameter(description = "offset") final Integer offset,
+            @QueryParam("status") @Parameter(description = "status") final String status,
             @QueryParam("limit") @Parameter(description = "limit") final Integer limit,
             @QueryParam("orderBy") @Parameter(description = "orderBy") final String orderBy,
             @QueryParam("sortOrder") @Parameter(description = "sortOrder") final String sortOrder) {
@@ -108,8 +109,8 @@ public class SelfClientsApiResource {
         final String externalId = null;
         final String hierarchy = null;
         final Boolean orphansOnly = null;
-        return this.clientApiResource.retrieveAll(uriInfo, sqlSearch, officeId, externalId, displayName, firstname, lastname, hierarchy,
-                offset, limit, orderBy, sortOrder, orphansOnly, true);
+        return this.clientApiResource.retrieveAll(uriInfo, sqlSearch, officeId, externalId, displayName, firstname, lastname, status,
+                hierarchy, offset, limit, orderBy, sortOrder, orphansOnly, true);
     }
 
     @GET


### PR DESCRIPTION
This PR adds a new parameter in client - onlyPending.
The reason for adding onlyPending and not isPending is because 
we are trying to remove the use of
"c.status_enum= 100"
Now that means the status should be "only pending".

Just to remember how we are fixing this:
1. This PR is merged
2. @luckyman20 makes changes in community App
3. We wait for confirmation from the community and remove sqlSearch param in the client.

Next up I will take up the loan module.
After which, if the community agrees we will completely remove the sqlSearch param in all APIs. 