### PR TITLE
FINERACT-1502 : To support Webhook with all paths instead of only absolute path

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/WebHookService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/WebHookService.java
@@ -38,22 +38,22 @@ public interface WebHookService {
     String API_KEY_HEADER = "X-Fineract-API-Key";
 
     // Ping
-    @GET("/")
+    @GET(".")
     Call<Void> sendEmptyRequest();
 
     // Template - Web
-    @POST("/")
+    @POST(".")
     Call<Void> sendJsonRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(ENDPOINT_HEADER) String endpointHeader, @Body JsonObject result);
 
     @FormUrlEncoded
-    @POST("/")
+    @POST(".")
     Call<Void> sendFormRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(ENDPOINT_HEADER) String endpointHeader,
             @FieldMap Map<String, String> params);
 
     // Template - SMS Bridge
-    @POST("/")
+    @POST(".")
     Call<Void> sendSmsBridgeRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(API_KEY_HEADER) String apiKeyHeader, @Body JsonObject result);
 


### PR DESCRIPTION
Updated WebhookService to support all paths instead of only absolute path. 

## Description

Current Implementation supports Webhook URL with absolute path like https://www.hostname.com but it does not support urls like https://www.hostname.com/v1/api/webhook/ or https://www.hostname.com/webhook/ 

**Currently Webhook URLs working** : Only AbsoluteUrls  as baseURL (http://www.hostname.com/)
**URLs Not working** : Relative Paths in baseURL like http://www.hostname.com/v1/api/webhook 

**Root Cause :** This problem is happening due to retrofit2 library as it removes relative path from baseURL due to "/" present in request like Get("/") , POST("/") etc. So it updates http://www.hostname.com/v1/api/webhook  to http://www.hostname.com/ while making API call and hence we get 404 error.


**Resolution** : 
So in order to support absolute url as well as all other relative URL Paths,  I updated Webhook Service Code and replaced GET("/") by GET(".") So that retrofit2 library does not remove anything from baseURL. I tested code and it is working fine with both kind of URLs.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
