### PR TITLE
field name issue fixed FINERACT-1382

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResourceSwagger.java
@@ -320,7 +320,9 @@ final class SavingsAccountsApiResourceSwagger {
         @Schema(example = "en")
         public String locale;
         @Schema(example = "05 September 2014")
-        public String unassignedDate;
+        public String approvedOnDate;
+        @Schema(example = "05 September 2014")
+        public String activatedOnDate;
     }
 
     @Schema(description = "PostSavingsAccountsAccountIdResponse")

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apache.fineract.client.models.PostSavingsAccountsAccountIdRequest;
+import org.apache.fineract.client.models.PostSavingsAccountsAccountIdResponse;
+import org.apache.fineract.client.models.PostSavingsAccountsRequest;
+import org.apache.fineract.client.models.PostSavingsAccountsResponse;
+import org.apache.fineract.integrationtests.client.IntegrationTest;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Response;
+
+/**
+ * Integration Test for /savingsaccounts API.
+ *
+ * @author Danish Jamal
+ *
+ */
+public class SavingsAccountsTest extends IntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SavingsAccountsTest.class);
+    private final String dateFormat = "dd MMMM yyyy";
+    private final String locale = "en";
+    private final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd MMM yyyy");
+    private final String formattedDate = simpleDateFormat.format(new Date());
+    private int savingId = 1;
+
+    @Test
+    @Order(1)
+    void submitSavingsAccountsApplication() {
+        LOG.info("------------------------------ CREATING NEW SAVINGS ACCOUNT APPLICATION ---------------------------------------");
+        PostSavingsAccountsRequest request = new PostSavingsAccountsRequest();
+        request.setClientId(1);
+        request.setProductId(1);
+        request.setLocale(locale);
+        request.setDateFormat(dateFormat);
+        request.submittedOnDate(formattedDate);
+
+        Response<PostSavingsAccountsResponse> response = okR(fineract().savingsAccounts.submitApplication2(request));
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNotNull();
+        savingId = response.body().getSavingsId();
+    }
+
+    @Test
+    @Order(2)
+    void approveSavingsAccount() {
+        LOG.info("------------------------------ APPROVING SAVINGS ACCOUNT ---------------------------------------");
+        PostSavingsAccountsAccountIdRequest request = new PostSavingsAccountsAccountIdRequest();
+        request.dateFormat(dateFormat);
+        request.setLocale(locale);
+        request.setApprovedOnDate(formattedDate);
+        Response<PostSavingsAccountsAccountIdResponse> response = okR(
+                fineract().savingsAccounts.handleCommands6((long) savingId, request, "approve"));
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNotNull();
+    }
+
+    @Test
+    @Order(3)
+    void activateSavingsAccount() {
+        LOG.info("------------------------------ ACTIVATING SAVINGS ACCOUNT ---------------------------------------");
+        PostSavingsAccountsAccountIdRequest request = new PostSavingsAccountsAccountIdRequest();
+        request.dateFormat(dateFormat);
+        request.setLocale(locale);
+        request.setActivatedOnDate(formattedDate);
+        Response<PostSavingsAccountsAccountIdResponse> response = okR(
+                fineract().savingsAccounts.handleCommands6((long) savingId, request, "activate"));
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNotNull();
+    }
+
+}


### PR DESCRIPTION
## Description

`unassignedDate` field renamed to `approvedOnDate`, to meet the api expectations.

[JIRA ticket #1382](https://issues.apache.org/jira/browse/FINERACT-1382).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
