### PR TITLE
Remove redundant testLogging etc. (FINERACT-1209)

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -61,13 +61,6 @@ cargoStartLocal.dependsOn ':fineract-provider:war'
 cargoStartLocal.mustRunAfter 'testClasses'
 
 test {
-    useJUnitPlatform()
-    testLogging {
-        // FINERACT-927
-        events 'skipped', 'failed'
-        showStandardStreams = false
-        exceptionFormat 'full'
-    }
     dependsOn cargoStartLocal
     finalizedBy cargoStopLocal
 }


### PR DESCRIPTION
because https://github.com/apache/fineract/pull/1477/files
moved this from fineract-provider/build.gradle to the root ./build.gradle
so it's inherited.