### PR TITLE
Disable receiving events for batch-only instances

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventListenerCondition.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventListenerCondition.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-public class EnableFineractEventsCondition implements Condition {
+public class EnableFineractEventListenerCondition implements Condition {
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
@@ -37,6 +37,7 @@ public class EnableFineractEventsCondition implements Condition {
         boolean isBatchModeEnabled = Optional.ofNullable(
                 context.getEnvironment().getProperty(FineractInstanceModeConstants.FINERACT_MODE_BATCH_ENABLE_PROPERTY, Boolean.class))
                 .orElse(true);
-        return !isReadModeEnabled && (isWriteModeEnabled || isBatchModeEnabled);
+        return (isReadModeEnabled && isBatchModeEnabled && isWriteModeEnabled) // All mode
+                || (!isReadModeEnabled && !isBatchModeEnabled && isWriteModeEnabled); // Write mode
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/instancemode/api/FineractInstanceModeConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/instancemode/api/FineractInstanceModeConstants.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.instancemode.api;
+
+public final class FineractInstanceModeConstants {
+
+    private FineractInstanceModeConstants() {
+
+    }
+
+    public static final String FINERACT_MODE_READ_ENABLE_PROPERTY = "fineract.mode.read-enabled";
+    public static final String FINERACT_MODE_WRITE_ENABLE_PROPERTY = "fineract.mode.write-enabled";
+    public static final String FINERACT_MODE_BATCH_ENABLE_PROPERTY = "fineract.mode.batch-enabled";
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/eventandlistener/ActiveMQNotificationEventListener.java
@@ -23,7 +23,7 @@ import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import lombok.RequiredArgsConstructor;
-import org.apache.fineract.infrastructure.core.config.EnableFineractEventsCondition;
+import org.apache.fineract.infrastructure.core.config.EnableFineractEventListenerCondition;
 import org.apache.fineract.notification.data.NotificationData;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("activeMqEnabled")
-@Conditional(EnableFineractEventsCondition.class)
+@Conditional(EnableFineractEventListenerCondition.class)
 @RequiredArgsConstructor
 public class ActiveMQNotificationEventListener implements SessionAwareMessageListener {
 

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventListenerConditionTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/core/config/EnableFineractEventListenerConditionTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.config;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.apache.fineract.infrastructure.instancemode.api.FineractInstanceModeConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EnableFineractEventListenerConditionTest {
+
+    @InjectMocks
+    private EnableFineractEventListenerCondition underTest;
+
+    @Mock
+    private AnnotatedTypeMetadata metadata;
+
+    private ConditionContext context;
+    private Environment environment;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ConditionContext.class);
+        environment = mock(Environment.class);
+    }
+
+    @Test
+    void testOnMessage_ShouldBlockOnMessage_WhenFineractIsInBatchMode() {
+
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_READ_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_WRITE_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_BATCH_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(context.getEnvironment()).willReturn(environment);
+
+        assertFalse(underTest.matches(context, metadata));
+    }
+
+    @Test
+    void testOnMessage_ShouldAllowOnMessage_WhenFineractIsInAllMode() {
+
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_READ_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_WRITE_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_BATCH_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(context.getEnvironment()).willReturn(environment);
+
+        assertTrue(underTest.matches(context, metadata));
+    }
+
+    @Test
+    void testOnMessage_ShouldAllowOnMessage_WhenFineractIsInWriteMode() {
+
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_READ_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_WRITE_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_BATCH_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(context.getEnvironment()).willReturn(environment);
+
+        assertTrue(underTest.matches(context, metadata));
+    }
+
+    @Test
+    void testOnMessage_ShouldBlockOnMessage_WhenFineractIsInReadMode() {
+
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_READ_ENABLE_PROPERTY, Boolean.class)).willReturn(true);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_WRITE_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(environment.getProperty(FineractInstanceModeConstants.FINERACT_MODE_BATCH_ENABLE_PROPERTY, Boolean.class)).willReturn(false);
+        given(context.getEnvironment()).willReturn(environment);
+
+        assertFalse(underTest.matches(context, metadata));
+    }
+
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/instancemode/InstanceModeMock.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/instancemode/InstanceModeMock.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.instancemode;
+
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+
+public final class InstanceModeMock {
+
+    private InstanceModeMock() {
+
+    }
+
+    public static FineractProperties.FineractModeProperties createModeProps(boolean readEnabled, boolean writeEnabled,
+            boolean batchEnabled) {
+        FineractProperties.FineractModeProperties modeProperties = new FineractProperties.FineractModeProperties();
+        modeProperties.setReadEnabled(readEnabled);
+        modeProperties.setWriteEnabled(writeEnabled);
+        modeProperties.setBatchEnabled(batchEnabled);
+        return modeProperties;
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/instancemode/filter/FineractInstanceModeApiFilterTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/instancemode/filter/FineractInstanceModeApiFilterTest.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.instancemode.InstanceModeMock;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetReadApisThrough_WhenFineractIsInAllModeAndIsGetApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(true, true, true);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(true, true, true);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getPathInfo()).willReturn("/loans");
@@ -83,7 +84,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetReadApisThrough_WhenFineractIsInReadOnlyModeAndIsGetApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(true, false, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(true, false, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getPathInfo()).willReturn("/loans");
@@ -97,7 +98,7 @@ class FineractInstanceModeApiFilterTest {
     void testDoFilterInternal_ShouldLetActuatorApisThrough_WhenFineractIsInReadOnlyModeAndIsHealthApi()
             throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(true, false, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(true, false, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getServletPath()).willReturn("/actuator/health");
@@ -111,7 +112,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldNotLetWriteApisThrough_WhenFineractIsInReadOnlyModeAndIsPostApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(true, false, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(true, false, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.POST.name());
         given(request.getPathInfo()).willReturn("/loans");
@@ -125,7 +126,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldNotLetBatchApisThrough_WhenFineractIsInReadOnlyModeAndIsJobsApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(true, false, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(true, false, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.POST.name());
         given(request.getPathInfo()).willReturn("/jobs/1");
@@ -139,7 +140,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetReadApisThrough_WhenFineractIsInWriteModeAndIsGetApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, true, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, true, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getPathInfo()).willReturn("/loans");
@@ -152,7 +153,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetWriteApisThrough_WhenFineractIsInWriteModeAndIsPostApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, true, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, true, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.POST.name());
         given(request.getPathInfo()).willReturn("/loans");
@@ -165,7 +166,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetWriteApisThrough_WhenFineractIsInWriteModeAndIsPutApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, true, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, true, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.PUT.name());
         given(request.getPathInfo()).willReturn("/loans/1");
@@ -178,7 +179,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetActuatorApisThrough_WhenFineractIsInWriteModeAndIsHelathApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, true, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, true, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getServletPath()).willReturn("/actuator/health");
@@ -192,7 +193,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldNotLetBatchApisThrough_WhenFineractIsInWriteModeAndIsJobsApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, true, false);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, true, false);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.POST.name());
         given(request.getPathInfo()).willReturn("/jobs/1");
@@ -206,7 +207,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetBatchApisThrough_WhenFineractIsInBatchModeAndIsJobsApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, false, true);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, false, true);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.POST.name());
         given(request.getPathInfo()).willReturn("/jobs/1");
