### PR TITLE
Fix broken build (var & Java 8/11 from FINERACT-1214)

### DIFF
--- a/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
+++ b/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
@@ -428,7 +428,7 @@ public final class FineractClient {
                         }
                     };
 
-                    var sslContext = SSLContext.getInstance("SSL");
+                    SSLContext sslContext = SSLContext.getInstance("SSL");
                     sslContext.init(null, new TrustManager[] { insecureX509TrustManager }, new SecureRandom());
                     SSLSocketFactory insecureSslSocketFactory = sslContext.getSocketFactory();
 


### PR DESCRIPTION
Removed usage of "var" in FineractClient which is incompatible with the JDK8 build.

FINERACT-1219