### PR TITLE
Added and Enforced AbbreviationAsWordInName Checkstyle (FINERACT-821)

### DIFF
--- a/fineract-provider/config/checkstyle/checkstyle.xml
+++ b/fineract-provider/config/checkstyle/checkstyle.xml
@@ -202,6 +202,10 @@
         </module>
         <module name="AvoidNoArgumentSuperConstructorCall"/>
         <module name="AvoidDoubleBraceInitialization"/>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="4"/>
+        </module>
 <!-- TODO Enable many more checks (go about this one by one, step by step, raise separate PRs fixing and then enforcing):
 
         <module name="HiddenField">
@@ -244,10 +248,6 @@
         <module name="ConstantName" />
 
 
-        <module name="AbbreviationAsWordInName">
-            <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="4"/>
-        </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/AccountNumberPreferencesTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/AccountNumberPreferencesTest.java
@@ -316,10 +316,10 @@ public class AccountNumberPreferencesTest {
         if (isAccountPreferenceSetUp) {
             String centerPrefixName = (String) this.accountNumberPreferencesHelper
                     .getAccountNumberPreference(this.centerAccountNumberPreferenceId, "prefixType.value");
-            final String CENTER_URL = "/fineract-provider/api/v1/centers/" + this.centerId + "?" + Utils.TENANT_IDENTIFIER;
+            final String centerURL = "/fineract-provider/api/v1/centers/" + this.centerId + "?" + Utils.TENANT_IDENTIFIER;
 
             if (centerPrefixName.equals(this.officeName)) {
-                final String centerOfficeName = Utils.performServerGet(requestSpec, responseSpec, CENTER_URL, "officeName");
+                final String centerOfficeName = Utils.performServerGet(requestSpec, responseSpec, centerURL, "officeName");
                 this.validateAccountNumberLengthAndStartsWithPrefix(center.getAccountNo(), centerOfficeName);
             }
         } else {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/AccountingScenarioIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/AccountingScenarioIntegrationTest.java
@@ -151,37 +151,37 @@ public class AccountingScenarioIntegrationTest {
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(TOTAL_INTEREST, JournalEntry.TransactionType.DEBIT),
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
+        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(totalInterestValue, JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT), };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, EXPECTED_DISBURSAL_DATE, assetAccountInitialEntry);
         LOG.info("CHECKING INCOME: ******************************************");
-        final JournalEntry incomeJournalEntry = new JournalEntry(TOTAL_INTEREST, JournalEntry.TransactionType.CREDIT);
+        final JournalEntry incomeJournalEntry = new JournalEntry(totalInterestValue, JournalEntry.TransactionType.CREDIT);
         this.journalEntryHelper.checkJournalEntryForIncomeAccount(incomeAccount, EXPECTED_DISBURSAL_DATE, incomeJournalEntry);
 
         // MAKE 1
         LOG.info("Repayment 1 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[1], REPAYMENT_AMOUNT[1], loanID);
-        final float FIRST_INTEREST = 200.0f;
-        final float FIRST_PRINCIPAL = 2000.0f;
-        float expected_value = LP_PRINCIPAL - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        final float firstInterestValue = 200.0f;
+        final float firstPrincipalValue = 2000.0f;
+        float expected_value = LP_PRINCIPAL - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(1, expected_value, loanID);
         final JournalEntry[] assetAccountFirstEntry = { new JournalEntry(REPAYMENT_AMOUNT[1], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(FIRST_INTEREST + FIRST_PRINCIPAL, JournalEntry.TransactionType.CREDIT) };
+                new JournalEntry(firstInterestValue + firstPrincipalValue, JournalEntry.TransactionType.CREDIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[1], assetAccountFirstEntry);
         LOG.info("Repayment 1 Done......");
 
         // REPAYMENT 2
         LOG.info("Repayment 2 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[2], REPAYMENT_AMOUNT[2], loanID);
-        final float SECOND_AND_THIRD_INTEREST = 400.0f;
-        final float SECOND_PRINCIPAL = REPAYMENT_AMOUNT[2] - SECOND_AND_THIRD_INTEREST;
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        final float secondAndThirdInterestValue = 400.0f;
+        final float secondPrincipalValue = REPAYMENT_AMOUNT[2] - secondAndThirdInterestValue;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(2, expected_value, loanID);
         final JournalEntry[] assetAccountSecondEntry = { new JournalEntry(REPAYMENT_AMOUNT[2], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(SECOND_AND_THIRD_INTEREST + SECOND_PRINCIPAL, JournalEntry.TransactionType.CREDIT) };
+                new JournalEntry(secondAndThirdInterestValue + secondPrincipalValue, JournalEntry.TransactionType.CREDIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[2], assetAccountSecondEntry);
         LOG.info("Repayment 2 Done ......");
 
@@ -199,7 +199,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 3
         LOG.info("Repayment 3 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[3], REPAYMENT_AMOUNT[3], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         final JournalEntry[] assetAccountThirdEntry = { new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.CREDIT) };
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(3, expected_value, loanID);
@@ -209,7 +209,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 4
         LOG.info("Repayment 4 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[4], REPAYMENT_AMOUNT[4], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(4, expected_value, loanID);
         final JournalEntry[] assetAccountFourthEntry = { new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.CREDIT) };
@@ -220,7 +220,7 @@ public class AccountingScenarioIntegrationTest {
         LOG.info("Repayment 5 ......");
         final JournalEntry[] assetAccountFifthEntry = { new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.CREDIT) };
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[5], REPAYMENT_AMOUNT[5], loanID);
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(5, expected_value, loanID);
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[5], assetAccountFifthEntry);
@@ -361,15 +361,15 @@ public class AccountingScenarioIntegrationTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = (daysInMonth - currentDate) + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
 
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
@@ -384,17 +384,17 @@ public class AccountingScenarioIntegrationTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(), VALID_FROM,
-                VALID_TO, SUBMITTED_ON_DATE, FixedDepositTest.WHOLE_TERM);
+                VALID_TO, submittedOnDate, FixedDepositTest.WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(requestSpec,
                 responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -404,8 +404,8 @@ public class AccountingScenarioIntegrationTest {
         // Checking initial Journal entries after Activation.
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         Integer transactionIdForPostInterest = this.fixedDepositAccountHelper.postInterestForFixedDeposit(fixedDepositAccountId);
         Assertions.assertNotNull(transactionIdForPostInterest);
@@ -416,8 +416,8 @@ public class AccountingScenarioIntegrationTest {
         // Checking initial Journal entries after Interest Posting.
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
     }
 
@@ -443,16 +443,16 @@ public class AccountingScenarioIntegrationTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
-        final String EXPECTED_FIRST_DEPOSIT_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
+        final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = (daysInMonth - currentDate) + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
         Assertions.assertNotNull(clientId);
@@ -462,7 +462,7 @@ public class AccountingScenarioIntegrationTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, RecurringDepositTest.WHOLE_TERM, EXPECTED_FIRST_DEPOSIT_ON_DATE);
+                VALID_FROM, VALID_TO, submittedOnDate, RecurringDepositTest.WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(requestSpec,
@@ -470,11 +470,11 @@ public class AccountingScenarioIntegrationTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(requestSpec, responseSpec,
@@ -482,14 +482,14 @@ public class AccountingScenarioIntegrationTest {
         Float depositAmount = (Float) recurringDepositAccountData.get("mandatoryRecommendedDepositAmount");
 
         Integer depositTransactionId = this.recurringDepositAccountHelper.depositToRecurringDepositAccount(recurringDepositAccountId,
-                depositAmount, EXPECTED_FIRST_DEPOSIT_ON_DATE);
+                depositAmount, expectedFirstDepositOnDate);
         Assertions.assertNotNull(depositTransactionId);
 
         // Checking initial Journal entries after Activation.
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, EXPECTED_FIRST_DEPOSIT_ON_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, EXPECTED_FIRST_DEPOSIT_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, expectedFirstDepositOnDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, expectedFirstDepositOnDate,
                 liablilityAccountInitialEntry);
 
         Integer interestPostingTransactionId = this.recurringDepositAccountHelper
@@ -502,8 +502,8 @@ public class AccountingScenarioIntegrationTest {
         // Checking initial Journal entries after Interest Posting.
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
     }
 
@@ -577,8 +577,8 @@ public class AccountingScenarioIntegrationTest {
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT), };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, EXPECTED_DISBURSAL_DATE, assetAccountInitialEntry);
@@ -589,42 +589,42 @@ public class AccountingScenarioIntegrationTest {
 
         // MAKE 1
         LOG.info("Repayment 1 ......");
-        final float FIRST_INTEREST = 200.0f;
-        final float FIRST_PRINCIPAL = 2000.0f;
-        final float FEE_PORTION = 0.0f;
-        final float PENALTY_PORTION = 0.0f;
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[1]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        final float firstInterestValue = 200.0f;
+        final float firstPrincipalValue = 2000.0f;
+        final float feePortion = 0.0f;
+        final float penaltyPortion = 0.0f;
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[1]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[1], REPAYMENT_AMOUNT[1], loanID);
-        float expected_value = LP_PRINCIPAL - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        float expected_value = LP_PRINCIPAL - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(1, expected_value, loanID);
         final JournalEntry[] assetAccountFirstEntry = { new JournalEntry(REPAYMENT_AMOUNT[1], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(FIRST_INTEREST + FIRST_PRINCIPAL, JournalEntry.TransactionType.CREDIT) };
+                new JournalEntry(firstInterestValue + firstPrincipalValue, JournalEntry.TransactionType.CREDIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[1], assetAccountFirstEntry);
         LOG.info("Repayment 1 Done......");
 
         // REPAYMENT 2
         LOG.info("Repayment 2 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[2], REPAYMENT_AMOUNT[2], loanID);
-        final float SECOND_AND_THIRD_INTEREST = 400.0f;
-        final float SECOND_PRINCIPAL = REPAYMENT_AMOUNT[2] - SECOND_AND_THIRD_INTEREST;
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[2]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[3]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        final float secondAndThirdInterestValue = 400.0f;
+        final float secondPrincipalValue = REPAYMENT_AMOUNT[2] - secondAndThirdInterestValue;
+        expected_value = expected_value - principalValueForEachPeriod;
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[2]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[3]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(2, expected_value, loanID);
         final JournalEntry[] assetAccountSecondEntry = { new JournalEntry(REPAYMENT_AMOUNT[2], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(SECOND_AND_THIRD_INTEREST + SECOND_PRINCIPAL, JournalEntry.TransactionType.CREDIT) };
+                new JournalEntry(secondAndThirdInterestValue + secondPrincipalValue, JournalEntry.TransactionType.CREDIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[2], assetAccountSecondEntry);
         LOG.info("Repayment 2 Done ......");
 
         // WAIVE INTEREST
         LOG.info("Waive Interest  ......");
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[4]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[5]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[4]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[5]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
         this.loanTransactionHelper.waiveInterest(REPAYMENT_DATE[4], AMOUNT_TO_BE_WAIVE.toString(), loanID);
 
         final JournalEntry waivedEntry = new JournalEntry(AMOUNT_TO_BE_WAIVE, JournalEntry.TransactionType.CREDIT);
@@ -637,7 +637,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 3
         LOG.info("Repayment 3 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[3], REPAYMENT_AMOUNT[3], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         final JournalEntry[] assetAccountThirdEntry = { new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.CREDIT) };
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(3, expected_value, loanID);
@@ -647,7 +647,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 4
         LOG.info("Repayment 4 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[4], REPAYMENT_AMOUNT[4], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(4, expected_value, loanID);
         final JournalEntry[] assetAccountFourthEntry = { new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.CREDIT) };
@@ -658,7 +658,7 @@ public class AccountingScenarioIntegrationTest {
         LOG.info("Repayment 5 ......");
         final JournalEntry[] assetAccountFifthEntry = { new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.CREDIT) };
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[5], REPAYMENT_AMOUNT[5], loanID);
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(5, expected_value, loanID);
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[5], assetAccountFifthEntry);
@@ -666,7 +666,7 @@ public class AccountingScenarioIntegrationTest {
     }
 
     @Test
-    public void checkPeriodicAccrualAccountingFlow_OVER_PAYMENT() throws InterruptedException, ParseException {
+    public void checkPeriodicAccrualAccountingFlowOverPayment() throws InterruptedException, ParseException {
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
         final Account expenseAccount = this.accountHelper.createExpenseAccount();
@@ -690,8 +690,8 @@ public class AccountingScenarioIntegrationTest {
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT), };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, EXPECTED_DISBURSAL_DATE, assetAccountInitialEntry);
@@ -702,14 +702,14 @@ public class AccountingScenarioIntegrationTest {
 
         // MAKE 1
         LOG.info("Repayment 1 ......");
-        final float FIRST_INTEREST = 200.0f;
-        final float FIRST_PRINCIPAL = 2000.0f;
-        final float FEE_PORTION = 0.0f;
-        final float PENALTY_PORTION = 0.0f;
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[1]), FIRST_INTEREST, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        final float firstInterestValue = 200.0f;
+        final float firstPrincipalValue = 2000.0f;
+        final float feePortion = 0.0f;
+        final float penaltyPortion = 0.0f;
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(REPAYMENT_DATE[1]), firstInterestValue,
+                feePortion, penaltyPortion, loanID);
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[1], 15000f, loanID);
-        float expected_value = LP_PRINCIPAL - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        float expected_value = LP_PRINCIPAL - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(1, expected_value, loanID);
         final JournalEntry[] assetAccountEntry = { new JournalEntry(15000f, JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(11000f, JournalEntry.TransactionType.CREDIT) };
@@ -733,12 +733,12 @@ public class AccountingScenarioIntegrationTest {
         final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, DATE_OF_JOINING);
         final Integer loanID = applyForLoanApplication(clientID, loanProductID);
 
-        final float FEE_PORTION = 50.0f;
-        final float PENALTY_PORTION = 100.0f;
+        final float feePortion = 50.0f;
+        final float penaltyPortion = 100.0f;
         Integer flat = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(FEE_PORTION), false));
+                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(feePortion), false));
         Integer flatSpecifiedDueDate = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(PENALTY_PORTION), true));
+                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(penaltyPortion), true));
 
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
         LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
@@ -754,30 +754,30 @@ public class AccountingScenarioIntegrationTest {
 
         todayDate.add(Calendar.DATE, -4);
 
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String loanDisbursementDateValue = dateFormat.format(todayDate.getTime());
 
         todayDate.add(Calendar.MONTH, 2);
-        final String FIRST_REPAYMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String firstRepaymentDate = dateFormat.format(todayDate.getTime());
 
         todayDate = Calendar.getInstance();
         todayDate.add(Calendar.DATE, -2);
 
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDateValue, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(flatSpecifiedDueDate), dateFormat.format(todayDate.getTime()), String.valueOf(PENALTY_PORTION)));
+                String.valueOf(flatSpecifiedDueDate), dateFormat.format(todayDate.getTime()), String.valueOf(penaltyPortion)));
         todayDate.add(Calendar.DATE, 1);
         this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(flat), dateFormat.format(todayDate.getTime()), String.valueOf(FEE_PORTION)));
+                String.valueOf(flat), dateFormat.format(todayDate.getTime()), String.valueOf(feePortion)));
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT), };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, loanDisbursementDateValue, assetAccountInitialEntry);
 
         final String jobName = "Add Periodic Accrual Transactions";
 
@@ -804,8 +804,8 @@ public class AccountingScenarioIntegrationTest {
         float interest4Days = totalInterest / totalDaysInPeriod * 4;
         interest4Days = Float.valueOf(numberFormat.format(interest4Days));
 
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(currentDate), interest4Days, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(currentDate), interest4Days, feePortion,
+                penaltyPortion, loanID);
 
     }
 
@@ -822,20 +822,20 @@ public class AccountingScenarioIntegrationTest {
         final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, DATE_OF_JOINING);
         final Integer loanID = applyForLoanApplication(clientID, loanProductID);
 
-        final float FEE_PORTION = 50.0f;
-        final float PENALTY_PORTION = 100.0f;
-        final float NEXT_FEE_PORTION = 55.0f;
-        final float NEXT_PENALTY_PORTION = 105.0f;
+        final float feePortion = 50.0f;
+        final float penaltyPortion = 100.0f;
+        final float nextFeePortion = 55.0f;
+        final float nextPenaltyPortion = 105.0f;
 
         Integer flat = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(FEE_PORTION), false));
+                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(feePortion), false));
         Integer flatSpecifiedDueDate = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(PENALTY_PORTION), true));
+                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(penaltyPortion), true));
 
         Integer flatNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_FEE_PORTION), false));
+                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(nextFeePortion), false));
         Integer flatSpecifiedDueDateNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_PENALTY_PORTION), true));
+                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(nextPenaltyPortion), true));
 
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
         LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
@@ -851,39 +851,39 @@ public class AccountingScenarioIntegrationTest {
 
         todayDate.add(Calendar.DATE, -4);
 
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String loanDisbursementDateValue = dateFormat.format(todayDate.getTime());
 
         todayDate.add(Calendar.MONTH, 2);
-        final String FIRST_REPAYMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String firstRepaymentDate = dateFormat.format(todayDate.getTime());
 
         todayDate = Calendar.getInstance();
         todayDate.add(Calendar.DATE, -2);
 
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDateValue, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(flatSpecifiedDueDate), dateFormat.format(todayDate.getTime()), String.valueOf(PENALTY_PORTION)));
+                String.valueOf(flatSpecifiedDueDate), dateFormat.format(todayDate.getTime()), String.valueOf(penaltyPortion)));
         todayDate.add(Calendar.DATE, 1);
         String runOndate = dateFormat.format(todayDate.getTime());
 
-        this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flat), runOndate, String.valueOf(FEE_PORTION)));
+        this.loanTransactionHelper.addChargesForLoan(loanID,
+                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flat), runOndate, String.valueOf(feePortion)));
 
         todayDate.add(Calendar.DATE, 1);
         this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(flatSpecifiedDueDateNext), dateFormat.format(todayDate.getTime()), String.valueOf(NEXT_PENALTY_PORTION)));
+                String.valueOf(flatSpecifiedDueDateNext), dateFormat.format(todayDate.getTime()), String.valueOf(nextPenaltyPortion)));
 
         this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(flatNext), dateFormat.format(todayDate.getTime()), String.valueOf(NEXT_FEE_PORTION)));
+                String.valueOf(flatNext), dateFormat.format(todayDate.getTime()), String.valueOf(nextFeePortion)));
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT), };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, loanDisbursementDateValue, assetAccountInitialEntry);
 
         this.periodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
 
@@ -907,16 +907,16 @@ public class AccountingScenarioIntegrationTest {
         DecimalFormat numberFormat = new DecimalFormat("#.00", new DecimalFormatSymbols(Locale.US));
         float interest3Days = totalInterest / totalDaysInPeriod * 3;
         interest3Days = Float.valueOf(numberFormat.format(interest3Days));
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(runOndate), interest3Days, FEE_PORTION,
-                PENALTY_PORTION, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(runOndate), interest3Days, feePortion,
+                penaltyPortion, loanID);
 
         runOndate = dateFormat.format(todayDate.getTime());
 
         this.periodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
         float interestPerDay = (totalInterest / totalDaysInPeriod * 4) - interest3Days;
         interestPerDay = Float.valueOf(numberFormat.format(interestPerDay));
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(runOndate), interestPerDay, NEXT_FEE_PORTION,
-                NEXT_PENALTY_PORTION, loanID);
+        this.loanTransactionHelper.checkAccrualTransactionForRepayment(getDateAsLocalDate(runOndate), interestPerDay, nextFeePortion,
+                nextPenaltyPortion, loanID);
 
     }
 
