### PR TITLE
Use of Azul Zulu JDK 11 LTS (FINERACT-1416)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,17 +41,24 @@ addons:
 # See https://issues.apache.org/jira/browse/FINERACT-937 for background re. what below is all about..
 # We basically remove the outdated OpenJDK 11.0.2 which Travis image grabbed from java.net in
 # https://github.com/travis-ci/travis-cookbooks/blob/master/cookbooks/travis_jdk/files/install-jdk.sh#L200
-# (which has 11.0.2 hard-coded!), and instead replace it with the latest openjdk-11-jdk-headless Ubuntu package.
+# (which has 11.0.2 hard-coded!), and instead replace it with the latest Azul Zulu Debian package.
 # NB /usr/local/lib/jvm/openjdk11/bin is also on the PATH, but there's no need to change it (because we rm -rf anyway)
+# Installing Azul Zulu as per official instructions https://docs.azul.com/core/zulu-openjdk/install/debian
 before_install:
   - echo $JAVA_HOME
   - which java
   - sudo rm -rf /usr/local/lib/jvm/
-  - sudo apt-get install -y openjdk-11-jdk-headless
-  - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-  - which java
-  - java -version
-  - $JAVA_HOME/bin/java -version
+
+install:
+  - unset _JAVA_OPTIONS
+  - sudo apt-get -q update
+  - sudo apt-get -yq install gnupg curl
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+  - curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+  - sudo apt-get -yq install ./zulu-repo_1.0.0-3_all.deb
+  - sudo apt-get -q update
+  - sudo apt-get -yq install zulu11-jdk
+  - export JAVA_HOME=/usr/lib/jvm/zulu11
   - echo "USE mysql;\nALTER USER 'root'@'localhost' IDENTIFIED BY 'mysql';\n" | mysql -u root
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_tenants`;'
   - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_default`;'
@@ -67,6 +74,17 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.m2
+
+# Check Java environment variables
+before_script:
+  - echo $JDK_JAVA_OPTIONS
+  - echo $JAVA_OPTIONS
+  - echo $JAVA_HOME
+  - which java
+  - java -version
+  - which javac
+  - javac -version
+  - $JAVA_HOME/bin/java -version
 
 # NOTE: We used to run with --info, which is quite a bit more verbose, but is VERY useful to understand failures on Travis,
 # where you do not have access to any files like build/reports/tests/index.html, only the Console.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:11 AS builder
+FROM azul/zulu-openjdk-debian:11 AS builder
 
 RUN apt-get update -qq && apt-get install -y wget
 
@@ -34,11 +34,17 @@ RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mys
 
 # =========================================
 
-FROM gcr.io/distroless/java:11 as fineract
+FROM azul/zulu-openjdk-alpine:11 AS fineract
 
 COPY --from=builder /fineract/fineract-provider/build/libs /app
 COPY --from=builder /fineract/libs /app/libs
 
-WORKDIR /app
+WORKDIR /
 
-ENTRYPOINT ["java", "-Dloader.path=/app/libs/", "-jar", "/app/fineract-provider.jar"]
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod 775 /entrypoint.sh
+
+EXPOSE 8443
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+while ! nc -zvw3 fineractmysql 3306 ; do
+    >&2 echo "DB Server is unavailable - sleeping"
+    sleep 5
+done
+>&2 echo "DB Server is up - executing command"
+
+java -Dloader.path=/app/libs/ -jar /app/fineract-provider.jar
+


### PR DESCRIPTION
## Description

Use of Azul Zulu JDK 11 LTS (FINERACT-1416) in Dockerfile, Travis-CI file and a entrypoint was added to have a better control when starting Fineract for checking the DB service status (Fineract was booting before the DB Server using the docker-compose command).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
