### PR TITLE
Fix NullPointerException at Base64$Encoder in ImagesApiResource (FINERACT-1224)

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
@@ -61,8 +61,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Scope("singleton")
 @Path("{entity}/{entityId}/images")
-
 public class ImagesApiResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImagesApiResource.class);
 
     private final PlatformSecurityContext context;
     private final ImageReadPlatformService imageReadPlatformService;
@@ -165,12 +166,12 @@ public class ImagesApiResource {
 
         try {
             byte[] resizedImageBytes = resizedImage.getByteSource().read();
-
-            if(resizedImageBytes != null){
+            if (resizedImageBytes != null) {
                 final String clientImageAsBase64Text = imageDataURISuffix + Base64.getMimeEncoder().encodeToString(resizedImageBytes);
                 return Response.ok(clientImageAsBase64Text, MediaType.TEXT_PLAIN_TYPE).build();
-            }else{
-                return Response.noContent().build();
+            } else {
+                LOG.error("resizedImageBytes is null for entityName={}, entityId={}, maxWidth={}, maxHeight={}", entityName, entityId, maxWidth, maxHeight);
+                return Response.serverError().build();
             }
         } catch (IOException e) {
             throw new ContentManagementException(imageData.name(), e.getMessage(), e);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
@@ -54,6 +54,8 @@ import org.apache.fineract.portfolio.client.data.ClientData;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -170,7 +172,8 @@ public class ImagesApiResource {
                 final String clientImageAsBase64Text = imageDataURISuffix + Base64.getMimeEncoder().encodeToString(resizedImageBytes);
                 return Response.ok(clientImageAsBase64Text, MediaType.TEXT_PLAIN_TYPE).build();
             } else {
-                LOG.error("resizedImageBytes is null for entityName={}, entityId={}, maxWidth={}, maxHeight={}", entityName, entityId, maxWidth, maxHeight);
+                LOG.error("resizedImageBytes is null for entityName={}, entityId={}, maxWidth={}, maxHeight={}", entityName, entityId,
+                        maxWidth, maxHeight);
                 return Response.serverError().build();
             }
         } catch (IOException e) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/api/ImagesApiResource.java
@@ -165,8 +165,13 @@ public class ImagesApiResource {
 
         try {
             byte[] resizedImageBytes = resizedImage.getByteSource().read();
-            final String clientImageAsBase64Text = imageDataURISuffix + Base64.getMimeEncoder().encodeToString(resizedImageBytes);
-            return Response.ok(clientImageAsBase64Text, MediaType.TEXT_PLAIN_TYPE).build();
+
+            if(resizedImageBytes != null){
+                final String clientImageAsBase64Text = imageDataURISuffix + Base64.getMimeEncoder().encodeToString(resizedImageBytes);
+                return Response.ok(clientImageAsBase64Text, MediaType.TEXT_PLAIN_TYPE).build();
+            }else{
+                return Response.noContent().build();
+            }
         } catch (IOException e) {
             throw new ContentManagementException(imageData.name(), e.getMessage(), e);
         }


### PR DESCRIPTION
## Description

Should fix the NullPointerException at Base64$Encoder.encode() in ImagesApiResource from https://issues.apache.org/jira/browse/FINERACT-1224 .
