### PR TITLE
Upgrade JaCoco version to 0.8.7 for suporting JDK 17 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 // TODO: this is work in progress, please follow FINERACT-1171
 buildscript {
     ext {
-        jacocoVersion = '0.8.6'
+        jacocoVersion = '0.8.7'
         retrofitVersion = '2.9.0'
         okhttpVersion = '4.9.1'
         oltuVersion = '1.0.1'


### PR DESCRIPTION
## Description

With the upgrade to JaCoco 0.8.7 the Fineract Code Base will be prepared to be tested with the new JDK 17 which extends the support until 2026 it is related to https://issues.apache.org/jira/browse/FINERACT-1407

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
