### PR TITLE
groups list and accountNo field data type fixed in swagger resource (FINERACT-1364)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
@@ -207,10 +207,24 @@ final class ClientsApiResourceSwagger {
 
         }
 
+        static final class GetClientsGroups {
+
+            private GetClientsGroups() {}
+
+            @Schema(example = "000000001")
+            public Long id;
+            @Schema(example = "000000002")
+            public String accountNo;
+            @Schema(example = "Group name")
+            public String name;
+            @Schema(example = "000000003")
+            public Long externalId;
+        }
+
         @Schema(example = "27")
         public Integer id;
         @Schema(example = "000000027")
-        public Long accountNo;
+        public String accountNo;
         public GetClientsClientIdStatus status;
         @Schema(example = "true")
         public Boolean active;
@@ -232,7 +246,7 @@ final class ClientsApiResourceSwagger {
         @Schema(example = "account overdraft")
         public String savingsProductName;
         @Schema(example = "[]")
-        public List<String> groups;
+        public List<GetClientsGroups> groups;
     }
 
     @Schema(description = "PostClientsRequest")
@@ -385,7 +399,7 @@ final class ClientsApiResourceSwagger {
             @Schema(example = "1")
             public Integer id;
             @Schema(example = "000000001")
-            public Long accountNo;
+            public String accountNo;
             @Schema(example = "456")
             public Integer externalId;
             @Schema(example = "1")
@@ -447,7 +461,7 @@ final class ClientsApiResourceSwagger {
             @Schema(example = "7")
             public Integer id;
             @Schema(example = "000000007")
-            public Long accountNo;
+            public String accountNo;
             @Schema(example = "2")
             public Integer productId;
             @Schema(example = "Other product")


### PR DESCRIPTION
## Description
- While fetching the client data the list of group(Object) is returned but in swagger resource the List<String> is defined. Hence fixed this issue by changing the type of field groups
- `accountNo` field in loan/savings account is defined as Long but returned is String. Fixed this issue.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
