### PR TITLE
Minor: Name PostgreSQL instead of MariaDB in build-postgresql.yml

### DIFF
--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -44,7 +44,7 @@ jobs:
           distribution: 'zulu'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-      - name: Verify MariaDB connection
+      - name: Verify PostgreSQL connection
         run: |
             while ! pg_isready -d postgres -U root -h 127.0.0.1 -p 5432 ; do
                 sleep 1


### PR DESCRIPTION
Minor nit fix (just because I noticed this while staring at running workflows on a PR).