### PR TITLE
Fix - use expected disbursement for ideal disbursement to fix wrong interest

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractLoanScheduleGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractLoanScheduleGenerator.java
@@ -123,12 +123,11 @@ public abstract class AbstractLoanScheduleGenerator implements LoanScheduleGener
         boolean isFirstRepayment = true;
         LocalDate firstRepaymentdate = this.scheduledDateGenerator
                 .generateNextRepaymentDate(loanApplicationTerms.getExpectedDisbursementDate(), loanApplicationTerms, isFirstRepayment);
-        final LocalDate idealDisbursementDate = this.scheduledDateGenerator.idealDisbursementDateBasedOnFirstRepaymentDate(
-                loanApplicationTerms.getLoanTermPeriodFrequencyType(), loanApplicationTerms.getRepaymentEvery(), firstRepaymentdate,
-                loanApplicationTerms.getLoanCalendar(), loanApplicationTerms.getHolidayDetailDTO(), loanApplicationTerms);
+
+        final LocalDate idealDisbursementDate = loanApplicationTerms.getExpectedDisbursementDate();
 
         if (!scheduleParams.isPartialUpdate()) {
-            // Set Fixed Principal Amount
+            // Set Fixed Principal  Amount
             updateAmortization(mc, loanApplicationTerms, scheduleParams.getPeriodNumber(), scheduleParams.getOutstandingBalance());
 
             if (loanApplicationTerms.isMultiDisburseLoan()) {


### PR DESCRIPTION
**ISSUE**
My issue/bug happens when I am setting "First repayment on" field I get a repayment schedule with a wrong interest rate for the first installment.
Example: When I set "First repayment on" to 01/02/21 and expected disbursement is 27/1/21(Frist image) then I get the wrong interest.The first installment interest is 21,232.88$ (second Image) - calculated for the entire month (31 days) instead of 5 days (the time from the disbursement to the first repayment), the right interest should be 3424.75$.

**After debugging:**
In AbstractLoanScheduleGenerator there is a function `calculateInterestStartDateForPeriod` - it uses the `idealDisbursment` for setting the interest start date for the first installment, The `idealDisbursment` is calculated by `idealDisbursementDateBasedOnFirstRepaymentDate` which does [`firstRepaymentDate` - 1 repayment Period Frequency] aka, for 01/02/21 with months as repyment frequency it will return 01/01/21.

So when we dont set the "First repayment on" the `idealDisbursment` will be the expected disbursement date because the first repayment is always `expectedDisbursment`+1. But if we set the  "First repayment on" we get the wrong value for the `idealDisbursment` - in my example we got 01/0/21 and this is why the first installment interest was calculated for an entire month instead of  5 days.

**Is it a bug or not?**
I am not sure why `idealDisbursementDateBasedOnFirstRepaymentDate` exists, the simple solution is to do  idealDisbursment=expectedDisbursmentDate.I tried it locally and looks like it works, I will be happy to make a PR, but want to make sure indeed that the `idealDisbursementDateBasedOnFirstRepaymentDate` is redundant.

@vorburger 

![image](https://user-images.githubusercontent.com/9163916/103640420-ab06d480-4f58-11eb-8dfa-55e441707bee.png)

![image](https://user-images.githubusercontent.com/9163916/103640438-b2c67900-4f58-11eb-8a47-96e17959f49a.png)

