### PR TITLE
missing field added in GetSavingsProductsPaymentTypeOptions (FINERACT-1377)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
@@ -471,6 +471,10 @@ final class SavingsProductsApiResourceSwagger {
             public String name;
             @Schema(example = "0")
             public Integer position;
+            @Schema(example = "Money Transfer")
+            public String description;
+            @Schema(example = "true")
+            public Boolean isCashPayment;
         }
 
         static final class GetSavingsProductsAccountingMappingOptions {


### PR DESCRIPTION
## Description

Missing field `isCashPayment` and `description` added in `GetSavingsProductsPaymentTypeOptions`.

For more info refer [Apache Fineract JIRA ticket #1377](https://issues.apache.org/jira/browse/FINERACT-1377).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
