### PR TITLE
feat: Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ fineract-provider/src/main/resources/application.properties
 fineract-provider/out/
 fineract-provider/config/swagger/config.json
 fineract-provider/config/swagger/fineract-input.yaml
+localtests

--- a/README.md
+++ b/README.md
@@ -187,6 +187,67 @@ To shutdown and reset your cluster, run:
 
 We have [some open issues in JIRA with Kubernetes related enhancement ideas](https://jira.apache.org/jira/browse/FINERACT-783?jql=labels%20%3D%20kubernetes%20AND%20project%20%3D%20%22Apache%20Fineract%22%20) which you are welcome to contribute to.
 
+Using Helm
+----------
+
+A [Helm](https://helm.sh/) chart is provided at [helm/fineract](helm/fineract). If you're familiar with Helm you probably know what to do. Here are some detailed steps:
+
+### Prerequisites
+
+* A Kubernetes cluster
+* Helm installed
+
+### Running
+
+1. Configure your values overrides
+
+Just like any typical Helm chart, you'll need to craft a custom `my-values.yaml` file that would define/override any of the values exposed into the default [values.yaml](helm/fineract/values.yaml), or the dependent [bitnami/mysql](https://artifacthub.io/packages/helm/bitnami/redis) chart it depends on.
+
+Check out the content of those files to understand the supported overrides.
+
+Some mandatory overrides include `mysql.auth.password` and `mysql.auth.rootPassword`.
+
+You may also want to set `global.storageClass`, which MySQL will use, according to your needs, as well as enable the ingress (disabled by default).
+
+Sample `my-values.yaml` file:
+
+```yaml
+global:
+  storageClass: my-storage-class
+
+mysql:
+  auth:
+    password: blah
+    rootPassword: blih
+
+ingress:
+  enables: true
+  hosts:
+  - fineract.example.com
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+```
+
+1. Install and run
+
+```sh
+# From the root of the repository...
+# Install chart dependencies
+helm dependency update helm/fineract
+
+# Installe your release
+helm upgrade --install --values my-values.yaml --namespace fineract --create-namespace my-fineract helm/fineract
+```
+
+You should see a few pods popping up in your namespace, depending on your replica configuration:
+
+```sh
+$ kubectl get pods --namespace fineract
+NAME                                READY   STATUS    RESTARTS   AGE
+fineract-backend-645c7fff69-p28cf   1/1     Running   0          121m
+fineract-mysql-0                    1/1     Running   0          121m
+fineract-ui-6fdcf99746-ndblt        1/1     Running   0          121m
+```
 
 Instructions to download Gradle wrapper
 ============

--- a/helm/fineract/.helmignore
+++ b/helm/fineract/.helmignore
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/fineract/Chart.yaml
+++ b/helm/fineract/Chart.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+appVersion: "1.0"
+description: "Apache Fineract: A Platform for Microfinance"
+name: finteract
+version: 0.1.0
+dependencies:
+  - name: mysql
+    version: ~8.4.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: mysql.enabled

--- a/helm/fineract/NOTES.txt
+++ b/helm/fineract/NOTES.txt
@@ -1,0 +1,1 @@
+Thank you for installing Fineract!

--- a/helm/fineract/requirements.lock
+++ b/helm/fineract/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.4.1
+digest: sha256:d020a39cd42a3a78eaa760ebd58527692f1dc81d6b2c2677fc042c901784255e
+generated: "2021-02-16T22:32:36.621097+02:00"

--- a/helm/fineract/templates/_helpers.tpl
+++ b/helm/fineract/templates/_helpers.tpl
@@ -1,21 +1,42 @@
-{{- define "secrets" -}}
-fineract_tenants_pwd: {{ .Values.mysql.auth.rootPassword | b64enc }}
-FINERACT_DEFAULT_TENANTDB_PWD: {{ .Values.mysql.auth.rootPassword | b64enc }}
-{{ if .Values.extraSecretEnv }}
-{{- range $key, $value := .Values.extraSecretEnv }}
-{{ $key }}: {{ $value | b64enc }}
-{{- end }}
-{{- end }}
-{{- end -}}
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 {{- define "mysql_host" -}}
 {{ .Release.Name }}-mysql
 {{- end -}}
 
 {{- define "mysql_url" -}}
-jdbc:mysql:thin://{{ include "mysql_host" . }}:3306/fineract_tenants
+jdbc:mysql:thin://{{ include "mysql_host" . }}:3306/{{ .Values.global.db.tenantsDb }}
 {{- end -}}
 
 {{- define "mysql_user" -}}
 {{ .Values.mysql.auth.username | default "root" }}
+{{- end -}}
+
+{{- define "mysql_password" -}}
+{{ coalesce .Values.mysql.auth.password .Values.mysql.auth.rootPassword }}
+{{- end -}}
+
+{{- define "secrets" -}}
+fineract_tenants_pwd: {{ include "mysql_password" . | b64enc }}
+FINERACT_DEFAULT_TENANTDB_PWD: {{ include "mysql_password" . | b64enc }}
+{{ if .Values.extraSecretEnv }}
+{{- range $key, $value := .Values.extraSecretEnv }}
+{{ $key }}: {{ $value | b64enc }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/helm/fineract/templates/_helpers.tpl
+++ b/helm/fineract/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{- define "secrets" -}}
+fineract_tenants_pwd: {{ .Values.mysql.auth.rootPassword | b64enc }}
+FINERACT_DEFAULT_TENANTDB_PWD: {{ .Values.mysql.auth.rootPassword | b64enc }}
+{{ if .Values.extraSecretEnv }}
+{{- range $key, $value := .Values.extraSecretEnv }}
+{{ $key }}: {{ $value | b64enc }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "mysql_host" -}}
+{{ .Release.Name }}-mysql
+{{- end -}}
+
+{{- define "mysql_url" -}}
+jdbc:mysql:thin://{{ include "mysql_host" . }}:3306/fineract_tenants
+{{- end -}}
+
+{{- define "mysql_user" -}}
+{{ .Values.mysql.auth.username | default "root" }}
+{{- end -}}

--- a/helm/fineract/templates/_helpers.tpl
+++ b/helm/fineract/templates/_helpers.tpl
@@ -36,7 +36,7 @@ fineract_tenants_pwd: {{ include "mysql_password" . | b64enc }}
 FINERACT_DEFAULT_TENANTDB_PWD: {{ include "mysql_password" . | b64enc }}
 {{ if .Values.extraSecretEnv }}
 {{- range $key, $value := .Values.extraSecretEnv }}
-{{ $key }}: {{ $value | b64enc }}
+{{ $key }}: {{ tpl $value $ | b64enc }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/helm/fineract/templates/_helpers.tpl
+++ b/helm/fineract/templates/_helpers.tpl
@@ -16,7 +16,7 @@
 #
 
 {{- define "mysql_host" -}}
-{{ .Release.Name }}-mysql
+{{ .Release.Name }}-mysql.{{ .Release.Namespace }}
 {{- end -}}
 
 {{- define "mysql_url" -}}

--- a/helm/fineract/templates/fineract-ingress.yaml
+++ b/helm/fineract/templates/fineract-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /fineract-provider
+            pathType: Prefix
+            backend:
+              serviceName: {{ .Release.Name }}-backend
+              servicePort: http
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: {{ .Release.Name }}-ui
+              servicePort: 80
+  {{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/helm/fineract/templates/fineract-secret.yaml
+++ b/helm/fineract/templates/fineract-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- include "secrets" . | nindent 2 }}
+type: Opaque

--- a/helm/fineract/templates/fineract-secret.yaml
+++ b/helm/fineract/templates/fineract-secret.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 kind: Secret
 apiVersion: v1
 metadata:

--- a/helm/fineract/templates/fineract-secret.yaml
+++ b/helm/fineract/templates/fineract-secret.yaml
@@ -13,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+{{- $unused := required "You must set a MySQL root password in mysql.auth.rootPassword" .Values.mysql.auth.rootPassword }}
+{{- $unused := required "You must set a MySQL user password in mysql.auth.password" .Values.mysql.auth.password }}
 
 kind: Secret
 apiVersion: v1

--- a/helm/fineract/templates/fineract-server-deployment.yml
+++ b/helm/fineract/templates/fineract-server-deployment.yml
@@ -38,11 +38,13 @@ spec:
         tier: backend
         instance: {{ .Release.Name }}
       annotations:
+        # Force a pod restart if secret values change
         checksum/secrets: {{ include "secrets" . | sha256sum }}
     spec:
       initContainers:
         - name: wait-db
           image: jwilder/dockerize
+          # We don't care about having the latest...
           imagePullPolicy: IfNotPresent
           args:
           - -wait
@@ -64,10 +66,11 @@ spec:
               value: {{ include "mysql_user" . }}
             - name: FINERACT_DEFAULT_TENANTDB_UID
               value: {{ include "mysql_user" . }}
-            {{ if .Values.fineractServer.extraEnv }}
+            {{- if .Values.fineractServer.extraEnv }}
             {{- range $key, $value := .Values.fineractServer.extraEnv }}
             - name: {{ $key | quote}}
-              value: {{ $value | quote }}
+              value: |-
+                {{- tpl $value $ | nindent 16 }}
             {{- end }}
             {{- end }}
           ports:
@@ -75,13 +78,15 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /fineract-provider/actuator/health
+              path: /fineract-provider/actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 90
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /fineract-provider/actuator/health
+              path: /fineract-provider/actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 300
+            initialDelaySeconds: 90
             timeoutSeconds: 10
+          resources:
+            {{- .Values.fineractServer.resources | toYaml | nindent 12 }}

--- a/helm/fineract/templates/fineract-server-deployment.yml
+++ b/helm/fineract/templates/fineract-server-deployment.yml
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fineract
+    tier: backend
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: fineract-backend
+      tier: backend
+      instance: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: fineract-backend
+        tier: backend
+        instance: {{ .Release.Name }}
+      annotations:
+        checksum/secrets: {{ include "secrets" . | sha256sum }}
+    spec:
+      initContainers:
+        - name: wait-db
+          image: jwilder/dockerize
+          imagePullPolicy: IfNotPresent
+          args:
+          - -wait
+          - tcp://{{ include "mysql_host" . }}:3306
+          - -timeout
+          - 300s
+      containers:
+        - name: fineract-backend
+          image: "{{ .Values.fineractServer.image.name }}:{{ .Values.fineractServer.image.tag }}"
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name | quote }}
+          env:
+            - name: FINERACT_DEFAULT_TENANTDB_HOSTNAME
+              value: {{ include "mysql_host" . }}
+            - name: fineract_tenants_url
+              value: {{ include "mysql_url" . }}
+            - name: fineract_tenants_uid
+              value: {{ include "mysql_user" . }}
+            - name: FINERACT_DEFAULT_TENANTDB_UID
+              value: {{ include "mysql_user" . }}
+            {{ if .Values.fineractServer.extraEnv }}
+            {{- range $key, $value := .Values.fineractServer.extraEnv }}
+            - name: {{ $key | quote}}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          ports:
+            - containerPort: 8080
+              name: http

