### PR TITLE
FINERACT-1575 IPv6 workaround

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/IPv6Config.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/IPv6Config.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.adapter.ForwardedHeaderTransformer;
+
+@Configuration
+public class IPv6Config {
+
+    @Bean
+    public ForwardedHeaderTransformer forwardedHeaderTransformer() {
+        ForwardedHeaderTransformer transformer = new ForwardedHeaderTransformer();
+        transformer.setRemoveOnly(true);
+        return transformer;
+    }
+}


### PR DESCRIPTION
## Description

A bean has been added as a workaround for supporting IPv6 address, which are used in fully managed serverless environments (like Firebase, AWS Amplify, GCP, Azure, Azure App Service).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
