### PR TITLE
Enable/Disable Messaging in Read Only instance mode

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventsCondition.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventsCondition.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.config;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class EnableFineractEventsCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        boolean isReadModeEnabled = Optional.ofNullable(context.getEnvironment().getProperty("fineract.mode.read-enabled", Boolean.class))
+                .orElse(true);
+        boolean isWriteModeEnabled = Optional.ofNullable(context.getEnvironment().getProperty("fineract.mode.write-enabled", Boolean.class))
+                .orElse(true);
+        boolean isBatchModeEnabled = Optional.ofNullable(context.getEnvironment().getProperty("fineract.mode.batch-enabled", Boolean.class))
+                .orElse(true);
+        return !isReadModeEnabled && (isWriteModeEnabled || isBatchModeEnabled);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/config/MessagingConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/config/MessagingConfiguration.java
@@ -21,11 +21,13 @@ package org.apache.fineract.notification.config;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.fineract.infrastructure.core.config.EnableFineractEventsCondition;
 import org.apache.fineract.notification.eventandlistener.NotificationEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
@@ -35,6 +37,7 @@ import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 @Configuration
 @Profile("activeMqEnabled")
+@Conditional(EnableFineractEventsCondition.class)
 public class MessagingConfiguration {
 
     @Autowired

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventListener.java
@@ -23,13 +23,16 @@ import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.config.EnableFineractEventsCondition;
 import org.apache.fineract.notification.data.NotificationData;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("activeMqEnabled")
+@Conditional(EnableFineractEventsCondition.class)
 @RequiredArgsConstructor
 public class ActiveMQNotificationEventListener implements SessionAwareMessageListener {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventPublisher.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventPublisher.java
@@ -21,13 +21,16 @@ package org.apache.fineract.notification.eventandlistener;
 import javax.jms.Queue;
 import lombok.RequiredArgsConstructor;
 import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.fineract.infrastructure.core.config.EnableFineractEventsCondition;
 import org.apache.fineract.notification.data.NotificationData;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @Profile("activeMqEnabled")
+@Conditional(EnableFineractEventsCondition.class)
 @RequiredArgsConstructor
 public class ActiveMQNotificationEventPublisher implements NotificationEventPublisher {
 


### PR DESCRIPTION
## Description

When a Fineract instance is running as read-only, all event receiving/sending shall be disabled

In case of a read-only instance, the best way to prevent events from being sent and received is to simply disable the messaging configuration (JMS/etc), that way there’s not even a connection established for the brokers.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