--- a/helm/fineract/templates/fineract-server-deployment.yml
+++ b/helm/fineract/templates/fineract-server-deployment.yml
@@ -31,8 +31,6 @@ spec:
       app: fineract-backend
       tier: backend
       instance: {{ .Release.Name }}
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
@@ -75,3 +73,15 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          readinessProbe:
+            httpGet:
+              path: /fineract-provider/actuator/health
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /fineract-provider/actuator/health
+              port: 8080
+            initialDelaySeconds: 300
+            timeoutSeconds: 10

--- a/helm/fineract/templates/fineract-server-svc.yml
+++ b/helm/fineract/templates/fineract-server-svc.yml
@@ -22,6 +22,7 @@ metadata:
   labels:
     app: fineract-server
   name: {{ .Release.Name }}-backend
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - protocol: TCP

--- a/helm/fineract/templates/fineract-server-svc.yml
+++ b/helm/fineract/templates/fineract-server-svc.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: fineract-server
+  name: {{ .Release.Name }}-backend
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: fineract-backend
+    tier: backend
+    instance: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/helm/fineract/templates/fineract-ui-deployment.yml
+++ b/helm/fineract/templates/fineract-ui-deployment.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fineract
+    tier: ui
+spec:
+  selector:
+    matchLabels:
+      app: fineract
+      tier: ui
+      instance: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: fineract
+        tier: ui
+        instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: fineract-ui
+          image: "{{ .Values.fineractUI.image.name }}:{{ .Values.fineractUI.image.tag }}"
+          ports:
+            - containerPort: 80
+              name: http

