### PR TITLE
FINERACT-982 - Completely ditch use of Drizzle JDBC Driver after all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ./gradlew --no-daemon -q -x rat -x compileTestJava -x test -x spotlessJavaCh
 # allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
 # The commented out lines in the docker-compose.yml illustrate how to do this.
 WORKDIR /fineract/libs
-RUN wget -q https://dlm.mariadb.com/1658656/connectors/java/connector-java-2.7.3/mariadb-java-client-2.7.3.jar
+RUN wget -q https://downloads.mariadb.com/Connectors/java/connector-java-2.7.3/mariadb-java-client-2.7.3.jar
 
 # =========================================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ./gradlew --no-daemon -q -x rat -x compileTestJava -x test -x spotlessJavaCh
 # allowing implementations to switch the driver used by changing start-up parameters (for both tenants and each tenant DB)
 # The commented out lines in the docker-compose.yml illustrate how to do this.
 WORKDIR /fineract/libs
-RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
+RUN wget -q https://dlm.mariadb.com/1658656/connectors/java/connector-java-2.7.3/mariadb-java-client-2.7.3.jar
 
 # =========================================
 

--- a/LICENSE_RELEASE
+++ b/LICENSE_RELEASE
@@ -243,9 +243,9 @@ This product bundles DOM4J, Copyright 2001-2005 (C) MetaStuff, Ltd.,
 which is available under a BSD license.
 For details, see licenses/binary/Dom4J.BSD
 
