### PR TITLE
Do not expose getApiClient() in FineractClient (FINERACT-1220)

### DIFF
--- a/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
+++ b/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
@@ -138,7 +138,7 @@ import org.apache.fineract.client.services.UsersApi;
 import org.apache.fineract.client.services.WorkingDaysApi;
 
 /**
- * Fineract Client Java SDK API entry point. This is recommended to be used instead of {@link ApiClient}.
+ * Fineract Client Java SDK API entry point. Use this instead of the {@link ApiClient}.
  *
  * @author Michael Vorburger.ch
  */
@@ -395,7 +395,7 @@ public final class FineractClient {
         public Builder logging(Level level) {
             HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
             logging.setLevel(level);
-            getApiClient().getOkBuilder().addInterceptor(logging);
+            apiClient.getOkBuilder().addInterceptor(logging);
             return this;
         }
 
@@ -458,13 +458,23 @@ public final class FineractClient {
         }
 
         /**
-         * Obtain the internal Retrofit ApiClient. This method is typically not required to be invoked for simple API
+         * Obtain the internal Retrofit Builder. This method is typically not required to be invoked for simple API
          * usages, but can be a handy back door for non-trivial advanced customizations of the API client.
          *
          * @return the {@link ApiClient} which {@link #build()} will use.
          */
-        public ApiClient getApiClient() {
-            return apiClient;
+        public retrofit2.Retrofit.Builder getRetrofitBuilder() {
+            return apiClient.getAdapterBuilder();
+        }
+
+        /**
+         * Obtain the internal OkHttp Builder. This method is typically not required to be invoked for simple API
+         * usages, but can be a handy back door for non-trivial advanced customizations of the API client.
+         *
+         * @return the {@link ApiClient} which {@link #build()} will use.
+         */
+        public okhttp3.OkHttpClient.Builder getOkBuilder() {
+            return apiClient.getOkBuilder();
         }
 
         private <T> T has(String propertyName, T value) throws IllegalStateException {

--- a/fineract-client/src/test/java/org/apache/fineract/client/test/FineractClientTest.java
+++ b/fineract-client/src/test/java/org/apache/fineract/client/test/FineractClientTest.java
@@ -55,10 +55,18 @@ public class FineractClientTest {
     }
 
     @Test
+    @Disabled // TODO FINERACT-1220
+    void testOfficesDateFormat() throws IOException {
+        FineractClient fineract = FineractClient.builder().baseURL("https://demo.fineract.dev/fineract-provider/api/v1/").tenant("default")
+                .basicAuth("mifos", "password").insecure(true).build();
+        ok(fineract.offices.retrieveOffices(true, null, null));
+    }
+
+    @Test
     @Disabled // TODO remove Ignore once https://issues.apache.org/jira/browse/FINERACT-1221 is fixed
     void testInvalidOperations() throws IOException {
         FineractClient.Builder builder = FineractClient.builder().baseURL("http://test/").tenant("default").basicAuth("mifos", "password");
-        builder.getApiClient().getAdapterBuilder().validateEagerly(true); // see FINERACT-1221
+        builder.getRetrofitBuilder().validateEagerly(true); // see FINERACT-1221
         builder.build();
     }
 


### PR DESCRIPTION
Because FineractClient is about to not use Swagger's ApiClient anymore.