### PR TITLE
FINERACT-1547: Cleanup credit bureau dependency in infrastructure core

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
@@ -21,7 +21,6 @@ package org.apache.fineract.infrastructure.core.data;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.fineract.infrastructure.creditbureau.data.CreditBureauReportData;
 
 /**
  * Represents the successful result of an REST API call that results in processing a command.
@@ -38,7 +37,7 @@ public class CommandProcessingResult implements Serializable {
     private final Long subResourceId;
     private final String transactionId;
     private final Map<String, Object> changes;
-    private final CreditBureauReportData creditBureauReportData;
+    private final Map<String, Object> creditBureauReportData;
     @SuppressWarnings("unused")
     private final String resourceIdentifier;
     private final Long productId;
@@ -55,7 +54,7 @@ public class CommandProcessingResult implements Serializable {
 
     public static CommandProcessingResult fromDetails(final Long commandId, final Long officeId, final Long groupId, final Long clientId,
             final Long loanId, final Long savingsId, final String resourceIdentifier, final Long entityId, final Long gsimId,
-            final Long glimId, final CreditBureauReportData creditBureauReportData, final String transactionId,
+            final Long glimId, final Map<String, Object> creditBureauReportData, final String transactionId,
             final Map<String, Object> changes, final Long productId, final Boolean rollbackTransaction, final Long subResourceId) {
         return new CommandProcessingResult(commandId, officeId, groupId, clientId, loanId, savingsId, resourceIdentifier, entityId,
                 transactionId, changes, productId, gsimId, glimId, creditBureauReportData, rollbackTransaction, subResourceId);
@@ -117,7 +116,7 @@ public class CommandProcessingResult implements Serializable {
     private CommandProcessingResult(final Long commandId, final Long officeId, final Long groupId, final Long clientId, final Long loanId,
             final Long savingsId, final String resourceIdentifier, final Long resourceId, final String transactionId,
             final Map<String, Object> changesOnly, final Long productId, final Long gsimId, final Long glimId,
-            final CreditBureauReportData creditBureauReportData, Boolean rollbackTransaction, final Long subResourceId) {
+            final Map<String, Object> creditBureauReportData, Boolean rollbackTransaction, final Long subResourceId) {
         this.commandId = commandId;
         this.officeId = officeId;
         this.groupId = groupId;
@@ -200,7 +199,7 @@ public class CommandProcessingResult implements Serializable {
         return this.transactionId;
     }
 
-    public CreditBureauReportData getCreditReport() {
+    public Map<String, Object> getCreditReport() {
         return this.creditBureauReportData;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResultBuilder.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResultBuilder.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.infrastructure.core.data;
 
 import java.util.Map;
-import org.apache.fineract.infrastructure.creditbureau.data.CreditBureauReportData;
 
 /**
  * Represents the successful result of an REST API call that results in processing a command.
@@ -39,7 +38,7 @@ public class CommandProcessingResultBuilder {
     private Long glimId;
     private String transactionId;
     private Map<String, Object> changes;
-    private CreditBureauReportData creditBureauReportData;
+    private Map<String, Object> creditBureauReportData;
     private Long productId;
     private boolean rollbackTransaction = false;
 
@@ -119,7 +118,7 @@ public class CommandProcessingResultBuilder {
         return this;
     }
 
-    public CommandProcessingResultBuilder withCreditReport(final CreditBureauReportData withCreditReport) {
+    public CommandProcessingResultBuilder withCreditReport(final Map<String, Object> withCreditReport) {
         this.creditBureauReportData = withCreditReport;
         return this;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/creditbureau/data/CreditBureauReportData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/creditbureau/data/CreditBureauReportData.java
@@ -54,4 +54,31 @@ public final class CreditBureauReportData implements Serializable {
         this.closedAccounts = closedAccounts;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getCreditScore() {
+        return creditScore;
+    }
+
+    public String getBorrowerInfo() {
+        return borrowerInfo;
+    }
+
+    public String[] getOpenAccounts() {
+        return openAccounts;
+    }
+
+    public String[] getClosedAccounts() {
+        return closedAccounts;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/creditbureau/service/CreditReportWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/creditbureau/service/CreditReportWritePlatformServiceImpl.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.persistence.PersistenceException;
@@ -103,7 +104,11 @@ public class CreditReportWritePlatformServiceImpl implements CreditReportWritePl
                 CreditBureauReportData reportobj = this.thitsaWorksCreditBureauIntegrationWritePlatformService
                         .getCreditReportFromThitsaWorks(command);
 
-                return new CommandProcessingResultBuilder().withCreditReport(reportobj).build();
+                Map<String, Object> reportMap = Map.of("name", reportobj.getName(), "gender", reportobj.getGender(), "address",
+                        reportobj.getAddress(), "creditScore", reportobj.getCreditScore(), "borrowerInfo", reportobj.getBorrowerInfo(),
+                        "openAccounts", reportobj.getOpenAccounts(), "closedAccounts", reportobj.getClosedAccounts());
+
+                return new CommandProcessingResultBuilder().withCreditReport(reportMap).build();
             }
 
             baseDataValidator.reset().failWithCode("creditBureau.has.not.been.Integrated");


### PR DESCRIPTION
In the infrastructure core packages we should never use any cross dependency to any other package. "CommandProcessingResult" contains an attribute with a type "CreditBureauReportData". We should apply the same strategy as with attribute "changes": convert to "Map<String, Object>".