### PR TITLE
Cherry-pick "Update dependency gradle to v6.6.1" to 1.4.0 also

### DIFF
--- a/fineract-provider/gradle/wrapper/gradle-wrapper.properties
+++ b/fineract-provider/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
back-port #1277 because https://github.com/gradle/gradle/releases/v6.6.1 says _We recommend that you use Gradle 6.6.1 over the initial release of Gradle 6.6._

@vidakovic if OK for you, do you want to merge this after the build passed?