### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-docker-postgresql.yml
+++ b/.github/workflows/build-docker-postgresql.yml
@@ -2,6 +2,9 @@ name: Fineract Docker build for PostgreSQL
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,6 +2,9 @@ name: Fineract Docker build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -1,6 +1,9 @@
 name: Fineract Gradle build - basicauth - PostgreSQL
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Fineract Gradle build - basicauth
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/fineract.dev.yaml
+++ b/.github/workflows/fineract.dev.yaml
@@ -15,6 +15,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   setup-build-deploy:
     name: Deploy on Fineract.dev

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,6 +1,9 @@
 name: Fineract Sonarqube
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,8 +5,14 @@ name: Mark stale issues and pull requests
 on:
   schedule:
   - cron: "0 0 * * *"
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v5


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
