### PR TITLE
FINERACT-1576 GCP Cloud SQL Support

### DIFF
--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -129,7 +129,13 @@ dependencies {
 
             // Although fineract (at the time of writing) doesn't have any compile time dep. on httpclient,
             // it's useful to have this for the Spring Boot TestRestTemplate http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-rest-templates-test-utility
-            'org.apache.httpcomponents:httpclient'
+            'org.apache.httpcomponents:httpclient',
+
+            //The Cloud SQL Connector for Java is a library that provides IAM-based authorization and encryption
+            //when connecting to a Cloud SQL instance.
+            //It can not provide a network path to a Cloud SQL instance if one is not already present.
+            //Apache License https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory
+            'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.4.4'
             )
 
     compileOnly 'org.projectlombok:lombok'

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/CompatibilityConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/CompatibilityConfig.java
@@ -99,6 +99,8 @@ public class CompatibilityConfig {
                 environment.getProperty("FINERACT_HIKARI_DS_PROPERTIES_LOG_SLOW_QUERIES"));
         LOG.warn("- Env var 'FINERACT_HIKARI_DS_PROPERTIES_DUMP_QUERIES_IN_EXCEPTION':  {}",
                 environment.getProperty("FINERACT_HIKARI_DS_PROPERTIES_DUMP_QUERIES_IN_EXCEPTION"));
+        LOG.warn("- Env var 'FINERACT_HIKARI_DS_PROPERTIES_INSTANCE_CONNECTION_NAME':  {}",
+                environment.getProperty("FINERACT_HIKARI_DS_PROPERTIES_INSTANCE_CONNECTION_NAME"));
         LOG.warn("===============================================================================================\n");
     }
 
@@ -128,6 +130,8 @@ public class CompatibilityConfig {
     // These are the properties for the all Tenants DB; the same configuration is also (hard-coded) in the
     // TomcatJdbcDataSourcePerTenantService class -->
     private Properties dataSourceProperties() {
+        Environment environment = context.getEnvironment();
+
         Properties props = new Properties();
 
         props.setProperty("cachePrepStmts", "true");
@@ -145,6 +149,13 @@ public class CompatibilityConfig {
         // TODO FINERACT-890: <prop key="logger">com.mysql.cj.log.Slf4JLogger</prop>
         props.setProperty("logSlowQueries", "true");
         props.setProperty("dumpQueriesOnException", "true");
+
+        // gcp sql INSTANCE_CONNECTION_NAME
+        if (environment.getProperty("FINERACT_HIKARI_DS_PROPERTIES_INSTANCE_CONNECTION_NAME") != null) {
+            props.setProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+            props.setProperty("cloudSqlInstance", environment.getProperty("FINERACT_HIKARI_DS_PROPERTIES_INSTANCE_CONNECTION_NAME"));
+            props.setProperty("ipTypes", "PUBLIC,PRIVATE");
+        }
 
         return props;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.infrastructure.core.domain;
 
-import java.sql.Connection;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 
@@ -196,9 +195,19 @@ public class FineractPlatformTenantConnection {
         return sb.toString();
     }
 
+    public static String toJdbcUrlGCP(String protocol, String db, String parameters) {
+        StringBuilder sb = new StringBuilder(protocol).append(":///").append(db);
+
+        if (!StringUtils.isEmpty(parameters)) {
+            sb.append('?').append(parameters);
+        }
+
+        return sb.toString();
+    }
+
     public static String toProtocol(DataSource dataSource) {
-        try (Connection connection = dataSource.getConnection()) {
-            String url = connection.getMetaData().getURL();
+        try {
+            String url = dataSource.getConnection().getMetaData().getURL();
             return url.substring(0, url.indexOf("://"));
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Description

GCP Cloud SQL Support has advantage for using a fully managed SQL environment, Cloud SQL on GCP supports MySQL & Postgresql. The Cloud SQL Connector for Java is a library that provides IAM-based authorization and encryption when connecting to a Cloud SQL instance. It can not provide a network path to a Cloud SQL instance if one is not already present. It is Apache licensed too. https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
