### PR TITLE
FINERACT-1506: Add WAR artifact to release distribution again

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Releasing
 
 Before you use Gradle to create a release you need to make sure that you provide the proper GPG parameters. You have to options:
 
-1. Provide the parameters via ~/gradle/gradle.properties in your home folder:
+1. Provide the parameters via ~/.gradle/gradle.properties in your home folder:
 ```
 signing.gnupg.keyName=7890ABCD
 signing.gnupg.passphrase=secret
@@ -469,23 +469,23 @@ NOTE: Let's assume your GPG key ID would be "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789
 
 Above tasks will create the following files in folder build/distributions:
 
-- binary distribution file: apache-fineract-1.4.0-binary.tar.gz
-- ASCII armored signature for binary distribution: apache-fineract-1.4.0-binary.tar.gz.asc
-- SHA512 checksum for binary distribution: apache-fineract-1.4.0-binary.tar.gz.sha512
-- source distribution file: apache-fineract-1.4.0-src.tar.gz
-- ASCII armored signature for source distribution: apache-fineract-1.4.0-src.tar.gz.asc
-- SHA512 checksum for source distribution: apache-fineract-1.4.0-src.tar.gz.sha512
+- binary distribution file: apache-fineract-1.6.0-binary.tar.gz
+- ASCII armored signature for binary distribution: apache-fineract-1.6.0-binary.tar.gz.asc
+- SHA512 checksum for binary distribution: apache-fineract-1.6.0-binary.tar.gz.sha512
+- source distribution file: apache-fineract-1.6.0-src.tar.gz
+- ASCII armored signature for source distribution: apache-fineract-1.6.0-src.tar.gz.asc
+- SHA512 checksum for source distribution: apache-fineract-1.6.0-src.tar.gz.sha512
 
 The signatures are automatically verified by the build script. It will throw an exception if the verification fails.
 
 Additionally, you can verify the validity of the release distribution files e. g. with:
 ```
-gpg --verify build/distributions/apache-fineract-1.4.0-binary.tar.gz.asc
+gpg --verify build/distributions/apache-fineract-1.6.0-binary.tar.gz.asc
 ```
 
 The output should look somewhat like this:
 ```
-gpg: assuming signed data in 'build/distributions/apache-fineract-1.4.0-binary.tgz'
+gpg: assuming signed data in 'build/distributions/apache-fineract-1.6.0-binary.tgz'
 gpg: Signature made Mi 26 Aug 2020 17:17:45 CEST
 gpg:                using RSA key ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD
 gpg: Good signature from "Aleksandar Vidakovic (Apache Fineract Release Manager) <aleks@apache.org>" [ultimate]

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -24,8 +24,6 @@ apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.gorylenko.gradle-git-properties'
 apply plugin: 'io.swagger.core.v3.swagger-gradle-plugin'
-apply plugin: 'distribution'
-apply plugin: 'signing'
 apply plugin: 'com.google.cloud.tools.jib'
 
 // Custom OpenJPA enhancement
@@ -268,6 +266,7 @@ jar {
 }
 
 jar.dependsOn resolve
