### PR TITLE
Fixes Swagger-UI for Accrual

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/accrual/api/AccrualAccountingApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/accrual/api/AccrualAccountingApiResource.java
@@ -59,10 +59,11 @@ public class AccrualAccountingApiResource {
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Executes Periodic Accrual Accounting", method = "POST", description = "Mandatory Fields\n" + "\n" + "tillDate\n")
-    @Parameter(required = true, schema = @Schema(implementation = AccrualAccountingApiResourceSwagger.PostRunaccrualsRequest.class, description = "Request Body\n"
-            + "\n" + "Field Descriptions: \n" + "tillDate: \n" + "which specifies periodic accruals should happen till the given Date"))
     @ApiResponses({ @ApiResponse(responseCode = "200", description = "OK") })
-    public String executePeriodicAccrualAccounting(@Parameter(hidden = true) final String jsonRequestBody) {
+    public String executePeriodicAccrualAccounting(
+            @Parameter(required = true, schema = @Schema(implementation = AccrualAccountingApiResourceSwagger.PostRunaccrualsRequest.class, description = "Request Body\n"
+                    + "\n" + "Field Descriptions: \n" + "tillDate: \n"
+                    + "which specifies periodic accruals should happen till the given Date")) final String jsonRequestBody) {
 
         final CommandWrapper commandRequest = new CommandWrapperBuilder().excuteAccrualAccounting().withJson(jsonRequestBody).build();
 


### PR DESCRIPTION
I am trying to try each API in swagger as a part of testing before launching it. 
The Accural APIs did not work in tryout, I found a parameter was marked as hidden, I think it is wrong(or maybe I am wrong?).

Link: https://demo.fineract.dev/fineract-provider/swagger-ui/index.html#/Periodic%20Accrual%20Accounting/executePeriodicAccrualAccounting

It works after removing hidden

