### PR TITLE
Minor performance optimization to Gradle build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qq && apt-get install -y wget
 COPY . fineract
 WORKDIR /fineract
 
-RUN ./gradlew -PautomatedBuild=true --no-daemon -q -x rat -x test bootJar
+RUN ./gradlew --no-daemon -q -x rat -x compileTestJava -x test -x spotlessJavaCheck -x spotlessJava bootJar
 
 WORKDIR /fineract/target
 RUN jar -xf /fineract/fineract-provider/build/libs/fineract-provider*.jar


### PR DESCRIPTION
This should make the `Dockerfile` build just a tiny bit faster.