+jar.dependsOn bootJar
 
 jib {
     from {
@@ -330,88 +329,6 @@ jib {
 }
 
 tasks.jibDockerBuild.dependsOn = ["bootJar"]
-
-tasks.withType(Tar) {
-    compression Compression.GZIP
-    extension 'tar.gz'
-}
-
-distributions {
-    binary {
-        if(project.hasProperty("distVersion")) {
-            distributionBaseName = "apache-fineract-$distVersion-binary"
-        } else {
-            distributionBaseName = "apache-fineract-binary"
-        }
-        contents {
-            from bootJar
-            // TODO: @vidakovic add war
-            // TODO: @vidakovic add client library
-            from("$rootDir/licenses/") {
-                into "licenses/"
-            }
-            from "$rootDir/LICENSE_RELEASE"
-            from "$rootDir/NOTICE_RELEASE"
-            rename ('LICENSE_RELEASE', 'LICENSE')
-            rename ('NOTICE_RELEASE', 'NOTICE')
-
-            from "$rootDir/DISCLAIMER"
-            from "$rootDir/README.md"
-        }
-    }
-    src {
-        if(project.hasProperty("distVersion")) {
-            distributionBaseName = "apache-fineract-$distVersion-src"
-        } else {
-            distributionBaseName = "apache-fineract-src"
-        }
-
-        contents {
-            from "$rootDir/"
-            exclude '**/build' , '.git', '**/.gradle', '.github', '**/.settings', '**/.project', '**/.classpath', '.idea', 'out', '._.DS_Store', '.DS_Store', 'WebContent', '**/.externalToolbuilders', '.theia', '.gitpod.yml', '.travis.yml', 'LICENSE_RELEASE', 'NOTICE_RELEASE', '**/licenses', '*.class', '**/bin', '*.log', '.dockerignore', '**/gradle', '**/.gitkeep'
-            rename ('LICENSE_SOURCE', 'LICENSE')
-            rename ('NOTICE_SOURCE', 'NOTICE')
-        }
-    }
-}
-
-tasks.binaryDistZip.enabled false
-tasks.srcDistZip.enabled false
-tasks.binaryDistTar.dependsOn bootJar
-tasks.srcDistTar.dependsOn prepareInputYaml
-
-// create signatures and checksums only if project parameter "fineract.release" is provided on the command line
-if( project.hasProperty("fineract.release") ) {
-    signing {
-        useGpgCmd()
-        sign (binaryDistTar, srcDistTar)
-    }
-    tasks.withType(Tar) { task ->
-        task.doLast {
-            ant.checksum file: task.archivePath, algorithm: 'SHA-512', fileext: '.sha512'
-        }
-    }
-    tasks.withType(Sign) { task ->
-        task.doLast {
-            task.getFilesToSign().each { f ->
-                new ByteArrayOutputStream().withStream { os ->
-                    def result = exec {
-                        workingDir "$buildDir/distributions"
-                        executable 'sh'
-                        args '-c', "gpg --verify ${f}.asc"
-                        standardOutput = os
-                    }
-                    if(result.exitValue==0) {
-                        println '+++ GPG signature correct!'
-                    } else {
-                        println '--- GPG signature incorrect!'
-                        throw new RuntimeException('--- GPG signature incorrect!')
-                    }
-                }
-            }
-        }
-    }
-}
 
 // Configuration for git properties gradle plugin
 // https://github.com/n0mer/gradle-git-properties

--- a/fineract-war/build.gradle
+++ b/fineract-war/build.gradle
@@ -19,6 +19,8 @@
 description = 'Fineract WAR'
 
 apply plugin: 'war'
+apply plugin: 'distribution'
+apply plugin: 'signing'
 
 war {
     archiveFileName = 'fineract-provider.war'
@@ -47,4 +49,91 @@ war {
 
 dependencies {
     implementation project(':fineract-provider')
+}
+
+tasks.withType(Tar) {
+    compression Compression.GZIP
+    extension 'tar.gz'
+}
+
+distributions {
+    binary {
+        if(project.hasProperty("distVersion")) {
+            distributionBaseName = "apache-fineract-$distVersion-binary"
+        } else {
+            distributionBaseName = "apache-fineract-binary"
+        }
+        contents {
+            from ("$rootDir/fineract-client/build/libs/") {
+                include 'fineract-client-*.jar'
+            }
+            from ("$rootDir/fineract-provider/build/libs/") {
+                include 'fineract-provider-*.jar'
+                exclude 'fineract-provider-*-plain.jar'
+            }
+            from war
+            from("$rootDir/licenses/") {
+                into "licenses/"
+            }
+            from "$rootDir/LICENSE_RELEASE"
+            from "$rootDir/NOTICE_RELEASE"
+            rename ('LICENSE_RELEASE', 'LICENSE')
+            rename ('NOTICE_RELEASE', 'NOTICE')
+
+            from "$rootDir/DISCLAIMER"
+            from "$rootDir/README.md"
+        }
+    }
+    src {
+        if(project.hasProperty("distVersion")) {
+            distributionBaseName = "apache-fineract-$distVersion-src"
+        } else {
+            distributionBaseName = "apache-fineract-src"
+        }
+
+        contents {
+            from "$rootDir/"
+            exclude '**/build' , '.git', '**/.gradle', '.github', '**/.settings', '**/.project', '**/.classpath', '.idea', 'out', '._.DS_Store', '.DS_Store', 'WebContent', '**/.externalToolbuilders', '.theia', '.gitpod.yml', '.travis.yml', 'LICENSE_RELEASE', 'NOTICE_RELEASE', '**/licenses', '*.class', '**/bin', '*.log', '.dockerignore', '**/gradle', '**/.gitkeep'
+            rename ('LICENSE_SOURCE', 'LICENSE')
+            rename ('NOTICE_SOURCE', 'NOTICE')
+        }
+    }
+}
+
+tasks.binaryDistZip.enabled false
+tasks.srcDistZip.enabled false
+tasks.binaryDistTar.dependsOn war
+// tasks.srcDistTar.dependsOn prepareInputYaml
+
+// create signatures and checksums only if project parameter "fineract.release" is provided on the command line
+if( project.hasProperty("fineract.release") ) {
+    signing {
+        useGpgCmd()
+        sign (binaryDistTar, srcDistTar)
+    }
+    tasks.withType(Tar) { task ->
+        task.doLast {
+            ant.checksum file: task.archivePath, algorithm: 'SHA-512', fileext: '.sha512'
+        }
+    }
+    tasks.withType(Sign) { task ->
+        task.doLast {
+            task.getFilesToSign().each { f ->
+                new ByteArrayOutputStream().withStream { os ->
+                    def result = exec {
+                        workingDir "$buildDir/distributions"
+                        executable 'sh'
+                        args '-c', "gpg --verify ${f}.asc"
+                        standardOutput = os
+                    }
+                    if(result.exitValue==0) {
+                        println '+++ GPG signature correct!'
+                    } else {
+                        println '--- GPG signature incorrect!'
+                        throw new RuntimeException('--- GPG signature incorrect!')
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

Since we split the WAR build into a separate module we've excluded the WAR, because of a circular dependency issue. Adding the WAR file again as there was no general vote to remove it. Includes also fineract-client.