### PR TITLE
Fix volume mounting issue in MySQL image (FINERACT-1294)

### DIFF
--- a/kubernetes/fineractmysql-deployment.yml
+++ b/kubernetes/fineractmysql-deployment.yml
@@ -107,14 +107,14 @@ spec:
             - containerPort: 3306
               name: fineractmysql
           volumeMounts:
-            - name: fineractmysql-persistent-storage
-              mountPath: /var/lib/mysql/
             - name: fineractmysql-initdb
               mountPath: /docker-entrypoint-initdb.d/
+            - name: fineractmysql-persistent-storage
+              mountPath: /var/lib/mysql/
       volumes:
-        - name: fineractmysql-persistent-storage
-          persistentVolumeClaim:
-            claimName: fineractmysql-pv-claim
         - name: fineractmysql-initdb
           configMap:
             name: fineractmysql-initdb
+        - name: fineractmysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: fineractmysql-pv-claim


### PR DESCRIPTION
FINERACT-1294

## Description

Fixed "Access Denied" issue came from MYSQL container which was caused by the order of volume mounting configured in mysql-deployment.yml.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
