### PR TITLE
remove weird ImageData.available (FINERACT-1201)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/data/ImageData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/data/ImageData.java
@@ -25,7 +25,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -175,36 +174,5 @@ public class ImageData {
 
     public String getEntityDisplayName() {
         return this.entityDisplayName;
-    }
-
-    public boolean available() {
-        int available = -1; // not -1
-        if (this.storageType.equals(StorageType.S3.getValue()) && this.inputStream != null) {
-            try {
-                available = this.inputStream.available();
-            } catch (IOException e) {
-                LOG.error("Error occured.", e);
-            }
-        } else if (this.storageType.equals(StorageType.FILE_SYSTEM.getValue()) && this.file != null) {
-            FileInputStream fileInputStream = null;
-            try {
-                fileInputStream = new FileInputStream(this.file);
-                available = fileInputStream.available();
-                fileInputStream.close();
-            } catch (FileNotFoundException e) {
-                LOG.error("Error occured.", e);
-            } catch (IOException e) {
-                LOG.error("Error occured.", e);
-            } finally {
-                if (fileInputStream != null) {
-                    try {
-                        fileInputStream.close();
-                    } catch (IOException e) {
-                        LOG.error("Problem occurred in available function", e);
-                    }
-                }
-            }
-        }
-        return available >= 0;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImpl.java
@@ -99,19 +99,9 @@ public class ImageReadPlatformServiceImpl implements ImageReadPlatformService {
 
             final String sql = "select " + imageMapper.schema(entityType);
 
-            final ImageData imageData = this.jdbcTemplate.queryForObject(sql, imageMapper, new Object[] { entityId });
+            final ImageData imageData = this.jdbcTemplate.queryForObject(sql, imageMapper, entityId);
             final ContentRepository contentRepository = this.contentRepositoryFactory.getRepository(imageData.storageType());
-            final ImageData result = contentRepository.fetchImage(imageData);
-
-            // Once we read content EofSensorInputStream, the wrappedStream
-            // object is becoming null. So further image source is becoming null
-            // For Amazon S3. If file is not present, already
-            // S3ContentRepository would have thrown this exception.
-            if (!result.available()) {
-                throw new ImageNotFoundException(entityType, entityId);
-            }
-
-            return result;
+            return contentRepository.fetchImage(imageData);
         } catch (final EmptyResultDataAccessException e) {
             throw new ImageNotFoundException("clients", entityId, e);
         }


### PR DESCRIPTION
I need to clean this up (remove it) so that I can proceed with significant refactorings I'm doing in the context of FINERACT-1201.

I don't understand what this really does, or how to test it. It seems to have been original introduced for FINERACT-288 in PR #259, but the description there doesn't clearly enough explain the problem.

Much related code is about to be substantially refactored, and whatever problem this originally worked around may no longer be present when the ongoing refactoring is fully completed.  If it still is, then there will likely be a better way to address it.