-This product bundles JDBC driver for MySQL and Drizzle v1.3, Copyright (c)
-2009-2013, Marcus Eriksson which is available under a BSD license.
-For details, see licenses/binary/Drizzle.BSD
+This product bundles JDBC driver for MariaDB v2.7.3, Copyright (c)
+which is available under a LGPL license.
+For details, see https://mariadb.com/kb/en/about-mariadb-connector-j/#license
 
 This product bundles Ical4J v1.0.4, Copyright (c) 2012, Ben Fortuna,
 which is available under a BSD license.

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ allprojects  {
             dependency 'com.google.truth.extensions:truth-java8-extension:1.1.3'
             dependency 'org.apache.commons:commons-email:1.5'
             dependency 'commons-io:commons-io:2.11.0'
-            dependency 'org.drizzle.jdbc:drizzle-jdbc:1.4'
+            dependency 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
             dependency 'com.github.librepdf:openpdf:1.3.26'
             dependency 'org.mnode.ical4j:ical4j:3.1.0'
             dependency 'org.quartz-scheduler:quartz:2.3.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,9 @@ version: '3.7'
 services:
   # Backend service
   fineractmysql:
-    image: mysql:5.7
+    image: mariadb:10.2
     volumes:
+      - ./fineract-db/server_collation.cnf:/etc/mysql/conf.d/server_collation.cnf
       - ./fineract-db/docker:/docker-entrypoint-initdb.d:Z,ro
     restart: always
     environment:
@@ -43,11 +44,11 @@ services:
     depends_on:
       - fineractmysql
     environment:
-      - DRIVERCLASS_NAME=org.drizzle.jdbc.DrizzleDriver
+      - DRIVERCLASS_NAME=org.mariadb.jdbc.Driver
       - PROTOCOL=jdbc
-      - SUB_PROTOCOL=mysql:thin
-      - fineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver
-      - fineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+      - SUB_PROTOCOL=mariadb
+      - fineract_tenants_driver=org.mariadb.jdbc.Driver
+      - fineract_tenants_url=jdbc:mariadb://fineractmysql:3306/fineract_tenants
       - fineract_tenants_uid=root
       - fineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca
       - FINERACT_DEFAULT_TENANTDB_HOSTNAME=fineractmysql

--- a/fineract-db/server_collation.cnf
+++ b/fineract-db/server_collation.cnf
@@ -1,0 +1,10 @@
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+collation-server=utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server=utf8mb4

--- a/fineract-db/server_collation.cnf
+++ b/fineract-db/server_collation.cnf
@@ -1,3 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 [client]
 default-character-set=utf8mb4
 

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -207,7 +207,7 @@ configurations {
     driver
 }
 dependencies {
-    driver 'org.drizzle.jdbc:drizzle-jdbc:1.4'
+    driver 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
 }
 
 URLClassLoader loader = GroovyObject.class.classLoader
@@ -218,7 +218,7 @@ configurations.driver.each {File file ->
 task createDB {
     description= "Creates the Database. Needs database name to be passed (like: -PdbName=someDBname)"
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mariadb://localhost:3306/', mysqlUser, mysqlPassword, 'org.mariadb.jdbc.Driver' )
         sql.execute( 'create database '+"`$dbName`" )
     }
 }
@@ -226,13 +226,13 @@ task createDB {
 task dropDB {
     description= "Drops the specified database. The database name has to be passed (like: -PdbName=someDBname)"
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mariadb://localhost:3306/', mysqlUser, mysqlPassword, 'org.mariadb.jdbc.Driver' )
         sql.execute( 'DROP DATABASE '+"`$dbName`")
     }
 }
 task setBlankPassword {
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mariadb://localhost:3306/', mysqlUser, mysqlPassword, 'org.mariadb.jdbc.Driver' )
         sql.execute('USE `fineract_tenants`')
         sql.execute('UPDATE fineract_tenants.tenants SET schema_server = \'localhost\', schema_server_port = \'3306\', schema_username = \'mifos\', schema_password = \'mysql\' WHERE id=1;')
     }

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -59,7 +59,7 @@ dependencies {
             'org.apache.poi:poi-ooxml-schemas',
             'org.apache.tika:tika-core',
 
-            'org.drizzle.jdbc:drizzle-jdbc',
+            'org.mariadb.jdbc:mariadb-java-client',
             'org.flywaydb:flyway-core',
 
             'com.github.librepdf:openpdf',

--- a/fineract-provider/src/main/resources/META-INF/spring/jdbc.properties
+++ b/fineract-provider/src/main/resources/META-INF/spring/jdbc.properties
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-DRIVERCLASS_NAME:org.drizzle.jdbc.DrizzleDriver
+DRIVERCLASS_NAME:org.mariadb.jdbc.Driver
 PROTOCOL:jdbc
-SUB_PROTOCOL:mysql:thin
+SUB_PROTOCOL:mariadb
 
-fineract_tenants_driver:org.drizzle.jdbc.DrizzleDriver
-fineract_tenants_url:jdbc:mysql:thin://localhost:3306/fineract_tenants
+fineract_tenants_driver:org.mariadb.jdbc.Driver
+fineract_tenants_url:jdbc:mariadb://localhost:3306/fineract_tenants
 fineract_tenants_uid:root
 fineract_tenants_pwd:mysql

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V342__topic_module_table.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V342__topic_module_table.sql
@@ -38,8 +38,8 @@ CREATE TABLE IF NOT EXISTS `topic_subscriber` (
   CONSTRAINT `fk_topic_has_m_appuser_m_appuser1` FOREIGN KEY (`user_id`) REFERENCES `m_appuser` (`id`)
 ) ENGINE = InnoDB;
 
-INSERT INTO topic (enabled, entity_type, entity_id, member_type, title) SELECT true, 'OFFICE', o.id as entity_id, UPPER(r.name) as member_type, CONCAT(r.name, ' of ', o.name) as title FROM m_office o, m_role r WHERE o.parent_id IS NULL AND CONCAT(r.name, ' of ', o.name) NOT IN (SELECT title FROM topic);
+INSERT INTO topic (enabled, entity_type, entity_id, member_type, title) SELECT true, 'OFFICE', o.id as entity_id, UPPER(r.name) as member_type, CONCAT(r.name, ' of ', o.name) as title FROM m_office o, m_role r WHERE o.parent_id IS NULL AND CONCAT(r.name, ' of ', o.name) COLLATE utf8mb4_general_ci  NOT IN (SELECT title FROM topic);
 
-INSERT INTO topic (enabled, entity_type, entity_id, member_type, title) SELECT true, 'BRANCH', o.id as entity_id, UPPER(r.name) as member_type, CONCAT(r.name, ' of ', o.name) as title FROM m_office o, m_role r WHERE o.parent_id IS NOT NULL AND CONCAT(r.name, ' of ', o.name) NOT IN (SELECT title FROM topic);
+INSERT INTO topic (enabled, entity_type, entity_id, member_type, title) SELECT true, 'BRANCH', o.id as entity_id, UPPER(r.name) as member_type, CONCAT(r.name, ' of ', o.name) as title FROM m_office o, m_role r WHERE o.parent_id IS NOT NULL AND CONCAT(r.name, ' of ', o.name) COLLATE utf8mb4_general_ci NOT IN (SELECT title FROM topic);
 
-INSERT INTO topic_subscriber( user_id, topic_id, subscription_date ) SELECT u.id AS user_id, t.id AS topic_id, NOW() FROM topic t, m_appuser u, m_appuser_role ur, m_role r WHERE u.office_id = t.entity_id AND u.id = ur.appuser_id AND ur.role_id = r.id AND r.name = t.member_type AND NOT EXISTS (SELECT user_id, topic_id FROM topic_subscriber WHERE user_id = u.id AND topic_id = t.id);
+INSERT INTO topic_subscriber( user_id, topic_id, subscription_date ) SELECT u.id AS user_id, t.id AS topic_id, NOW() FROM topic t, m_appuser u, m_appuser_role ur, m_role r WHERE u.office_id = t.entity_id AND u.id = ur.appuser_id AND ur.role_id = r.id AND r.name COLLATE utf8mb4_general_ci  = t.member_type AND NOT EXISTS (SELECT user_id, topic_id FROM topic_subscriber WHERE user_id = u.id AND topic_id = t.id);

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V352__interop_init.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V352__interop_init.sql
@@ -44,7 +44,7 @@ INSERT INTO `m_appuser`
 VALUES (NULL, 0, 1, NULL, @interop_username, 'Interop', 'User', '5787039480429368bf94732aacc771cd0a3ea02bcf504ffe1185ab94213bc63a',
                             'email@email.com', b'0', b'1', b'1', b'1', b'1', CURDATE(), 0, b'0');
 
-INSERT INTO `m_appuser_role` VALUES ((SELECT id FROM m_appuser WHERE username = @interop_username), 1);
+INSERT INTO `m_appuser_role` VALUES ((SELECT id FROM m_appuser WHERE username COLLATE utf8mb4_general_ci = @interop_username), 1);
 
 -- Interoperation permissions
 

--- a/kubernetes/fineract-server-deployment.yml
+++ b/kubernetes/fineract-server-deployment.yml
@@ -82,15 +82,15 @@ spec:
           periodSeconds: 1
         env:
         - name: DRIVERCLASS_NAME
-          value: org.drizzle.jdbc.DrizzleDriver
+          value: org.mariadb.jdbc.Driver
         - name: PROTOCOL
           value: jdbc
         - name: SUB_PROTOCOL
-          value: mysql:thin
+          value: mariadb
         - name: fineract_tenants_driver
-          value: org.drizzle.jdbc.DrizzleDriver
+          value: org.mariadb.jdbc.Driver
         - name: fineract_tenants_url
-          value: jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+          value: jdbc:mariadb://fineractmysql:3306/fineract_tenants
         - name: fineract_tenants_uid
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Description

Changes were done for replacing the Drizzle JDBC Driver as per issue reported at FINERACT-982 - Completely ditch use of Drizzle JDBC Driver after all. Now using MariaDB with charset utf8mb4 and collation utf8_unicode_ci

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
