### PR TITLE
chore: Switch GitHub rebase action checkout@master to @v2

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Automatic Rebase


### PR DESCRIPTION
Using a fixed version here is more stable (otherwise future changes in actions/checkout@v3 could theoretically break this for us), and in line with https://github.com/cirrus-actions/rebase/commit/51854755db80c104a3f4be4b617988933209b5a1, which I've stumbled upon from #1509. This is also consistent with our other GitHub actions.