### PR TITLE
use @TestMethodOrder(MethodName.class) in SchedulerJobsTestResults

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
@@ -64,10 +64,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 @SuppressWarnings({ "unchecked" })
-
+@TestMethodOrder(MethodName.class)
 public class SchedulerJobsTestResults {
 
     private static final String FROM_ACCOUNT_TYPE_LOAN = "1";


### PR DESCRIPTION
re. FINERACT-1293 - but doesn't help, but let's still add it, just to clarify for the future (once FINERACT-924 is fixed)