### PR TITLE
swagger resource fixed for creating datatable & entries (FINERACT-1365)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
@@ -283,7 +283,7 @@ public class DatatablesApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Create Entry in Data Table", description = "Adds a row to the data table.\n" + "\n"
             + "Note that the default datatable UI functionality converts any field name containing spaces to underscores when using the API. This means the field name \"Business Description\" is considered the same as \"Business_Description\". So you shouldn't have both \"versions\" in any data table.")
-    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = DatatablesApiResourceSwagger.PostDataTablesAppTableIdRequest.class)))
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = String.class)), description = "{\n  \"BusinessDescription\": \"Livestock sales\",\n  \"Comment\": \"First comment made\",\n  \"Education_cv\": \"Primary\",\n  \"Gender_cd\": 6,\n  \"HighestRatePaid\": 8.5,\n  \"NextVisit\": \"01 October 2012\",\n  \"YearsinBusiness\": 5,\n  \"dateFormat\": \"dd MMMM yyyy\",\n  \"locale\": \"en\"\n}")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DatatablesApiResourceSwagger.PostDataTablesAppTableIdResponse.class))) })
     public String createDatatableEntry(@PathParam("datatable") @Parameter(description = "datatable") final String datatable,

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
@@ -50,17 +50,32 @@ final class DatatablesApiResourceSwagger {
     @Schema(description = "PostDataTablesRequest")
     public static final class PostDataTablesRequest {
 
-        private PostDataTablesRequest() {
+        private PostDataTablesRequest() {}
 
+        static final class PostColumnHeaderData {
+
+            private PostColumnHeaderData() {}
+
+            @Schema(required = true, example = "DOB")
+            public String name;
+            @Schema(required = true, example = "String", description = "Any of them: Boolean | Date | DateTime | Decimal | Dropdown | Number | String | Text")
+            public String type;
+            @Schema(example = "Gender", description = "Used in Code Value fields. Column name becomes: code_cd_name. Mandatory if using type Dropdown, otherwise an error is returned.")
+            public String code;
+            @Schema(example = "true", description = "Defaults to false")
+            public Boolean mandatory;
+            @Schema(example = "1653", description = "Length of the text field. Mandatory if type String is used, otherwise an error is returned.")
+            public Long length;
         }
 
-        @Schema(example = "m_client")
-        public String applicationTableName;
-        @Schema(example = "extra_client_details")
-        public String registeredTableName;
+        @Schema(required = true, example = "m_client")
+        public String apptableName;
+        @Schema(required = true, example = "extra_client_details")
+        public String datatableName;
         @Schema(required = false, description = "Allows to create multiple entries in the Data Table. Optional, defaults to false. If this property is not provided Data Table will allow only one entry.", example = "true")
         public boolean multiRow;
-        public List<ResultsetColumnHeaderData> columnHeaderData;
+        @Schema(required = true)
+        public List<PostColumnHeaderData> columns;
     }
 
     @Schema(description = "PostDataTablesResponse")


### PR DESCRIPTION
## Description

Fixed the `PostDataTablesRequest` in `DatatablesApiResourcesSwagger`, for creating the datable. Also fixed the entry creating endpoint in `createDatatableEntry` in `SatablesApiResource` file.

Fore more info checkout  [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-1365).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
