### PR TITLE
Add client IDs for selfservice user in auth credentials (FINERACT-1340)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
@@ -31,9 +31,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
@@ -94,7 +96,8 @@ public class AuthenticationApiResource {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AuthenticationApiResourceSwagger.PostAuthenticationResponse.class))),
             @ApiResponse(responseCode = "400", description = "Unauthenticated. Please login") })
-    public String authenticate(final String apiRequestBodyAsJson) {
+    public String authenticate(final String apiRequestBodyAsJson,
+            @QueryParam("returnClientList") @DefaultValue("false") boolean returnClientList) {
         // TODO FINERACT-819: sort out Jersey so JSON conversion does not have
         // to be done explicitly via GSON here, but implicit by arg
         AuthenticateRequest request = new Gson().fromJson(apiRequestBodyAsJson, AuthenticateRequest.class);
@@ -147,7 +150,7 @@ public class AuthenticationApiResource {
                 authenticatedUserData = new AuthenticatedUserData(request.username, officeId, officeName, staffId, staffDisplayName,
                         organisationalRole, roles, permissions, principal.getId(),
                         new String(base64EncodedAuthenticationKey, StandardCharsets.UTF_8), isTwoFactorRequired,
-                        principal.isSelfServiceUser() ? clientReadPlatformService.retrieveUserClients(userId) : null);
+                        returnClientList ? clientReadPlatformService.retrieveUserClients(userId) : null);
             }
 
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/data/AuthenticatedUserData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/data/AuthenticatedUserData.java
@@ -50,6 +50,8 @@ public class AuthenticatedUserData {
     @SuppressWarnings("unused")
     private final Collection<String> permissions;
 
+    private final Collection<Long> clients;
+
     @SuppressWarnings("unused")
     private final boolean shouldRenewPassword;
 
@@ -70,12 +72,13 @@ public class AuthenticatedUserData {
         this.permissions = permissions;
         this.shouldRenewPassword = false;
         this.isTwoFactorAuthenticationRequired = false;
+        clients = null;
     }
 
     public AuthenticatedUserData(final String username, final Long officeId, final String officeName, final Long staffId,
             final String staffDisplayName, final EnumOptionData organisationalRole, final Collection<RoleData> roles,
             final Collection<String> permissions, final Long userId, final String base64EncodedAuthenticationKey,
-            final boolean isTwoFactorAuthenticationRequired) {
+            final boolean isTwoFactorAuthenticationRequired, Collection<Long> aListOfClientIDs) {
         this.username = username;
         this.officeId = officeId;
         this.officeName = officeName;
@@ -89,6 +92,7 @@ public class AuthenticatedUserData {
         this.permissions = permissions;
         this.shouldRenewPassword = false;
         this.isTwoFactorAuthenticationRequired = isTwoFactorAuthenticationRequired;
+        clients = aListOfClientIDs;
     }
 
     public AuthenticatedUserData(final String username, final Long userId, final String base64EncodedAuthenticationKey,
@@ -106,5 +110,6 @@ public class AuthenticatedUserData {
         this.permissions = null;
         this.shouldRenewPassword = true;
         this.isTwoFactorAuthenticationRequired = isTwoFactorAuthenticationRequired;
+        clients = null;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformService.java
@@ -46,6 +46,15 @@ public interface ClientReadPlatformService {
 
     ClientData retrieveAllNarrations(String clientNarrations);
 
+    /**
+     * Gets a list of Client IDs associated with a user ID.
+     * <p>
+     * This is used in self service authentication
+     *
+     * @param aUserID
+     *            the user id (not null)
+     * @return client IDs listing (may be null)
+     */
     Collection<Long> retrieveUserClients(Long aUserID);
 
     Date retrieveClientTransferProposalDate(Long clientId);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformService.java
@@ -46,6 +46,8 @@ public interface ClientReadPlatformService {
 
     ClientData retrieveAllNarrations(String clientNarrations);
 
+    Collection<Long> retrieveUserClients(Long aUserID);
+
     Date retrieveClientTransferProposalDate(Long clientId);
 
     void validateClient(Long clientId);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -865,4 +865,9 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
         }
     }
 
+    @Override
+    public Collection<Long> retrieveUserClients(Long aUserID) {
+        String sql = "SELECT  m.client_id FROM m_selfservice_user_client_mapping m INNER JOIN m_client c ON c.id = m.client_id WHERE m.appuser_id = ?";
+        return jdbcTemplate.queryForList(sql, Long.class, new Object[] { aUserID });
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/security/api/SelfAuthenticationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/security/api/SelfAuthenticationApiResource.java
@@ -57,6 +57,6 @@ public class SelfAuthenticationApiResource {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SelfAuthenticationApiResourceSwagger.PostSelfAuthenticationResponse.class))) })
     public String authenticate(final String apiRequestBodyAsJson) {
-        return this.authenticationApiResource.authenticate(apiRequestBodyAsJson);
+        return this.authenticationApiResource.authenticate(apiRequestBodyAsJson, true);
     }
 }


### PR DESCRIPTION
## Description

Details in Apache Fineract JIRA ticket FINERACT-1340

Client IDs to be returned ONLY for self service calls. `https://localhost:8443/fineract-provider/api/v1/self/authentication`

Below one won't return client IDs in JSON and will continue working as it has been
`https://localhost:8443/fineract-provider/api/v1/authentication`
```
curl \
  --header "Content-Type: application/json" \
  --header "Authorization: Basic bWlmb3M6cGFzc3dvcmQ=" \
  --header "Fineract-Platform-TenantId: default" \
  --request POST \
  --data  '{"username":"mifos", "password":"password"}' \
  https://localhost:8443/fineract-provider/api/v1/authentication --insecure
```

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
