### PR TITLE
[FINERACT-1404] fix loan provisioning entry deduplication

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/domain/LoanProductProvisioningEntry.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/domain/LoanProductProvisioningEntry.java
@@ -143,4 +143,11 @@ public class LoanProductProvisioningEntry extends AbstractPersistableCustom {
         return Objects.hash(entry.getId(), criteriaId, office.getId(), currencyCode, loanProduct.getId(), provisioningCategory.getId(),
                 overdueInDays, reservedAmount, liabilityAccount.getId(), expenseAccount.getId());
     }
+
+    public int partialHashCode() {
+        // this is used to group together all the entries that have similar parameters (excluding the amount reserved)
+        // rather than a check for if the objects are the same based on their values, this tells if they are similar
+        return Objects.hash(entry.getId(), criteriaId, office.getId(), currencyCode, loanProduct.getId(), provisioningCategory.getId(),
+                overdueInDays, liabilityAccount.getId(), expenseAccount.getId());
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl.java
@@ -230,7 +230,7 @@ public class ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl implements
     private Collection<LoanProductProvisioningEntry> generateLoanProvisioningEntry(ProvisioningEntry parent, Date date) {
         Collection<LoanProductProvisioningEntryData> entries = this.provisioningEntriesReadPlatformService
                 .retrieveLoanProductsProvisioningData(date);
-        Map<LoanProductProvisioningEntry, LoanProductProvisioningEntry> provisioningEntries = new HashMap<>();
+        Map<Integer, LoanProductProvisioningEntry> provisioningEntries = new HashMap<>();
         for (LoanProductProvisioningEntryData data : entries) {
             LoanProduct loanProduct = this.loanProductRepository.findById(data.getProductId()).get();
             Office office = this.officeRepositoryWrapper.findOneWithNotFoundDetection(data.getOfficeId());
@@ -245,10 +245,10 @@ public class ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl implements
                     provisioningCategory, data.getOverdueInDays(), amountToReserve.getAmount(), liabilityAccount, expenseAccount,
                     criteraId);
             entry.setProvisioningEntry(parent);
-            if (!provisioningEntries.containsKey(entry)) {
-                provisioningEntries.put(entry, entry);
+            if (!provisioningEntries.containsKey(entry.partialHashCode())) {
+                provisioningEntries.put(entry.partialHashCode(), entry);
             } else {
-                LoanProductProvisioningEntry entry1 = provisioningEntries.get(entry);
+                LoanProductProvisioningEntry entry1 = provisioningEntries.get(entry.partialHashCode());
                 entry1.addReservedAmount(entry.getReservedAmount());
             }
         }


### PR DESCRIPTION
## Description

The previous/current approach to removing duplicates from the `LoanProductProvisioningEntry` collection generated is to check for equality between two objects and add the reserved amount of one to the other if they are the same. This doesn't take into account the possibility that the new total amount may make the object similar to another object in the collection. 

The change I'm proposing is to group the similar entries before considering the reserved amount. So if the only difference between two entries is the reserve amount, we should sum up their values. Any other entries that remain will have at least some other field that is different and shouldn't cause duplicates. 

See details in [FINERACT-1404](https://issues.apache.org/jira/browse/FINERACT-1404).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
