### PR TITLE
Fix for reading multirow datatable entry reads non-belonging entry

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/adhocquery/service/AdHocScheduledJobRunnerServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/adhocquery/service/AdHocScheduledJobRunnerServiceImpl.java
@@ -82,7 +82,7 @@ public class AdHocScheduledJobRunnerServiceImpl implements AdHocScheduledJobRunn
                                 run = Math.toIntExact(ChronoUnit.YEARS.between(start, end)) >= 1;
                             break;
                             case CUSTOM:
-                                next = start.plusDays((int) (long) adhoc.getReportRunEvery());
+                                next = start.plusDays((long) adhoc.getReportRunEvery());
                                 run = Math.toIntExact(ChronoUnit.DAYS.between(start, end)) >= adhoc.getReportRunEvery();
                             break;
                             default:

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
@@ -38,7 +38,6 @@ public class CommandProcessingResult implements Serializable {
     private final String transactionId;
     private final Map<String, Object> changes;
     private final Map<String, Object> creditBureauReportData;
-    @SuppressWarnings("unused")
     private final String resourceIdentifier;
     private final Long productId;
     private final Long gsimId;
@@ -49,6 +48,13 @@ public class CommandProcessingResult implements Serializable {
         return new CommandProcessingResult(commandResult.commandId, commandResult.officeId, commandResult.groupId, commandResult.clientId,
                 commandResult.loanId, commandResult.savingsId, commandResult.resourceIdentifier, commandResult.resourceId,
                 commandResult.transactionId, commandResult.changes, commandResult.productId, commandResult.gsimId, commandResult.glimId,
+                commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId);
+    }
+
+    public static CommandProcessingResult fromCommandProcessingResult(CommandProcessingResult commandResult, final Long resourceId) {
+        return new CommandProcessingResult(commandResult.commandId, commandResult.officeId, commandResult.groupId, commandResult.clientId,
+                commandResult.loanId, commandResult.savingsId, commandResult.resourceIdentifier, resourceId, commandResult.transactionId,
+                commandResult.changes, commandResult.productId, commandResult.gsimId, commandResult.glimId,
                 commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/handler/CreateDatatableEntryCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/handler/CreateDatatableEntryCommandHandler.java
@@ -21,7 +21,6 @@ package org.apache.fineract.infrastructure.dataqueries.handler;
 import org.apache.fineract.commands.handler.NewCommandSourceHandler;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
-import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.dataqueries.service.ReadWriteNonCoreDataService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -41,17 +40,6 @@ public class CreateDatatableEntryCommandHandler implements NewCommandSourceHandl
     @Override
     public CommandProcessingResult processCommand(final JsonCommand command) {
 
-        final CommandProcessingResult commandProcessingResult = this.writePlatformService.createNewDatatableEntry(command.entityName(),
-                command.entityId(), command);
-
-        return new CommandProcessingResultBuilder() //
-                .withCommandId(command.commandId()) //
-                .withEntityId(command.entityId()) //
-                .withOfficeId(commandProcessingResult.getOfficeId()) //
-                .withGroupId(commandProcessingResult.getGroupId()) //
-                .withClientId(commandProcessingResult.getClientId()) //
-                .withSavingsId(commandProcessingResult.getSavingsId()) //
-                .withLoanId(commandProcessingResult.getLoanId()) //
-                .build();
+        return this.writePlatformService.createNewDatatableEntry(command.entityName(), command.entityId(), command);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
@@ -1040,8 +1040,7 @@ public final class LoanApplicationTerms {
             break;
             case DAILY:
                 // For daily work out number of days in the period
-                BigDecimal numberOfDaysInPeriod = BigDecimal
-                        .valueOf(Math.toIntExact(ChronoUnit.DAYS.between(periodStartDate, periodEndDate)));
+                BigDecimal numberOfDaysInPeriod = BigDecimal.valueOf(ChronoUnit.DAYS.between(periodStartDate, periodEndDate));
 
                 final BigDecimal oneDayOfYearInterestRate = this.annualNominalInterestRate.divide(loanTermPeriodsInYearBigDecimal, mc)
                         .divide(divisor, mc);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
@@ -52,11 +52,11 @@ public class DatatableHelper {
     }
 
     public Integer createDatatableEntry(final String apptableName, final String datatableName, final Integer apptableId,
-            final boolean genericResultSet, final String dateFormat) {
+            final boolean genericResultSet, final String dateFormat, final String jsonAttributeToGetBack) {
         return Utils.performServerPost(
                 this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + apptableId + "?genericResultSet="
                         + Boolean.toString(genericResultSet) + "&" + Utils.TENANT_IDENTIFIER,
-                getTestDatatableEntryAsJSON(dateFormat), "resourceId");
+                getTestDatatableEntryAsJSON(dateFormat), jsonAttributeToGetBack);
     }
 
     public String readDatatableEntry(final String datatableName, final Integer resourceId, final boolean genericResultset) {
@@ -65,9 +65,16 @@ public class DatatableHelper {
     }
 
     public List<String> readDatatableEntry(final String datatableName, final Integer resourceId, final boolean genericResultset,
-            final String jsonAttributeToGetBack) {
-        return Utils.performServerGetList(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + resourceId
-                + "?genericResultSet=" + String.valueOf(genericResultset) + "&" + Utils.TENANT_IDENTIFIER, jsonAttributeToGetBack);
+            final Integer datatableResourceId, final String jsonAttributeToGetBack) {
+        if (datatableResourceId == null) {
+            return Utils.performServerGetList(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + resourceId
+                    + "?genericResultSet=" + String.valueOf(genericResultset) + "&" + Utils.TENANT_IDENTIFIER, jsonAttributeToGetBack);
+        } else {
+            return Utils.performServerGetList(
+                    this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + resourceId + "/" + datatableResourceId
+                            + "?genericResultSet=" + String.valueOf(genericResultset) + "&" + Utils.TENANT_IDENTIFIER,
+                    jsonAttributeToGetBack);
+        }
     }
 
     public Date readDatatableEntry(final String datatableName, final Integer resourceId, final boolean genericResultset, final int position,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableIntegrationTest.java
@@ -63,11 +63,11 @@ public class DatatableIntegrationTest {
         // creating new client datatable entry
         final boolean genericResultSet = true;
         Integer datatableResourceID = this.datatableHelper.createDatatableEntry(CLIENT_APP_TABLE_NAME, datatableName, clientID,
-                genericResultSet, "yyyy-MM-dd");
+                genericResultSet, "yyyy-MM-dd", "resourceId");
         assertNotNull(datatableResourceID, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
 
         // Read the Datatable entry generated with genericResultSet in true (default)
-        final List<String> items = this.datatableHelper.readDatatableEntry(datatableName, clientID, genericResultSet, "data");
+        final List<String> items = this.datatableHelper.readDatatableEntry(datatableName, clientID, genericResultSet, null, "data");
         assertEquals(1, items.size());
 
         // Read the Datatable entry generated with genericResultSet in false
@@ -84,4 +84,50 @@ public class DatatableIntegrationTest {
         assertEquals(datatableName, deletedDataTableName, "ERROR IN DELETING THE DATATABLE");
     }
 
+    @Test
+    public void validateReadDatatableMultirow() {
+        // creating multirow datatable for client entity
+        String datatableName = this.datatableHelper.createDatatable(CLIENT_APP_TABLE_NAME, true);
+        DatatableHelper.verifyDatatableCreatedOnServer(this.requestSpec, this.responseSpec, datatableName);
+
+        // creating first client with datatables
+        final Integer clientIdA = ClientHelper.createClientAsPerson(requestSpec, responseSpec);
+
+        // creating second client with datatables
+        final Integer clientIdB = ClientHelper.createClientAsPerson(requestSpec, responseSpec);
+
+        // creating new client datatable entry for first client
+        final boolean genericResultSet = true;
+        final Integer datatableResourceIdA = this.datatableHelper.createDatatableEntry(CLIENT_APP_TABLE_NAME, datatableName, clientIdA,
+                genericResultSet, "yyyy-MM-dd", "resourceId");
+        assertNotNull(datatableResourceIdA, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+
+        // creating new client datatable entry for second client
+        final Integer datatableResourceIdB = this.datatableHelper.createDatatableEntry(CLIENT_APP_TABLE_NAME, datatableName, clientIdB,
+                genericResultSet, "yyyy-MM-dd", "resourceId");
+        assertNotNull(datatableResourceIdB, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+
+        // Read the Datatable entry generated for first client
+        List<String> items;
+        items = this.datatableHelper.readDatatableEntry(datatableName, clientIdA, genericResultSet, datatableResourceIdA, "data");
+        assertEquals(1, items.size());
+
+        // Read the Datatable entry generated for second client
+        items = this.datatableHelper.readDatatableEntry(datatableName, clientIdB, genericResultSet, datatableResourceIdB, "data");
+        assertEquals(1, items.size());
+
+        // Read the Datatable entry generated for first client and second client's record Id
+        items = this.datatableHelper.readDatatableEntry(datatableName, clientIdA, genericResultSet, datatableResourceIdB, "data");
+        assertEquals(0, items.size());
+
+        // deleting datatable entries
+        Integer appTableIdA = this.datatableHelper.deleteDatatableEntries(datatableName, clientIdA, "clientId");
+        assertEquals(clientIdA, appTableIdA, "ERROR IN DELETING THE DATATABLE ENTRIES");
+        Integer appTableIdB = this.datatableHelper.deleteDatatableEntries(datatableName, clientIdB, "clientId");
+        assertEquals(clientIdB, appTableIdB, "ERROR IN DELETING THE DATATABLE ENTRIES");
+
+        // deleting the datatable
+        String deletedDataTableName = this.datatableHelper.deleteDatatable(datatableName);
+        assertEquals(datatableName, deletedDataTableName, "ERROR IN DELETING THE DATATABLE");
+    }
 }


### PR DESCRIPTION
## Description

The endpoint `datatables/{datatable}/{apptableId}/{datatableId}` was not honoring `appTableId` path param when `datatableId` is not null in request. This results in API allowing access to a datatableId that belongs to a different apptableId.

This only was for _multirow_ datatable and It was giving priority only to the datatable record Id instead of the relationship between `apptableId` (entity Id) and the `datatableId` (record Id)

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
