### PR TITLE
Updated Report-name Regex (FINERACT-1156)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -68,7 +68,7 @@ import org.springframework.stereotype.Service;
 public class ReadReportingServiceImpl implements ReadReportingService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReadReportingServiceImpl.class);
-    private static final String REPORT_NAME_REGEX_PATTERN = "^[a-zA-Z][a-zA-Z0-9\\-_\\s]{0,48}[a-zA-Z0-9]$";
+    private static final String REPORT_NAME_REGEX_PATTERN = "^[a-zA-Z][a-zA-Z0-9\\-_\\s]{0,48}[a-zA-Z0-9\\s](\\([a-zA-Z]*\\))?$";
 
     private final JdbcTemplate jdbcTemplate;
     private final DataSource dataSource;


### PR DESCRIPTION
Refer: https://issues.apache.org/jira/browse/FINERACT-1156

I got this issue in the email thread, no jira Ticket:
![image](https://user-images.githubusercontent.com/42006277/93928309-bcc0c500-fd37-11ea-8556-a2c7ebffa5f3.png)


The report names with "(" threw SQL injection error, I identified the mistake to be incorrect Regex, I am not sure how this worked in the past. 

Still testing this. 

cc: @edcable  @bharathc27 