### PR TITLE
Introduce automatic Git tag based version management in Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ plugins {
     id 'org.asciidoctor.jvm.gems' version '3.3.2' apply false
     id 'org.asciidoctor.kindlegen.base' version '3.2.0' apply false
     id "com.google.cloud.tools.jib" version "3.1.4" apply false
+    id 'fr.brouillard.oss.gradle.jgitver' version '0.10.0-rc03'
     id "org.sonarqube" version "3.3"
 }
 
@@ -87,8 +88,13 @@ ext['swaggerFile'] = "$rootDir/fineract-provider/build/classes/java/main/static/
 allprojects  {
     group = 'org.apache.fineract'
 
+    jgitver {
+        strategy 'PATTERN'
+        versionPattern '${M}.${m}.${p}-${meta.GIT_SHA1_8}'
+    }
+
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     apply plugin: 'io.spring.dependency-management'

--- a/fineract-doc/build.gradle
+++ b/fineract-doc/build.gradle
@@ -51,7 +51,7 @@ asciidoctorj {
         imagesdir: 'images',
         diagrams: 'diagrams',
         years: '2015-2020',
-        revnumber: "$releaseVersion".toString(),
+        revnumber: "$version".toString(),
         rootdir: "$rootDir".toString(),
         baseurl: 'fineract.apache.org'
     ]

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -255,7 +255,7 @@ jib {
     to {
         image = 'fineract'
         tags = [
-            "${releaseVersion}",
+            "${version}",
             'latest'
         ]
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,4 @@
 # under the License.
 #
 org.gradle.jvmargs=-Xmx2g
-releaseVersion=1.5.0
 buildType=BUILD


### PR DESCRIPTION
## Description

With this change we will always have proper versions based on Git tags and Git hashes (for development branches and pull requests). No more manual editing (and forgetting) of gradle.properties ("releaseVersion").