@@ -220,7 +221,7 @@ class FineractInstanceModeApiFilterTest {
     void testDoFilterInternal_ShouldLetBatchApisThrough_WhenFineractIsInBatchModeAndIsListingJobsApi()
             throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, false, true);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, false, true);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getPathInfo()).willReturn("/jobs");
@@ -233,7 +234,7 @@ class FineractInstanceModeApiFilterTest {
     @Test
     void testDoFilterInternal_ShouldLetActuatorApisThrough_WhenFineractIsInBatchModeAndIsHealthApi() throws ServletException, IOException {
         // given
-        FineractProperties.FineractModeProperties modeProperties = createModeProps(false, false, true);
+        FineractProperties.FineractModeProperties modeProperties = InstanceModeMock.createModeProps(false, false, true);
         given(fineractProperties.getMode()).willReturn(modeProperties);
         given(request.getMethod()).willReturn(HttpMethod.GET.name());
         given(request.getServletPath()).willReturn("/actuator/health");
@@ -242,13 +243,5 @@ class FineractInstanceModeApiFilterTest {
         underTest.doFilterInternal(request, response, filterChain);
         // then
         verify(filterChain).doFilter(request, response);
-    }
-
-    private FineractProperties.FineractModeProperties createModeProps(boolean readEnabled, boolean writeEnabled, boolean batchEnabled) {
-        FineractProperties.FineractModeProperties modeProperties = new FineractProperties.FineractModeProperties();
-        modeProperties.setReadEnabled(readEnabled);
-        modeProperties.setWriteEnabled(writeEnabled);
-        modeProperties.setBatchEnabled(batchEnabled);
-        return modeProperties;
     }
 }


### PR DESCRIPTION
## Description

It was created a Conditional for enabling the Event Listener (`EnableFineractEventListenerCondition`) only for Write instances, and It was updated with the `@Conditional` annotation in the `ActiveMQNotificationEventListener` class

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
