### PR TITLE
Use java8 instead of joda as dateLibrary in Swagger Client (FINERACT-838)

### DIFF
--- a/fineract-provider/config/swagger/config.json
+++ b/fineract-provider/config/swagger/config.json
@@ -5,7 +5,7 @@
    "invokerPackage": "org.apache.fineract.client",
    "modelPackage": "org.apache.fineract.client.models",
    "apiPackage": "org.apache.fineract.client.services",
-   "dateLibrary": "joda",
+   "dateLibrary": "java8",
    "hideGenerationTimestamp": "true",
    "library": "retrofit2"
 }


### PR DESCRIPTION
see FINERACT-838, this is a #1206 follow-up

In light of @percyashu #1179 for FINERACT-826, IMHO we should promote Java 8 native JSR-310 and not Joda Time even for clients.

@Grandolf49 @thesmallstar @ptuomola OK for you? Merge.

I've NOT actually tested (run) this, it's just based on https://openapi-generator.tech/docs/generators/java/.