### PR TITLE
Savings Interest Posting Job Fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
@@ -180,7 +180,7 @@ public final class SavingsAccountData implements Serializable {
         this.reasonForBlock = null;
         this.timeline = null;
         this.currency = null;
-        this.nominalAnnualInterestRate = nominalAnnualInterestRate;
+        this.nominalAnnualInterestRate = nominalAnnualInterestRate !=null ? nominalAnnualInterestRate : BigDecimal.ZERO;
         this.interestCompoundingPeriodType = interestCompoundingPeriodType;
         this.interestPostingPeriodType = interestPostingPeriodType;
         this.interestCalculationType = interestCalculationType;
@@ -537,7 +537,7 @@ public final class SavingsAccountData implements Serializable {
         this.reasonForBlock = null;
         this.timeline = null;
         this.currency = null;
-        this.nominalAnnualInterestRate = nominalAnnualInterestRate;
+        this.nominalAnnualInterestRate = nominalAnnualInterestRate == null ? BigDecimal.ZERO: nominalAnnualInterestRate;
         this.interestCompoundingPeriodType = interestCompoundingPeriodType;
         this.interestPostingPeriodType = interestPostingPeriodType;
         this.interestCalculationType = interestCalculationType;
@@ -959,7 +959,7 @@ public final class SavingsAccountData implements Serializable {
         this.reasonForBlock = reasonForBlock;
         this.timeline = timeline;
         this.currency = currency;
-        this.nominalAnnualInterestRate = nominalAnnualInterestRate;
+        this.nominalAnnualInterestRate = nominalAnnualInterestRate == null ? BigDecimal.ZERO: nominalAnnualInterestRate;
         this.interestCompoundingPeriodType = interestPeriodType;
         this.interestPostingPeriodType = interestPostingPeriodType;
         this.interestCalculationType = interestCalculationType;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountSummaryData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountSummaryData.java
@@ -78,7 +78,7 @@ public class SavingsAccountSummaryData implements Serializable {
         this.interestNotPosted = interestNotPosted;
         this.lastInterestCalculationDate = lastInterestCalculationDate;
         this.availableBalance = availableBalance;
-        this.interestPostedTillDate = interestPostedTillDate;
+        this.interestPostedTillDate = interestPostedTillDate==null ? lastInterestCalculationDate:interestPostedTillDate;
     }
 
     public void setPrevInterestPostedTillDate(LocalDate interestPostedTillDate) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountInterestPostingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountInterestPostingServiceImpl.java
@@ -108,7 +108,7 @@ public class SavingsAccountInterestPostingServiceImpl implements SavingsAccountI
                         newPostingTransaction = SavingsAccountTransactionData.interestPosting(savingsAccountData,
                                 interestPostingTransactionDate, interestEarnedToBePostedForPeriod, interestPostingPeriod.isUserPosting());
                     } else {
-                        newPostingTransaction = SavingsAccountTransactionData.interestPosting(savingsAccountData,
+                        newPostingTransaction = SavingsAccountTransactionData.overdraftInterest(savingsAccountData,
                                 interestPostingTransactionDate, interestEarnedToBePostedForPeriod.negated(),
                                 interestPostingPeriod.isUserPosting());
                     }
@@ -250,7 +250,7 @@ public class SavingsAccountInterestPostingServiceImpl implements SavingsAccountI
         final List<PostingPeriod> allPostingPeriods = new ArrayList<>();
 
         Money periodStartingBalance;
-        if (savingsAccountData.getStartInterestCalculationDate() != null) {
+        if (savingsAccountData.getStartInterestCalculationDate() != null  && !savingsAccountData.getStartInterestCalculationDate().equals(savingsAccountData.getActivationLocalDate())) {
             final SavingsAccountTransactionData transaction = retrieveLastTransactions(savingsAccountData);
 
             if (transaction == null) {
@@ -361,7 +361,8 @@ public class SavingsAccountInterestPostingServiceImpl implements SavingsAccountI
     }
 
     private BigDecimal getEffectiveOverdraftInterestRateAsFraction(MathContext mc, final SavingsAccountData savingsAccountData) {
-        return savingsAccountData.getNominalAnnualInterestRateOverdraft().divide(BigDecimal.valueOf(100L), mc);
+        return savingsAccountData.getNominalAnnualInterestRateOverdraft() != null ? savingsAccountData.getNominalAnnualInterestRateOverdraft().divide(BigDecimal.valueOf(100L), mc)
+                : BigDecimal.ZERO;
     }
 
     @SuppressWarnings("unused")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -274,7 +274,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
                     + "where (CASE WHEN sa.interest_posted_till_date is not null THEN tr.transaction_date >= sa.interest_posted_till_date ELSE tr.transaction_date >= sa.activatedon_date END) ";
         }
 
-        sql = sql + "and apm.product_type=2 and sa.interest_posted_till_date < '" + java.sql.Date.valueOf(currentDate) + "'";
+        sql = sql + " and (sa.interest_posted_till_date is null or sa.interest_posted_till_date < '" + java.sql.Date.valueOf(currentDate) + "') ";
         sql = sql + " order by sa.id, tr.transaction_date, tr.created_date, tr.id";
 
         List<SavingsAccountData> savingsAccountDataList = this.jdbcTemplate.query(sql, this.savingAccountMapperForInterestPosting, // NOSONAR

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.fineract.integrationtests.common.*;
+import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
+import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
+import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SavingsInterestPostingJobIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SavingsInterestPostingIntegrationTest.class);
+    public static final String ACCOUNT_TYPE_INDIVIDUAL = "INDIVIDUAL";
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private SavingsProductHelper savingsProductHelper;
+    private SavingsAccountHelper savingsAccountHelper;
+    private SchedulerJobHelper scheduleJobHelper;
+
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
+        this.savingsProductHelper = new SavingsProductHelper();
+        this.scheduleJobHelper = new SchedulerJobHelper(requestSpec);
+    }
+
+    @Test
+    public void testSavingsDailyInterestPostingJob() {
+        // client activation, savings activation and 1st transaction date
+        final String startDate = "10 April 2022";
+        final String jobName = "Post Interest For Savings";
+        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+        Assertions.assertNotNull(clientID);
+
+        final Integer savingsId = createSavingsAccountDailyPosting(clientID, startDate);
+
+
+        this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+
+        /***
+         * Runs Post interest posting job and verify the new account created with accounting configuration
+         * set as none is picked up by job
+         */
+        this.scheduleJobHelper.executeAndAwaitJob(jobName);
+        HashMap accountDetails = this.savingsAccountHelper.getSavingsDetails(savingsId);
+        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
+        HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 3);
+        for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
+            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+        }
+        assertEquals("2.7405", interestPostingTransaction.get("amount").toString(), "Equality check for interest posted amount");
+        assertEquals("[2022, 4, 12]", interestPostingTransaction.get("date").toString(), "Date check for Interest Posting transaction");
+    }
+
+    @Test
+    public void testSavingsDailyOverdraftInterestPostingJob() {
+        // client activation, savings activation and 1st transaction date
+        final String startDate = "10 April 2022";
+        final String jobName = "Post Interest For Savings";
+        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+        Assertions.assertNotNull(clientID);
+
+
+        final Integer savingsId= createSavingsAccountDailyPostingOverdraft(clientID, startDate);
+
+        this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+        /***
+         * Runs Post interest posting job and verify the new account created with Overdraft is posting negative interest
+         */
+        this.scheduleJobHelper.executeAndAwaitJob(jobName);
+        HashMap accountDetails = this.savingsAccountHelper.getSavingsDetails(savingsId);
+        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
+        HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size()-2);
+        for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
+            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+        }
+        assertEquals("2.7397", interestPostingTransaction.get("amount").toString(), "Equality check for overdatft interest posted amount");
+        assertEquals("[2022, 4, 11]", interestPostingTransaction.get("date").toString(), "Date check for overdraft Interest Posting transaction");
+
+    }
+
+    private Integer createSavingsAccountDailyPosting(final Integer clientID, final String startDate) {
+        final Integer savingsProductID = createSavingsProductDailyPosting();
+        Assertions.assertNotNull(savingsProductID);
+        final Integer savingsId = this.savingsAccountHelper.applyForSavingsApplicationOnDate(clientID, savingsProductID,
+                ACCOUNT_TYPE_INDIVIDUAL, startDate);
+        Assertions.assertNotNull(savingsId);
+        HashMap savingsStatusHashMap = this.savingsAccountHelper.approveSavingsOnDate(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
+        savingsStatusHashMap = this.savingsAccountHelper.activateSavingsAccount(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        return savingsId;
+    }
+
+    private Integer createSavingsAccountDailyPostingOverdraft(final Integer clientID, final String startDate) {
+        final Integer savingsProductID = createSavingsProductDailyPostingOverdraft();
+        Assertions.assertNotNull(savingsProductID);
+        final Integer savingsId = this.savingsAccountHelper.applyForSavingsApplicationOnDate(clientID, savingsProductID,
+                ACCOUNT_TYPE_INDIVIDUAL, startDate);
+        Assertions.assertNotNull(savingsId);
+        HashMap savingsStatusHashMap = this.savingsAccountHelper.approveSavingsOnDate(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
+        savingsStatusHashMap = this.savingsAccountHelper.activateSavingsAccount(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        return savingsId;
+    }
+
+    private Integer createSavingsProductDailyPosting() {
+        final String savingsProductJSON = this.savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
+                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().build();
+        return SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
+    }
+    private Integer createSavingsProductDailyPostingOverdraft() {
+        final String overDraftLimit = "10000.0";
+        final String nominalAnnualInterestRateOverdraft="10";
+        final String savingsProductJSON = this.savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
+                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().withOverDraftRate(overDraftLimit,nominalAnnualInterestRateOverdraft).build();
+        return SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
+    }
+    // Reset configuration fields
+    @AfterEach
+    public void tearDown() {
+        GlobalConfigurationHelper.resetAllDefaultGlobalConfigurations(this.requestSpec, this.responseSpec);
+        GlobalConfigurationHelper.verifyAllDefaultGlobalConfigurations(this.requestSpec, this.responseSpec);
+    }
+
+
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
@@ -243,7 +243,7 @@ public class SavingsProductHelper {
         this.overdraftLimit = overdraftLimit;
         return this;
     }
-    public SavingsProductHelper withOverDraft(final String overdraftLimit,String nominalAnnualInterestRateOverdraft) {
+    public SavingsProductHelper withOverDraftRate(final String overdraftLimit,String nominalAnnualInterestRateOverdraft) {
         this.allowOverdraft = "true";
         this.overdraftLimit = overdraftLimit;
         this.nominalAnnualInterestRateOverdraft=nominalAnnualInterestRateOverdraft;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
@@ -90,6 +90,7 @@ public class SavingsProductHelper {
     private String maxAllowedLienLimit = null;
     private Boolean withHoldTax = false;
     private String taxGroupId = null;
+    private String nominalAnnualInterestRateOverdraft=null;
     private boolean isDormancyTrackingActive = false;
     private String daysToInactive = null;
     private String daysToDormancy = null;
@@ -134,6 +135,7 @@ public class SavingsProductHelper {
         map.put("lienAllowed", this.lienAllowed);
         map.put("maxAllowedLienLimit", this.maxAllowedLienLimit);
         map.put("withHoldTax", this.withHoldTax.toString());
+        map.put("nominalAnnualInterestRateOverdraft" ,this.nominalAnnualInterestRateOverdraft);
 
         if (withHoldTax) {
             map.put("taxGroupId", taxGroupId);
@@ -239,6 +241,12 @@ public class SavingsProductHelper {
     public SavingsProductHelper withOverDraft(final String overdraftLimit) {
         this.allowOverdraft = "true";
         this.overdraftLimit = overdraftLimit;
+        return this;
+    }
+    public SavingsProductHelper withOverDraft(final String overdraftLimit,String nominalAnnualInterestRateOverdraft) {
+        this.allowOverdraft = "true";
+        this.overdraftLimit = overdraftLimit;
+        this.nominalAnnualInterestRateOverdraft=nominalAnnualInterestRateOverdraft;
         return this;
     }
 


### PR DESCRIPTION
System is posting positive interest for Overdraft account([FINERACT-1518](https://issues.apache.org/jira/browse/FINERACT-1518))
Savings Interest Posting Job: New accounts are not picked up by interest posting job([FINERACT-1600](https://issues.apache.org/jira/browse/FINERACT-1600))
Savings Interest Posting Job : If accounting configuration is product set as none, then accounts are not picked up by the job([FINERACT-1601](https://issues.apache.org/jira/browse/FINERACT-1601))
Savings Interest Posting Job : When overdraft interest is not set at product level, the job fails ([FINERACT-1602](https://issues.apache.org/jira/browse/FINERACT-1602))
Savings Interest Posting Job : Interest Compounding is not happening for Daily Posting Period ([FINERACT-1603](https://issues.apache.org/jira/browse/FINERACT-1603))