### PR TITLE
FINERACT-1429 : FD Interest Transfer on a backdated account

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -102,4 +102,6 @@ public interface ConfigurationDomainService {
     String getAccountMappingForPaymentType();
 
     String getAccountMappingForCharge();
+
+    boolean isNextDayFixedDepositInterestTransferEnabledForPeriodEnd();
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
@@ -393,4 +393,11 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
         return defaultValue;
     }
 
+    @Override
+    public boolean isNextDayFixedDepositInterestTransferEnabledForPeriodEnd() {
+        final String propertyName = "fixed-deposit-transfer-interest-next-day-for-period-end-posting";
+        final GlobalConfigurationPropertyData property = getGlobalConfigurationPropertyData(propertyName);
+        return property.isEnabled();
+    }
+
 }

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V375__transfer_fixed_deposit_interest_next_day_for_period_end_posting.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V375__transfer_fixed_deposit_interest_next_day_for_period_end_posting.sql
@@ -1,0 +1,22 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+
+INSERT INTO `c_configuration` (`id`, `name`, `enabled`, `description`)
+VALUES (NULL, 'fixed-deposit-transfer-interest-next-day-for-period-end-posting', '0', "Transfer fixed transfer interest next day(t+1) for period end posting");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
@@ -89,8 +89,8 @@ public class GlobalConfigurationHelper {
         ArrayList<HashMap> actualGlobalConfigurations = getAllGlobalConfigurations(requestSpec, responseSpec);
 
         // There are currently 32 global configurations.
-        Assertions.assertEquals(32, expectedGlobalConfigurations.size());
-        Assertions.assertEquals(32, actualGlobalConfigurations.size());
+        Assertions.assertEquals(33, expectedGlobalConfigurations.size());
+        Assertions.assertEquals(33, actualGlobalConfigurations.size());
 
         for (int i = 0; i < expectedGlobalConfigurations.size(); i++) {
 
@@ -379,6 +379,15 @@ public class GlobalConfigurationHelper {
         isAccountMappedForCharge.put("trapDoor", false);
         isAccountMappedForCharge.put("string_value", "Income");
         defaults.add(isAccountMappedForCharge);
+
+        HashMap<String, Object> isNextDayFixedDepositInterestTransferEnabledForPeriodEnd = new HashMap<>();
+        isNextDayFixedDepositInterestTransferEnabledForPeriodEnd.put("id", 37);
+        isNextDayFixedDepositInterestTransferEnabledForPeriodEnd.put("name",
+                "fixed-deposit-transfer-interest-next-day-for-period-end-posting");
+        isNextDayFixedDepositInterestTransferEnabledForPeriodEnd.put("value", 0);
+        isNextDayFixedDepositInterestTransferEnabledForPeriodEnd.put("enabled", false);
+        isNextDayFixedDepositInterestTransferEnabledForPeriodEnd.put("trapDoor", false);
+        defaults.add(isNextDayFixedDepositInterestTransferEnabledForPeriodEnd);
 
         return defaults;
     }


### PR DESCRIPTION
## Description

There is an erratic behaviour when the transfer job runs and transfers posted interest in a backdated FD account to a linked savings account.

This happens especially when  Interest posting is set to  be in the end of period.

(https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

![screencapture-localhost-9002-2021-11-05-01_31_28](https://user-images.githubusercontent.com/56754851/140411504-2d3557d2-afcc-4454-8ad2-b00b2a19536f.png)


FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