--- a/helm/fineract/templates/fineract-ui-deployment.yml
+++ b/helm/fineract/templates/fineract-ui-deployment.yml
@@ -56,3 +56,5 @@ spec:
               port: 80
             initialDelaySeconds: 30
             timeoutSeconds: 10
+          resources:
+            {{- .Values.fineractUI.resources | toYaml | nindent 12 }}

--- a/helm/fineract/templates/fineract-ui-deployment.yml
+++ b/helm/fineract/templates/fineract-ui-deployment.yml
@@ -25,13 +25,12 @@ metadata:
     app: fineract
     tier: ui
 spec:
+  replicas: {{ .Values.fineractUI.replicas }}
   selector:
     matchLabels:
       app: fineract
       tier: ui
       instance: {{ .Release.Name }}
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
@@ -45,3 +44,15 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            timeoutSeconds: 10

--- a/helm/fineract/templates/fineract-ui-svc.yml
+++ b/helm/fineract/templates/fineract-ui-svc.yml
@@ -23,6 +23,7 @@ metadata:
     app: fineract
     tier: ui
   name: {{ .Release.Name }}-ui
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - protocol: TCP

--- a/helm/fineract/templates/fineract-ui-svc.yml
+++ b/helm/fineract/templates/fineract-ui-svc.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: fineract
+    tier: ui
+  name: {{ .Release.Name }}-ui
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: fineract
+    tier: ui
+    instance: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/helm/fineract/values.yaml
+++ b/helm/fineract/values.yaml
@@ -1,41 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TODO: add option to install ActiveMQ?
+
 fineractServer:
   replicas: 1
   image:
     name: apache/fineract
     tag: latest
