### PR TITLE
Replace drizzle driver by MariaDB driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ./gradlew --no-daemon -q -x rat -x compileTestJava -x test -x spotlessJavaCh
 # allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
 # The commented out lines in the docker-compose.yml illustrate how to do this.
 WORKDIR /fineract/libs
-RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
+RUN wget -q https://dlm.mariadb.com/1658656/connectors/java/connector-java-2.7.3/mariadb-java-client-2.7.3.jar
 
 # =========================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,11 +43,11 @@ services:
     depends_on:
       - fineractmysql
     environment:
-      - DRIVERCLASS_NAME=org.drizzle.jdbc.DrizzleDriver
+      - DRIVERCLASS_NAME=org.mariadb.jdbc.Driver
       - PROTOCOL=jdbc
-      - SUB_PROTOCOL=mysql:thin
-      - fineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver
-      - fineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+      - SUB_PROTOCOL=mariadb
+      - fineract_tenants_driver=org.mariadb.jdbc.Driver
+      - fineract_tenants_url=jdbc:mariadb://fineractmysql:3306/fineract_tenants
       - fineract_tenants_uid=root
       - fineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca
       - FINERACT_DEFAULT_TENANTDB_HOSTNAME=fineractmysql


### PR DESCRIPTION
## Description

Driver has been changed in docker-compose.yml and Dockerfile in order to use MariaDB Driver

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
