### PR TITLE
FINERACT-1529: Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,10 @@ buildscript {
                 'integration-tests',
                 'twofactor-tests',
                 'oauth2-tests',
-                'fineract-client'
+                'fineract-client',
+                'core',
+                'service',
+                'starter'
             ].contains(it.name)
         }
         fineractPublishProjects = subprojects.findAll{
@@ -71,7 +74,7 @@ plugins {
     id 'org.asciidoctor.jvm.revealjs' version '3.3.2' apply false
     id 'org.asciidoctor.jvm.gems' version '3.3.2' apply false
     id 'org.asciidoctor.kindlegen.base' version '3.2.0' apply false
-    id "com.google.cloud.tools.jib" version '3.2.0' apply false
+    id 'com.google.cloud.tools.jib' version '3.2.0' apply false
     id 'fr.brouillard.oss.gradle.jgitver' version '0.10.0-rc03'
     id 'org.sonarqube' version '3.3'
     id 'com.github.andygoossens.modernizer' version '1.6.2' apply false
@@ -99,8 +102,6 @@ allprojects  {
         mavenCentral()
     }
 
-    apply plugin: 'idea'
-    apply plugin: 'java'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.adarshr.test-logger'
     apply plugin: 'com.diffplug.spotless'
@@ -115,10 +116,13 @@ allprojects  {
         imports {
             mavenBom 'org.springframework:spring-framework-bom:5.3.17'
             mavenBom 'org.springframework.boot:spring-boot-dependencies:2.6.5'
+            mavenBom 'org.jetbrains.kotlin:kotlin-bom:1.6.10'
             mavenBom 'org.junit:junit-bom:5.8.2'
             mavenBom 'com.fasterxml.jackson:jackson-bom:2.13.2'
             mavenBom 'io.cucumber:cucumber-bom:7.2.3'
             mavenBom 'io.netty:netty-bom:4.1.75.Final'
+            mavenBom 'org.mockito:mockito-bom:4.4.0'
+            mavenBom 'io.github.swagger2markup:swagger2markup-bom:1.3.4'
         }
 
         dependencies {
@@ -126,11 +130,20 @@ allprojects  {
             // We do not use :+ to get the latest available version available on Maven Central, as that could suddenly break things.
             // We use the Renovate Bot to automatically propose Pull Requests (PRs) when upgrades for all of these versions are available.
 
+            dependency 'org.slf4j:slf4j-api:1.7.36'
+            dependency 'org.slf4j:slf4j-simple:1.7.36'
+            dependency 'org.slf4j:jcl-over-slf4j:1.7.36'
+            dependency 'org.slf4j:jul-to-slf4j:1.7.36'
+            dependency 'org.slf4j:log4j-over-slf4j:1.7.36'
+            dependency 'ch.qos.logback:logback-core:1.2.11'
+            dependency 'ch.qos.logback:logback-classic:1.2.11'
+
             dependency 'org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10'
             dependency 'com.google.guava:guava:31.1-jre'
             dependency 'com.google.code.gson:gson:2.9.0'
             dependency 'com.google.truth:truth:1.1.3'
             dependency 'com.google.truth.extensions:truth-java8-extension:1.1.3'
+            dependency 'com.google.googlejavaformat:google-java-format:1.15.0'
             dependency 'org.apache.commons:commons-email:1.5'
             dependency 'commons-io:commons-io:2.11.0'
             dependency 'com.github.librepdf:openpdf:1.3.27'
@@ -146,7 +159,6 @@ allprojects  {
             dependency 'jakarta.jms:jakarta.jms-api:2.0.3'
             dependency 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3' // Swagger needs exactly this version
             dependency 'org.glassfish.jaxb:jaxb-runtime:2.3.6' // Swagger needs exactly this version
-            dependency 'org.apache.activemq:activemq-broker:5.16.4'
             dependency 'org.apache.bval:org.apache.bval.bundle:2.0.5'
             dependency 'joda-time:joda-time:2.10.14'
 
@@ -188,12 +200,16 @@ allprojects  {
             dependency "io.gsonfire:gson-fire:1.8.5"
             dependency "io.swagger:swagger-core:1.6.5"
             dependency "io.swagger:swagger-annotations:1.6.5"
-            dependency "javax.annotation:javax.annotation-api:1.3.2"
+            dependency "jakarta.annotation:jakarta.annotation-api:1.3.5"
             dependency "com.google.code.findbugs:jsr305:3.0.2"
             dependency "commons-codec:commons-codec:1.15"
             dependency "org.bouncycastle:bcpkix-jdk15to18:1.70"
             dependency "org.bouncycastle:bcprov-jdk15to18:1.70"
 
+
+            dependency ('org.apache.activemq:activemq-broker:5.17.0') {
+                exclude 'javax.annotation:javax.annotation-api'
+            }
 
             dependency 'io.swagger.core.v3:swagger-annotations:2.1.13'
             dependency ('io.swagger.core.v3:swagger-jaxrs2:2.1.13') {
@@ -211,7 +227,7 @@ allprojects  {
                 exclude 'pull-parser:pull-parser'
             }
 
-            dependencySet(group: 'org.apache.poi', version: '4.1.2') {
+            dependencySet(group: 'org.apache.poi', version: '5.2.2') {
                 entry 'poi'
                 entry 'poi-ooxml'
                 entry 'poi-ooxml-schemas'
@@ -272,6 +288,8 @@ allprojects  {
             "**/static/swagger-ui/**",
             "**/api-docs/**",
             "**/banner.txt",
+            "**/build.gradle.mustache",
+            "**/pom.mustache",
         ])
         strictCheck true
     }
@@ -631,6 +649,34 @@ configure(project.fineractJavaProjects) {
                     // "FieldCanBeFinal"
                     )
         }
+    }
+
+    dependencies {
+        implementation (
+                'ch.qos.logback:logback-core',
+                'org.slf4j:slf4j-api',
+                'org.slf4j:log4j-over-slf4j',
+                'org.slf4j:jul-to-slf4j',
+                )
+        implementation ("ch.qos.logback:logback-classic") {
+            exclude(module: "slf4j-api")
+        }
+
+        testImplementation( 'org.mockito:mockito-core',
+                'org.mockito:mockito-junit-jupiter',
+                'org.junit.jupiter:junit-jupiter-api',
+                'org.junit.jupiter:junit-jupiter-engine',
+                'org.junit.platform:junit-platform-runner', // required to be able to run tests directly under Eclipse, see FINERACT-943 & FINERACT-1021
+                'org.bouncycastle:bcpkix-jdk15to18',
+                'org.bouncycastle:bcprov-jdk15to18',
+                'org.awaitility:awaitility',
+                'com.google.truth:truth',
+                'com.google.truth.extensions:truth-java8-extension',
+                'io.cucumber:cucumber-core',
+                'io.cucumber:cucumber-java',
+                'io.cucumber:cucumber-java8',
+                'io.cucumber:cucumber-junit-platform-engine',
+                )
     }
 
     test {

--- a/custom/foo/service/dependencies.gradle
+++ b/custom/foo/service/dependencies.gradle
@@ -20,4 +20,5 @@
 dependencies {
     implementation(project(':module:dummy:core'),
             'org.springframework:spring-context')
+    testImplementation('io.cucumber:cucumber-spring')
 }

--- a/custom/foo/service/src/main/java/com/acmecorp/fineract/foo/service/FooDummyServiceImpl.java
+++ b/custom/foo/service/src/main/java/com/acmecorp/fineract/foo/service/FooDummyServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class FooDummyServiceImpl implements DummyService {
+
     @Override
     public DummyMessage getMessage() {
         return new DummyMessage("Hello: FOO!");

--- a/fineract-client/dependencies.gradle
+++ b/fineract-client/dependencies.gradle
@@ -34,13 +34,4 @@ dependencies {
         exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
         exclude group: 'org.slf4j'
     }
-
-    testImplementation(
-            'org.junit.jupiter:junit-jupiter-api',
-            'com.google.truth:truth',
-            'com.google.truth.extensions:truth-java8-extension'
-            )
-    testRuntimeOnly(
-            'org.junit.jupiter:junit-jupiter-engine'
-            )
 }

--- a/fineract-doc/build.gradle
+++ b/fineract-doc/build.gradle
@@ -22,26 +22,8 @@ apply plugin: 'org.asciidoctor.jvm.revealjs'
 // apply plugin: 'org.asciidoctor.jvm.epub'
 // apply plugin: 'org.asciidoctor.kindlegen.base'
 
-// NOTE: need to wait for new release of Swagger to Asciidoc plugin
-
-//if(file("$swaggerFile").exists()) {
-//    apply plugin: 'io.github.lhotari.swagger2markup'
-//
-//    convertSwagger2markup {
-//        swaggerInput file("$swaggerFile").getAbsolutePath()
-//        outputDir file("$buildDir/generated/asciidoc")
-//        config = [
-//            'swagger2markup.markupLanguage': 'ASCIIDOC',
-//            'swagger2markup.pathsGroupedBy': 'TAGS'
-//        ]
-//        dependsOn ':fineract-provider:resolve'
-//    }
-//
-//    asciidoctor.dependsOn convertSwagger2markup
-//}
-
 asciidoctorj {
-    version = '2.4.0'
+    version = '2.5.3'
 
     attributes = [
         version: "$project.version",
@@ -55,10 +37,10 @@ asciidoctorj {
     ]
 
     modules {
-        pdf.version '1.5.3'
-        diagram.version '2.0.2'
-        epub.version '1.5.0-alpha.18'
-        revealjs.version '4.0.1'
+        pdf.version '1.6.2'
+        diagram.version '2.2.1'
+        epub.version '1.5.1'
+        revealjs.version '4.1.0'
     }
 
     fatalWarnings ~/include file not found|missing callout|image to embed not found or not readable/

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -51,7 +51,6 @@ dependencies {
             'commons-io:commons-io',
             'org.apache.poi:poi',
             'org.apache.poi:poi-ooxml',
-            'org.apache.poi:poi-ooxml-schemas',
             'org.apache.tika:tika-core',
 
             'org.liquibase:liquibase-core',
@@ -125,16 +124,7 @@ dependencies {
     // testCompile dependencies are ONLY used in src/test, not src/main.
     // Do NOT repeat dependencies which are ALREADY in implementation or runtimeOnly!
     //
-    testImplementation( 'org.mockito:mockito-core',
-            'org.mockito:mockito-junit-jupiter',
-            'org.junit.platform:junit-platform-runner', // required to be able to run tests directly under Eclipse, see FINERACT-943 & FINERACT-1021
-            'org.bouncycastle:bcpkix-jdk15to18',
-            'org.bouncycastle:bcprov-jdk15to18',
-            'io.cucumber:cucumber-core',
-            'io.cucumber:cucumber-java',
-            'io.cucumber:cucumber-java8',
-            'io.cucumber:cucumber-junit-platform-engine',
-            'io.cucumber:cucumber-spring',
+    testImplementation( 'io.cucumber:cucumber-spring',
             'io.github.classgraph:classgraph',
             project(':module:dummy:core'),
             project(':module:dummy:service'),

--- a/integration-tests/dependencies.gradle
+++ b/integration-tests/dependencies.gradle
@@ -24,16 +24,6 @@ dependencies {
     testImplementation( files("$rootDir/fineract-provider/build/classes/java/main/"),
             project(path: ':fineract-provider', configuration: 'runtimeElements'),
             project(path: ':fineract-client', configuration: 'runtimeElements'),
-            'org.junit.jupiter:junit-jupiter-api',
-            'com.google.truth:truth',
-            'com.google.truth.extensions:truth-java8-extension',
-            'org.awaitility:awaitility',
-            'org.bouncycastle:bcpkix-jdk15to18',
-            'org.bouncycastle:bcprov-jdk15to18',
-            'io.cucumber:cucumber-core',
-            'io.cucumber:cucumber-java',
-            'io.cucumber:cucumber-java8',
-            'io.cucumber:cucumber-junit-platform-engine',
             'io.cucumber:cucumber-spring',
             'com.intuit.karate:karate-junit5',
             // 'com.google.code.gson:gson',
@@ -48,7 +38,4 @@ dependencies {
         exclude group: 'org.apache.sling'
         exclude group: 'com.sun.xml.bind'
     }
-    testRuntimeOnly(
-            'org.junit.jupiter:junit-jupiter-engine'
-            )
 }

--- a/module/dummy/core/src/main/java/org/apache/fineract/dummy/core/data/DummyMessage.java
+++ b/module/dummy/core/src/main/java/org/apache/fineract/dummy/core/data/DummyMessage.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.dummy.core.data;
 
 public class DummyMessage {
+
     private String message;
 
     public DummyMessage(String message) {

--- a/module/dummy/core/src/main/java/org/apache/fineract/dummy/core/service/DummyService.java
+++ b/module/dummy/core/src/main/java/org/apache/fineract/dummy/core/service/DummyService.java
@@ -21,5 +21,6 @@ package org.apache.fineract.dummy.core.service;
 import org.apache.fineract.dummy.core.data.DummyMessage;
 
 public interface DummyService {
+
     DummyMessage getMessage();
 }

--- a/module/dummy/service/dependencies.gradle
+++ b/module/dummy/service/dependencies.gradle
@@ -20,4 +20,5 @@
 dependencies {
     implementation(project(':module:dummy:core'),
             'org.springframework:spring-context')
+    testImplementation('io.cucumber:cucumber-spring')
 }

--- a/module/dummy/service/src/main/java/org/apache/fineract/dummy/service/DummyServiceImpl.java
+++ b/module/dummy/service/src/main/java/org/apache/fineract/dummy/service/DummyServiceImpl.java
@@ -22,6 +22,7 @@ import org.apache.fineract.dummy.core.data.DummyMessage;
 import org.apache.fineract.dummy.core.service.DummyService;
 
 public class DummyServiceImpl implements DummyService {
+
     @Override
     public DummyMessage getMessage() {
         return new DummyMessage("Hello: DEFAULT DUMMY!");

--- a/module/dummy/starter/dependencies.gradle
+++ b/module/dummy/starter/dependencies.gradle
@@ -21,4 +21,5 @@ dependencies {
     implementation(project(':module:dummy:core'),
             project(':module:dummy:service'),
             'org.springframework.boot:spring-boot-starter')
+    testImplementation('io.cucumber:cucumber-spring')
 }

--- a/module/dummy/starter/src/main/java/org/apache/fineract/dummy/starter/DummyAutoConfiguration.java
+++ b/module/dummy/starter/src/main/java/org/apache/fineract/dummy/starter/DummyAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnMissingBean(DummyService.class)
 public class DummyAutoConfiguration {
+
     @Bean
     public DummyService dummyService() {
         return new DummyServiceImpl();


### PR DESCRIPTION
Dependencies
 * org.slf4j:slf4j-api [1.7.36]
 * org.slf4j:slf4j-simple [1.7.36]
 * org.slf4j:jcl-over-slf4j [1.7.36]
 * org.slf4j:jul-to-slf4j [1.7.36]
 * org.slf4j:log4j-over-slf4j [1.7.36]
 * ch.qos.logback:logback-core [1.2.11]
 * ch.qos.logback:logback-classic [1.2.11]
 * com.google.googlejavaformat:google-java-format [1.15.0]
 * jakarta.annotation:jakarta.annotation-api [1.3.5]
 * org.mockito:mockito-core [4.0.0 -> 4.4.0]
 * org.mockito:mockito-junit-jupiter [4.0.0 -> 4.4.0]
 * org.apache.activemq:activemq-broker [5.16.3 -> 5.17.0]
 * org.apache.poi:poi [4.1.2 -> 5.2.2]
 * org.asciidoctor:asciidoctorj [2.4.0 -> 2.5.3]

Note:
 * default dependencies (logging, common test libraries) for all Java projects/sub-modules defined in one place (build.gradle file in the root folder)
 * the Google Format lib update is notable, because it's working now officially with JDK17 (some unstable tests might be explainable by this one)
 * I had to add a Maven BOM for Kotlin (used in the OKHttp lib), because all of a sudden Tomcat (aka the Gradle Cargo plugin) would sporadically complain about missing Kotlin Standard lib not being included in the WAR file
 * I cleaned up the Slf4j and Log Implementation dependencies; the standard is now Logback; this removes also some ugly warnings of Slf4j not being able to find a proper logger implementation during builds and tests
 * fixed sub-module plugin definition; we had previously too many module marked as 'java'