### PR TITLE
FINERACT-1082: Changing version from hardcoded to autogenerated for Swagger

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -195,6 +195,20 @@ openjpa {
 
 // Configuration for Swagger documentation generation task
 // https://github.com/swagger-api/swagger-core/tree/master/modules/swagger-gradle-plugin
+import org.apache.tools.ant.filters.ReplaceTokens
+
+task prepareInputYaml(dependsOn: 'generateGitProperties') {
+    doLast {
+        copy {
+            from file('config/swagger/fineract-input.yaml.template')
+            into file('config/swagger')
+            rename { String filename -> return 'fineract-input.yaml' }
+            filter(ReplaceTokens, tokens: [VERSION: project.ext.gitProps['git.commit.id.describe']])
+        }
+    }
+}
+
+
 resolve {
     logging.captureStandardOutput LogLevel.INFO
     outputFileName = 'fineract'
@@ -204,6 +218,8 @@ resolve {
     outputDir = file("${buildDir}/classes/java/main/static/swagger-ui")
     openApiFile = file("config/swagger/fineract-input.yaml")
 }
+
+resolve.dependsOn prepareInputYaml
 
 // Configuration for JaCoCo code coverage task
 // https://www.eclemma.org/jacoco/
@@ -290,6 +306,7 @@ rat {
         '**/*.github/**',
         '**/MANIFEST.MF',
         '**/*.json',
+        '**/*.json.template',
         '**/*.txt',
         '**/*.log',
         '**/fineractdev-eclipse-preferences.epf',
@@ -846,14 +863,27 @@ gitProperties {
     dateFormat = "yyyy-MM-dd'T'HH:mmZ"
     dateFormatTimeZone = "GMT"
     failOnNoGitDirectory = false
+    extProperty = 'gitProps'
 }
 
 // make sure the generateGitProperties task always executes (even when git.properties is not changed)
 generateGitProperties.outputs.upToDateWhen { false }
 
-//This is for swagger code generation
+// This is for swagger code generation
+// https://github.com/int128/gradle-swagger-generator-plugin
 dependencies {
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.18'
+}
+
+task prepareConfigJson(dependsOn: 'generateGitProperties') {
+    doLast {
+        copy {
+            from file('config/swagger/config.json.template')
+            into file('config/swagger')
+            rename { String filename -> return 'config.json' }
+            filter(ReplaceTokens, tokens: [VERSION: project.ext.gitProps['git.commit.id.describe']])
+        }
+    }
 }
 
 swaggerSources {
@@ -865,3 +895,5 @@ swaggerSources {
         }
     }
 }
+
+generateSwaggerCodeFineract.dependsOn prepareConfigJson

--- a/fineract-provider/config/swagger/config.json.template
+++ b/fineract-provider/config/swagger/config.json.template
@@ -1,7 +1,7 @@
 {
    "groupId": "org.apache.fineract",
    "artifactId": "client",
-   "artifactVersion": "1.4.0",
+   "artifactVersion": "@VERSION@",
    "invokerPackage": "org.apache.fineract.client",
    "modelPackage": "org.apache.fineract.client.models",
    "apiPackage": "org.apache.fineract.client.services",

--- a/fineract-provider/config/swagger/fineract-input.yaml.template
+++ b/fineract-provider/config/swagger/fineract-input.yaml.template
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 1.4.0
+  version: @VERSION@
   title: Apache Fineract
   description: |-
     Apache Fineract is a secure, multi-tenanted microfinance platform


### PR DESCRIPTION
## Description
Use the git describe as version ID for Swagger UI and Swagger generated client

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [x] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [x] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [x] Integration tests have been created/updated for verifying the changes made.

- [x] All Integrations tests are passing with the new commits.

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
