### PR TITLE
aligning Spring Boot versions to 2.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ allprojects  {
     dependencyManagement {
         imports {
             mavenBom 'org.springframework:spring-framework-bom:5.3.0'
-            mavenBom 'org.springframework.boot:spring-boot-dependencies:2.3.4.RELEASE'
+            mavenBom 'org.springframework.boot:spring-boot-dependencies:2.3.5.RELEASE'
             mavenBom 'org.junit:junit-bom:5.7.0'
         }
 


### PR DESCRIPTION

## Description

org.springframework.boot plugin version is 2.3.5 : 
https://github.com/apache/fineract/blob/169b01d72b68eb116d911f63dfd921c3f23696ca/build.gradle#L61 

, so aligning the maven BOM version accordingly for consistency 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