+  # key/value pairs to pass as environment variables to the backend pods
   extraEnv:
     DRIVERCLASS_NAME: org.drizzle.jdbc.DrizzleDriver
     PROTOCOL: jdbc
     SUB_PROTOCOL: mysql:thin
     fineract_tenants_driver: org.drizzle.jdbc.DrizzleDriver
     FINERACT_DEFAULT_TENANTDB_PORT: "3306"
+  # sensitive key/value pairs to pass as environment variables to the backend pods as secrets
   extraSecretEnv: {}
 
 fineractUI:
+  replicas: 1
   image:
     name: openmf/community-app
     tag: latest
 
+# Globals will be available to subcharts
+global:
+  db:
+    tenantsDb: fineract_tenants
+    defaultDb: fineract_default
+
 # Any other parameter from https://artifacthub.io/packages/helm/bitnami/mysql
-# TODO: support non-root user
 mysql:
   enabled: true
   # Required because db driver doesn't support mysql 8...
   image:
     tag: '5.7'
   auth:
+    # Please change these...
     rootPassword: ozIRdODs8Jvs3BzZywgK
-    database: fineract_tenants
-    # username: fineract
-    # password: ihcqsCcsX6
+    password: ihcqsCcsX6
+    username: fineract
   initdbScripts:
+    # WARNING! These db init scripts will only be executed on a brand new, uninitialized instance!
+    # Further changes will be ignored after the first init, unless you wipe the underlying PV/PVC volumes
     create_db.sql: |
       # create databases
