### PR TITLE
Datatables Backward compatibility with CodeLookUp values

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetColumnHeaderData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetColumnHeaderData.java
@@ -75,6 +75,9 @@ public final class ResultsetColumnHeaderData implements Serializable {
             if (isString()) {
                 displayType = "STRING";
             } else if (isAnyInteger()) {
+                if (isInteger()) {
+                    this.columnType = this.columnType.toUpperCase();
+                }
                 displayType = "INTEGER";
             } else if (isDate()) {
                 displayType = "DATE";
@@ -92,7 +95,7 @@ public final class ResultsetColumnHeaderData implements Serializable {
             }
 
         } else {
-            if (isInt()) {
+            if (isInt() || isInteger()) {
                 displayType = "CODELOOKUP";
             } else if (isVarchar()) {
                 displayType = "CODEVALUE";


### PR DESCRIPTION
## Description

Datatables Backward compatibility with CodeLookUp values

Set the "`columnDisplayType`" as "`CODELOOKUP`" when the column is linked to DataCode , and
Fill the "`columnValues`" with the values of the DataCode linked

<img width="613" alt="Screen Shot 2022-04-25 at 14 40 39" src="https://user-images.githubusercontent.com/44206706/165168742-af772ad4-91af-4888-86ee-af4f25a0e69a.png">


Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
