### PR TITLE
field renamed in various places of SavingsProductsApiResourceSwagger (FINERACT-1376)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsProductsApiResourceSwagger.java
@@ -148,7 +148,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savings.interest.period.savingsCompoundingInterestPeriodType.daily")
             public String code;
             @Schema(example = "Daily")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsInterestPostingPeriodType {
@@ -160,7 +160,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savings.interest.posting.period.savingsPostingInterestPeriodType.monthly")
             public String code;
             @Schema(example = "Monthly")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsInterestCalculationType {
@@ -172,7 +172,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savingsInterestCalculationType.dailybalance")
             public String code;
             @Schema(example = "Daily Balance")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsInterestCalculationDaysInYearType {
@@ -184,7 +184,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savingsInterestCalculationDaysInYearType.days365")
             public String code;
             @Schema(example = "365 Days")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsAccountingRule {
@@ -196,7 +196,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "accountingRuleType.cash")
             public String code;
             @Schema(example = "CASH BASED")
-            public String description;
+            public String value;
         }
 
         @Schema(example = "1")
@@ -434,7 +434,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "accountingRuleType.none")
             public String code;
             @Schema(example = "NONE")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsLockinPeriodFrequencyTypeOptions {
@@ -446,7 +446,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savings.lockin.savingsPeriodFrequencyType.days")
             public String code;
             @Schema(example = "Days")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsWithdrawalFeeTypeOptions {
@@ -458,7 +458,7 @@ final class SavingsProductsApiResourceSwagger {
             @Schema(example = "savingsWithdrawalFeesType.flat")
             public String code;
             @Schema(example = "Flat")
-            public String description;
+            public String value;
         }
 
         static final class GetSavingsProductsPaymentTypeOptions {


### PR DESCRIPTION
## Description

`description` field renamed to `value` in following classes in `SavingsProductsApiResourceSwagger `.
- GetSavingsProductsInterestCompoundingPeriodType
- GetSavingsProductsInterestPostingPeriodType
- GetSavingsProductsInterestCalculationType
- GetSavingsProductsInterestCalculationDaysInYearType
- GetSavingsProductsTemplateAccountingRule
- GetSavingsProductsLockinPeriodFrequencyTypeOptions
- GetSavingsProductsWithdrawalFeeTypeOptions
- GetSavingsProductsTemplateAccountingRule

For more info refer [Apache Fineract JIRA ticket #1376](https://issues.apache.org/jira/browse/FINERACT-1376).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
