### PR TITLE
missing field added in ResultsetColumnHeaderData (FINERACT-1385)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetColumnHeaderData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetColumnHeaderData.java
@@ -33,7 +33,6 @@ public final class ResultsetColumnHeaderData implements Serializable {
     private final Long columnLength;
     private final String columnDisplayType;
     private final boolean isColumnNullable;
-    @SuppressWarnings("unused")
     private final boolean isColumnPrimaryKey;
 
     private final List<ResultsetColumnValueData> columnValues;
@@ -225,6 +224,14 @@ public final class ResultsetColumnHeaderData implements Serializable {
 
     public Long getColumnLength() {
         return this.columnLength;
+    }
+
+    public boolean getIsColumnNullable() {
+        return isColumnNullable;
+    }
+
+    public boolean getIsColumnPrimaryKey() {
+        return isColumnPrimaryKey;
     }
 
     public String getColumnDisplayType() {


### PR DESCRIPTION
## Description

`isColumnNullable` and `isColumnPrimaryKey` getter added for the fields to be generated in `ResultsetColumnHeaderData`.

For more info refer [Apache Fineract JIRA ticket #1385](https://issues.apache.org/jira/browse/FINERACT-1385).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
