### PR TITLE
Add initial Fineract SDK Java API Client documentation (FINERACT-1216)

### DIFF
--- a/docs/developers/swagger/client.md
+++ b/docs/developers/swagger/client.md
@@ -3,6 +3,20 @@ Generate Apache Fineract API Client
 
 Apache Fineract supports client code generation using [OpenAPI Generator](https://openapi-generator.tech). It uses [OpenAPI Specification Version 3.0.3](https://swagger.io/specification/).
 
+## Fineract SDK Java API Client
+
+The `fineract-client.jar` will eventually be available on Maven Central (watch [FINERACT-1102](https://issues.apache.org/jira/browse/FINERACT-1102)).  Until it is, you can quite easily build the latest and greatest version locally from source, see below.
+
+The [`FineractClient`](https://github.com/apache/fineract/search?q=FineractClient.java) is the entry point to the _Fineract SDK Java API Client_. [`Calls`](https://github.com/apache/fineract/search?q=Calls.java) is a convenient and recommended utility to simplify the use of the [`retrofit2.Call`](https://square.github.io/retrofit/2.x/retrofit/retrofit2/Call.html) type which all API operations return. Their benefit is illustrated e.g. in the [`FineractClientTest`](https://github.com/apache/fineract/search?q=FineractClientTest.java), but in short:
+
+```java
+import org.apache.fineract.client.util.FineractClient;
+import static org.apache.fineract.client.util.Calls.ok;
+
+FineractClient fineract = FineractClient.builder().baseURL("https://demo.fineract.dev/fineract-provider/api/v1/").tenant("default").basicAuth("mifos", "password").build();
+System.out.println(ok(fineract.clients.retrieveAll(...).getTotalFilteredRecords());
+```
+
 ## Generate API Client
 
 The API client is built as part of the overall Fineract Gradle build. If you want to save (maybe) some time you can try to execute just the following line in root directory of the project:


### PR DESCRIPTION
@vidakovic @ptuomola @Grandolf49 how about this, as initial end-user doc?

This will conclude FINERACT-1216, for now (from my side).