### PR TITLE
type of accountingMappingOptions field changed to GetSavingsProductsAcuntingMappingOptions (FINERACT-1378)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
@@ -719,7 +719,7 @@ final class SavingsProductsApiResourceSwagger {
         public Set<GetSavingsProductsWithdrawalFeeTypeOptions> withdrawalFeeTypeOptions;
         public Set<GetSavingsProductsPaymentTypeOptions> paymentTypeOptions;
         public Set<GetSavingsProductsTemplateAccountingRule> accountingRuleOptions;
-        public Set<GetSavingsProductsAccountingMappingOptions> accountingMappingOptions;
+        public GetSavingsProductsAccountingMappingOptions accountingMappingOptions;
         public Set<GetSavingsProductsChargeOptions> chargeOptions;
     }
 


### PR DESCRIPTION
## Description

Type of field `accountingMappingOptions` changed to `GetSavingsProductsAcuntingMappingOptions`, earlier was `Set< GetSavingsProductsAcuntingMappingOptions>`.
This change is required because the actual returns object bu in generated client class it was defined as list of objects.

For more info refer [Apache Fineract JIRA ticket #1378](https://issues.apache.org/jira/browse/FINERACT-1378).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
