### PR TITLE
Enable JavaTimeDefaultTimeZone rule in ErrorProne (FINERACT-1112)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -561,6 +561,7 @@ configure(project.fineractJavaProjects) {
                     "ClassNewInstance",
                     "UnnecessaryStaticImport",
                     "UnsafeFinalization",
+                    "JavaTimeDefaultTimeZone",
                     "JodaPlusMinusLong",
                     "MutableMethodReturnType",
                     "SwitchDefault",


### PR DESCRIPTION
Let's enable https://errorprone.info/bugpattern/JavaTimeDefaultTimeZone given @percyashu work in #1493 for FINERACT-1112.

There are probably a lot more https://errorprone.info/bugpatterns we could enable now (time related, perhaps even others)... interested?