-      CREATE DATABASE IF NOT EXISTS `fineract_tenants`;
-      CREATE DATABASE IF NOT EXISTS `fineract_default`;
+      CREATE DATABASE IF NOT EXISTS `{{ .Values.global.db.tenantsDb }}`;
+      CREATE DATABASE IF NOT EXISTS `{{ .Values.global.db.defaultDb }}`;
 
       # create root user and grant rights
-      GRANT ALL ON *.* TO 'root'@'%';
+      GRANT ALL ON {{ .Values.global.db.tenantsDb }}.* TO '{{ .Values.auth.username | default "root" }}'@'%';
+      GRANT ALL ON {{ .Values.global.db.defaultDb }}.* TO '{{ .Values.auth.username | default "root" }}'@'%';
 
 service:
   type: ClusterIP
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/helm/fineract/values.yaml
+++ b/helm/fineract/values.yaml
@@ -1,0 +1,41 @@
+fineractServer:
+  replicas: 1
+  image:
+    name: apache/fineract
+    tag: latest
+  extraEnv:
+    DRIVERCLASS_NAME: org.drizzle.jdbc.DrizzleDriver
+    PROTOCOL: jdbc
+    SUB_PROTOCOL: mysql:thin
+    fineract_tenants_driver: org.drizzle.jdbc.DrizzleDriver
+    FINERACT_DEFAULT_TENANTDB_PORT: "3306"
+  extraSecretEnv: {}
+
+fineractUI:
+  image:
+    name: openmf/community-app
+    tag: latest
+
+# Any other parameter from https://artifacthub.io/packages/helm/bitnami/mysql
+# TODO: support non-root user
+mysql:
+  enabled: true
+  # Required because db driver doesn't support mysql 8...
+  image:
+    tag: '5.7'
+  auth:
+    rootPassword: ozIRdODs8Jvs3BzZywgK
+    database: fineract_tenants
+    # username: fineract
+    # password: ihcqsCcsX6
+  initdbScripts:
+    create_db.sql: |
+      # create databases
+      CREATE DATABASE IF NOT EXISTS `fineract_tenants`;
+      CREATE DATABASE IF NOT EXISTS `fineract_default`;
+
+      # create root user and grant rights
+      GRANT ALL ON *.* TO 'root'@'%';
+
+service:
+  type: ClusterIP

--- a/helm/fineract/values.yaml
+++ b/helm/fineract/values.yaml
@@ -23,6 +23,7 @@ fineractServer:
     name: apache/fineract
     tag: latest
   # key/value pairs to pass as environment variables to the backend pods
+  # They will be evaluated as Helm templates
   extraEnv:
     DRIVERCLASS_NAME: org.drizzle.jdbc.DrizzleDriver
     PROTOCOL: jdbc
@@ -30,13 +31,22 @@ fineractServer:
     fineract_tenants_driver: org.drizzle.jdbc.DrizzleDriver
     FINERACT_DEFAULT_TENANTDB_PORT: "3306"
   # sensitive key/value pairs to pass as environment variables to the backend pods as secrets
+  # They will be evaluated as Helm templates
   extraSecretEnv: {}
+  resources:
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
 
 fineractUI:
   replicas: 1
   image:
     name: openmf/community-app
     tag: latest
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "100Mi"
 
 # Globals will be available to subcharts
 global:
@@ -52,8 +62,8 @@ mysql:
     tag: '5.7'
   auth:
     # Please change these...
-    rootPassword: ozIRdODs8Jvs3BzZywgK
-    password: ihcqsCcsX6
+    rootPassword: ''
+    password: ''
     username: fineract
   initdbScripts:
     # WARNING! These db init scripts will only be executed on a brand new, uninitialized instance!


### PR DESCRIPTION
## Description

This is a proper Helm chart to run it on Kubernetes, as a more flexible alternative to the existing deployment definitions and setup scripts. It uses the bitnami mysql chart as a dependency to install MySQL, so all these values can be overridden.

To install, just run:

```sh
# Install mysql chart dependency
helm dependency update

# Install chart
helm upgrade --install --set mysql.auth.rootPassword=xxxx my-fineract helm/fineract
```

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
