### PR TITLE
FINERACT-1052 global config loan overpayment leaving situation as is

### DIFF
--- a/fineract-provider/config/swagger/fineract-input.yaml
+++ b/fineract-provider/config/swagger/fineract-input.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  version: release-1.4.0-561-g9bad487-dirty
+  title: Apache Fineract
+  description: |-
+    Apache Fineract is a secure, multi-tenanted microfinance platform
+
+    The goal of the Apache Fineract API is to empower developers to build apps on top of the Apache Fineract Platform<br>The [reference app](https://cui.fineract.dev) (username: mifos, password: password) works on the same demo tenant as the interactive links in this documentation
+
+    - The API is organized around [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)
+    - Find out more about Apache Fineract [here](/fineract-provider/api-docs/apiLive.htm#top)
+    - You can [Try The API From Your Browser](/fineract-provider/api-docs/apiLive.htm#interact)
+    - The Generic Options are available [here](/fineract-provider/api-docs/apiLive.htm#genopts)
+    - Find out more about [Updating Dates and Numbers](/fineract-provider/api-docs/apiLive.htm#dates_and_numbers)
+    - For the Authentication and the Basic of HTTP and HTTPS refer [here](/fineract-provider/api-docs/apiLive.htm#authentication_overview)
+    - Check about ERROR codes [here](/fineract-provider/api-docs/apiLive.htm#errors)
+
+    Please refer to the [old documentation](/fineract-provider/api-docs/apiLive.htm) for any documentation queries
+  contact:
+    email: dev@fineract.apache.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+- url: https://demo.fineract.dev/fineract-provider/api/v1
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    tenantid:        
+      type: apiKey
+      in: header       
+      name: fineract-platform-tenantid 
+security:
+  - basicAuth: []
+    tenantid: []

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V362__Loan_Overpayment_Global_Configuration.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V362__Loan_Overpayment_Global_Configuration.sql
@@ -1,0 +1,23 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--adding new configuration to enable/disable loan over payment
+
+INSERT INTO `c_configuration` (`name`, `enabled`,`description`)
+VALUES ('Enable-Loan-Overpayment',TRUE, 'configuration to enable loan payment beyond outstanding balance');


### PR DESCRIPTION
## Description
https://github.com/apache/fineract/pull/1186

Addressing the following comments from @ptuomola 

**Addressing these comments below**  
The current behaviour should be kept as the default - i.e. without a configuration present in the database, the same behaviour should remain (overpayments allowed)
The default configuration added to this should also keep the current behaviour as-is - i.e. the default Flyway script should create the configuration in such way that it allows overpayments
The existing integration tests should be kept-as is and they should continue to be used to test the current behaviour (i.e. overpayment allowed)

**but Not able to answer this**
We should create a new integration test (or multiple tests) to test the scenario where overpayments are not allowed. These tests should first set the flag to disable overpayments, then carry out the tests to confirm that overpayments fail in different scenarios, and then reset the flag back to enabling overpayments

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Commit message starts with the issue number from https://issues.apache.org/jira/projects/FINERACT/. Ex: FINERACT-646 Pockets API.

- [ ] Coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions have been followed.

- [ ] API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm has been updated with details of any API changes.

- [ ] Integration tests have been created/updated for verifying the changes made.

- [ ] All Integrations tests are passing with the new commits.

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the list.)

Our guidelines for code reviews is at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide
