### PR TITLE
FINERACT-1177: Add feature to include external libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,23 +24,21 @@ WORKDIR /fineract
 
 RUN ./gradlew --no-daemon -q -x rat -x compileTestJava -x test -x spotlessJavaCheck -x spotlessJava bootJar
 
-WORKDIR /fineract/target
-RUN jar -xf /fineract/fineract-provider/build/libs/fineract-provider*.jar
-
 # https://issues.apache.org/jira/browse/LEGAL-462
 # https://issues.apache.org/jira/browse/FINERACT-762
 # We include an alternative JDBC driver (which is faster, but not allowed to be default in Apache distribution)
 # allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
 # The commented out lines in the docker-compose.yml illustrate how to do this.
-WORKDIR /fineract/target/BOOT-INF/lib
-RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.20/mysql-connector-java-8.0.20.jar
+WORKDIR /fineract/libs
+RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
 
 # =========================================
 
 FROM gcr.io/distroless/java:11 as fineract
 
-COPY --from=builder /fineract/target/BOOT-INF/lib /app/lib
-COPY --from=builder /fineract/target/META-INF /app/META-INF
-COPY --from=builder /fineract/target/BOOT-INF/classes /app
+COPY --from=builder /fineract/fineract-provider/build/libs /app
+COPY --from=builder /fineract/libs /app/libs
 
-ENTRYPOINT ["java", "-cp", "app:app/lib/*", "org.apache.fineract.ServerApplication"]
+WORKDIR /app
+
+ENTRYPOINT ["java", "-Dloader.path=/app/libs/", "-jar", "/app/fineract-provider.jar"]

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -250,6 +250,9 @@ springBoot {
 
 bootJar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    manifest {
+        attributes 'Main-Class': 'org.springframework.boot.loader.PropertiesLauncher'
+    }
 }
 
 bootWar {


### PR DESCRIPTION
## Description

These changes allow us to add external libraries to the Spring Boot classloader without unpacking the Spring Boot uber-jar. Any jar file that is available at "/app/libs" in the Docker container will be available/visible in Fineract during runtime. As part of the Docker image build we download and copy the official Mysql JDBC driver into that directory. Later these mechanics can also be used to load "modules" (like the reporting module that is currently worked on).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