@@ -955,8 +955,8 @@ public class AccountingScenarioIntegrationTest {
 
         // CHECK ACCOUNT ENTRIES
         LOG.info("Entries ......");
-        final float PRINCIPAL_VALUE_FOR_EACH_PERIOD = 2000.0f;
-        final float TOTAL_INTEREST = 1000.0f;
+        final float principalValueForEachPeriod = 2000.0f;
+        final float totalInterestValue = 1000.0f;
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(LP_PRINCIPAL, JournalEntry.TransactionType.DEBIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, EXPECTED_DISBURSAL_DATE, assetAccountInitialEntry);
@@ -964,31 +964,31 @@ public class AccountingScenarioIntegrationTest {
         // MAKE 1
         LOG.info("Repayment 1 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[1], REPAYMENT_AMOUNT[1], loanID);
-        final float FIRST_INTEREST = 200.0f;
-        final float FIRST_PRINCIPAL = 2000.0f;
-        float expected_value = LP_PRINCIPAL - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        final float firstInterestValue = 200.0f;
+        final float firstPrincipalValue = 2000.0f;
+        float expected_value = LP_PRINCIPAL - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(1, expected_value, loanID);
         final JournalEntry[] assetAccountFirstEntry = { new JournalEntry(REPAYMENT_AMOUNT[1], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(FIRST_PRINCIPAL, JournalEntry.TransactionType.CREDIT) };
+                new JournalEntry(firstPrincipalValue, JournalEntry.TransactionType.CREDIT) };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[1], assetAccountFirstEntry);
         LOG.info("CHECKING INCOME: ******************************************");
         this.journalEntryHelper.checkJournalEntryForIncomeAccount(incomeAccount, REPAYMENT_DATE[1],
-                new JournalEntry(FIRST_INTEREST, JournalEntry.TransactionType.CREDIT));
+                new JournalEntry(firstInterestValue, JournalEntry.TransactionType.CREDIT));
         LOG.info("Repayment 1 Done......");
 
         // REPAYMENT 2
         LOG.info("Repayment 2 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[2], REPAYMENT_AMOUNT[2], loanID);
-        final float SECOND_AND_THIRD_INTEREST = 400.0f;
-        final float SECOND_PRINCIPAL = REPAYMENT_AMOUNT[2] - SECOND_AND_THIRD_INTEREST;
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        final float secondAndThirdInterestValue = 400.0f;
+        final float secondPrincipalValue = REPAYMENT_AMOUNT[2] - secondAndThirdInterestValue;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(2, expected_value, loanID);
         final JournalEntry[] assetAccountSecondEntry = { new JournalEntry(REPAYMENT_AMOUNT[2], JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(SECOND_PRINCIPAL, JournalEntry.TransactionType.CREDIT), };
+                new JournalEntry(secondPrincipalValue, JournalEntry.TransactionType.CREDIT), };
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[2], assetAccountSecondEntry);
         LOG.info("CHECKING INCOME: ******************************************");
         this.journalEntryHelper.checkJournalEntryForIncomeAccount(incomeAccount, REPAYMENT_DATE[2],
-                new JournalEntry(SECOND_AND_THIRD_INTEREST, JournalEntry.TransactionType.CREDIT));
+                new JournalEntry(secondAndThirdInterestValue, JournalEntry.TransactionType.CREDIT));
         LOG.info("Repayment 2 Done ......");
 
         // WAIVE INTEREST
@@ -1002,7 +1002,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 3
         LOG.info("Repayment 3 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[3], REPAYMENT_AMOUNT[3], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         final JournalEntry[] assetAccountThirdEntry = { new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[3], JournalEntry.TransactionType.CREDIT) };
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(3, expected_value, loanID);
@@ -1012,7 +1012,7 @@ public class AccountingScenarioIntegrationTest {
         // REPAYMENT 4
         LOG.info("Repayment 4 ......");
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[4], REPAYMENT_AMOUNT[4], loanID);
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(4, expected_value, loanID);
         final JournalEntry[] assetAccountFourthEntry = { new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[4], JournalEntry.TransactionType.CREDIT) };
@@ -1023,7 +1023,7 @@ public class AccountingScenarioIntegrationTest {
         LOG.info("Repayment 5 ......");
         final JournalEntry[] assetAccountFifthEntry = { new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(REPAYMENT_AMOUNT[5], JournalEntry.TransactionType.CREDIT) };
-        expected_value = expected_value - PRINCIPAL_VALUE_FOR_EACH_PERIOD;
+        expected_value = expected_value - principalValueForEachPeriod;
         this.loanTransactionHelper.makeRepayment(REPAYMENT_DATE[5], REPAYMENT_AMOUNT[5], loanID);
         this.loanTransactionHelper.verifyRepaymentScheduleEntryFor(5, expected_value, loanID);
         this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, REPAYMENT_DATE[5], assetAccountFifthEntry);

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * Client Loan Integration Test for checking Loan Application Repayments Schedule, loan charges, penalties, loan
  * repayments and verifying accounting transactions
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
+@SuppressWarnings({ "rawtypes", "unchecked", "AbbreviationAsWordInName" })
 public class ClientLoanIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientLoanIntegrationTest.class);
@@ -112,7 +112,7 @@ public class ClientLoanIntegrationTest {
     }
 
     @Test
