### PR TITLE
FINERACT-1140 - Adopt GenerationType.TABLE as ID generation strategy [Discussion]

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -130,6 +130,7 @@ dependencyManagement {
         dependency 'org.mock-server:mockserver-junit-jupiter:5.11.0'
         dependency 'org.webjars.npm:swagger-ui-dist:3.32.5'
         dependency 'org.webjars:webjars-locator-core:0.46'
+        dependency 'org.gaul:modernizer-maven-annotations:2.1.0'
 
         dependency ('org.dom4j:dom4j:2.1.3') {
             exclude 'relaxngDatatype:relaxngDatatype' // already in com.sun.xml.bind:jaxb-osgi:2.3.0.1

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -80,7 +80,8 @@ dependencies {
 
             'com.github.spotbugs:spotbugs-annotations',
             'io.swagger.core.v3:swagger-annotations',
-            'org.webjars:webjars-locator-core'
+            'org.webjars:webjars-locator-core',
+            'org.gaul:modernizer-maven-annotations'
             )
     implementation ('org.apache.activemq:activemq-broker') {
         exclude group: 'org.apache.geronimo.specs'

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/TableAbstractAuditable.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/TableAbstractAuditable.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.domain;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.data.domain.Auditable;
+import org.springframework.data.jpa.domain.AbstractAuditable;
+
+/**
+ * A custom copy of {@link AbstractAuditable} to override the column names used on database. It also uses Instant
+ * instead of LocalDateTime for created and modified.
+ *
+ * Abstract base class for auditable entities. Stores the audit values in persistent fields.
+ *
+ * @param <U>
+ *            the auditing type. Typically some kind of user.
+ * @param <PK>
+ *            the type of the auditing type's identifier
+ */
+@MappedSuperclass
+public abstract class TableAbstractAuditable implements Auditable<AppUser, Long, Instant> {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "createdby_id")
+    private AppUser createdBy;
+
+    @Column(name = "created_date")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lastmodifiedby_id")
+    private AppUser lastModifiedBy;
+
+    @Column(name = "lastmodified_date")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastModifiedDate;
+
+    @Override
+    public Optional<AppUser> getCreatedBy() {
+        return Optional.ofNullable(this.createdBy);
+    }
+
+    @Override
+    public void setCreatedBy(final AppUser createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    @Override
+    public Optional<Instant> getCreatedDate() {
+        return null == this.createdDate ? Optional.empty() : Optional.of(this.createdDate.toInstant());
+    }
+
+    @Override
+    public void setCreatedDate(final Instant createdDate) {
+        this.createdDate = null == createdDate ? null : Date.from(createdDate);
+    }
+
+    @Override
+    public Optional<AppUser> getLastModifiedBy() {
+        return Optional.ofNullable(this.lastModifiedBy);
+    }
+
+    @Override
+    public void setLastModifiedBy(final AppUser lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    @Override
+    public Optional<Instant> getLastModifiedDate() {
+        return null == this.lastModifiedDate ? Optional.empty() : Optional.of(this.lastModifiedDate.toInstant());
+    }
+
+    @Override
+    public void setLastModifiedDate(final Instant lastModifiedDate) {
+        this.lastModifiedDate = null == lastModifiedDate ? null : Date.from(lastModifiedDate);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
@@ -18,6 +18,8 @@
  */
 package org.apache.fineract.portfolio.loanaccount.domain;
 
+import java.beans.Transient;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.Date;
@@ -27,21 +29,33 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.TableGenerator;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import org.apache.fineract.infrastructure.core.domain.AbstractAuditableCustom;
+import org.apache.fineract.infrastructure.core.domain.TableAbstractAuditable;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.joda.time.LocalDate;
 
+@org.gaul.modernizer_maven_annotations.SuppressModernizer
 @Entity
 @Table(name = "m_loan_repayment_schedule")
-public final class LoanRepaymentScheduleInstallment extends AbstractAuditableCustom
-        implements Comparable<LoanRepaymentScheduleInstallment> {
+public class LoanRepaymentScheduleInstallment extends TableAbstractAuditable
+        implements Comparable<LoanRepaymentScheduleInstallment>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "installmentTable")
+    @TableGenerator(name = "installmentTable", table = "installment_id_gen", pkColumnName = "id", valueColumnName = "installment_id_value", pkColumnValue = "id")
+    private Long id;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "loan_id", referencedColumnName = "id")
@@ -170,6 +184,21 @@ public final class LoanRepaymentScheduleInstallment extends AbstractAuditableCus
             result = null;
         }
         return result;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    protected void setId(final Long id) {
+        this.id = id;
+    }
+
+    @Override
+    @Transient // DATAJPA-622
+    public boolean isNew() {
+        return null == this.id;
     }
 
     public Loan getLoan() {

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V362__installement_table generator.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V362__installement_table generator.sql
@@ -1,0 +1,22 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE `installment_id_gen` (`id` VARCHAR(50) NOT NULL, `installment_id_value` DECIMAL(38), PRIMARY KEY (`id`));
+INSERT INTO `installment_id_gen` (`id`, `installment_id_value`)
+    VALUES ('id', (SELECT IF((SELECT COUNT(`id`) FROM `m_loan_repayment_schedule`)>0, (SELECT  MAX(`id`) FROM `m_loan_repayment_schedule`), 0)));


### PR DESCRIPTION
Considering the discussion we had on the mailing list about the way to set up this generation strategy. 
I tried setting up an AbstractPersistable class for this but it didn't work out because the IDs for all ~200 entities where being generated by one table and thus the IDs were not controlled, causing even way more trouble than what this change was meant to resolve.
I know there was alot of comments about this being confusing but I am still trying to picture how bad it is to have this applied to just one entity.