### PR TITLE
missing field added in ClientsApiResourceSwagger (FINERACT-1387)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
@@ -429,7 +429,7 @@ final class ClientsApiResourceSwagger {
                 @Schema(example = "savingsAccountStatusType.submitted.and.pending.approval")
                 public String code;
                 @Schema(example = "Submitted and pending approval")
-                public String description;
+                public String value;
                 @Schema(example = "true")
                 public Boolean submittedAndPendingApproval;
                 @Schema(example = "false")
@@ -442,6 +442,26 @@ final class ClientsApiResourceSwagger {
                 public Boolean active;
                 @Schema(example = "false")
                 public Boolean closed;
+                @Schema(example = "false")
+                public Boolean prematureClosed;
+                @Schema(example = "false")
+                public Boolean transferInProgress;
+                @Schema(example = "false")
+                public Boolean transferOnHold;
+                @Schema(example = "false")
+                public Boolean matured;
+            }
+
+            static final class GetClientsSavingsAccountsDepositType {
+
+                private GetClientsSavingsAccountsDepositType() {}
+
+                @Schema(example = "100")
+                public Integer id;
+                @Schema(example = "depositAccountType.savingsDeposit")
+                public String code;
+                @Schema(example = "Savings")
+                public String value;
             }
 
             @Schema(example = "7")
@@ -452,8 +472,11 @@ final class ClientsApiResourceSwagger {
             public Integer productId;
             @Schema(example = "Other product")
             public String productName;
+            @Schema(example = "OP")
+            public String shortProductName;
             public GetClientsSavingsAccountsStatus status;
             public GetClientsSavingsAccountsCurrency currency;
+            public GetClientsSavingsAccountsDepositType depositType;
         }
 
         public Set<GetClientsLoanAccounts> loanAccounts;


### PR DESCRIPTION
## Description

Missing fields added in `ClientsApiResourceSwagger` for the endpoint fetching clients account using the endpoint `clients/{clientId}/accounts`.

For more info refer  [Apache Fineract JIRA ticket #1387](https://issues.apache.org/jira/browse/FINERACT-1387).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
