### PR TITLE
Added ReadinessProbe for mysql container (FINERACT-1292)

### DIFF
--- a/kubernetes/fineractmysql-deployment.yml
+++ b/kubernetes/fineractmysql-deployment.yml
@@ -103,6 +103,15 @@ spec:
                 - localhost
             failureThreshold: 10
             timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysqladmin ping -uroot -p${MYSQL_PASSWORD}
+            failureThreshold: 10
+            initialDelaySeconds: 5
+            periodSeconds: 5
           ports:
             - containerPort: 3306
               name: fineractmysql


### PR DESCRIPTION
FINERACT-1292

## Description

Added ReadinessProbe configuration values for MySql container.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
