### PR TITLE
FINERACT-1247: Cleanup test configuration and test dependencies

### DIFF
--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -118,22 +118,15 @@ dependencies {
     // testCompile dependencies are ONLY used in src/test, not src/main.
     // Do NOT repeat dependencies which are ALREADY in implementation or runtimeOnly!
     //
-    testImplementation( 'org.mockito:mockito-core',
-            'org.mockito:mockito-junit-jupiter',
-            'org.junit.platform:junit-platform-runner', // required to be able to run tests directly under Eclipse, see FINERACT-943 & FINERACT-1021
-            'io.github.classgraph:classgraph',
-            'org.awaitility:awaitility'
-            )
-    testImplementation('org.mock-server:mockserver-junit-jupiter') {
-        exclude group: 'com.sun.mail', module: 'mailapi'
-        exclude group: 'javax.servlet', module: 'javax.servlet-api'
-        exclude group: 'javax.validation'
-    }
     testImplementation ('io.rest-assured:rest-assured') {
         exclude group: 'commons-logging'
         exclude group: 'org.apache.sling'
         exclude group: 'com.sun.xml.bind'
     }
+    testImplementation( 'org.junit.jupiter:junit-jupiter-api',
+            'org.awaitility:awaitility',
+            )
+
     testImplementation ('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'com.jayway.jsonpath', module: 'json-path'
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -61,13 +61,6 @@ cargoStartLocal.dependsOn ':fineract-provider:war'
 cargoStartLocal.mustRunAfter 'testClasses'
 
 test {
-    useJUnitPlatform()
-    testLogging {
-        // FINERACT-927
-        events 'skipped', 'failed'
-        showStandardStreams = false
-        exceptionFormat 'full'
-    }
     dependsOn cargoStartLocal
     finalizedBy cargoStopLocal
 }


### PR DESCRIPTION
## Description

As discussed on FINERACT-1247. Removed unnecessary test dependencies from "fineract-provider", and "integration-tests" build.gradle test configuration is "trimmed".