### PR TITLE
Fixed kubernetes startup & shutdown commands issue (FINERACT-1288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ You can follow [this](https://cwiki.apache.org/confluence/display/FINERACT/Insta
 Now e.g. from your Google Cloud shell, run the following commands:
 
 1. `git clone https://github.com/apache/fineract.git ; cd fineract/kubernetes`
-1. `./kubectl-startup`
+1. `./kubectl-startup.sh`
 
 To shutdown and reset your Cluster, run:
 
-    ./kubectl-shutdown
+    ./kubectl-shutdown.sh
 
 Using Minikube
 --------------
@@ -176,7 +176,7 @@ You can check Fineract logs using:
 
 To shutdown and reset your cluster, run:
 
-    ./kubectl-shutdown
+    ./kubectl-shutdown.sh
 
 We have [some open issues in JIRA with Kubernetes related enhancement ideas](https://jira.apache.org/jira/browse/FINERACT-783?jql=labels%20%3D%20kubernetes%20AND%20project%20%3D%20%22Apache%20Fineract%22%20) which you are welcome to contribute to.
 


### PR DESCRIPTION
## Description

Commands mentioned in README.md file for starting-up & shutting-down the K8s cluster is not accurate according to the naming conventions of the bash files.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
