### PR TITLE
Only use Travis for SonarQube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,7 @@ dist: bionic
 
 language: generic
 
-services:
-  - mysql
-  - docker
-
 addons:
-  apt:
-    packages:
-    - curl
-    - graphviz
-    - gv
   sonarcloud:
     organization: "apache"
     token:
@@ -57,13 +48,8 @@ install:
   - curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
   - sudo apt-get -yq install ./zulu-repo_1.0.0-3_all.deb
   - sudo apt-get -q update
-  - sudo apt-get -yq install zulu17-jdk
-  - export JAVA_HOME=/usr/lib/jvm/zulu17
-  - echo "USE mysql;\nALTER USER 'root'@'localhost' IDENTIFIED BY 'mysql';\n" | mysql -u root
-  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_tenants`;'
-  - mysql -u root -pmysql -e 'CREATE DATABASE IF NOT EXISTS `fineract_default`;'
-# Hardcoding the time zone is a temporary fix for https://issues.apache.org/jira/browse/FINERACT-723
-  - export TZ=Asia/Kolkata
+  - sudo apt-get -yq install zulu11-jdk
+  - export JAVA_HOME=/usr/lib/jvm/zulu11
 
 # https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:
@@ -86,19 +72,7 @@ before_script:
   - javac -version
   - $JAVA_HOME/bin/java -version
 
-# NOTE: We used to run with --info, which is quite a bit more verbose, but is VERY useful to understand failures on Travis,
-# where you do not have access to any files like build/reports/tests/index.html, only the Console.
-# @see http://mrhaki.blogspot.ch/2013/05/gradle-goodness-show-more-information.html
-# @see http://forums.gradle.org/gradle/topics/whats_new_in_gradle_1_1_test_logging for alternative
-# https://jira.apache.org/jira/browse/FINERACT-732 removed that again, because it made Travis CI fail.
 script:
-  - date
-# using "&&" instead of several "-" means that integrationTest does not run if test fails,
-# and Docker test does not run if integration test fails, which makes PR failure easier to understand.
-# @see https://docs.travis-ci.com/user/job-lifecycle/#customizing-the-build-phase
-# We stop the mysql system service when running the Docker test to avoid port 3306 conflicts (unless we run the mysql in docker-compose on another port; req. FINERACT-773)
-# The fancy /actuator/info test makes sure that has more than 100 characters of JSON to test that the git.properties worked (see FINERACT-983)
-  - ./gradlew -q --no-daemon --console=plain licenseMain licenseTest check build test --fail-fast doc &&  sudo service mysql stop  &&  docker-compose build  &&  docker-compose up -d  &&  sleep 60s  && curl -f -k --retry 5 --retry-connrefused --connect-timeout 30 --retry-delay 30 https://localhost:8443/fineract-provider/actuator/health  &&  (( $(curl -f -k --retry 5 --retry-connrefused --connect-timeout 30 --retry-delay 30 https://localhost:8443/fineract-provider/actuator/info | wc --chars) > 100 ))
   - date
 # Using travis_wait for a proccess that could take longer than 20 minutes, in this case the SonaQube analysis
 # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

--- a/fineract-client/build.gradle
+++ b/fineract-client/build.gradle
@@ -31,7 +31,7 @@ openApiMeta {
 }
 
 openApiValidate {
-    inputSpec = "$swaggerFile"
+    inputSpec = "file://$swaggerFile"
     recommend = true
 }
 
@@ -40,7 +40,7 @@ task buildJavaSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateT
     verbose = false
     validateSpec = false
     skipValidateSpec = true
-    inputSpec = "$swaggerFile"
+    inputSpec = "file://$swaggerFile"
     outputDir = "$buildDir/generated/java".toString()
     templateDir = "$rootDir/fineract-client/src/main/resources/java/template/"
     groupId = 'org.apache.fineract'
@@ -58,7 +58,7 @@ task buildJavaSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateT
     ignoreFileOverride = "$projectDir/.openapi-generator-ignore"
     // trick to make sure fineract.yaml is generated first
     dependsOn = [
-        ':fineract-provider:compileJava'
+        ':fineract-provider:resolve'
     ]
     finalizedBy = [licenseFormat]
     // uncomment below block to automatically copy the custom files in generated SDK
@@ -73,7 +73,7 @@ task buildTypescriptAngularSdk(type: org.openapitools.generator.gradle.plugin.ta
     verbose = false
     validateSpec = false
     skipValidateSpec = true
-    inputSpec = "$swaggerFile"
+    inputSpec = "file://$swaggerFile"
     outputDir = "$buildDir/generated/typescript".toString()
     apiPackage = 'org.apache.fineract.client.services'
     invokerPackage = 'org.apache.fineract.client'
@@ -83,6 +83,9 @@ task buildTypescriptAngularSdk(type: org.openapitools.generator.gradle.plugin.ta
         configurationPrefix: 'fineract',
         ngVersion: '10.0.0',
         npmName: 'apache-fineract-client'
+    ]
+    dependsOn = [
+        ':fineract-provider:resolve'
     ]
     finalizedBy = [licenseFormat]
 }


### PR DESCRIPTION
## Description

As we now have all the integration and docker tests running in a Github Action, we can disable the same activities from Travis. We need to use Travis for SonarQube as there is no easy way to handle the secrets for SonarQube with Github Actions. 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
