### PR TITLE
FINERACT-1165

### DIFF
--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V363__mnote_indexing_for_performance.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V363__mnote_indexing_for_performance.sql
@@ -1,0 +1,21 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+ALTER TABLE `m_note`
+    ADD INDEX `savings_account_transaction_id` (`savings_account_transaction_id`);


### PR DESCRIPTION
FINERACT-1165

**resending the PR**
When tested the load capacity on the platform for the savings module with 40k accounts along with around 100 Transactions for each account, it takes approx 45 Sec to bring up a savings account.

further identified the solution that adding an index to a column "savings_account_transaction_id" of table "m_note" would fix the issue.
This Pull request contains a flyway script to add indexing to the m_note table's savings_account_transaction_id column.

Note:
I have used the Version number as V363 as the latest on develop branch was V362.
Not sure how we are maintaining and picking the numbers in series, please let me know if V363 is already taken and to which number I can change.