### PR TITLE
Use environment variable for mysql server availability check in dockerfile entrypoint (FINERACT-1163)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,10 @@
 
 set -e
 
-while ! nc -zvw3 fineractmysql 3306 ; do
+while ! nc -zvw3 $FINERACT_DEFAULT_TENANTDB_HOSTNAME $FINERACT_DEFAULT_TENANTDB_PORT ; do
     >&2 echo "DB Server is unavailable - sleeping"
     sleep 5
 done
 >&2 echo "DB Server is up - executing command"
 
 java -Dloader.path=/app/libs/ -jar /app/fineract-provider.jar
-


### PR DESCRIPTION
## Description
Get the database location from environment variable instead of using hardcoded values [FINERACT-1163](https://issues.apache.org/jira/browse/FINERACT-1163)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
