### PR TITLE
datatable field added in client swagger resource (FINERACT-1363)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.client.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -240,6 +241,17 @@ final class ClientsApiResourceSwagger {
 
         private PostClientsRequest() {}
 
+        static final class PostClientsDatatable {
+
+            private PostClientsDatatable() {}
+
+            @Schema(example = "Client Beneficiary information")
+            public String registeredTableName;
+            @Schema(example = "data")
+            public HashMap<String, Object> data;
+
+        }
+
         @Schema(example = "1")
         public Integer officeId;
         @Schema(example = "Client of group")
@@ -254,6 +266,9 @@ final class ClientsApiResourceSwagger {
         public Boolean active;
         @Schema(example = "04 March 2009")
         public String activationDate;
+        @Schema(description = "List of PostClientsDatatable")
+        public List<PostClientsDatatable> datatables;
+
     }
 
     @Schema(description = "PostClientsResponse")


### PR DESCRIPTION
## Description

Added new schema `PostClientsDatatable` which is used while creating the client. Earlier the the client creating model (`PostClientsRequest`) doesn't have a `datatables` field but a List of datable is required incase the entity is associated with any databale.

For more info see [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-1363).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