-    public void testLoanCharges_DISBURSEMENT_FEE() {
+    public void testLoanChargesDisbursementFee() {
         this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -3117,7 +3117,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -3127,7 +3127,7 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
                 LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate, null,
                 LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
@@ -3144,12 +3144,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3164,9 +3164,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3225,7 +3225,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -3235,7 +3235,7 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseInterestStrategy, null,
                 null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate, null,
                 LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
@@ -3252,12 +3252,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3272,9 +3272,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3304,7 +3304,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -3318,7 +3318,7 @@ public class ClientLoanIntegrationTest {
         Integer installmentCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
                 ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "10", false));
         addCharges(charges, installmentCharge, "10", null);
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate, null,
                 LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
@@ -3335,12 +3335,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3355,9 +3355,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3400,7 +3400,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -3408,11 +3408,11 @@ public class ClientLoanIntegrationTest {
         final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
                 LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
                 LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", loanDisbursementDate,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", loanDisbursementDate,
                 LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
                 LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
@@ -3430,12 +3430,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3459,9 +3459,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3514,7 +3514,7 @@ public class ClientLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         Integer compoundingDayOfMonth = getDayOfMonth(todaysDate);
         Integer compoundingDayOfWeek = getDayOfWeek(todaysDate);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         Integer restDayOfMonth = getDayOfMonth(todaysDate);
         Integer restDayOfWeek = getDayOfWeek(todaysDate);
@@ -3541,12 +3541,12 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.DEFAULT_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
                 LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", loanDisbursementDate,
                 LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, compoundingDayOfMonth, compoundingDayOfWeek,
                 restDayOfMonth, restDayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
+                loanDisbursementDate, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
@@ -3562,12 +3562,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3582,9 +3582,9 @@ public class ClientLoanIntegrationTest {
 
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(repaymentDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3647,7 +3647,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -4);
         Integer restDateOfMonth = getDayOfMonth(todaysDate);
         Integer restDateOfWeek = getDayOfWeek(todaysDate);
@@ -3677,7 +3677,7 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, null, null, preCloseInterestStrategy, null,
                 null, null, restDateOfMonth, restDateOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
                 REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
@@ -3694,12 +3694,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3714,9 +3714,9 @@ public class ClientLoanIntegrationTest {
 
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(repaymentDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3747,7 +3747,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7 * 3);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         final String REST_START_DATE = dateFormat.format(todaysDate.getTime());
 
@@ -3769,7 +3769,7 @@ public class ClientLoanIntegrationTest {
                 recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null,
                 overdueFeeChargeId.toString(), false, null, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
                 REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, null);
 
         Assertions.assertNotNull(loanID);
@@ -3786,12 +3786,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3819,10 +3819,10 @@ public class ClientLoanIntegrationTest {
 
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7 * 2);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(repaymentDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
         totalDueForCurrentPeriod = totalDueForCurrentPeriod - Float.valueOf("252.89");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3867,7 +3867,7 @@ public class ClientLoanIntegrationTest {
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("Disbursal Date Calendar {}", todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -3878,7 +3878,7 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
                 LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, accounts, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate, null,
                 LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
@@ -3896,12 +3896,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -3916,7 +3916,7 @@ public class ClientLoanIntegrationTest {
 
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(10000.0f, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(10000.0f, JournalEntry.TransactionType.DEBIT), };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, loanDisbursementDate, assetAccountInitialEntry);
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         String runOndate = dateFormat.format(todaysDate.getTime());
         LOG.info("runOndate : {}", runOndate);
@@ -3926,9 +3926,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         expectedvalues = new ArrayList<>();
@@ -3965,20 +3965,20 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
         final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
                 LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
                 LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "1", LOAN_DISBURSEMENT_DATE,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", loanDisbursementDate,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "1", loanDisbursementDate,
                 LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, getDayOfMonth(todaysDate),
                 getDayOfWeek(todaysDate), getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<HashMap>(0));
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
+                loanDisbursementDate, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
@@ -3995,12 +3995,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -4022,9 +4022,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
@@ -4046,7 +4046,7 @@ public class ClientLoanIntegrationTest {
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("----timeeeeeeeeeeeeee------> {}", dateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -4055,13 +4055,13 @@ public class ClientLoanIntegrationTest {
         final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.RBI_INDIA_STRATEGY,
                 LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
                 LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
+                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", loanDisbursementDate,
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
                 recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null,
                 true, null, null, getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<HashMap>(0));
+        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
+                loanDisbursementDate, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<HashMap>(0));
 
         Assertions.assertNotNull(loanID);
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
@@ -4078,12 +4078,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
@@ -4105,9 +4105,9 @@ public class ClientLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
@@ -4138,7 +4138,7 @@ public class ClientLoanIntegrationTest {
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
@@ -4148,8 +4148,8 @@ public class ClientLoanIntegrationTest {
                 LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseStrategy, null, null,
                 null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientID, loanProductID,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0), "1", null);
+        final Integer loanID = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientID, loanProductID, loanDisbursementDate,
+                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0), "1", null);
 
         Assertions.assertNotNull(loanID);
         HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
@@ -4166,12 +4166,12 @@ public class ClientLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.approveLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
         LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Client Savings Integration Test for checking Savings Application.
  */
-@SuppressWarnings({ "rawtypes" })
+@SuppressWarnings({ "rawtypes", "AbbreviationAsWordInName" })
 public class ClientSavingsIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientSavingsIntegrationTest.class);
@@ -201,10 +201,10 @@ public class ClientSavingsIntegrationTest {
 
         DateFormat dateFormat = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
         Calendar todaysDate = Calendar.getInstance();
-        final String CLOSEDON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
         String withdrawBalance = "false";
         ArrayList<HashMap> savingsAccountErrorData = (ArrayList<HashMap>) validationErrorHelper
-                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, CLOSEDON_DATE);
+                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, closedOnDateValue);
         assertEquals("validation.msg.savingsaccount.close.results.in.balance.not.zero",
                 savingsAccountErrorData.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
 
@@ -281,7 +281,7 @@ public class ClientSavingsIntegrationTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testSavingsAccount_DELETE_APPLICATION() {
+    public void testSavingsAccountDeleteApplication() {
         this.savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
 
         SavingsAccountHelper savingsAccountHelperValidationError = new SavingsAccountHelper(this.requestSpec,
@@ -707,7 +707,7 @@ public class ClientSavingsIntegrationTest {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.set(Calendar.DAY_OF_MONTH, 1);
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final Integer lastDayOfMonth = todaysDate.getActualMaximum(Calendar.DAY_OF_MONTH);
         todaysDate.set(Calendar.DAY_OF_MONTH, lastDayOfMonth);
         final String TRANSACTION_DATE = dateFormat.format(todaysDate.getTime());
@@ -718,7 +718,7 @@ public class ClientSavingsIntegrationTest {
          * @param activationDate
          *            this value is every time first day of previous month
          */
-        savingsStatusHashMap = activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        savingsStatusHashMap = activateSavingsAccount(savingsId, activationDate);
         SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
 
         /***
@@ -736,7 +736,7 @@ public class ClientSavingsIntegrationTest {
          * there prior to this transaction)
          */
         Integer withdrawTransactionId = (Integer) this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, WITHDRAW_AMOUNT,
-                ACTIVATION_DATE, CommonConstants.RESPONSE_RESOURCE_ID);
+                activationDate, CommonConstants.RESPONSE_RESOURCE_ID);
         HashMap withdrawTransaction = this.savingsAccountHelper.getSavingsTransaction(savingsId, withdrawTransactionId);
         balance -= Float.valueOf(WITHDRAW_AMOUNT);
         assertEquals(Float.valueOf(WITHDRAW_AMOUNT), withdrawTransaction.get("amount"), "Verifying Withdrawal Amount");
@@ -785,10 +785,10 @@ public class ClientSavingsIntegrationTest {
         assertEquals(interestPosted, actualInterestPosted, "Verifying interest posted");
 
         todaysDate = Calendar.getInstance();
-        final String CLOSEDON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
         String withdrawBalance = "false";
         ArrayList<HashMap> savingsAccountErrorData = (ArrayList<HashMap>) validationErrorHelper
-                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, CLOSEDON_DATE);
+                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, closedOnDateValue);
         assertEquals("validation.msg.savingsaccount.close.results.in.balance.not.zero",
                 savingsAccountErrorData.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
     }
@@ -839,7 +839,7 @@ public class ClientSavingsIntegrationTest {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
 
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
 
         /***
          * Activate the application and verify account status
@@ -847,7 +847,7 @@ public class ClientSavingsIntegrationTest {
          * @param activationDate
          *            this value is every time first day of previous month
          */
-        savingsStatusHashMap = activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        savingsStatusHashMap = activateSavingsAccount(savingsId, activationDate);
         SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
         /***
          * Verify the account summary
@@ -1090,7 +1090,7 @@ public class ClientSavingsIntegrationTest {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
 
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
 
         /***
          * Activate the application and verify account status
@@ -1098,7 +1098,7 @@ public class ClientSavingsIntegrationTest {
          * @param activationDate
          *            this value is every time first day of previous month
          */
-        savingsStatusHashMap = activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        savingsStatusHashMap = activateSavingsAccount(savingsId, activationDate);
         SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
         /***
          * Verify the account summary
@@ -1124,7 +1124,7 @@ public class ClientSavingsIntegrationTest {
          * there prior to this transaction)
          */
         Integer withdrawTransactionId = (Integer) this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, WITHDRAW_AMOUNT,
-                ACTIVATION_DATE, CommonConstants.RESPONSE_RESOURCE_ID);
+                activationDate, CommonConstants.RESPONSE_RESOURCE_ID);
         HashMap withdrawTransaction = this.savingsAccountHelper.getSavingsTransaction(savingsId, withdrawTransactionId);
         balance -= Float.valueOf(WITHDRAW_AMOUNT);
         assertEquals(Float.valueOf(WITHDRAW_AMOUNT), withdrawTransaction.get("amount"), "Verifying Withdrawal Amount");
@@ -1352,7 +1352,7 @@ public class ClientSavingsIntegrationTest {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.set(Calendar.DAY_OF_MONTH, 1);
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final Integer lastDayOfMonth = todaysDate.getActualMaximum(Calendar.DAY_OF_MONTH);
         todaysDate.set(Calendar.DAY_OF_MONTH, lastDayOfMonth);
         final String TRANSACTION_DATE = dateFormat.format(todaysDate.getTime());
@@ -1368,7 +1368,7 @@ public class ClientSavingsIntegrationTest {
          * @param activationDate
          *            this value is every time first day of previous month
          */
-        savingsStatusHashMap = activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        savingsStatusHashMap = activateSavingsAccount(savingsId, activationDate);
         SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
 
         /***
@@ -1386,7 +1386,7 @@ public class ClientSavingsIntegrationTest {
          * there prior to this transaction)
          */
         Integer withdrawTransactionId = (Integer) this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, WITHDRAW_AMOUNT,
-                ACTIVATION_DATE, CommonConstants.RESPONSE_RESOURCE_ID);
+                activationDate, CommonConstants.RESPONSE_RESOURCE_ID);
         HashMap withdrawTransaction = this.savingsAccountHelper.getSavingsTransaction(savingsId, withdrawTransactionId);
         balance -= Float.valueOf(WITHDRAW_AMOUNT);
         assertEquals(Float.valueOf(WITHDRAW_AMOUNT), withdrawTransaction.get("amount"), "Verifying Withdrawal Amount");
@@ -1447,7 +1447,7 @@ public class ClientSavingsIntegrationTest {
         LOG.info("------Post Interest As On After doing a post interest Successfully worked--------");
 
         todaysDate = Calendar.getInstance();
-        final String CLOSEDON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         Calendar interestPostingDate = Calendar.getInstance();
         Calendar todysDate = Calendar.getInstance();
@@ -1460,12 +1460,12 @@ public class ClientSavingsIntegrationTest {
         if (TODYS_POSTING_DATE.equalsIgnoreCase(INTEREST_POSTING_DATE)) {
             final SavingsAccountHelper validationErrorHelper = new SavingsAccountHelper(this.requestSpec, responseSpec);
             validationErrorHelper.closeSavingsAccountPostInterestAndGetBackRequiredField(savingsId, withdrawBalance,
-                    CommonConstants.RESPONSE_ERROR, CLOSEDON_DATE);
+                    CommonConstants.RESPONSE_ERROR, closedOnDateValue);
         } else {
             final SavingsAccountHelper validationErrorHelper = new SavingsAccountHelper(this.requestSpec, errorResponse);
             ArrayList<HashMap> savingsAccountErrorData = (ArrayList<HashMap>) validationErrorHelper
                     .closeSavingsAccountPostInterestAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR,
-                            CLOSEDON_DATE);
+                            closedOnDateValue);
             assertEquals("error.msg.postInterest.notDone", savingsAccountErrorData.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
         }
 
@@ -1520,7 +1520,7 @@ public class ClientSavingsIntegrationTest {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.set(Calendar.DAY_OF_MONTH, 1);
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final Integer lastDayOfMonth = todaysDate.getActualMaximum(Calendar.DAY_OF_MONTH);
         todaysDate.set(Calendar.DAY_OF_MONTH, lastDayOfMonth);
         final String TRANSACTION_DATE = dateFormat.format(todaysDate.getTime());
@@ -1541,7 +1541,7 @@ public class ClientSavingsIntegrationTest {
          * @param activationDate
          *            this value is every time first day of previous month
          */
-        savingsStatusHashMap = activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        savingsStatusHashMap = activateSavingsAccount(savingsId, activationDate);
         SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
 
         /***
@@ -1559,7 +1559,7 @@ public class ClientSavingsIntegrationTest {
          * there prior to this transaction)
          */
         Integer withdrawTransactionId = (Integer) this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, WITHDRAW_AMOUNT,
-                ACTIVATION_DATE, CommonConstants.RESPONSE_RESOURCE_ID);
+                activationDate, CommonConstants.RESPONSE_RESOURCE_ID);
         HashMap withdrawTransaction = this.savingsAccountHelper.getSavingsTransaction(savingsId, withdrawTransactionId);
         balance -= Float.valueOf(WITHDRAW_AMOUNT);
         assertEquals(Float.valueOf(WITHDRAW_AMOUNT), withdrawTransaction.get("amount"), "Verifying Withdrawal Amount");

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/FixedDepositTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/FixedDepositTest.java
@@ -153,17 +153,17 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -180,7 +180,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -190,13 +190,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -208,8 +208,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         /***
          * Update interest earned of FD account
@@ -231,13 +231,13 @@ public class FixedDepositTest {
          */
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -250,9 +250,9 @@ public class FixedDepositTest {
         HashMap accountDetails = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
                 fixedDepositAccountId);
         Float maturityAmount = Float.valueOf(accountDetails.get("maturityAmount").toString());
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT));
 
     }
@@ -285,17 +285,17 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -313,7 +313,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -323,13 +323,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -341,8 +341,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         /***
          * Update interest earned of FD account
@@ -365,13 +365,13 @@ public class FixedDepositTest {
          */
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -389,11 +389,11 @@ public class FixedDepositTest {
         Assertions.assertNotNull(summary.get("totalWithholdTax"));
         Float withHoldTax = (Float) summary.get("totalWithholdTax");
 
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, closedOnDateValue,
                 new JournalEntry(withHoldTax, JournalEntry.TransactionType.CREDIT));
 
     }
@@ -427,9 +427,9 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -20);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
@@ -438,7 +438,7 @@ public class FixedDepositTest {
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
         Calendar closedOn = Calendar.getInstance();
         closedOn.add(Calendar.MONTH, -6);
-        final String CLOSED_ON_DATE = dateFormat.format(closedOn.getTime());
+        final String closedOnDateValue = dateFormat.format(closedOn.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -456,7 +456,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -466,13 +466,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -484,8 +484,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         /***
          * Update interest earned of FD account
@@ -517,7 +517,7 @@ public class FixedDepositTest {
         HashMap summary = (HashMap) accountDetails.get("summary");
         Assertions.assertNotNull(summary.get("totalWithholdTax"));
         Float withHoldTax = (Float) summary.get("totalWithholdTax");
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, closedOnDateValue,
                 new JournalEntry(withHoldTax, JournalEntry.TransactionType.CREDIT));
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -536,7 +536,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithPeriodInterestRateChart_AMOUNT_VARIATION() {
+    public void testFixedDepositAccountWithPeriodInterestRateChartAmountVariation() {
         final String chartToUse = "period";
         final String depositAmount = "2000";
         final String depositPeriod = "12";
@@ -545,7 +545,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithPeriodInterestRateChart_PERIOD_VARIATION() {
+    public void testFixedDepositAccountWithPeriodInterestRateChartPeriodVariation() {
         final String chartToUse = "period";
         final String depositAmount = "10000";
         final String depositPeriod = "18";
@@ -563,7 +563,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithAmountInterestRateChart_AMOUNT_VARIATION() {
+    public void testFixedDepositAccountWithAmountInterestRateChartAmountVariation() {
         final String chartToUse = "amount";
         final String depositAmount = "5000";
         final String depositPeriod = "12";
@@ -572,7 +572,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithAmountInterestRateChart_PERIOD_VARIATION() {
+    public void testFixedDepositAccountWithAmountInterestRateChartPeriodVariation() {
         final String chartToUse = "amount";
         final String depositAmount = "10000";
         final String depositPeriod = "26";
@@ -590,7 +590,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithPeriodAndAmountInterestRateChart_AMOUNT_VARIATION() {
+    public void testFixedDepositAccountWithPeriodAndAmountInterestRateChartAmountVariation() {
         final String chartToUse = "period_amount";
         final String depositAmount = "5000";
         final String depositPeriod = "12";
@@ -599,7 +599,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithPeriodAndAmountInterestRateChart_PERIOD_VARIATION() {
+    public void testFixedDepositAccountWithPeriodAndAmountInterestRateChartPeriodVariation() {
         final String chartToUse = "period_amount";
         final String depositAmount = "10000";
         final String depositPeriod = "20";
@@ -617,7 +617,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithAmountAndPeriodInterestRateChart_AMOUNT_VARIATION() {
+    public void testFixedDepositAccountWithAmountAndPeriodInterestRateChartAmountVariation() {
         final String chartToUse = "amount_period";
         final String depositAmount = "5000";
         final String depositPeriod = "12";
@@ -626,7 +626,7 @@ public class FixedDepositTest {
     }
 
     @Test
-    public void testFixedDepositAccountWithAmountAndPeriodInterestRateChart_PERIOD_VARIATION() {
+    public void testFixedDepositAccountWithAmountAndPeriodInterestRateChartPeriodVariation() {
         final String chartToUse = "amount_period";
         final String depositAmount = "10000";
         final String depositPeriod = "6";
@@ -643,9 +643,9 @@ public class FixedDepositTest {
         final String VALID_FROM = "01 March 2014";
         final String VALID_TO = "01 March 2016";
 
-        final String SUBMITTED_ON_DATE = "01 March 2015";
-        final String APPROVED_ON_DATE = "01 March 2015";
-        final String ACTIVATION_DATE = "01 March 2015";
+        final String submittedOnDate = "01 March 2015";
+        final String approvedOnDate = "01 March 2015";
+        final String activationDate = "01 March 2015";
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -661,7 +661,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM, depositAmount, depositPeriod);
+                submittedOnDate, WHOLE_TERM, depositAmount, depositPeriod);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -671,13 +671,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositDetails(fixedDepositAccountId);
@@ -716,17 +716,17 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -759,17 +759,17 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -781,8 +781,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         /***
          * Update interest earned of FD account
@@ -804,8 +804,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
         HashMap savingsSummaryBefore = this.savingsAccountHelper.getSavingsSummary(savingsId);
         Float balanceBefore = (Float) savingsSummaryBefore.get("accountBalance");
@@ -815,13 +815,14 @@ public class FixedDepositTest {
          */
         Account financialAccount = getMappedLiabilityFinancialAccount();
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         /***
          * Preclose the account and verify journal entries
          */
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId,
+                CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -836,11 +837,11 @@ public class FixedDepositTest {
          * Verify journal entry transactions for preclosure transaction As this transaction is an account transfer you
          * should get financial account mapping details and verify amounts
          */
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(prematurityAmount, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(prematurityAmount, JournalEntry.TransactionType.DEBIT));
 
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(financialAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(financialAccount, closedOnDateValue,
                 new JournalEntry(prematurityAmount, JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(prematurityAmount, JournalEntry.TransactionType.CREDIT));
 
@@ -886,17 +887,17 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -910,17 +911,17 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap accountSummary = this.fixedDepositAccountHelper.getFixedDepositSummary(fixedDepositAccountId);
@@ -932,8 +933,8 @@ public class FixedDepositTest {
          */
         final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountInitialEntry = { new JournalEntry(depositAmount, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, ACTIVATION_DATE, assetAccountInitialEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, ACTIVATION_DATE, liablilityAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, activationDate, assetAccountInitialEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, activationDate, liablilityAccountInitialEntry);
 
         fixedDepositAccountId = this.fixedDepositAccountHelper.calculateInterestForFixedDeposit(fixedDepositAccountId);
         Assertions.assertNotNull(fixedDepositAccountId);
@@ -949,13 +950,13 @@ public class FixedDepositTest {
          */
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         ArrayList<HashMap> errorResponse = (ArrayList<HashMap>) fixedDepositAccountHelperValidationError.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_REINVEST, null, CommonConstants.RESPONSE_ERROR);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_REINVEST, null, CommonConstants.RESPONSE_ERROR);
 
         assertEquals("validation.msg.fixeddepositaccount.onAccountClosureId.reinvest.not.allowed",
                 errorResponse.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
@@ -1019,8 +1020,8 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1031,14 +1032,14 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.undoApproval(fixedDepositAccountId);
@@ -1062,8 +1063,8 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String REJECTED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String rejectedOnDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1074,14 +1075,14 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.rejectApplication(fixedDepositAccountId, REJECTED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.rejectApplication(fixedDepositAccountId, rejectedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsRejected(fixedDepositAccountStatusHashMap);
         FixedDepositAccountStatusChecker.verifyFixedDepositAccountIsClosed(fixedDepositAccountStatusHashMap);
     }
@@ -1103,8 +1104,8 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String WITHDRAWN_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String withdrawnOnDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1115,14 +1116,14 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.withdrawApplication(fixedDepositAccountId, WITHDRAWN_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.withdrawApplication(fixedDepositAccountId, withdrawnOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsWithdrawn(fixedDepositAccountStatusHashMap);
         FixedDepositAccountStatusChecker.verifyFixedDepositAccountIsClosed(fixedDepositAccountStatusHashMap);
     }
@@ -1143,7 +1144,7 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1154,7 +1155,7 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -1184,8 +1185,8 @@ public class FixedDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -1197,14 +1198,14 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1250,8 +1251,8 @@ public class FixedDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -1263,18 +1264,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1321,13 +1322,13 @@ public class FixedDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1337,17 +1338,17 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1382,10 +1383,10 @@ public class FixedDepositTest {
         principal += interestPerMonth;
         LOG.info("principal = {}", principal);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -1421,13 +1422,13 @@ public class FixedDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1437,21 +1438,21 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1485,10 +1486,10 @@ public class FixedDepositTest {
         principal += interestPerMonth;
         LOG.info("principal = {}", principal);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -1524,13 +1525,13 @@ public class FixedDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1540,17 +1541,17 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, TILL_PREMATURE_WITHDRAWAL);
+                submittedOnDate, TILL_PREMATURE_WITHDRAWAL);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1562,10 +1563,10 @@ public class FixedDepositTest {
         ArrayList<ArrayList<HashMap>> interestRateChartData = FixedDepositProductHelper
                 .getInterestRateChartSlabsByProductId(this.requestSpec, this.responseSpec, fixedDepositProductId);
 
-        Calendar activationDate = Calendar.getInstance();
-        activationDate.add(Calendar.MONTH, -1);
-        activationDate.add(Calendar.DAY_OF_MONTH, -1);
-        DateTime startDate = new DateTime(activationDate.getTime());
+        Calendar activationDateValue = Calendar.getInstance();
+        activationDateValue.add(Calendar.MONTH, -1);
+        activationDateValue.add(Calendar.DAY_OF_MONTH, -1);
+        DateTime startDate = new DateTime(activationDateValue.getTime());
 
         Calendar prematureClosureDate = Calendar.getInstance();
         DateTime endDate = new DateTime(prematureClosureDate.getTime());
@@ -1594,10 +1595,10 @@ public class FixedDepositTest {
         principal += interestPerMonth;
         LOG.info("principal = {}", principal);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -1634,13 +1635,13 @@ public class FixedDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1650,21 +1651,21 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, TILL_PREMATURE_WITHDRAWAL);
+                submittedOnDate, TILL_PREMATURE_WITHDRAWAL);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, TILL_PREMATURE_WITHDRAWAL,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, TILL_PREMATURE_WITHDRAWAL,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1676,10 +1677,10 @@ public class FixedDepositTest {
         ArrayList<ArrayList<HashMap>> interestRateChartData = FixedDepositProductHelper
                 .getInterestRateChartSlabsByProductId(this.requestSpec, this.responseSpec, fixedDepositProductId);
 
-        Calendar activationDate = Calendar.getInstance();
-        activationDate.add(Calendar.MONTH, -1);
-        activationDate.add(Calendar.DAY_OF_MONTH, -1);
-        DateTime startDate = new DateTime(activationDate.getTime());
+        Calendar activationDateValue = Calendar.getInstance();
+        activationDateValue.add(Calendar.MONTH, -1);
+        activationDateValue.add(Calendar.DAY_OF_MONTH, -1);
+        DateTime startDate = new DateTime(activationDateValue.getTime());
 
         Calendar prematureClosureDate = Calendar.getInstance();
         DateTime endDate = new DateTime(prematureClosureDate.getTime());
@@ -1708,10 +1709,10 @@ public class FixedDepositTest {
         principal += interestPerMonth;
         LOG.info("principal = {}", principal);
 
-        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, CLOSED_ON_DATE);
+        this.fixedDepositAccountHelper.calculatePrematureAmountForFixedDeposit(fixedDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.fixedDepositAccountHelper.prematureCloseForFixedDeposit(
-                fixedDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                fixedDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
@@ -1747,8 +1748,8 @@ public class FixedDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -1760,18 +1761,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, MONTHLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1819,12 +1820,12 @@ public class FixedDepositTest {
         // todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
-        LOG.info("Submitted Date: {}", SUBMITTED_ON_DATE);
+        LOG.info("Submitted Date: {}", submittedOnDate);
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
 
@@ -1833,18 +1834,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, MONTHLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1900,9 +1901,9 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1913,21 +1914,21 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, ANNUALLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -1983,9 +1984,9 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
@@ -1996,21 +1997,21 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, ANNUALLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -2067,8 +2068,8 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -2080,18 +2081,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, BI_ANNUALLY, BI_ANNUALLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -2148,8 +2149,8 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -2161,18 +2162,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, BI_ANNUALLY, BI_ANNUALLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -2229,8 +2230,8 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -2242,18 +2243,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, QUARTERLY, QUARTERLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -2309,8 +2310,8 @@ public class FixedDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         dateFormat.format(todaysDate.getTime());
         monthDayFormat.format(todaysDate.getTime());
 
@@ -2322,18 +2323,18 @@ public class FixedDepositTest {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM);
+                submittedOnDate, WHOLE_TERM);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         this.fixedDepositAccountHelper.updateInterestCalculationConfigForFixedDeposit(clientId.toString(), fixedDepositProductId.toString(),
-                fixedDepositAccountId.toString(), SUBMITTED_ON_DATE, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
+                fixedDepositAccountId.toString(), submittedOnDate, VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM,
                 INTEREST_CALCULATION_USING_DAILY_BALANCE, QUARTERLY, QUARTERLY);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(this.requestSpec,
                 this.responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         HashMap fixedDepositAccountData = FixedDepositAccountHelper.getFixedDepositAccountById(this.requestSpec, this.responseSpec,
@@ -2394,9 +2395,9 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
@@ -2423,7 +2424,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM, maturityInstructionId);
+                submittedOnDate, WHOLE_TERM, maturityInstructionId);
 
         Assertions.assertNotNull(fixedDepositAccountId);
 
@@ -2434,13 +2435,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
     }
 
@@ -2474,9 +2475,9 @@ public class FixedDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
@@ -2503,7 +2504,7 @@ public class FixedDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(),
-                SUBMITTED_ON_DATE, WHOLE_TERM, maturityInstructionId);
+                submittedOnDate, WHOLE_TERM, maturityInstructionId);
 
         Assertions.assertNotNull(fixedDepositAccountId);
 
@@ -2514,13 +2515,13 @@ public class FixedDepositTest {
         /***
          * Approve the FD account and verify whether account is approved
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
         /***
          * Activate the FD Account and verify whether account is activated
          */
-        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = this.fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
     }
 
@@ -2631,14 +2632,14 @@ public class FixedDepositTest {
     }
 
     private Account getMappedLiabilityFinancialAccount() {
-        final Integer LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID = FinancialActivity.LIABILITY_TRANSFER.getValue();
+        final Integer liabilityTransferFinancialActivityID = FinancialActivity.LIABILITY_TRANSFER.getValue();
         List<HashMap> financialActivities = this.financialActivityAccountHelper.getAllFinancialActivityAccounts(this.responseSpec);
         final Account financialAccount;
         /***
          * if no financial activities are defined for account transfers, create liability financial accounting mappings
          */
         if (financialActivities.isEmpty()) {
-            financialAccount = createLiabilityFinancialAccountTransferType(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID);
+            financialAccount = createLiabilityFinancialAccountTransferType(liabilityTransferFinancialActivityID);
         } else {
             /***
              * extract mapped liability financial account
@@ -2646,7 +2647,7 @@ public class FixedDepositTest {
             Account mappedLiabilityAccount = null;
             for (HashMap financialActivity : financialActivities) {
                 HashMap financialActivityData = (HashMap) financialActivity.get("financialActivityData");
-                if (financialActivityData.get("id").equals(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID)) {
+                if (financialActivityData.get("id").equals(liabilityTransferFinancialActivityID)) {
                     HashMap glAccountData = (HashMap) financialActivity.get("glAccountData");
                     mappedLiabilityAccount = new Account((Integer) glAccountData.get("id"), AccountType.LIABILITY);
                     break;
@@ -2656,7 +2657,7 @@ public class FixedDepositTest {
              * If liability transfer is not defined create liability transfer
              */
             if (mappedLiabilityAccount == null) {
-                mappedLiabilityAccount = createLiabilityFinancialAccountTransferType(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID);
+                mappedLiabilityAccount = createLiabilityFinancialAccountTransferType(liabilityTransferFinancialActivityID);
             }
             financialAccount = mappedLiabilityAccount;
         }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/GroupSavingsIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/GroupSavingsIntegrationTest.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Group Savings Integration Test for checking Savings Application.
  */
-@SuppressWarnings({ "rawtypes", "unused" })
+@SuppressWarnings({ "rawtypes", "unused", "AbbreviationAsWordInName" })
 public class GroupSavingsIntegrationTest {
 
     public static final String DEPOSIT_AMOUNT = "2000";
@@ -160,10 +160,10 @@ public class GroupSavingsIntegrationTest {
 
         DateFormat dateFormat = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
         Calendar todaysDate = Calendar.getInstance();
-        final String CLOSEDON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDate = dateFormat.format(todaysDate.getTime());
         String withdrawBalance = "false";
         ArrayList<HashMap> savingsAccountErrorData = (ArrayList<HashMap>) validationErrorHelper
-                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, CLOSEDON_DATE);
+                .closeSavingsAccountAndGetBackRequiredField(savingsId, withdrawBalance, CommonConstants.RESPONSE_ERROR, closedOnDate);
         assertEquals("validation.msg.savingsaccount.close.results.in.balance.not.zero",
                 savingsAccountErrorData.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
 
@@ -367,10 +367,10 @@ public class GroupSavingsIntegrationTest {
 
         DateFormat dateFormat = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
         Calendar todaysDate = Calendar.getInstance();
-        final String CLOSEDON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDate = dateFormat.format(todaysDate.getTime());
         String withdrawBalance = "false";
         ArrayList<HashMap> savingsAccountErrorData = (ArrayList<HashMap>) validationErrorHelper
-                .closeGsimSavingsAccountAndGetBackRequiredField(gsimID, withdrawBalance, CommonConstants.RESPONSE_ERROR, CLOSEDON_DATE);
+                .closeGsimSavingsAccountAndGetBackRequiredField(gsimID, withdrawBalance, CommonConstants.RESPONSE_ERROR, closedOnDate);
         assertEquals("validation.msg.savingsaccount.close.results.in.balance.not.zero",
                 savingsAccountErrorData.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/LoanWithWaiveInterestAndWriteOffIntegrationTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/LoanWithWaiveInterestAndWriteOffIntegrationTest.java
@@ -140,7 +140,7 @@ public class LoanWithWaiveInterestAndWriteOffIntegrationTest {
     }
 
     @Test
-    public void checkClientLoan_WRITTEN_OFF() {
+    public void checkClientLoanWrittenOff() {
         // CREATE CLIENT
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, DATE_OF_JOINING);
         ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/MinimumDaysBetweenDisbursalAndFirstRepaymentTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/MinimumDaysBetweenDisbursalAndFirstRepaymentTest.java
@@ -70,7 +70,7 @@ public class MinimumDaysBetweenDisbursalAndFirstRepaymentTest {
      * is set as 7. system should allow to create this loan and allow to disburse
      */
     @Test
-    public void createLoanEntity_WITH_DAY_BETWEEN_DISB_DATE_AND_REPAY_START_DATE_GREATER_THAN_MIN_DAY_CRITERIA() {
+    public void createLoanEntryWithDayBetweenDisbDateAndRepayStartDateGreaterThanMidCriteria() {
 
         this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
         this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
@@ -116,7 +116,7 @@ public class MinimumDaysBetweenDisbursalAndFirstRepaymentTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void createLoanEntity_WITH_DAY_BETWEEN_DISB_DATE_AND_REPAY_START_DATE_LESS_THAN_MIN_DAY_CRITERIA() {
+    public void createLoanEntityWithDayBetweenDisbDateAndRepayStartDateLessThanMinDayCriteria() {
 
         this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
         this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
@@ -152,18 +152,18 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         /***
          * Create client for applying Deposit account
@@ -183,7 +183,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -194,14 +194,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -238,20 +238,20 @@ public class RecurringDepositTest {
 
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
         /***
          * Calculate expected premature closure amount
          */
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         /***
          * Preclose the RD account verify whether account is preClosed
          */
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -264,9 +264,9 @@ public class RecurringDepositTest {
         recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec, this.responseSpec,
                 recurringDepositAccountId);
         Float maturityAmount = Float.valueOf(recurringDepositAccountData.get("maturityAmount").toString());
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT));
 
     }
@@ -302,18 +302,18 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         /***
          * Create client for applying Deposit and Savings accounts
@@ -361,7 +361,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -372,14 +372,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -416,8 +416,8 @@ public class RecurringDepositTest {
 
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
         /***
          * Get saving account balance before preClosing RD account
@@ -426,7 +426,7 @@ public class RecurringDepositTest {
         Float balanceBefore = (Float) savingsSummaryBefore.get("accountBalance");
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         /***
          * Retrieve mapped financial account for liability transfer
@@ -437,7 +437,7 @@ public class RecurringDepositTest {
          * Preclose the RD account verify whether account is preClosed
          */
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId,
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId,
                 CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
@@ -452,11 +452,11 @@ public class RecurringDepositTest {
          * Verify journal entry transactions for preclosure transaction As this transaction is an account transfer you
          * should get financial account mapping details and verify amounts
          */
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT));
 
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(financialAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(financialAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT));
         /***
@@ -504,18 +504,18 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         /***
          * Create client for applying Deposit and Savings accounts
@@ -564,7 +564,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -575,14 +575,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -620,8 +620,8 @@ public class RecurringDepositTest {
 
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
         /***
          * Get saving account balance before preClosing RD account
@@ -630,7 +630,7 @@ public class RecurringDepositTest {
         Float balanceBefore = (Float) savingsSummaryBefore.get("accountBalance");
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         /***
          * Retrieve mapped financial account for liability transfer
@@ -641,7 +641,7 @@ public class RecurringDepositTest {
          * Preclose the RD account verify whether account is preClosed
          */
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId,
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_TRANSFER_TO_SAVINGS, savingsId,
                 CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
@@ -656,11 +656,11 @@ public class RecurringDepositTest {
          * Verify journal entry transactions for preclosure transaction As this transaction is an account transfer you
          * should get financial account mapping details and verify amounts
          */
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT),
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT));
 
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(financialAccount, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(financialAccount, closedOnDateValue,
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.DEBIT),
                 new JournalEntry(maturityAmount, JournalEntry.TransactionType.CREDIT));
         /***
@@ -672,7 +672,7 @@ public class RecurringDepositTest {
         HashMap summary = (HashMap) recurringDepositData.get("summary");
         Assertions.assertNotNull(summary.get("totalWithholdTax"));
         Float withHoldTax = (Float) summary.get("totalWithholdTax");
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, closedOnDateValue,
                 new JournalEntry(withHoldTax, JournalEntry.TransactionType.CREDIT));
 
         HashMap savingsSummaryAfter = this.savingsAccountHelper.getSavingsSummary(savingsId);
@@ -713,20 +713,20 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -20);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
         Calendar closedOn = Calendar.getInstance();
         closedOn.add(Calendar.MONTH, -6);
-        final String CLOSED_ON_DATE = dateFormat.format(closedOn.getTime());
+        final String closedOnDateValue = dateFormat.format(closedOn.getTime());
 
         /***
          * Create client for applying Deposit and Savings accounts
@@ -775,7 +775,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -786,14 +786,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -832,7 +832,7 @@ public class RecurringDepositTest {
         HashMap summary = (HashMap) accountDetails.get("summary");
         Assertions.assertNotNull(summary.get("totalWithholdTax"));
         Float withHoldTax = (Float) summary.get("totalWithholdTax");
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, CLOSED_ON_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccountForTax, closedOnDateValue,
                 new JournalEntry(withHoldTax, JournalEntry.TransactionType.CREDIT));
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -875,18 +875,18 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         Integer daysInMonth = todaysDate.getActualMaximum(Calendar.DATE);
         Integer numberOfDaysLeft = daysInMonth - currentDate + 1;
         todaysDate.add(Calendar.DATE, numberOfDaysLeft);
-        final String INTEREST_POSTED_DATE = dateFormat.format(todaysDate.getTime());
-        final String CLOSED_ON_DATE = dateFormat.format(Calendar.getInstance().getTime());
+        final String interestPostedDate = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(Calendar.getInstance().getTime());
 
         /***
          * Create client for applying Deposit account
@@ -911,7 +911,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -922,14 +922,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -966,20 +966,20 @@ public class RecurringDepositTest {
 
         final JournalEntry[] expenseAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.DEBIT) };
         final JournalEntry[] liablilityAccountEntry = { new JournalEntry(totalInterestPosted, JournalEntry.TransactionType.CREDIT) };
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, INTEREST_POSTED_DATE, expenseAccountEntry);
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, INTEREST_POSTED_DATE, liablilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(expenseAccount, interestPostedDate, expenseAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, interestPostedDate, liablilityAccountEntry);
 
         /***
          * Calculate expected premature closure amount
          */
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         /***
          * Expected to get an error response from api because re-invest option is not supported for account preClosure
          */
         ArrayList<HashMap> errorResponse = (ArrayList<HashMap>) recurringDepositAccountHelperValidationError
-                .prematureCloseForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_REINVEST, null,
+                .prematureCloseForRecurringDeposit(recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_REINVEST, null,
                         CommonConstants.RESPONSE_ERROR);
 
         assertEquals("validation.msg.recurringdepositaccount.onAccountClosureId.reinvest.not.allowed",
@@ -1006,9 +1006,9 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1018,14 +1018,14 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         todaysDate.add(Calendar.DATE, -1);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateRecurringDepositAccount(clientId.toString(),
                 recurringDepositProductId.toString(), recurringDepositAccountId.toString(), VALID_FROM, VALID_TO, WHOLE_TERM,
-                SUBMITTED_ON_DATE);
+                submittedOnDate);
         Assertions.assertTrue(modificationsHashMap.containsKey("submittedOnDate"));
 
     }
@@ -1049,10 +1049,10 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1062,7 +1062,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1070,7 +1070,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.undoApproval(recurringDepositAccountId);
@@ -1097,10 +1097,10 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String REJECTED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String rejectedOnDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1110,7 +1110,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1118,7 +1118,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.rejectApplication(recurringDepositAccountId,
-                REJECTED_ON_DATE);
+                rejectedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsRejected(recurringDepositAccountStatusHashMap);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositAccountIsClosed(recurringDepositAccountStatusHashMap);
     }
@@ -1143,10 +1143,10 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String WITHDRAWN_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String withdrawnOnDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1156,7 +1156,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1164,7 +1164,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.withdrawApplication(recurringDepositAccountId,
-                WITHDRAWN_ON_DATE);
+                withdrawnOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsWithdrawn(recurringDepositAccountStatusHashMap);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositAccountIsClosed(recurringDepositAccountStatusHashMap);
     }
@@ -1188,9 +1188,9 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1200,7 +1200,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1240,13 +1240,13 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
-        final String DEPOSIT_DATE = dateFormat.format(todaysDate.getTime());
+        final String depositDate = dateFormat.format(todaysDate.getTime());
 
         /***
          * Create client for applying Deposit account
@@ -1266,7 +1266,7 @@ public class RecurringDepositTest {
          * Apply for RD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1277,14 +1277,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositSummaryBefore = this.recurringDepositAccountHelper.getRecurringDepositSummary(recurringDepositAccountId);
@@ -1294,12 +1294,12 @@ public class RecurringDepositTest {
          * Perform Deposit transaction and verify journal entries are posted for the transaction
          */
         Integer transactionIdForDeposit = this.recurringDepositAccountHelper.depositToRecurringDepositAccount(recurringDepositAccountId,
-                DEPOSIT_AMOUNT, DEPOSIT_DATE);
+                DEPOSIT_AMOUNT, depositDate);
         Assertions.assertNotNull(transactionIdForDeposit);
 
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, DEPOSIT_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, depositDate,
                 new JournalEntry(DEPOSIT_AMOUNT, JournalEntry.TransactionType.DEBIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, DEPOSIT_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, depositDate,
                 new JournalEntry(DEPOSIT_AMOUNT, JournalEntry.TransactionType.CREDIT));
 
         /***
@@ -1316,12 +1316,12 @@ public class RecurringDepositTest {
          */
         Float updatedTransactionAmount = DEPOSIT_AMOUNT - 1000.0f;
         Integer updateTransactionId = this.recurringDepositAccountHelper.updateTransactionForRecurringDeposit(recurringDepositAccountId,
-                transactionIdForDeposit, DEPOSIT_DATE, updatedTransactionAmount);
+                transactionIdForDeposit, depositDate, updatedTransactionAmount);
         Assertions.assertNotNull(updateTransactionId);
 
-        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, DEPOSIT_DATE,
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, depositDate,
                 new JournalEntry(updatedTransactionAmount, JournalEntry.TransactionType.DEBIT));
-        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, DEPOSIT_DATE,
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, depositDate,
                 new JournalEntry(updatedTransactionAmount, JournalEntry.TransactionType.CREDIT));
 
         expectedBalanceAfter = DEPOSIT_AMOUNT - updatedTransactionAmount;
@@ -1331,7 +1331,7 @@ public class RecurringDepositTest {
         Assertions.assertEquals(expectedBalanceAfter, balanceAfter, "Verifying account balance after updating Transaction");
 
         Integer undoTransactionId = this.recurringDepositAccountHelper.undoTransactionForRecurringDeposit(recurringDepositAccountId,
-                updateTransactionId, DEPOSIT_DATE, 0.0f);
+                updateTransactionId, depositDate, 0.0f);
         Assertions.assertNotNull(undoTransactionId);
 
         expectedBalanceAfter = expectedBalanceAfter - updatedTransactionAmount;
@@ -1364,11 +1364,11 @@ public class RecurringDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1378,7 +1378,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1386,7 +1386,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1439,11 +1439,11 @@ public class RecurringDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1453,11 +1453,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY,
                 expectedFirstDepositOnDate);
 
@@ -1466,7 +1466,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1517,11 +1517,11 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -1531,7 +1531,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1539,11 +1539,11 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1614,13 +1614,13 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
@@ -1635,7 +1635,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1643,11 +1643,11 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1696,10 +1696,10 @@ public class RecurringDepositTest {
         LOG.info("principal = {}", principal);
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -1738,13 +1738,13 @@ public class RecurringDepositTest {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
@@ -1759,11 +1759,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY,
                 expectedFirstDepositOnDate);
 
@@ -1772,11 +1772,11 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1825,10 +1825,10 @@ public class RecurringDepositTest {
         LOG.info("principal = {}", principal);
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -1868,14 +1868,14 @@ public class RecurringDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
@@ -1890,7 +1890,7 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, TILL_PREMATURE_WITHDRAWAL, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, TILL_PREMATURE_WITHDRAWAL, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -1898,11 +1898,11 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -1914,10 +1914,10 @@ public class RecurringDepositTest {
         ArrayList<ArrayList<HashMap>> interestRateChartData = RecurringDepositProductHelper
                 .getInterestRateChartSlabsByProductId(this.requestSpec, this.responseSpec, recurringDepositProductId);
 
-        Calendar activationDate = Calendar.getInstance();
-        activationDate.add(Calendar.MONTH, -1);
-        activationDate.add(Calendar.DAY_OF_MONTH, -1);
-        DateTime start = new DateTime(activationDate.getTime());
+        Calendar activationDateValue = Calendar.getInstance();
+        activationDateValue.add(Calendar.MONTH, -1);
+        activationDateValue.add(Calendar.DAY_OF_MONTH, -1);
+        DateTime start = new DateTime(activationDateValue.getTime());
 
         Calendar prematureClosureDate = Calendar.getInstance();
         DateTime end = new DateTime(prematureClosureDate.getTime());
@@ -1961,10 +1961,10 @@ public class RecurringDepositTest {
         LOG.info("principal = {}", principal);
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -2004,14 +2004,14 @@ public class RecurringDepositTest {
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         todaysDate.add(Calendar.DAY_OF_MONTH, 1);
-        final String CLOSED_ON_DATE = dateFormat.format(todaysDate.getTime());
+        final String closedOnDateValue = dateFormat.format(todaysDate.getTime());
 
         final Account assetAccount = this.accountHelper.createAssetAccount();
         final Account incomeAccount = this.accountHelper.createIncomeAccount();
@@ -2026,11 +2026,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, TILL_PREMATURE_WITHDRAWAL, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, TILL_PREMATURE_WITHDRAWAL, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, TILL_PREMATURE_WITHDRAWAL, INTEREST_CALCULATION_USING_DAILY_BALANCE, MONTHLY, MONTHLY,
                 expectedFirstDepositOnDate);
 
@@ -2039,11 +2039,11 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2055,10 +2055,10 @@ public class RecurringDepositTest {
         ArrayList<ArrayList<HashMap>> interestRateChartData = RecurringDepositProductHelper
                 .getInterestRateChartSlabsByProductId(this.requestSpec, this.responseSpec, recurringDepositProductId);
 
-        Calendar activationDate = Calendar.getInstance();
-        activationDate.add(Calendar.MONTH, -1);
-        activationDate.add(Calendar.DAY_OF_MONTH, -1);
-        DateTime start = new DateTime(activationDate.getTime());
+        Calendar activationDateValue = Calendar.getInstance();
+        activationDateValue.add(Calendar.MONTH, -1);
+        activationDateValue.add(Calendar.DAY_OF_MONTH, -1);
+        DateTime start = new DateTime(activationDateValue.getTime());
 
         Calendar prematureClosureDate = Calendar.getInstance();
         DateTime end = new DateTime(prematureClosureDate.getTime());
@@ -2102,10 +2102,10 @@ public class RecurringDepositTest {
         LOG.info("principal = {}", principal);
 
         HashMap recurringDepositPrematureData = this.recurringDepositAccountHelper
-                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, CLOSED_ON_DATE);
+                .calculatePrematureAmountForRecurringDeposit(recurringDepositAccountId, closedOnDateValue);
 
         Integer prematureClosureTransactionId = (Integer) this.recurringDepositAccountHelper.prematureCloseForRecurringDeposit(
-                recurringDepositAccountId, CLOSED_ON_DATE, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
+                recurringDepositAccountId, closedOnDateValue, CLOSURE_TYPE_WITHDRAW_DEPOSIT, null, CommonConstants.RESPONSE_RESOURCE_ID);
         Assertions.assertNotNull(prematureClosureTransactionId);
 
         recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker.getStatusOfRecurringDepositAccount(this.requestSpec,
@@ -2143,11 +2143,11 @@ public class RecurringDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2156,11 +2156,11 @@ public class RecurringDepositTest {
         Integer recurringDepositProductId = createRecurringDepositProduct(VALID_FROM, VALID_TO, accountingRule);
         Assertions.assertNotNull(recurringDepositProductId);
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, MONTHLY,
                 expectedFirstDepositOnDate);
 
@@ -2169,7 +2169,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2222,11 +2222,11 @@ public class RecurringDepositTest {
         todaysDate.add(Calendar.MONTH, -1);
         Integer currentDate = Integer.valueOf(currentDateFormat.format(todaysDate.getTime()));
         todaysDate.add(Calendar.DATE, -(currentDate - 1));
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2236,11 +2236,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, MONTHLY,
                 expectedFirstDepositOnDate);
 
@@ -2249,7 +2249,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2310,11 +2310,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2324,11 +2324,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, BI_ANNUALLY, BI_ANNUALLY,
                 expectedFirstDepositOnDate);
 
@@ -2337,7 +2337,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2400,11 +2400,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2414,11 +2414,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, BI_ANNUALLY, BI_ANNUALLY,
                 expectedFirstDepositOnDate);
 
@@ -2427,7 +2427,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2489,11 +2489,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2503,11 +2503,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, ANNUALLY,
                 expectedFirstDepositOnDate);
 
@@ -2516,7 +2516,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2579,11 +2579,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2593,11 +2593,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, DAILY, ANNUALLY,
                 expectedFirstDepositOnDate);
 
@@ -2606,7 +2606,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2670,11 +2670,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2684,11 +2684,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_365, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, QUARTERLY, QUARTERLY,
                 expectedFirstDepositOnDate);
 
@@ -2697,7 +2697,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2760,11 +2760,11 @@ public class RecurringDepositTest {
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
         final String VALID_TO = null;
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         final String expectedFirstDepositOnDate = dateFormat.format(todaysDate.getTime());
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2774,11 +2774,11 @@ public class RecurringDepositTest {
         Assertions.assertNotNull(recurringDepositProductId);
 
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, expectedFirstDepositOnDate);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, expectedFirstDepositOnDate);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap modificationsHashMap = this.recurringDepositAccountHelper.updateInterestCalculationConfigForRecurringDeposit(
-                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), SUBMITTED_ON_DATE,
+                clientId.toString(), recurringDepositProductId.toString(), recurringDepositAccountId.toString(), submittedOnDate,
                 VALID_FROM, VALID_TO, DAYS_360, WHOLE_TERM, INTEREST_CALCULATION_USING_DAILY_BALANCE, QUARTERLY, QUARTERLY,
                 expectedFirstDepositOnDate);
 
@@ -2787,7 +2787,7 @@ public class RecurringDepositTest {
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsPending(recurringDepositAccountStatusHashMap);
 
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -2830,7 +2830,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithPeriodInterestRateChart_AMOUNT_VARIATION() {
+    public void testRecurringDepositAccountWithPeriodInterestRateChartAmountVariation() {
         final String chartToUse = "period";
         final String depositAmount = "10000";
         final String depositPeriod = "12";
@@ -2839,7 +2839,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithPeriodInterestRateChart_PERIOD_VARIATION() {
+    public void testRecurringDepositAccountWithPeriodInterestRateChartPeriodVariation() {
         final String chartToUse = "period";
         final String depositAmount = "1000";
         final String depositPeriod = "18";
@@ -2857,7 +2857,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithAmountInterestRateChart_AMOUNT_VARIATION() {
+    public void testRecurringDepositAccountWithAmountInterestRateChartAmountVariation() {
         final String chartToUse = "amount";
         final String depositAmount = "500";
         final String depositPeriod = "12";
@@ -2866,7 +2866,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithAmountInterestRateChart_PERIOD_VARIATION() {
+    public void testRecurringDepositAccountWithAmountInterestRateChartPeriodVariation() {
         final String chartToUse = "amount";
         final String depositAmount = "500";
         final String depositPeriod = "10";
@@ -2884,7 +2884,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithPeriodAndAmountInterestRateChart_AMOUNT_VARIATION() {
+    public void testRecurringDepositAccountWithPeriodAndAmountInterestRateChartAmountVariation() {
         final String chartToUse = "period_amount";
         final String depositAmount = "400";
         final String depositPeriod = "12";
@@ -2893,7 +2893,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithPeriodAndAmountInterestRateChart_PERIOD_VARIATION() {
+    public void testRecurringDepositAccountWithPeriodAndAmountInterestRateChartPeriodVariation() {
         final String chartToUse = "period_amount";
         final String depositAmount = "1000";
         final String depositPeriod = "14";
@@ -2911,7 +2911,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithAmountAndPeriodInterestRateChart_AMOUNT_VARIATION() {
+    public void testRecurringDepositAccountWithAmountAndPeriodInterestRateChartAmountVariation() {
         final String chartToUse = "amount_period";
         final String depositAmount = "100";
         final String depositPeriod = "12";
@@ -2920,7 +2920,7 @@ public class RecurringDepositTest {
     }
 
     @Test
-    public void testRecurringDepositAccountWithAmountAndPeriodInterestRateChart_PERIOD_VARIATION() {
+    public void testRecurringDepositAccountWithAmountAndPeriodInterestRateChartPeriodVariation() {
         final String chartToUse = "amount_period";
         final String depositAmount = "1000";
         final String depositPeriod = "6";
@@ -2938,9 +2938,9 @@ public class RecurringDepositTest {
         final String VALID_FROM = "01 March 2014";
         final String VALID_TO = "01 March 2016";
 
-        final String SUBMITTED_ON_DATE = "01 March 2015";
-        final String APPROVED_ON_DATE = "01 March 2015";
-        final String ACTIVATION_DATE = "01 March 2015";
+        final String submittedOnDate = "01 March 2015";
+        final String approvedOnDate = "01 March 2015";
+        final String activationDate = "01 March 2015";
 
         Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
         Assertions.assertNotNull(clientId);
@@ -2956,7 +2956,7 @@ public class RecurringDepositTest {
          * Apply for FD account with created product and verify status
          */
         Integer recurringDepositAccountId = applyForRecurringDepositApplication(clientId.toString(), recurringDepositProductId.toString(),
-                VALID_FROM, VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, SUBMITTED_ON_DATE, depositAmount, depositPeriod);
+                VALID_FROM, VALID_TO, submittedOnDate, WHOLE_TERM, submittedOnDate, depositAmount, depositPeriod);
         Assertions.assertNotNull(recurringDepositAccountId);
 
         HashMap recurringDepositAccountStatusHashMap = RecurringDepositAccountStatusChecker
@@ -2967,14 +2967,14 @@ public class RecurringDepositTest {
          * Approve the RD account and verify whether account is approved
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.approveRecurringDeposit(recurringDepositAccountId,
-                APPROVED_ON_DATE);
+                approvedOnDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsApproved(recurringDepositAccountStatusHashMap);
 
         /***
          * Activate the RD Account and verify whether account is activated
          */
         recurringDepositAccountStatusHashMap = this.recurringDepositAccountHelper.activateRecurringDeposit(recurringDepositAccountId,
-                ACTIVATION_DATE);
+                activationDate);
         RecurringDepositAccountStatusChecker.verifyRecurringDepositIsActive(recurringDepositAccountStatusHashMap);
 
         HashMap recurringDepositAccountData = RecurringDepositAccountHelper.getRecurringDepositAccountById(this.requestSpec,
@@ -3082,14 +3082,14 @@ public class RecurringDepositTest {
     }
 
     private Account getMappedLiabilityFinancialAccount() {
-        final Integer LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID = FinancialActivity.LIABILITY_TRANSFER.getValue();
+        final Integer liabilityTransferFinancialActivityID = FinancialActivity.LIABILITY_TRANSFER.getValue();
         List<HashMap> financialActivities = this.financialActivityAccountHelper.getAllFinancialActivityAccounts(this.responseSpec);
         final Account financialAccount;
         /***
          * if no financial activities are defined for account transfers, create liability financial accounting mappings
          */
         if (financialActivities.isEmpty()) {
-            financialAccount = createLiabilityFinancialAccountTransferType(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID);
+            financialAccount = createLiabilityFinancialAccountTransferType(liabilityTransferFinancialActivityID);
         } else {
             /***
              * extract mapped liability financial account
@@ -3097,7 +3097,7 @@ public class RecurringDepositTest {
             Account mappedLiabilityAccount = null;
             for (HashMap financialActivity : financialActivities) {
                 HashMap financialActivityData = (HashMap) financialActivity.get("financialActivityData");
-                if (financialActivityData.get("id").equals(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID)) {
+                if (financialActivityData.get("id").equals(liabilityTransferFinancialActivityID)) {
                     HashMap glAccountData = (HashMap) financialActivity.get("glAccountData");
                     mappedLiabilityAccount = new Account((Integer) glAccountData.get("id"), AccountType.LIABILITY);
                     break;
@@ -3107,7 +3107,7 @@ public class RecurringDepositTest {
              * If liability transfer is not defined create liability transfer
              */
             if (mappedLiabilityAccount == null) {
-                mappedLiabilityAccount = createLiabilityFinancialAccountTransferType(LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID);
+                mappedLiabilityAccount = createLiabilityFinancialAccountTransferType(liabilityTransferFinancialActivityID);
             }
             financialAccount = mappedLiabilityAccount;
         }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
@@ -422,9 +422,9 @@ public class SchedulerJobsTestResults {
         this.schedulerJobHelper.executeAndAwaitJob(JobName);
         final HashMap runningBalanceAfter = this.accountHelper.getAccountingWithRunningBalanceById(accountID.toString());
 
-        final Integer INT_BALANCE = Integer.valueOf(MINIMUM_OPENING_BALANCE);
+        final Integer intBalance = Integer.valueOf(MINIMUM_OPENING_BALANCE);
 
-        Assertions.assertEquals(INT_BALANCE, runningBalanceAfter.get("organizationRunningBalance"),
+        Assertions.assertEquals(intBalance, runningBalanceAfter.get("organizationRunningBalance"),
                 "Verifying Account Running Balance after running Update Accounting Running Balances Scheduler Job");
 
     }
@@ -475,11 +475,11 @@ public class SchedulerJobsTestResults {
         final String currentDate = dateFormat.format(todayDate.getTime());
 
         todayDate.add(Calendar.MONTH, -1);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todayDate.getTime());
 
         todayDate = Calendar.getInstance();
         todayDate.add(Calendar.DATE, -5);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todayDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todayDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
         Assertions.assertNotNull(clientID);
@@ -496,14 +496,14 @@ public class SchedulerJobsTestResults {
         loanStatusHashMap = this.loanTransactionHelper.approveLoan(AccountTransferTest.LOAN_APPROVAL_DATE, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
 
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         ArrayList<HashMap> loanScheduleBefore = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
 
         Float totalDueForCurrentPeriod = (Float) loanScheduleBefore.get(1).get("totalDueForPeriod");
 
-        this.loanTransactionHelper.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanID);
 
         HashMap loanSummary = this.loanTransactionHelper.getLoanSummary(requestSpec, responseSpec, loanID);
 
@@ -537,11 +537,11 @@ public class SchedulerJobsTestResults {
         final String currentDate = dateFormat.format(todaysDate.getTime());
 
         todaysDate.add(Calendar.MONTH, -1);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.DATE, -5);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
 
         final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
         Assertions.assertNotNull(clientID);
@@ -566,7 +566,7 @@ public class SchedulerJobsTestResults {
         loanStatusHashMap = this.loanTransactionHelper.approveLoan(AccountTransferTest.LOAN_APPROVAL_DATE, loanID);
         LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
 
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(LOAN_DISBURSEMENT_DATE, loanID);
+        loanStatusHashMap = this.loanTransactionHelper.disburseLoan(loanDisbursementDate, loanID);
         LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
         HashMap loanSummaryBefore = this.loanTransactionHelper.getLoanSummary(requestSpec, responseSpec, loanID);
@@ -594,7 +594,7 @@ public class SchedulerJobsTestResults {
         todaysDate.add(Calendar.WEEK_OF_YEAR, -1);
         final String VALID_FROM = dateFormat.format(todaysDate.getTime());
 
-        final String MONTH_DAY = monthDayFormat.format(todaysDate.getTime());
+        final String monthDayValue = monthDayFormat.format(todaysDate.getTime());
 
         todaysDate.add(Calendar.YEAR, 1);
         final String VALID_TO = dateFormat.format(todaysDate.getTime());
@@ -640,7 +640,7 @@ public class SchedulerJobsTestResults {
 
         Integer standingInstructionId = this.standingInstructionsHelper.createStandingInstruction(clientID.toString(),
                 fromSavingsId.toString(), toSavingsId.toString(), FROM_ACCOUNT_TYPE_SAVINGS, TO_ACCOUNT_TYPE_SAVINGS, VALID_FROM, VALID_TO,
-                MONTH_DAY);
+                monthDayValue);
         Assertions.assertNotNull(standingInstructionId);
 
         String JobName = "Execute Standing Instruction";
@@ -839,9 +839,9 @@ public class SchedulerJobsTestResults {
 
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -2);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String APPROVED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String ACTIVATION_DATE = dateFormat.format(todaysDate.getTime());
+        final String submittedOnDate = dateFormat.format(todaysDate.getTime());
+        final String approvedOnDate = dateFormat.format(todaysDate.getTime());
+        final String activationDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.MONTH, 1);
         final String WHOLE_TERM = "1";
 
@@ -870,17 +870,17 @@ public class SchedulerJobsTestResults {
         Assertions.assertNotNull(fixedDepositProductId);
 
         Integer fixedDepositAccountId = applyForFixedDepositApplication(clientId.toString(), fixedDepositProductId.toString(), VALID_FROM,
-                VALID_TO, SUBMITTED_ON_DATE, WHOLE_TERM, savingsId.toString(), true, fixedDepositAccountHelper);
+                VALID_TO, submittedOnDate, WHOLE_TERM, savingsId.toString(), true, fixedDepositAccountHelper);
         Assertions.assertNotNull(fixedDepositAccountId);
 
         HashMap fixedDepositAccountStatusHashMap = FixedDepositAccountStatusChecker.getStatusOfFixedDepositAccount(requestSpec,
                 responseSpec, fixedDepositAccountId.toString());
         FixedDepositAccountStatusChecker.verifyFixedDepositIsPending(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, APPROVED_ON_DATE);
+        fixedDepositAccountStatusHashMap = fixedDepositAccountHelper.approveFixedDeposit(fixedDepositAccountId, approvedOnDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsApproved(fixedDepositAccountStatusHashMap);
 
-        fixedDepositAccountStatusHashMap = fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, ACTIVATION_DATE);
+        fixedDepositAccountStatusHashMap = fixedDepositAccountHelper.activateFixedDeposit(fixedDepositAccountId, activationDate);
         FixedDepositAccountStatusChecker.verifyFixedDepositIsActive(fixedDepositAccountStatusHashMap);
         summary = savingsAccountHelper.getSavingsSummary(savingsId);
         balance = Float.valueOf(MINIMUM_OPENING_BALANCE);

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/BatchHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/BatchHelper.java
@@ -410,8 +410,8 @@ public final class BatchHelper {
     public static void verifyClientCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String externalId) {
         LOG.info("------------------------------CHECK CLIENT DETAILS------------------------------------\n");
-        final String CLIENT_URL = "/fineract-provider/api/v1/clients?externalId=" + externalId + "&" + Utils.TENANT_IDENTIFIER;
-        final Integer responseRecords = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL, "totalFilteredRecords");
+        final String clientURL = "/fineract-provider/api/v1/clients?externalId=" + externalId + "&" + Utils.TENANT_IDENTIFIER;
+        final Integer responseRecords = Utils.performServerGet(requestSpec, responseSpec, clientURL, "totalFilteredRecords");
         Assertions.assertEquals((long) 0, (long) responseRecords, "No records found with given externalId");
     }
 }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CalendarHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CalendarHelper.java
@@ -46,11 +46,11 @@ public final class CalendarHelper {
 
         LOG.info("---------------------------------CREATING A MEETING CALENDAR FOR THE GROUP------------------------------");
 
-        final String CALENDAR_RESOURCE_URL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "?" + Utils.TENANT_IDENTIFIER;
+        final String calendarResourceURL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "?" + Utils.TENANT_IDENTIFIER;
 
-        LOG.info("{}", CALENDAR_RESOURCE_URL);
+        LOG.info("{}", calendarResourceURL);
 
-        return Utils.performServerPost(requestSpec, responseSpec, CALENDAR_RESOURCE_URL,
+        return Utils.performServerPost(requestSpec, responseSpec, calendarResourceURL,
                 getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate), "resourceId");
     }
 
@@ -60,11 +60,11 @@ public final class CalendarHelper {
 
         LOG.info("---------------------------------UPDATING A MEETING CALENDAR FOR THE GROUP------------------------------");
 
-        final String CALENDAR_RESOURCE_URL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "/" + calendarID;
+        final String calendarResourceURL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "/" + calendarID;
 
-        LOG.info("{}", CALENDAR_RESOURCE_URL);
+        LOG.info("{}", calendarResourceURL);
         // TODO: check that resource id indeed exists in calendar update put.
-        return Utils.performServerPut(requestSpec, responseSpec, CALENDAR_RESOURCE_URL,
+        return Utils.performServerPut(requestSpec, responseSpec, calendarResourceURL,
                 getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate), "resourceId");
     }
 
@@ -88,8 +88,8 @@ public final class CalendarHelper {
     public static void verifyCalendarCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedGroupId, final Integer generatedCalendarId) {
         LOG.info("------------------------------CHECK CALENDAR DETAILS------------------------------------\n");
-        final String CLIENT_URL = "/fineract-provider/api/v1/groups/" + generatedGroupId + "?associations=all&" + Utils.TENANT_IDENTIFIER;
-        final String responseCalendarDetailsinJSON = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL,
+        final String clientURL = "/fineract-provider/api/v1/groups/" + generatedGroupId + "?associations=all&" + Utils.TENANT_IDENTIFIER;
+        final String responseCalendarDetailsinJSON = Utils.performServerGet(requestSpec, responseSpec, clientURL,
                 "collectionMeetingCalendar");
         final Integer responseCalendarId = JsonPath.from(responseCalendarDetailsinJSON).get("id");
         assertEquals(generatedCalendarId, responseCalendarId, "ERROR IN CREATING THE CALENDAR");
@@ -100,11 +100,11 @@ public final class CalendarHelper {
 
         LOG.info("---------------------------------CREATING A MEETING CALENDAR FOR THE GROUP------------------------------");
 
-        final String CALENDAR_RESOURCE_URL = BASE_URL + CENTER_ENTITY + groupId + ENITY_NAME + "?" + Utils.TENANT_IDENTIFIER;
+        final String calendarResourceURL = BASE_URL + CENTER_ENTITY + groupId + ENITY_NAME + "?" + Utils.TENANT_IDENTIFIER;
 
-        LOG.info("{}", CALENDAR_RESOURCE_URL);
+        LOG.info("{}", calendarResourceURL);
 
-        return Utils.performServerPost(requestSpec, responseSpec, CALENDAR_RESOURCE_URL,
+        return Utils.performServerPost(requestSpec, responseSpec, calendarResourceURL,
                 getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate), "resourceId");
     }
 
@@ -113,12 +113,12 @@ public final class CalendarHelper {
 
         LOG.info("---------------------------------UPADATING A MEETING CALENDAR FOR THE CENTER------------------------------");
 
-        final String CALENDAR_RESOURCE_URL = BASE_URL + CENTER_ENTITY + centerId + ENITY_NAME + "/" + calendarID + "?"
+        final String calendarResourceURL = BASE_URL + CENTER_ENTITY + centerId + ENITY_NAME + "/" + calendarID + "?"
                 + Utils.TENANT_IDENTIFIER;
 
-        LOG.info("{}", CALENDAR_RESOURCE_URL);
+        LOG.info("{}", calendarResourceURL);
 
-        return Utils.performServerPut(requestSpec, responseSpec, CALENDAR_RESOURCE_URL, getTestCalendarMeetingAsJSON(oldDate, startDate),
+        return Utils.performServerPut(requestSpec, responseSpec, calendarResourceURL, getTestCalendarMeetingAsJSON(oldDate, startDate),
                 "resourceId");
 
     }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CenterHelper.java
@@ -37,33 +37,33 @@ public final class CenterHelper {
     private static final String CENTERS_URL = "/fineract-provider/api/v1/centers";
 
     public static final String CREATED_DATE = "29 December 2014";
-    private static final String CREATE_CENTER_URL = "/fineract-provider/api/v1/centers?" + Utils.TENANT_IDENTIFIER;
+    private static final String createCenterURL = "/fineract-provider/api/v1/centers?" + Utils.TENANT_IDENTIFIER;
 
     private CenterHelper() {
 
     }
 
     public static CenterDomain retrieveByID(int id, final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        final String GET_CENTER_BY_ID_URL = CENTERS_URL + "/" + id + "?associations=groupMembers&" + Utils.TENANT_IDENTIFIER;
+        final String getCenterByIDurl = CENTERS_URL + "/" + id + "?associations=groupMembers&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING CENTER AT {}-------------------------", id);
-        Object get = Utils.performServerGet(requestSpec, responseSpec, GET_CENTER_BY_ID_URL, "");
+        Object get = Utils.performServerGet(requestSpec, responseSpec, getCenterByIDurl, "");
         final String jsonData = new Gson().toJson(get);
         return new Gson().fromJson(jsonData, new TypeToken<CenterDomain>() {}.getType());
     }
 
     public static ArrayList<CenterDomain> paginatedListCenters(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_CENTER = CENTERS_URL + "?paged=true&limit=-1&" + Utils.TENANT_IDENTIFIER;
+        final String getCenterURL = CENTERS_URL + "?paged=true&limit=-1&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING CENTERS-------------------------");
-        Object get = Utils.performServerGet(requestSpec, responseSpec, GET_CENTER, "pageItems");
+        Object get = Utils.performServerGet(requestSpec, responseSpec, getCenterURL, "pageItems");
         final String jsonData = new Gson().toJson(get);
         return new Gson().fromJson(jsonData, new TypeToken<ArrayList<CenterDomain>>() {}.getType());
     }
 
     public static ArrayList<CenterDomain> listCenters(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        final String GET_CENTER = CENTERS_URL + "?limit=-1&" + Utils.TENANT_IDENTIFIER;
+        final String getCenterURL = CENTERS_URL + "?limit=-1&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING CENTERS-------------------------");
-        Object get = Utils.performServerGet(requestSpec, responseSpec, GET_CENTER, "");
+        Object get = Utils.performServerGet(requestSpec, responseSpec, getCenterURL, "");
         final String jsonData = new Gson().toJson(get);
         return new Gson().fromJson(jsonData, new TypeToken<ArrayList<CenterDomain>>() {}.getType());
     }
@@ -86,7 +86,7 @@ public final class CenterHelper {
     public static int createCenter(final String name, final int officeId, final String externalId, final int staffId,
             final int[] groupMembers, final String activationDate, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String CREATE_CENTER_URL = CENTERS_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String createCenterURL = CENTERS_URL + "?" + Utils.TENANT_IDENTIFIER;
         HashMap hm = new HashMap();
         hm.put("name", name);
         hm.put("officeId", officeId);
@@ -109,25 +109,25 @@ public final class CenterHelper {
         }
 
         LOG.info("------------------------CREATING CENTER-------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_CENTER_URL, new Gson().toJson(hm), "resourceId");
+        return Utils.performServerPost(requestSpec, responseSpec, createCenterURL, new Gson().toJson(hm), "resourceId");
     }
 
     public static HashMap<String, String> updateCenter(final int id, HashMap request, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String UPDATE_CENTER_URL = CENTERS_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
+        final String updateCenterURL = CENTERS_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE CENTER AT {}---------------------------------------------", id);
-        HashMap<String, String> hash = Utils.performServerPut(requestSpec, responseSpec, UPDATE_CENTER_URL, new Gson().toJson(request),
+        HashMap<String, String> hash = Utils.performServerPut(requestSpec, responseSpec, updateCenterURL, new Gson().toJson(request),
                 "changes");
         return hash;
     }
 
     public static int[] associateGroups(final int id, final int[] groupMembers, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String ASSOCIATE_GROUP_CENTER_URL = CENTERS_URL + "/" + id + "?command=associateGroups&" + Utils.TENANT_IDENTIFIER;
+        final String associateGroupCenterURL = CENTERS_URL + "/" + id + "?command=associateGroups&" + Utils.TENANT_IDENTIFIER;
         HashMap groupMemberHashMap = new HashMap();
         groupMemberHashMap.put("groupMembers", groupMembers);
         LOG.info("---------------------------------ASSOCIATING GROUPS AT {}--------------------------------------------", id);
-        HashMap hash = Utils.performServerPost(requestSpec, responseSpec, ASSOCIATE_GROUP_CENTER_URL, new Gson().toJson(groupMemberHashMap),
+        HashMap hash = Utils.performServerPost(requestSpec, responseSpec, associateGroupCenterURL, new Gson().toJson(groupMemberHashMap),
                 "changes");
         LOG.info("{}", hash.toString());
         ArrayList<String> arr = (ArrayList<String>) hash.get("groupMembers");
@@ -139,9 +139,9 @@ public final class CenterHelper {
     }
 
     public static void deleteCenter(final int id, final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        final String DELETE_CENTER_URL = CENTERS_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
+        final String deleteCenterURL = CENTERS_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------DELETING CENTER AT {}--------------------------------------------", id);
-        Utils.performServerDelete(requestSpec, responseSpec, DELETE_CENTER_URL, "");
+        Utils.performServerDelete(requestSpec, responseSpec, deleteCenterURL, "");
     }
 
     public static Integer createCenter(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
@@ -153,44 +153,43 @@ public final class CenterHelper {
     public static Integer createCenter(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String activationDate) {
         LOG.info("---------------------------------CREATING A CENTER---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_CENTER_URL, getTestCenterAsJSON(true, activationDate), "groupId");
+        return Utils.performServerPost(requestSpec, responseSpec, createCenterURL, getTestCenterAsJSON(true, activationDate), "groupId");
     }
 
     public static Integer createCenter(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
         LOG.info("---------------------------------CREATING A CENTER---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_CENTER_URL, getTestCenterAsJSON(true, CenterHelper.CREATED_DATE),
+        return Utils.performServerPost(requestSpec, responseSpec, createCenterURL, getTestCenterAsJSON(true, CenterHelper.CREATED_DATE),
                 "groupId");
     }
 
     public static int createCenterWithStaffId(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer staffId) {
         LOG.info("---------------------------------CREATING A CENTER---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_CENTER_URL,
+        return Utils.performServerPost(requestSpec, responseSpec, createCenterURL,
                 getTestCenterWithStaffAsJSON(true, CenterHelper.CREATED_DATE, staffId), "groupId");
     }
 
     public static void verifyCenterCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCenterID) {
         LOG.info("------------------------------CHECK CENTER DETAILS------------------------------------\n");
-        final String CENTER_URL = "/fineract-provider/api/v1/centers/" + generatedCenterID + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responseCenterID = Utils.performServerGet(requestSpec, responseSpec, CENTER_URL, "id");
+        final String centerURL = "/fineract-provider/api/v1/centers/" + generatedCenterID + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responseCenterID = Utils.performServerGet(requestSpec, responseSpec, centerURL, "id");
         assertEquals(generatedCenterID, responseCenterID, "ERROR IN CREATING THE CENTER");
     }
 
     public static void verifyCenterActivatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCenterID, final boolean generatedCenterStatus) {
         LOG.info("------------------------------CHECK CENTER STATUS------------------------------------\n");
-        final String CENTER_URL = "/fineract-provider/api/v1/centers/" + generatedCenterID + "?" + Utils.TENANT_IDENTIFIER;
-        final Boolean responseCenterStatus = Utils.performServerGet(requestSpec, responseSpec, CENTER_URL, "active");
+        final String centerURL = "/fineract-provider/api/v1/centers/" + generatedCenterID + "?" + Utils.TENANT_IDENTIFIER;
+        final Boolean responseCenterStatus = Utils.performServerGet(requestSpec, responseSpec, centerURL, "active");
         assertEquals(generatedCenterStatus, responseCenterStatus, "ERROR IN ACTIVATING THE CENTER");
     }
 
     public static Integer activateCenter(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String centerId) {
-        final String CENTER_ASSOCIATE_URL = "/fineract-provider/api/v1/centers/" + centerId + "?command=activate&"
-                + Utils.TENANT_IDENTIFIER;
+        final String centerAssociateURL = "/fineract-provider/api/v1/centers/" + centerId + "?command=activate&" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------ACTIVATE A CENTER---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CENTER_ASSOCIATE_URL, activateCenterAsJSON(""), "groupId");
+        return Utils.performServerPost(requestSpec, responseSpec, centerAssociateURL, activateCenterAsJSON(""), "groupId");
     }
 
     public static String getTestCenterWithStaffAsJSON(final boolean active, final String activationDate, final Integer staffId) {
@@ -265,18 +264,18 @@ public final class CenterHelper {
 
     public static Object assignStaff(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final String groupId,
             final Long staffId) {
-        final String GROUP_ASSIGN_STAFF_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
+        final String groupAssignStaffURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
                 + "&command=assignStaff";
         LOG.info("---------------------------------Assign Staff---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSIGN_STAFF_URL, assignStaffAsJSON(staffId), "changes");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssignStaffURL, assignStaffAsJSON(staffId), "changes");
     }
 
     public static Object unassignStaff(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String groupId, final Long staffId) {
-        final String GROUP_ASSIGN_STAFF_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
+        final String groupAssignStaffURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
                 + "&command=unassignStaff";
         LOG.info("---------------------------------Unassign Staff---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSIGN_STAFF_URL, unassignStaffAsJSON(staffId), "changes");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssignStaffURL, unassignStaffAsJSON(staffId), "changes");
     }
 
 }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -168,11 +168,11 @@ public class ClientHelper {
 
     public static Object assignStaffToClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String clientId, final String staffId) {
-        final String CLIENT_ASSIGN_STAFF_URL = "/fineract-provider/api/v1/clients/" + clientId + "?" + Utils.TENANT_IDENTIFIER
+        final String clientAssignStaffURL = "/fineract-provider/api/v1/clients/" + clientId + "?" + Utils.TENANT_IDENTIFIER
                 + "&command=assignStaff";
 
         LOG.info("---------------------------------CREATING A CLIENT---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CLIENT_ASSIGN_STAFF_URL, assignStaffToClientAsJson(staffId), "changes");
+        return Utils.performServerPost(requestSpec, responseSpec, clientAssignStaffURL, assignStaffToClientAsJson(staffId), "changes");
     }
 
     public static Integer getClientsStaffId(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
@@ -300,16 +300,16 @@ public class ClientHelper {
     public static void verifyClientCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedClientID) {
         LOG.info("------------------------------CHECK CLIENT DETAILS------------------------------------\n");
-        final String CLIENT_URL = "/fineract-provider/api/v1/clients/" + generatedClientID + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responseClientID = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL, "id");
+        final String clientURL = "/fineract-provider/api/v1/clients/" + generatedClientID + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responseClientID = Utils.performServerGet(requestSpec, responseSpec, clientURL, "id");
         assertEquals(generatedClientID, responseClientID, "ERROR IN CREATING THE CLIENT");
     }
 
     public static Object getClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final String clientId,
             final String jsonReturn) {
-        final String GET_CLIENT_URL = "/fineract-provider/api/v1/clients/" + clientId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getClientURL = "/fineract-provider/api/v1/clients/" + clientId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------GET A CLIENT---------------------------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_CLIENT_URL, jsonReturn);
+        return Utils.performServerGet(requestSpec, responseSpec, getClientURL, jsonReturn);
 
     }
 
@@ -549,37 +549,37 @@ public class ClientHelper {
     public static Integer addChargesForClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer clientId, final String request) {
         LOG.info("--------------------------------- ADD CHARGES FOR Client --------------------------------");
-        final String ADD_CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/charges?" + Utils.TENANT_IDENTIFIER;
-        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, ADD_CHARGES_URL, request, "");
+        final String addChargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/charges?" + Utils.TENANT_IDENTIFIER;
+        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, addChargesURL, request, "");
         return (Integer) response.get("resourceId");
     }
 
     public static String payChargesForClients(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer clientId, final Integer clientChargeId, final String json) {
         LOG.info("--------------------------------- PAY CHARGES FOR CLIENT --------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?command=paycharge&"
+        final String chargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?command=paycharge&"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL, json, "");
+        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, chargesURL, json, "");
         return response.get("transactionId") != null ? response.get("transactionId").toString() : null;
     }
 
     public static String waiveChargesForClients(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer clientId, final Integer clientChargeId, final String json) {
         LOG.info("--------------------------------- WAIVE CHARGES FOR CLIENT --------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?command=waive&"
+        final String chargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?command=waive&"
                 + Utils.TENANT_IDENTIFIER;
 
-        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL, json, "");
+        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, chargesURL, json, "");
         return response.get("transactionId").toString();
     }
 
     public static Integer revertClientChargeTransaction(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String clientId, String clientChargeId) {
         LOG.info("---------------------------------UNDO TRANSACTION---------------------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/transactions/" + clientChargeId + "?command=undo&"
+        final String chargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/transactions/" + clientChargeId + "?command=undo&"
                 + Utils.TENANT_IDENTIFIER;
 
-        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL, "", "");
+        final HashMap<?, ?> response = Utils.performServerPost(requestSpec, responseSpec, chargesURL, "", "");
         return (Integer) response.get("resourceId");
 
     }
@@ -587,17 +587,17 @@ public class ClientHelper {
     public static Object getClientCharge(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String clientId, final String clientChargeId) {
         LOG.info("---------------------------------GET CLIENT CHARGE---------------------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?"
+        final String chargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/charges/" + clientChargeId + "?"
                 + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, CHARGES_URL, "amountOutstanding");
+        return Utils.performServerGet(requestSpec, responseSpec, chargesURL, "amountOutstanding");
     }
 
     public static Boolean getClientTransactions(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String clientId, final String transactionId) {
         LOG.info("---------------------------------GET CLIENT CHARGE TRANSACTIONS---------------------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/clients/" + clientId + "/transactions/" + transactionId + "?"
+        final String chargesURL = "/fineract-provider/api/v1/clients/" + clientId + "/transactions/" + transactionId + "?"
                 + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, CHARGES_URL, "reversed");
+        return Utils.performServerGet(requestSpec, responseSpec, chargesURL, "reversed");
     }
 
     public Workbook getClientEntityWorkbook(GlobalEntityType clientsEntity, String dateFormat) throws IOException {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CurrenciesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/CurrenciesHelper.java
@@ -39,9 +39,9 @@ public final class CurrenciesHelper {
 
     public static ArrayList<CurrencyDomain> getAllCurrencies(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_ALL_CURRENCIES_URL = CURRENCIES_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String getAllCurrenciesURL = CURRENCIES_URL + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING ALL CURRENCIES -------------------------");
-        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, GET_ALL_CURRENCIES_URL, "");
+        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, getAllCurrenciesURL, "");
         ArrayList<HashMap> selectedCurrencyOptions = (ArrayList<HashMap>) response.get("selectedCurrencyOptions");
         ArrayList<HashMap> currencyOptions = (ArrayList<HashMap>) response.get("currencyOptions");
         currencyOptions.addAll(selectedCurrencyOptions);
@@ -51,9 +51,9 @@ public final class CurrenciesHelper {
 
     public static ArrayList<CurrencyDomain> getSelectedCurrencies(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_ALL_SELECTED_CURRENCIES_URL = CURRENCIES_URL + "?fields=selectedCurrencyOptions" + "&" + Utils.TENANT_IDENTIFIER;
+        final String getAllSelectedCurrenciesURL = CURRENCIES_URL + "?fields=selectedCurrencyOptions" + "&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING ALL SELECTED CURRENCIES -------------------------");
-        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, GET_ALL_SELECTED_CURRENCIES_URL, "");
+        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, getAllSelectedCurrenciesURL, "");
         final String jsonData = new Gson().toJson(response.get("selectedCurrencyOptions"));
         return new Gson().fromJson(jsonData, new TypeToken<ArrayList<CurrencyDomain>>() {}.getType());
     }
@@ -71,9 +71,9 @@ public final class CurrenciesHelper {
 
     public static ArrayList<String> updateSelectedCurrencies(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final ArrayList<String> currencies) {
-        final String CURRENCIES_UPDATE_URL = CURRENCIES_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String currenciesUpdateURL = CURRENCIES_URL + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE SELECTED CURRENCIES LIST---------------------------------------------");
-        HashMap hash = Utils.performServerPut(requestSpec, responseSpec, CURRENCIES_UPDATE_URL, currenciesToJSON(currencies), "changes");
+        HashMap hash = Utils.performServerPut(requestSpec, responseSpec, currenciesUpdateURL, currenciesToJSON(currencies), "changes");
         return (ArrayList<String>) hash.get("currencies");
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ExternalServicesConfigurationHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/ExternalServicesConfigurationHelper.java
@@ -36,22 +36,22 @@ public class ExternalServicesConfigurationHelper {
 
     public static ArrayList<HashMap> getExternalServicesConfigurationByServiceName(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String serviceName) {
-        final String GET_EXTERNAL_SERVICES_CONFIG_BY_SERVICE_NAME_URL = "/fineract-provider/api/v1/externalservice/" + serviceName + "?"
+        final String getExternalServicesConfigByServiceNameURL = "/fineract-provider/api/v1/externalservice/" + serviceName + "?"
                 + Utils.TENANT_IDENTIFIER;
         // system.out.println("------------------------ RETRIEVING GLOBAL
         // CONFIGURATION
         // BY ID -------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_EXTERNAL_SERVICES_CONFIG_BY_SERVICE_NAME_URL, "");
+        return Utils.performServerGet(requestSpec, responseSpec, getExternalServicesConfigByServiceNameURL, "");
     }
 
     public static HashMap updateValueForExternaServicesConfiguration(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String serviceName, final String name, final String value) {
-        final String EXTERNAL_SERVICES_CONFIG_UPDATE_URL = "/fineract-provider/api/v1/externalservice/" + serviceName + "?"
+        final String externalServicesConfigUpdateURL = "/fineract-provider/api/v1/externalservice/" + serviceName + "?"
                 + Utils.TENANT_IDENTIFIER;
         // system.out.println("---------------------------------UPDATE VALUE FOR
         // GLOBAL
         // CONFIG---------------------------------------------");
-        HashMap map = Utils.performServerPut(requestSpec, responseSpec, EXTERNAL_SERVICES_CONFIG_UPDATE_URL,
+        HashMap map = Utils.performServerPut(requestSpec, responseSpec, externalServicesConfigUpdateURL,
                 updateExternalServicesConfigUpdateValueAsJSON(name, value), "");
 
         return (HashMap) map.get("changes");

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
@@ -41,18 +41,17 @@ public class GlobalConfigurationHelper {
 
     public static ArrayList<HashMap> getAllGlobalConfigurations(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_ALL_GLOBAL_CONFIG_URL = "/fineract-provider/api/v1/configurations?" + Utils.TENANT_IDENTIFIER;
+        final String getAllGlobalConfigURL = "/fineract-provider/api/v1/configurations?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING ALL GLOBAL CONFIGURATIONS -------------------------");
-        final HashMap<String, ArrayList<HashMap>> response = Utils.performServerGet(requestSpec, responseSpec, GET_ALL_GLOBAL_CONFIG_URL,
-                "");
+        final HashMap<String, ArrayList<HashMap>> response = Utils.performServerGet(requestSpec, responseSpec, getAllGlobalConfigURL, "");
         return response.get("globalConfiguration");
     }
 
     public static HashMap getGlobalConfigurationById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String configId) {
-        final String GET_GLOBAL_CONFIG_BY_ID_URL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getGlobalConfigByIdURL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING GLOBAL CONFIGURATION BY ID -------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_GLOBAL_CONFIG_BY_ID_URL, "");
+        return Utils.performServerGet(requestSpec, responseSpec, getGlobalConfigByIdURL, "");
     }
 
     public static void resetAllDefaultGlobalConfigurations(final RequestSpecification requestSpec,
@@ -367,42 +366,42 @@ public class GlobalConfigurationHelper {
 
     public static Integer updateValueForGlobalConfiguration(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String configId, final String value) {
-        final String GLOBAL_CONFIG_UPDATE_URL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getGlobalConfigUpdateURL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE VALUE FOR GLOBAL CONFIG---------------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, GLOBAL_CONFIG_UPDATE_URL, updateGlobalConfigUpdateValueAsJSON(value),
+        return Utils.performServerPut(requestSpec, responseSpec, getGlobalConfigUpdateURL, updateGlobalConfigUpdateValueAsJSON(value),
                 "resourceId");
     }
 
     public static Integer updateEnabledFlagForGlobalConfiguration(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String configId, final Boolean enabled) {
-        final String GLOBAL_CONFIG_UPDATE_URL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getGlobalConfigUpdateURL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE GLOBAL CONFIG FOR ENABLED FLAG---------------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, GLOBAL_CONFIG_UPDATE_URL,
+        return Utils.performServerPut(requestSpec, responseSpec, getGlobalConfigUpdateURL,
                 updateGlobalConfigUpdateEnabledFlagAsJSON(enabled), "resourceId");
     }
 
     public static ArrayList getGlobalConfigurationIsCacheEnabled(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_IS_CACHE_GLOBAL_CONFIG_URL = "/fineract-provider/api/v1/caches?" + Utils.TENANT_IDENTIFIER;
+        final String getIsCacheGlobalConfigURL = "/fineract-provider/api/v1/caches?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING IS CACHE ENABLED GLOBAL CONFIGURATION -------------------------");
-        final ArrayList<HashMap> response = Utils.performServerGet(requestSpec, responseSpec, GET_IS_CACHE_GLOBAL_CONFIG_URL, "");
+        final ArrayList<HashMap> response = Utils.performServerGet(requestSpec, responseSpec, getIsCacheGlobalConfigURL, "");
         return response;
     }
 
     public static HashMap updateIsCacheEnabledForGlobalConfiguration(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String cacheType) {
-        final String IS_CACHE_GLOBAL_CONFIG_UPDATE_URL = "/fineract-provider/api/v1/caches?" + Utils.TENANT_IDENTIFIER;
+        final String getIsCacheGlobalConfigUpdateURL = "/fineract-provider/api/v1/caches?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------UPDATE GLOBAL CONFIG FOR IS CACHE ENABLED----------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, IS_CACHE_GLOBAL_CONFIG_UPDATE_URL,
+        return Utils.performServerPut(requestSpec, responseSpec, getIsCacheGlobalConfigUpdateURL,
                 updateIsCacheEnabledGlobalConfigUpdateAsJSON(cacheType), "changes");
     }
 
     public static Object updatePasswordResetDaysForGlobalConfiguration(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final Integer configId, final String value, final String enabled,
             final String jsonAttributeToGetBack) {
-        final String UPDATE_URL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
+        final String updateURL = "/fineract-provider/api/v1/configurations/" + configId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------UPDATE GLOBAL CONFIG FOR FORCE PASSWORD RESET DAYS----------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_URL, updatePasswordResetDaysGlobalConfigAsJSON(value, enabled),
+        return Utils.performServerPut(requestSpec, responseSpec, updateURL, updatePasswordResetDaysGlobalConfigAsJSON(value, enabled),
                 jsonAttributeToGetBack);
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/GroupHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/GroupHelper.java
@@ -79,55 +79,55 @@ public class GroupHelper {
 
     public static Integer associateClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String groupId, final String clientMember) {
-        final String GROUP_ASSOCIATE_URL = "/fineract-provider/api/v1/groups/" + groupId + "?command=associateClients&"
+        final String groupAssociateURL = "/fineract-provider/api/v1/groups/" + groupId + "?command=associateClients&"
                 + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------Associate Client To A GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSOCIATE_URL, associateClientAsJSON(clientMember), "groupId");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssociateURL, associateClientAsJSON(clientMember), "groupId");
     }
 
     public static Integer disAssociateClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String groupId, final String clientMember) {
-        final String GROUP_ASSOCIATE_URL = "/fineract-provider/api/v1/groups/" + groupId + "?command=disassociateClients&"
+        final String groupAssociateURL = "/fineract-provider/api/v1/groups/" + groupId + "?command=disassociateClients&"
                 + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------Disassociate Client To A GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSOCIATE_URL, associateClientAsJSON(clientMember), "groupId");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssociateURL, associateClientAsJSON(clientMember), "groupId");
     }
 
     public static Integer activateGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String groupId) {
-        final String GROUP_ASSOCIATE_URL = "/fineract-provider/api/v1/groups/" + groupId + "?command=activate&" + Utils.TENANT_IDENTIFIER;
+        final String groupAssociateURL = "/fineract-provider/api/v1/groups/" + groupId + "?command=activate&" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------Activate A GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSOCIATE_URL, activateGroupAsJSON(""), "groupId");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssociateURL, activateGroupAsJSON(""), "groupId");
     }
 
     public static Integer updateGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final String name,
             final String groupId) {
-        final String GROUP_ASSOCIATE_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER;
+        final String groupAssociateURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE GROUP---------------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, GROUP_ASSOCIATE_URL, updateGroupAsJSON(name), "groupId");
+        return Utils.performServerPut(requestSpec, responseSpec, groupAssociateURL, updateGroupAsJSON(name), "groupId");
     }
 
     public static Integer deleteGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String groupId) {
-        final String GROUP_ASSOCIATE_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER;
+        final String groupAssociateURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------DELETE GROUP---------------------------------------------");
-        return Utils.performServerDelete(requestSpec, responseSpec, GROUP_ASSOCIATE_URL, "groupId");
+        return Utils.performServerDelete(requestSpec, responseSpec, groupAssociateURL, "groupId");
     }
 
     public static Object assignStaff(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, final String groupId,
             final Long staffId) {
-        final String GROUP_ASSIGN_STAFF_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
+        final String groupAssignStaffURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
                 + "&command=assignStaff";
         LOG.info("---------------------------------DELETE GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSIGN_STAFF_URL, assignStaffAsJSON(staffId), "changes");
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssignStaffURL, assignStaffAsJSON(staffId), "changes");
     }
 
     public static Object assignStaffInheritStaffForClientAccounts(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String groupId, final String staffId) {
-        final String GROUP_ASSIGN_STAFF_URL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
+        final String groupAssignStaffURL = "/fineract-provider/api/v1/groups/" + groupId + "?" + Utils.TENANT_IDENTIFIER
                 + "&command=assignStaff";
         LOG.info("---------------------------------DELETE GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, GROUP_ASSIGN_STAFF_URL,
+        return Utils.performServerPost(requestSpec, responseSpec, groupAssignStaffURL,
                 assignStaffAndInheritStaffForClientAccountsAsJSON(staffId), "changes");
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/HolidayHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/HolidayHelper.java
@@ -77,15 +77,15 @@ public class HolidayHelper {
 
     public static Integer activateHolidays(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String holidayID) {
-        final String ACTIVATE_HOLIDAY_URL = HOLIDAYS_URL + "/" + holidayID + "?command=activate&" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(requestSpec, responseSpec, ACTIVATE_HOLIDAY_URL, getActivateHolidayDataAsJSON(), "resourceId");
+        final String activateHolidayURL = HOLIDAYS_URL + "/" + holidayID + "?command=activate&" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPost(requestSpec, responseSpec, activateHolidayURL, getActivateHolidayDataAsJSON(), "resourceId");
     }
 
     public static HashMap getHolidayById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String holidayID) {
-        final String GET_HOLIDAY_BY_ID_URL = HOLIDAYS_URL + "/" + holidayID + "?" + Utils.TENANT_IDENTIFIER;
+        final String getHolidayByIdURL = HOLIDAYS_URL + "/" + holidayID + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING HOLIDAY BY ID -------------------------");
-        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, GET_HOLIDAY_BY_ID_URL, "");
+        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, getHolidayByIdURL, "");
         return response;
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/HookHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/HookHelper.java
@@ -68,38 +68,38 @@ public class HookHelper {
 
     public Integer updateHook(final String payloadURL, final Long hookId) {
         LOG.info("---------------------------------UPDATING HOOK---------------------------------------------");
-        final String UPDATE_HOOK_URL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPut(this.requestSpec, this.responseSpec, UPDATE_HOOK_URL, getTestHookAsJson(payloadURL), "resourceId");
+        final String updateHookURL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPut(this.requestSpec, this.responseSpec, updateHookURL, getTestHookAsJson(payloadURL), "resourceId");
     }
 
     public Integer deleteHook(final Long hookId) {
         LOG.info("---------------------------------DELETING HOOK---------------------------------------------");
-        final String DELETE_HOOK_URL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerDelete(this.requestSpec, this.responseSpec, DELETE_HOOK_URL, "resourceId");
+        final String deleteHookURL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerDelete(this.requestSpec, this.responseSpec, deleteHookURL, "resourceId");
     }
 
     public void verifyHookCreatedOnServer(final Long hookId) {
         LOG.info("------------------------------CHECK CREATE HOOK DETAILS------------------------------------\n");
-        final String GET_URL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responseHookId = Utils.performServerGet(this.requestSpec, this.responseSpec, GET_URL, "id");
+        final String getURL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responseHookId = Utils.performServerGet(this.requestSpec, this.responseSpec, getURL, "id");
         assertEquals(hookId.toString(), responseHookId.toString());
     }
 
     public void verifyUpdateHook(final String updateURL, final Long hookId) {
         LOG.info("------------------------------CHECK UPDATE HOOK DETAILS------------------------------------\n");
-        final String GET_URL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getURL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
         ArrayList<HashMap<String, String>> map = Utils.<ArrayList<HashMap<String, String>>>performServerGet(this.requestSpec,
-                this.responseSpec, GET_URL, "config");
+                this.responseSpec, getURL, "config");
         HashMap<String, String> hash = map.get(1);
         assertEquals(updateURL, hash.get("fieldValue"));
     }
 
     public void verifyDeleteHook(final Long hookId) {
         LOG.info("------------------------------CHECK DELETE HOOK DETAILS------------------------------------\n");
-        final String GET_URL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getURL = "/fineract-provider/api/v1/hooks/" + hookId + "?" + Utils.TENANT_IDENTIFIER;
         ResponseSpecification responseSpec404 = new ResponseSpecBuilder().expectStatusCode(404).build();
         ArrayList<HashMap<String, String>> array = Utils.<ArrayList<HashMap<String, String>>>performServerGet(this.requestSpec,
-                responseSpec404, GET_URL, "errors");
+                responseSpec404, getURL, "errors");
         HashMap<String, String> map = array.get(0);
         assertEquals("error.msg.hook.identifier.not.found", map.get("userMessageGlobalisationCode"));
     }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/NotificationHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/NotificationHelper.java
@@ -38,8 +38,8 @@ public class NotificationHelper {
 
     public static Object getNotifications(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String jsonReturn) {
-        final String GET_NOTIFICATIONS_URL = NOTIFICATION_API_URL;
+        final String getNotificationURL = NOTIFICATION_API_URL;
         LOG.info("-----------------------------GET NOTIFICATIONS-----------------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_NOTIFICATIONS_URL, "");
+        return Utils.performServerGet(requestSpec, responseSpec, getNotificationURL, "");
     }
 }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
@@ -33,21 +33,21 @@ public final class PasswordPreferencesHelper {
 
     public static Object updatePasswordPreferences(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             String validationPolicyId) {
-        final String UPDATE_PASSWORD_PREFERENCES_URL = PASSWORD_PREFERENCES_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String updatePasswordPreferencesURL = PASSWORD_PREFERENCES_URL + "?" + Utils.TENANT_IDENTIFIER;
         // system.out.println("---------------------------------UPDATE PASSWORD
         // PREFERENCE---------------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_PASSWORD_PREFERENCES_URL,
-                updatePreferencesAsJson(validationPolicyId), "");
+        return Utils.performServerPut(requestSpec, responseSpec, updatePasswordPreferencesURL, updatePreferencesAsJson(validationPolicyId),
+                "");
     }
 
     public static Object updateWithInvalidValidationPolicyId(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, String invalidValidationPolicyId, String jsonAttributeToGetback) {
-        final String UPDATE_PASSWORD_PREFERENCES_URL = PASSWORD_PREFERENCES_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String updatePasswordPreferencesURL = PASSWORD_PREFERENCES_URL + "?" + Utils.TENANT_IDENTIFIER;
         // system.out
         // .println("---------------------------------UPDATE PASSWORD
         // PREFERENCES WITH INVALID
         // ID-----------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_PASSWORD_PREFERENCES_URL,
+        return Utils.performServerPut(requestSpec, responseSpec, updatePasswordPreferencesURL,
                 updatePreferencesWithInvalidId(invalidValidationPolicyId), jsonAttributeToGetback);
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PaymentTypeHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/PaymentTypeHelper.java
@@ -66,17 +66,17 @@ public final class PaymentTypeHelper {
             final Integer generatedPaymentTypeID) {
         // system.out.println("------------------------------CHECK PAYMENT
         // DETAILS------------------------------------\n");
-        final String GET_PAYMENTTYPE_URL = PAYMENTTYPE_URL + "/" + generatedPaymentTypeID + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responsePaymentTypeID = Utils.performServerGet(requestSpec, responseSpec, GET_PAYMENTTYPE_URL, "id");
+        final String getPaymentTypeURL = PAYMENTTYPE_URL + "/" + generatedPaymentTypeID + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responsePaymentTypeID = Utils.performServerGet(requestSpec, responseSpec, getPaymentTypeURL, "id");
         assertEquals(generatedPaymentTypeID, responsePaymentTypeID, "ERROR IN CREATING THE PAYMENT TYPE");
     }
 
     public static PaymentTypeDomain retrieveById(RequestSpecification requestSpec, ResponseSpecification responseSpec,
             final Integer paymentTypeId) {
-        final String GET_PAYMENTTYPE_URL = PAYMENTTYPE_URL + "/" + paymentTypeId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getPaymentTypeURL = PAYMENTTYPE_URL + "/" + paymentTypeId + "?" + Utils.TENANT_IDENTIFIER;
         // system.out.println("---------------------------------GET PAYMENT
         // TYPE---------------------------------------------");
-        Object get = Utils.performServerGet(requestSpec, responseSpec, GET_PAYMENTTYPE_URL, "");
+        Object get = Utils.performServerGet(requestSpec, responseSpec, getPaymentTypeURL, "");
         final String jsonData = new Gson().toJson(get);
         return new Gson().fromJson(jsonData, new TypeToken<PaymentTypeDomain>() {}.getType());
 
@@ -84,22 +84,22 @@ public final class PaymentTypeHelper {
 
     public static HashMap<String, String> updatePaymentType(final int id, HashMap request, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String UPDATE_PAYMENTTYPE_URL = PAYMENTTYPE_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
+        final String updatePaymentTypeURL = PAYMENTTYPE_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
         // system.out.println("---------------------------------UPDATE PAYMENT
         // TYPE " +
         // id + "---------------------------------------------");
-        HashMap<String, String> hash = Utils.performServerPut(requestSpec, responseSpec, UPDATE_PAYMENTTYPE_URL, new Gson().toJson(request),
+        HashMap<String, String> hash = Utils.performServerPut(requestSpec, responseSpec, updatePaymentTypeURL, new Gson().toJson(request),
                 "changes");
         return hash;
     }
 
     public static Integer deletePaymentType(final int id, final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String DELETE_PAYMENTTYPE_URL = PAYMENTTYPE_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
+        final String deletePaymentTypeURL = PAYMENTTYPE_URL + "/" + id + "?" + Utils.TENANT_IDENTIFIER;
         // system.out.println("---------------------------------DELETING PAYMENT
         // TYPE "
         // + id + "--------------------------------------------");
-        return Utils.performServerDelete(requestSpec, responseSpec, DELETE_PAYMENTTYPE_URL, "resourceId");
+        return Utils.performServerDelete(requestSpec, responseSpec, deletePaymentTypeURL, "resourceId");
     }
 
     public static String randomNameGenerator(final String prefix, final int lenOfRandomSuffix) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
@@ -56,9 +56,9 @@ public class SchedulerJobHelper {
     }
 
     private List<Map<String, Object>> getAllSchedulerJobs() {
-        final String GET_ALL_SCHEDULER_JOBS_URL = "/fineract-provider/api/v1/jobs?" + Utils.TENANT_IDENTIFIER;
+        final String getAllSchedulerJobsURL = "/fineract-provider/api/v1/jobs?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING ALL SCHEDULER JOBS -------------------------");
-        List<Map<String, Object>> response = Utils.performServerGet(requestSpec, response200Spec, GET_ALL_SCHEDULER_JOBS_URL, "");
+        List<Map<String, Object>> response = Utils.performServerGet(requestSpec, response200Spec, getAllSchedulerJobsURL, "");
         assertNotNull(response);
         return response;
     }
@@ -76,32 +76,32 @@ public class SchedulerJobHelper {
     }
 
     public Map<String, Object> getSchedulerJobById(int jobId) {
-        final String GET_SCHEDULER_JOB_BY_ID_URL = "/fineract-provider/api/v1/jobs/" + jobId + "?" + Utils.TENANT_IDENTIFIER;
+        final String getSchedulerJobByIdURL = "/fineract-provider/api/v1/jobs/" + jobId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING SCHEDULER JOB BY ID -------------------------");
-        final Map<String, Object> response = Utils.performServerGet(requestSpec, response200Spec, GET_SCHEDULER_JOB_BY_ID_URL, "");
+        final Map<String, Object> response = Utils.performServerGet(requestSpec, response200Spec, getSchedulerJobByIdURL, "");
         LOG.info("{}", response.toString());
         assertNotNull(response);
         return response;
     }
 
     public Boolean getSchedulerStatus() {
-        final String GET_SCHEDULER_STATUS_URL = "/fineract-provider/api/v1/scheduler?" + Utils.TENANT_IDENTIFIER;
+        final String getSchedulerStatusURL = "/fineract-provider/api/v1/scheduler?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING SCHEDULER STATUS -------------------------");
-        final Map<String, Object> response = Utils.performServerGet(requestSpec, response200Spec, GET_SCHEDULER_STATUS_URL, "");
+        final Map<String, Object> response = Utils.performServerGet(requestSpec, response200Spec, getSchedulerStatusURL, "");
         return (Boolean) response.get("active");
     }
 
     public void updateSchedulerStatus(final boolean on) {
         String command = on ? "start" : "stop";
-        final String UPDATE_SCHEDULER_STATUS_URL = "/fineract-provider/api/v1/scheduler?command=" + command + "&" + Utils.TENANT_IDENTIFIER;
+        final String updateSchedulerStatusURL = "/fineract-provider/api/v1/scheduler?command=" + command + "&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ UPDATING SCHEDULER STATUS -------------------------");
-        Utils.performServerPost(requestSpec, response202Spec, UPDATE_SCHEDULER_STATUS_URL, runSchedulerJobAsJSON(), null);
+        Utils.performServerPost(requestSpec, response202Spec, updateSchedulerStatusURL, runSchedulerJobAsJSON(), null);
     }
 
     public Map<String, Object> updateSchedulerJob(int jobId, final boolean active) {
-        final String UPDATE_SCHEDULER_JOB_URL = "/fineract-provider/api/v1/jobs/" + jobId + "?" + Utils.TENANT_IDENTIFIER;
+        final String updateSchedulerJobURL = "/fineract-provider/api/v1/jobs/" + jobId + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ UPDATING SCHEDULER JOB -------------------------");
-        final Map<String, Object> response = Utils.performServerPut(requestSpec, response200Spec, UPDATE_SCHEDULER_JOB_URL,
+        final Map<String, Object> response = Utils.performServerPut(requestSpec, response200Spec, updateSchedulerJobURL,
                 updateSchedulerJobAsJSON(active), "changes");
         return response;
     }
@@ -115,9 +115,9 @@ public class SchedulerJobHelper {
 
     private void runSchedulerJob(int jobId) {
         final ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        final String RUN_SCHEDULER_JOB_URL = "/fineract-provider/api/v1/jobs/" + jobId + "?command=executeJob&" + Utils.TENANT_IDENTIFIER;
+        final String runSchedulerJobURL = "/fineract-provider/api/v1/jobs/" + jobId + "?command=executeJob&" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RUN SCHEDULER JOB -------------------------");
-        Utils.performServerPost(requestSpec, responseSpec, RUN_SCHEDULER_JOB_URL, runSchedulerJobAsJSON(), null);
+        Utils.performServerPost(requestSpec, responseSpec, runSchedulerJobURL, runSchedulerJobAsJSON(), null);
     }
 
     private static String runSchedulerJobAsJSON() {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/StandingInstructionsHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/StandingInstructionsHelper.java
@@ -108,20 +108,20 @@ public class StandingInstructionsHelper {
     public HashMap getStandingInstructionById(final String standingInstructionId) {
 
         LOG.info("----------------------------- RETRIEVING STANDING INSTRUCTION BY ID---------------------------");
-        final String GET_STANDING_INSTRUCTION_BY_ID_URL = STANDING_INSTRUCTIONS_URL + "/" + standingInstructionId + "?"
+        final String getStandingInstructionsByIdURL = STANDING_INSTRUCTIONS_URL + "/" + standingInstructionId + "?"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerGet(this.requestSpec, this.responseSpec, GET_STANDING_INSTRUCTION_BY_ID_URL, "");
+        final HashMap response = Utils.performServerGet(this.requestSpec, this.responseSpec, getStandingInstructionsByIdURL, "");
         return response;
     }
 
     public List<HashMap> getStandingInstructionHistory(Integer fromSavingsId, Integer fromAccountType, Integer fromClientId,
             Integer transferType) {
-        final String STANDING_INSTRUCTIONS_HISTORY_URL = STANDING_INSTRUCTIONS_RUNHISTORY_URL + "?" + Utils.TENANT_IDENTIFIER
+        final String standingInstructionsHistoryURL = STANDING_INSTRUCTIONS_RUNHISTORY_URL + "?" + Utils.TENANT_IDENTIFIER
                 + "&fromSavingsId=" + fromSavingsId + "&fromAccountType=" + fromAccountType + "&clientId=" + fromClientId + "&transferType="
                 + transferType;
-        LOG.info("STANDING_INSTRUCTIONS_HISTORY_URL= {}", STANDING_INSTRUCTIONS_HISTORY_URL);
+        LOG.info("standingInstructionsHistoryURL= {}", standingInstructionsHistoryURL);
         final List<HashMap> response = (List<HashMap>) Utils.performServerGet(this.requestSpec, this.responseSpec,
-                STANDING_INSTRUCTIONS_HISTORY_URL, "pageItems");
+                standingInstructionsHistoryURL, "pageItems");
         return response;
     }
 }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SurveyHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/SurveyHelper.java
@@ -71,9 +71,9 @@ public final class SurveyHelper {
     public static void verifySurveyCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedClientID) {
         LOG.info("------------------------------CHECK CLIENT DETAILS------------------------------------\n");
-        final String SURVEY_URL = "/fineract-provider/api/v1/Survey/ppi_kenya_2009/clientid/entryId" + generatedClientID + "?"
+        final String surveyURL = "/fineract-provider/api/v1/Survey/ppi_kenya_2009/clientid/entryId" + generatedClientID + "?"
                 + Utils.TENANT_IDENTIFIER;
-        final Integer responseClientID = Utils.performServerGet(requestSpec, responseSpec, SURVEY_URL, "id");
+        final Integer responseClientID = Utils.performServerGet(requestSpec, responseSpec, surveyURL, "id");
         assertEquals(generatedClientID, responseClientID, "ERROR IN CREATING THE CLIENT");
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/WorkingDaysHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/WorkingDaysHelper.java
@@ -36,16 +36,16 @@ public final class WorkingDaysHelper {
     private static final String WORKINGDAYS_URL = "/fineract-provider/api/v1/workingdays";
 
     public static Object updateWorkingDays(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        final String UPDATE_WORKINGDAYS_URL = WORKINGDAYS_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String updateWorkingDaysURL = WORKINGDAYS_URL + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE WORKINGDAY---------------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_WORKINGDAYS_URL, updateWorkingDaysAsJson(), "");
+        return Utils.performServerPut(requestSpec, responseSpec, updateWorkingDaysURL, updateWorkingDaysAsJson(), "");
     }
 
     public static Object updateWorkingDaysWithWrongRecurrence(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, String jsonAttributeToGetback) {
-        final String UPDATE_WORKINGDAYS_URL = WORKINGDAYS_URL + "?" + Utils.TENANT_IDENTIFIER;
+        final String updateWorkingDaysURL = WORKINGDAYS_URL + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("---------------------------------UPDATE WORKINGDAY WITH WRONG RECURRENCE-----------------------------------------");
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_WORKINGDAYS_URL, updateWorkingDayWithWrongRecur(),
+        return Utils.performServerPut(requestSpec, responseSpec, updateWorkingDaysURL, updateWorkingDayWithWrongRecur(),
                 jsonAttributeToGetback);
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/accounting/AccountHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/accounting/AccountHelper.java
@@ -67,15 +67,15 @@ public class AccountHelper {
     }
 
     public ArrayList getAccountingWithRunningBalances() {
-        final String GET_RUNNING_BALANCE_URL = "/fineract-provider/api/v1/glaccounts?fetchRunningBalance=true";
-        final ArrayList<HashMap> accountRunningBalance = Utils.performServerGet(this.requestSpec, this.responseSpec,
-                GET_RUNNING_BALANCE_URL, "");
+        final String getRunningBalanceURL = "/fineract-provider/api/v1/glaccounts?fetchRunningBalance=true";
+        final ArrayList<HashMap> accountRunningBalance = Utils.performServerGet(this.requestSpec, this.responseSpec, getRunningBalanceURL,
+                "");
         return accountRunningBalance;
     }
 
     public HashMap getAccountingWithRunningBalanceById(final String accountId) {
-        final String GET_RUNNING_BALANCE_URL = "/fineract-provider/api/v1/glaccounts/" + accountId + "?fetchRunningBalance=true";
-        final HashMap accountRunningBalance = Utils.performServerGet(this.requestSpec, this.responseSpec, GET_RUNNING_BALANCE_URL, "");
+        final String getRunningBalanceURL = "/fineract-provider/api/v1/glaccounts/" + accountId + "?fetchRunningBalance=true";
+        final HashMap accountRunningBalance = Utils.performServerGet(this.requestSpec, this.responseSpec, getRunningBalanceURL, "");
         return accountRunningBalance;
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
@@ -37,8 +37,8 @@ public final class ChargesHelper {
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(ChargesHelper.class);
-    private static final String CHARGES_URL = "/fineract-provider/api/v1/charges";
-    private static final String CREATE_CHARGES_URL = CHARGES_URL + "?" + Utils.TENANT_IDENTIFIER;
+    private static final String chargesURL = "/fineract-provider/api/v1/charges";
+    private static final String CREATE_CHARGES_URL = chargesURL + "?" + Utils.TENANT_IDENTIFIER;
 
     private static final Integer CHARGE_APPLIES_TO_LOAN = 1;
     private static final Integer CHARGE_APPLIES_TO_SAVINGS = 2;
@@ -365,29 +365,29 @@ public final class ChargesHelper {
     }
 
     public static ArrayList<HashMap> getCharges(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        return (ArrayList) Utils.performServerGet(requestSpec, responseSpec, CHARGES_URL + "?" + Utils.TENANT_IDENTIFIER, "");
+        return (ArrayList) Utils.performServerGet(requestSpec, responseSpec, chargesURL + "?" + Utils.TENANT_IDENTIFIER, "");
     }
 
     public static HashMap getChargeById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer chargeId) {
-        return Utils.performServerGet(requestSpec, responseSpec, CHARGES_URL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, "");
+        return Utils.performServerGet(requestSpec, responseSpec, chargesURL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, "");
     }
 
     public static HashMap getChargeChanges(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer chargeId) {
-        return Utils.performServerGet(requestSpec, responseSpec, CHARGES_URL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER,
+        return Utils.performServerGet(requestSpec, responseSpec, chargesURL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER,
                 CommonConstants.RESPONSE_CHANGES);
     }
 
     public static HashMap updateCharges(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer chargeId, final String request) {
-        return Utils.performServerPut(requestSpec, responseSpec, CHARGES_URL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, request,
+        return Utils.performServerPut(requestSpec, responseSpec, chargesURL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, request,
                 CommonConstants.RESPONSE_CHANGES);
     }
 
     public static Integer deleteCharge(final ResponseSpecification responseSpec, final RequestSpecification requestSpec,
             final Integer chargeId) {
-        return Utils.performServerDelete(requestSpec, responseSpec, CHARGES_URL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER,
+        return Utils.performServerDelete(requestSpec, responseSpec, chargesURL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER,
                 CommonConstants.RESPONSE_RESOURCE_ID);
     }
 
@@ -487,7 +487,7 @@ public final class ChargesHelper {
     }
 
     public static String applyCharge(RequestSpecification requestSpec, ResponseSpecification responseSpec, String chargeId, String json) {
-        return Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, json,
+        return Utils.performServerPost(requestSpec, responseSpec, chargesURL + "/" + chargeId + "?" + Utils.TENANT_IDENTIFIER, json,
                 "status");
 
     }

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountHelper.java
@@ -144,9 +144,9 @@ public class FixedDepositAccountHelper {
 
     public static HashMap getFixedDepositAccountById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer accountID) {
-        final String GET_FIXED_DEPOSIT_BY_ID_URL = FIXED_DEPOSIT_ACCOUNT_URL + "/" + accountID + "?" + Utils.TENANT_IDENTIFIER;
+        final String getFixedDepositByIdURL = FIXED_DEPOSIT_ACCOUNT_URL + "/" + accountID + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING FIXED DEPOSIT ACCOUNT BY ID -------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_FIXED_DEPOSIT_BY_ID_URL, "");
+        return Utils.performServerGet(requestSpec, responseSpec, getFixedDepositByIdURL, "");
     }
 
     public HashMap getFixedDepositSummary(final Integer accountID) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountStatusChecker.java
@@ -82,9 +82,9 @@ public final class FixedDepositAccountStatusChecker {
 
     public static HashMap getStatusOfFixedDepositAccount(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String fixedDepositAccountID) {
-        final String GET_STATUS_OF_FIXED_DEPOSIT_ACCOUNT_URL = FIXED_DEPOSIT_ACCOUNT_URL + "/" + fixedDepositAccountID + "?"
+        final String getStatusOfFixedDepositAccountURL = FIXED_DEPOSIT_ACCOUNT_URL + "/" + fixedDepositAccountID + "?"
                 + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, GET_STATUS_OF_FIXED_DEPOSIT_ACCOUNT_URL, "status");
+        return Utils.performServerGet(requestSpec, responseSpec, getStatusOfFixedDepositAccountURL, "status");
     }
 
     public static void verifyFixedDepositAccountIsPrematureClosed(HashMap fixedDepositStatusHashMap) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositProductHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositProductHelper.java
@@ -436,8 +436,8 @@ public class FixedDepositProductHelper {
     public static HashMap retrieveFixedDepositProductById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String productId) {
         LOG.info("------------------------ RETRIEVING FIXED DEPOSIT PRODUCT BY ID ------------------------");
-        final String GET_FD_PRODUCT_BY_ID_URL = FIXED_DEPOSIT_PRODUCT_URL + "/" + productId + "?" + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, GET_FD_PRODUCT_BY_ID_URL, "");
+        final String getFdProductByIdURL = FIXED_DEPOSIT_PRODUCT_URL + "/" + productId + "?" + Utils.TENANT_IDENTIFIER;
+        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, getFdProductByIdURL, "");
         return response;
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -161,8 +161,8 @@ public class LoanTransactionHelper {
     }
 
     public ArrayList getLoanCharges(final Integer loanId) {
-        final String GET_LOAN_CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, GET_LOAN_CHARGES_URL, "");
+        final String getLoanChargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerGet(requestSpec, responseSpec, getLoanChargesURL, "");
     }
 
     public HashMap approveLoan(final String approvalDate, final Integer loanID) {
@@ -303,46 +303,46 @@ public class LoanTransactionHelper {
 
     public Integer addChargesForLoan(final Integer loanId, final String request) {
         LOG.info("--------------------------------- ADD CHARGES FOR LOAN --------------------------------");
-        final String ADD_CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, ADD_CHARGES_URL, request, "");
+        final String addChargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
+        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, addChargesURL, request, "");
         return (Integer) response.get("resourceId");
     }
 
     public Object addChargesForAllreadyDisursedLoan(final Integer loanId, final String request,
             final ResponseSpecification responseSpecification) {
-        final String ADD_CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(this.requestSpec, responseSpecification, ADD_CHARGES_URL, request, "");
+        final String addChargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPost(this.requestSpec, responseSpecification, addChargesURL, request, "");
     }
 
     public Integer updateChargesForLoan(final Integer loanId, final Integer loanchargeId, final String request) {
         LOG.info("--------------------------------- ADD CHARGES FOR LOAN --------------------------------");
-        final String UPDATE_CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?"
+        final String updateChargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerPut(requestSpec, responseSpec, UPDATE_CHARGES_URL, request, "");
+        final HashMap response = Utils.performServerPut(requestSpec, responseSpec, updateChargesURL, request, "");
         return (Integer) response.get("resourceId");
     }
 
     public Integer deleteChargesForLoan(final Integer loanId, final Integer loanchargeId) {
         LOG.info("--------------------------------- DELETE CHARGES FOR LOAN --------------------------------");
-        final String DELETE_CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?"
+        final String deleteChargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerDelete(requestSpec, responseSpec, DELETE_CHARGES_URL, "");
+        final HashMap response = Utils.performServerDelete(requestSpec, responseSpec, deleteChargesURL, "");
         return (Integer) response.get("resourceId");
     }
 
     public Integer waiveChargesForLoan(final Integer loanId, final Integer loanchargeId, final String json) {
         LOG.info("--------------------------------- WAIVE CHARGES FOR LOAN --------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?command=waive&"
+        final String chargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?command=waive&"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL, json, "");
+        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, chargesURL, json, "");
         return (Integer) response.get("resourceId");
     }
 
     public Integer payChargesForLoan(final Integer loanId, final Integer loanchargeId, final String json) {
         LOG.info("--------------------------------- WAIVE CHARGES FOR LOAN --------------------------------");
-        final String CHARGES_URL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?command=pay&"
+        final String chargesURL = "/fineract-provider/api/v1/loans/" + loanId + "/charges/" + loanchargeId + "?command=pay&"
                 + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, CHARGES_URL, json, "");
+        final HashMap response = Utils.performServerPost(requestSpec, responseSpec, chargesURL, json, "");
         return (Integer) response.get("resourceId");
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/organisation/CampaignsHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/organisation/CampaignsHelper.java
@@ -53,50 +53,50 @@ public class CampaignsHelper {
 
     public Integer createCampaign(String reportName, Integer triggerType) {
         LOG.info("---------------------------------CREATING A CAMPAIGN---------------------------------------------");
-        final String CREATE_SMS_CAMPAIGNS_URL = SMS_CAMPAIGNS_URL + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_SMS_CAMPAIGNS_URL, getCreateCampaignJSON(reportName, triggerType),
+        final String createSmsCampaignsURL = SMS_CAMPAIGNS_URL + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPost(requestSpec, responseSpec, createSmsCampaignsURL, getCreateCampaignJSON(reportName, triggerType),
                 "resourceId");
     }
 
     public void verifyCampaignCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCampaignId) {
         LOG.info("------------------------------CHECK CAMPAIGN DETAILS------------------------------------\n");
-        final String RETRIEVE_SMS_CAMPAIGNS_URL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responseCampaignId = Utils.performServerGet(requestSpec, responseSpec, RETRIEVE_SMS_CAMPAIGNS_URL, "id");
+        final String retriveSMScampaignsURL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responseCampaignId = Utils.performServerGet(requestSpec, responseSpec, retriveSMScampaignsURL, "id");
         assertEquals(generatedCampaignId, responseCampaignId, "ERROR IN CREATING THE CAMPAIGN");
     }
 
     public Integer updateCampaign(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCampaignId, String reportName, Integer triggerType) {
         LOG.info("------------------------------UPDATE CAMPAIGN DETAILS------------------------------------\n");
-        final String UPDATE_SMS_CAMPAIGNS_URL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_SMS_CAMPAIGNS_URL, getUpdateCampaignJSON(reportName, triggerType),
+        final String updateSMSCampaignsURL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPut(requestSpec, responseSpec, updateSMSCampaignsURL, getUpdateCampaignJSON(reportName, triggerType),
                 "resourceId");
     }
 
     public Integer deleteCampaign(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCampaignId) {
         LOG.info("------------------------------DELETE CAMPAIGN DETAILS------------------------------------\n");
-        final String DELETE_SMS_CAMPAIGNS_URL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerDelete(requestSpec, responseSpec, DELETE_SMS_CAMPAIGNS_URL, "resourceId");
+        final String deleteSMScampaignURL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerDelete(requestSpec, responseSpec, deleteSMScampaignURL, "resourceId");
     }
 
     public Integer performActionsOnCampaign(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedCampaignId, String command) {
         LOG.info("------------------------------PERFORM ACTION ON CAMPAIGN DETAILS------------------------------------\n");
-        final String SMS_CAMPAIGNS_ACTION_URL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?command=" + command + "&"
+        final String smsCampaignsActionURL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?command=" + command + "&"
                 + Utils.TENANT_IDENTIFIER;
         String actionDate = Utils.getLocalDateOfTenant().toString(DATE_FORMAT);
-        return Utils.performServerPost(requestSpec, responseSpec, SMS_CAMPAIGNS_ACTION_URL, getJSONForCampaignAction(command, actionDate),
+        return Utils.performServerPost(requestSpec, responseSpec, smsCampaignsActionURL, getJSONForCampaignAction(command, actionDate),
                 "resourceId");
     }
 
     public Object performActionsOnCampaignWithFailure(final Integer generatedCampaignId, String command, String actionDate,
             String responseJsonAttribute) {
         LOG.info("--------------------------PERFORM ACTION ON CAMPAIGN DETAILS WITH FAILURE-------------------------------\n");
-        final String SMS_CAMPAIGNS_ACTION_URL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?command=" + command + "&"
+        final String smsCampaignsActionURL = SMS_CAMPAIGNS_URL + "/" + generatedCampaignId + "?command=" + command + "&"
                 + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(this.requestSpec, this.responseSpec, SMS_CAMPAIGNS_ACTION_URL,
+        return Utils.performServerPost(this.requestSpec, this.responseSpec, smsCampaignsActionURL,
                 getJSONForCampaignAction(command, actionDate), responseJsonAttribute);
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountHelper.java
@@ -156,9 +156,9 @@ public class RecurringDepositAccountHelper {
 
     public static HashMap getRecurringDepositAccountById(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer accountID) {
-        final String GET_RECURRING_DEPOSIT_BY_ID_URL = RECURRING_DEPOSIT_ACCOUNT_URL + "/" + accountID + "?" + Utils.TENANT_IDENTIFIER;
+        final String getRecurringDepositByIdURL = RECURRING_DEPOSIT_ACCOUNT_URL + "/" + accountID + "?" + Utils.TENANT_IDENTIFIER;
         LOG.info("------------------------ RETRIEVING RECURRING DEPOSIT ACCOUNT BY ID -------------------------");
-        return Utils.performServerGet(requestSpec, responseSpec, GET_RECURRING_DEPOSIT_BY_ID_URL, "");
+        return Utils.performServerGet(requestSpec, responseSpec, getRecurringDepositByIdURL, "");
     }
 
     public HashMap getRecurringDepositSummary(final Integer accountID) {
@@ -221,10 +221,10 @@ public class RecurringDepositAccountHelper {
         Calendar todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.MONTH, -1);
         todaysDate.add(Calendar.DATE, -1);
-        final String SUBMITTED_ON_DATE = dateFormat.format(todaysDate.getTime());
-        final String EXPECTED_FIRST_DEPOSIT_ON_ON_DATE = SUBMITTED_ON_DATE;
+        final String submittedOnDateValue = dateFormat.format(todaysDate.getTime());
+        final String expectedFirstDepositOnDate = submittedOnDateValue;
         final String recurringDepositApplicationJSON = new RecurringDepositAccountHelper(this.requestSpec, this.responseSpec)
-                .withSubmittedOnDate(SUBMITTED_ON_DATE).withExpectedFirstDepositOnDate(EXPECTED_FIRST_DEPOSIT_ON_ON_DATE)
+                .withSubmittedOnDate(submittedOnDateValue).withExpectedFirstDepositOnDate(expectedFirstDepositOnDate)
                 .build(clientID, productID, penalInterestType);
 
         return Utils.performServerPut(this.requestSpec, this.responseSpec,

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountStatusChecker.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositAccountStatusChecker.java
@@ -84,9 +84,9 @@ public final class RecurringDepositAccountStatusChecker {
 
     public static HashMap getStatusOfRecurringDepositAccount(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String recurringDepositAccountID) {
-        final String GET_STATUS_OF_RECURRING_DEPOSIT_ACCOUNT_URL = RECURRING_DEPOSIT_ACCOUNT_URL + "/" + recurringDepositAccountID + "?"
+        final String getStatusOfRecurringDepositAccountURL = RECURRING_DEPOSIT_ACCOUNT_URL + "/" + recurringDepositAccountID + "?"
                 + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, GET_STATUS_OF_RECURRING_DEPOSIT_ACCOUNT_URL, "status");
+        return Utils.performServerGet(requestSpec, responseSpec, getStatusOfRecurringDepositAccountURL, "status");
     }
 
     public static void verifyRecurringDepositAccountIsPrematureClosed(HashMap recurringDepositStatusHashMap) {

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositProductHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/recurringdeposit/RecurringDepositProductHelper.java
@@ -244,8 +244,8 @@ public class RecurringDepositProductHelper {
     public static HashMap retrieveRecurringDepositProductById(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec, final String productId) {
         LOG.info("-------------------- RETRIEVING RECURRING DEPOSIT PRODUCT BY ID --------------------------");
-        final String GET_RD_PRODUCT_BY_ID_URL = RECURRING_DEPOSIT_PRODUCT_URL + "/" + productId + "?" + Utils.TENANT_IDENTIFIER;
-        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, GET_RD_PRODUCT_BY_ID_URL, "");
+        final String getRdProductByIdURL = RECURRING_DEPOSIT_PRODUCT_URL + "/" + productId + "?" + Utils.TENANT_IDENTIFIER;
+        final HashMap response = Utils.performServerGet(requestSpec, responseSpec, getRdProductByIdURL, "");
         return response;
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
@@ -290,8 +290,8 @@ public class SavingsProductHelper {
     public static void verifySavingsProductCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final Integer generatedProductID) {
         LOG.info("------------------------------CHECK CLIENT DETAILS------------------------------------\n");
-        final String GET_SAVINGS_PRODUCT_URL = SAVINGS_PRODUCT_URL + "/" + generatedProductID + "?" + Utils.TENANT_IDENTIFIER;
-        final Integer responseSavingsProductID = Utils.performServerGet(requestSpec, responseSpec, GET_SAVINGS_PRODUCT_URL, "id");
+        final String getSavingProductURL = SAVINGS_PRODUCT_URL + "/" + generatedProductID + "?" + Utils.TENANT_IDENTIFIER;
+        final Integer responseSavingsProductID = Utils.performServerGet(requestSpec, responseSpec, getSavingProductURL, "id");
         assertEquals(generatedProductID, responseSavingsProductID, "ERROR IN CREATING THE Savings Product");
     }
 

--- a/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/loanaccount/guarantor/GuarantorTest.java
+++ b/fineract-provider/src/integrationTest/java/org/apache/fineract/integrationtests/loanaccount/guarantor/GuarantorTest.java
@@ -232,7 +232,7 @@ public class GuarantorTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void testGuarantor_UNDO_DISBURSAL() {
+    public void testGuarantorUndoDisbursal() {
 
         Float self1_hold_funds = Float.valueOf((float) 0);
         Float external1_hold_funds = Float.valueOf((float) 0);
@@ -426,7 +426,7 @@ public class GuarantorTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void testGuarantor_RECOVER_GUARANTEES() {
+    public void testGurantorRecoverGurantees() {
 
         Float self1_hold_funds = Float.valueOf((float) 0);
         Float external1_hold_funds = Float.valueOf((float) 0);
@@ -480,10 +480,10 @@ public class GuarantorTest {
         ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
         external1_hold_funds -= Float.valueOf((float) 993.104);
-        this.loanTransactionHelper.makeRepayment(LOAN_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanRepaymentDate, totalDueForCurrentPeriod, loanID);
         verifySavingsOnHoldBalance(selfSavigsId, self1_hold_funds);
         verifySavingsOnHoldBalance(externalSavigsId_1, external1_hold_funds);
 
@@ -495,7 +495,7 @@ public class GuarantorTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void testGuarantor_RECOVER_GUARANTEES_WITH_MORE_GUARANTEE() {
+    public void testGurantorRecoverGuranteesWithMoreGurantee() {
 
         Float self1_hold_funds = Float.valueOf((float) 0);
         Float external1_hold_funds = Float.valueOf((float) 0);
@@ -554,10 +554,10 @@ public class GuarantorTest {
         ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
         external1_hold_funds -= Float.valueOf((float) 3227.588);
-        this.loanTransactionHelper.makeRepayment(LOAN_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanRepaymentDate, totalDueForCurrentPeriod, loanID);
         verifySavingsOnHoldBalance(selfSavigsId, self1_hold_funds);
         verifySavingsOnHoldBalance(externalSavigsId_1, external1_hold_funds);
 
@@ -624,16 +624,16 @@ public class GuarantorTest {
         ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec, loanID);
         todaysDate = Calendar.getInstance();
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
-        final String LOAN_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
         Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
         external1_hold_funds -= Float.valueOf((float) 993.104);
-        this.loanTransactionHelper.makeRepayment(LOAN_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        this.loanTransactionHelper.makeRepayment(loanRepaymentDate, totalDueForCurrentPeriod, loanID);
         verifySavingsOnHoldBalance(selfSavigsId, self1_hold_funds);
         verifySavingsOnHoldBalance(externalSavigsId_1, external1_hold_funds);
 
         todaysDate = Calendar.getInstance();
-        final String LOAN_WRITEOFF_DATE = dateFormat.format(todaysDate.getTime());
-        this.loanTransactionHelper.writeOffLoan(LOAN_WRITEOFF_DATE, loanID);
+        final String loanWriteoffDate = dateFormat.format(todaysDate.getTime());
+        this.loanTransactionHelper.writeOffLoan(loanWriteoffDate, loanID);
         verifySavingsBalanceAndOnHoldBalance(selfSavigsId, Float.valueOf((float) 0), SELF1_BALANCE);
         verifySavingsBalanceAndOnHoldBalance(externalSavigsId_1, Float.valueOf((float) 0), EXTERNAL1_BALANCE);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/api/AuditsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/api/AuditsApiResource.java
@@ -171,10 +171,10 @@ public class AuditsApiResource {
 
         final AuditSearchData auditSearchData = this.auditReadPlatformService.retrieveSearchTemplate("audit");
 
-        final Set<String> RESPONSE_DATA_PARAMETERS_SEARCH_TEMPLATE = new HashSet<>(
+        final Set<String> responseDataParemetersSearchTemplate = new HashSet<>(
                 Arrays.asList("appUsers", "actionNames", "entityNames", "processingResults"));
 
-        return this.toApiJsonSerializerSearchTemplate.serialize(settings, auditSearchData, RESPONSE_DATA_PARAMETERS_SEARCH_TEMPLATE);
+        return this.toApiJsonSerializerSearchTemplate.serialize(settings, auditSearchData, responseDataParemetersSearchTemplate);
     }
 
     private SQLBuilder getExtraCriteria(final String actionName, final String entityName, final Long resourceId, final Long makerId,

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/api/MakercheckersApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/api/MakercheckersApiResource.java
@@ -132,9 +132,9 @@ public class MakercheckersApiResource {
 
         final AuditSearchData auditSearchData = this.readPlatformService.retrieveSearchTemplate("makerchecker");
 
-        final Set<String> RESPONSE_DATA_PARAMETERS_SEARCH_TEMPLATE = new HashSet<>(Arrays.asList("appUsers", "actionNames", "entityNames"));
+        final Set<String> responseDataParemetersSearchTemplate = new HashSet<>(Arrays.asList("appUsers", "actionNames", "entityNames"));
 
-        return this.toApiJsonSerializerSearchTemplate.serialize(settings, auditSearchData, RESPONSE_DATA_PARAMETERS_SEARCH_TEMPLATE);
+        return this.toApiJsonSerializerSearchTemplate.serialize(settings, auditSearchData, responseDataParemetersSearchTemplate);
     }
 
     @POST

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.configuration.domain;
 import java.util.Date;
 import org.apache.fineract.infrastructure.cache.domain.CacheType;
 
+@SuppressWarnings({ "AbbreviationAsWordInName" })
 public interface ConfigurationDomainService {
 
     boolean isMakerCheckerEnabledForTask(String taskPermissionCode);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesConstants.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.configuration.service;
 import java.util.HashSet;
 import java.util.Set;
 
+@SuppressWarnings({ "AbbreviationAsWordInName" })
 public final class ExternalServicesConstants {
 
     private ExternalServicesConstants() {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/EmbeddedTomcatWithSSLConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/EmbeddedTomcatWithSSLConfiguration.java
@@ -55,7 +55,7 @@ public class EmbeddedTomcatWithSSLConfiguration {
             File keystore = getFile(getKeystore());
             connector.setScheme("https");
             connector.setSecure(true);
-            connector.setPort(getHTTPSPort());
+            connector.setPort(getHttpsPort());
             protocol.setSSLEnabled(true);
             protocol.setKeystoreFile(keystore.getAbsolutePath());
             protocol.setKeystorePass(getKeystorePass());
@@ -65,7 +65,7 @@ public class EmbeddedTomcatWithSSLConfiguration {
         }
     }
 
-    protected int getHTTPSPort() {
+    protected int getHttpsPort() {
         // TODO This shouldn't be hard-coded here, but configurable
         return 8443;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
@@ -414,11 +414,10 @@ public class ClientsApiResource {
 
         final AccountSummaryCollectionData clientAccount = this.accountDetailsReadPlatformService.retrieveClientAccountDetails(clientId);
 
-        final Set<String> CLIENT_ACCOUNTS_DATA_PARAMETERS = new HashSet<>(
-                Arrays.asList("loanAccounts", "savingsAccounts", "shareAccounts"));
+        final Set<String> clientAccountDataParameters = new HashSet<>(Arrays.asList("loanAccounts", "savingsAccounts", "shareAccounts"));
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
-        return this.clientAccountSummaryToApiJsonSerializer.serialize(settings, clientAccount, CLIENT_ACCOUNTS_DATA_PARAMETERS);
+        return this.clientAccountSummaryToApiJsonSerializer.serialize(settings, clientAccount, clientAccountDataParameters);
     }
 
     @GET

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResource.java
@@ -408,11 +408,11 @@ public class CentersApiResource {
 
         final AccountSummaryCollectionData groupAccount = this.accountDetailsReadPlatformService.retrieveGroupAccountDetails(centerId);
 
-        final Set<String> GROUP_ACCOUNTS_DATA_PARAMETERS = new HashSet<>(
+        final Set<String> groupAccountsDataParameters = new HashSet<>(
                 Arrays.asList("loanAccounts", "savingsAccounts", "memberLoanAccounts", "memberSavingsAccounts"));
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
-        return this.groupSummaryToApiJsonSerializer.serialize(settings, groupAccount, GROUP_ACCOUNTS_DATA_PARAMETERS);
+        return this.groupSummaryToApiJsonSerializer.serialize(settings, groupAccount, groupAccountsDataParameters);
     }
 
     @GET

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResource.java
@@ -555,11 +555,11 @@ public class GroupsApiResource {
 
         final AccountSummaryCollectionData groupAccount = this.accountDetailsReadPlatformService.retrieveGroupAccountDetails(groupId);
 
-        final Set<String> GROUP_ACCOUNTS_DATA_PARAMETERS = new HashSet<>(Arrays.asList("loanAccounts",
-                "groupLoanIndividualMonitoringAccounts", "savingsAccounts", "memberLoanAccounts", "memberSavingsAccounts"));
+        final Set<String> groupAccountsDataParameters = new HashSet<>(Arrays.asList("loanAccounts", "groupLoanIndividualMonitoringAccounts",
+                "savingsAccounts", "memberLoanAccounts", "memberSavingsAccounts"));
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
-        return this.groupSummaryToApiJsonSerializer.serialize(settings, groupAccount, GROUP_ACCOUNTS_DATA_PARAMETERS);
+        return this.groupSummaryToApiJsonSerializer.serialize(settings, groupAccount, groupAccountsDataParameters);
     }
 
     @GET
@@ -596,11 +596,11 @@ public class GroupsApiResource {
                     parentLoanAccountNo);
         }
 
-        final Set<String> GLIM_ACCOUNTS_DATA_PARAMETERS = new HashSet<>(
+        final Set<String> glimAccountsDataParameters = new HashSet<>(
                 Arrays.asList("groupId", "accountNumber", "childGLIMAccounts", "memberLoanAccounts", "parentPrincipalAmount"));
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
-        return this.glimContainerToApiJsonSerializer.serialize(settings, glimContainer, GLIM_ACCOUNTS_DATA_PARAMETERS);
+        return this.glimContainerToApiJsonSerializer.serialize(settings, glimContainer, glimAccountsDataParameters);
 
     }
 
@@ -624,11 +624,11 @@ public class GroupsApiResource {
 
         }
 
-        final Set<String> GSIM_ACCOUNTS_DATA_PARAMETERS = new HashSet<>(
+        final Set<String> gsimAccountsDataParameters = new HashSet<>(
                 Arrays.asList("gsimId", "groupId", "accountNumber", "childGSIMAccounts", "parentBalance", "savingsStatus"));
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
-        return this.gsimContainerToApiJsonSerializer.serialize(settings, gsimContainer, GSIM_ACCOUNTS_DATA_PARAMETERS);
+        return this.gsimContainerToApiJsonSerializer.serialize(settings, gsimContainer, gsimAccountsDataParameters);
 
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/RolesApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/RolesApiResourceSwagger.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 /**
  * Created by sanyam on 23/8/17.
  */
-@SuppressWarnings({ "MemberName" })
+@SuppressWarnings({ "MemberName", "AbbreviationAsWordInName" })
 final class RolesApiResourceSwagger {
 
     private RolesApiResourceSwagger() {


### PR DESCRIPTION
this PR enforces AbbreviationAsWordInName  checkstyle, now only constantName checkstyle for "naming" is left. 

A detailed review would help, even if it takes time and we don't merge this quickly, since there are a lot of changes.
I have suppressed the checkstyle at a few places, where I thought either this check style is not really useful/added unnecessary work. 