### PR TITLE
invalid field name fixed in GetDataTablesResponse (FINERACT-1372)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
@@ -41,10 +41,10 @@ final class DatatablesApiResourceSwagger {
         }
 
         @Schema(example = "m_client")
-        public String appTableName;
+        public String applicationTableName;
         @Schema(example = "extra_client_details")
-        public String datatableName;
-        public List<ResultsetColumnHeaderData> column;
+        public String registeredTableName;
+        public List<ResultsetColumnHeaderData> columnHeaderData;
     }
 
     @Schema(description = "PostDataTablesRequest")


### PR DESCRIPTION
## Description

Field renamed to match the api actual response, below are the fields renamed.
- `appTableName` to `applicationTableName`
- `datatableName` to `registeredTableName`
- `column` to `columnHeaderData`

For more info refer [Apache Fineract JIRA ticket #1372](https://issues.apache.org/jira/browse/FINERACT-1372).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
