### PR TITLE
Specify query parameters for LoanTransactionsApi retrieveTransaction

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/batch/command/CommandStrategyUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/batch/command/CommandStrategyUtils.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.infrastructure.core.api.MutableUriInfo;
+
+public final class CommandStrategyUtils {
+
+    private CommandStrategyUtils() {
+
+    }
+
+    /**
+     * Get query parameters from relative URL.
+     *
+     * @param relativeUrl
+     *            the relative URL
+     * @return the query parameters in a map
+     */
+    public static Map<String, String> getQueryParameters(final String relativeUrl) {
+        final String queryParameterStr = StringUtils.substringAfter(relativeUrl, "?");
+        final String[] queryParametersArray = StringUtils.split(queryParameterStr, "&");
+        final Map<String, String> queryParametersMap = new HashMap<>();
+        for (String parameterStr : queryParametersArray) {
+            String[] keyValue = StringUtils.split(parameterStr, "=");
+            queryParametersMap.put(keyValue[0], keyValue[1]);
+        }
+        return queryParametersMap;
+    }
+
+    /**
+     * Add query parameters(received in the relative URL) to URI info query parameters.
+     *
+     * @param uriInfo
+     *            the URI info
+     * @param queryParameters
+     *            the query parameters
+     */
+    public static void addQueryParametersToUriInfo(final MutableUriInfo uriInfo, final Map<String, String> queryParameters) {
+        for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
+            uriInfo.addAdditionalQueryParameter(entry.getKey(), entry.getValue());
+        }
+    }
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResource.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.loanaccount.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -206,6 +207,7 @@ public class LoanTransactionsApiResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsTransactionIdResponse.class))) })
     public String retrieveTransaction(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
             @PathParam("transactionId") @Parameter(description = "transactionId") final Long transactionId,
+            @QueryParam("fields") @Parameter(in = ParameterIn.QUERY, name = "fields", description = "Optional Loan Transaction attribute list to be in the response", required = false, example = "id,date,amount") final String fields,
             @Context final UriInfo uriInfo) {
 
         this.context.authenticatedUser().validateHasReadPermission(this.resourceNameForPermissions);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/loanaccount/api/SelfLoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/loanaccount/api/SelfLoansApiResource.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.self.loanaccount.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -61,7 +62,6 @@ import org.springframework.stereotype.Component;
 @Path("/self/loans")
 @Component
 @Scope("singleton")
-
 @Tag(name = "Self Loans", description = "")
 public class SelfLoansApiResource {
 
@@ -119,13 +119,14 @@ public class SelfLoansApiResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SelfLoansApiResourceSwagger.GetSelfLoansLoanIdTransactionsTransactionIdResponse.class))) })
     public String retrieveTransaction(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
             @PathParam("transactionId") @Parameter(description = "transactionId") final Long transactionId,
+            @QueryParam("fields") @Parameter(in = ParameterIn.QUERY, name = "fields", description = "Optional Loan Transaction attribute list to be in the response", required = false, example = "id,date,amount") final String fields,
             @Context final UriInfo uriInfo) {
 
         this.dataValidator.validateRetrieveTransaction(uriInfo);
 
         validateAppuserLoanMapping(loanId);
 
-        return this.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, uriInfo);
+        return this.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, fields, uriInfo);
     }
 
     @GET

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/GetTransactionByIdCommandStrategyTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/GetTransactionByIdCommandStrategyTest.java
@@ -20,9 +20,12 @@ package org.apache.fineract.batch.command.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
+import java.util.stream.Stream;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -33,22 +36,30 @@ import org.apache.fineract.portfolio.loanaccount.exception.LoanNotFoundException
 import org.apache.fineract.portfolio.loanaccount.exception.LoanTransactionNotFoundException;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class GetTransactionByIdCommandStrategyTest {
 
+    private static Stream<Arguments> provideQueryParameters() {
+        return Stream.of(Arguments.of(null, 0), Arguments.of("id,date,amount", 1));
+    }
+
     /**
      * Test {@link GetTransactionByIdCommandStrategy#execute} happy path scenario.
      */
-    @Test
-    public void testExecuteSuccessScenario() {
+    @ParameterizedTest
+    @MethodSource("provideQueryParameters")
+    public void testExecuteSuccessScenario(final String fields, final int noOfQueryParams) {
         // given
         final TestContext testContext = new TestContext();
 
         final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
         final Long transactionId = Long.valueOf(RandomStringUtils.randomNumeric(4));
-        final BatchRequest request = getBatchRequest(loanId, transactionId);
+        final BatchRequest request = getBatchRequest(loanId, transactionId, fields);
         final String responseBody = "{\"id\":12,\"officeId\":1,\"officeName\":\"Head Office\",\"type\":{\"id\":10,\"code\":"
                 + "\"loanTransactionType.accrual\",\"value\":\"Accrual\",\"disbursement\":false,\"repaymentAtDisbursement\":false,"
                 + "\"repayment\":false,\"contra\":false,\"waiveInterest\":false,\"waiveCharges\":false,\"accrual\":true,\"writeOff\":false,"
@@ -60,7 +71,7 @@ public class GetTransactionByIdCommandStrategyTest {
                 + "\"unrecognizedIncomePortion\":0,\"outstandingLoanBalance\":0,\"submittedOnDate\":[2022,3,29],\"manuallyReversed\":false,"
                 + "\"loanChargePaidByList\":[],\"numberOfRepayments\":0}";
 
-        given(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, testContext.uriInfo))
+        given(testContext.loanTransactionsApiResource.retrieveTransaction(eq(loanId), eq(transactionId), eq(fields), any(UriInfo.class)))
                 .willReturn(responseBody);
 
         // when
@@ -82,9 +93,9 @@ public class GetTransactionByIdCommandStrategyTest {
         final TestContext testContext = new TestContext();
         final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
         final Long transactionId = Long.valueOf(RandomStringUtils.randomNumeric(4));
-        final BatchRequest request = getBatchRequest(loanId, transactionId);
+        final BatchRequest request = getBatchRequest(loanId, transactionId, null);
 
-        given(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, testContext.uriInfo))
+        given(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, null, testContext.uriInfo))
                 .willThrow(new RuntimeException("Some error"));
 
         // when
@@ -106,9 +117,9 @@ public class GetTransactionByIdCommandStrategyTest {
         final TestContext testContext = new TestContext();
         final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
         final Long transactionId = Long.valueOf(RandomStringUtils.randomNumeric(4));
-        final BatchRequest request = getBatchRequest(loanId, transactionId);
+        final BatchRequest request = getBatchRequest(loanId, transactionId, null);
 
-        given(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, testContext.uriInfo))
+        given(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, null, testContext.uriInfo))
                 .willThrow(new LoanNotFoundException(loanId));
 
         // when
@@ -129,9 +140,9 @@ public class GetTransactionByIdCommandStrategyTest {
         final TestContext testContext = new TestContext();
         final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
         final Long transactionId = Long.valueOf(RandomStringUtils.randomNumeric(4));
-        final BatchRequest request = getBatchRequest(loanId, transactionId);
+        final BatchRequest request = getBatchRequest(loanId, transactionId, null);
 
-        when(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, testContext.uriInfo))
+        when(testContext.loanTransactionsApiResource.retrieveTransaction(loanId, transactionId, null, testContext.uriInfo))
                 .thenThrow(new LoanTransactionNotFoundException(transactionId));
 
         final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
@@ -151,10 +162,13 @@ public class GetTransactionByIdCommandStrategyTest {
      *            the transaction id
      * @return BatchRequest
      */
-    private BatchRequest getBatchRequest(final Long loanId, final Long transactionId) {
+    private BatchRequest getBatchRequest(final Long loanId, final Long transactionId, final String fields) {
 
         final BatchRequest br = new BatchRequest();
         String relativeUrl = "loans/" + loanId + "/transactions/" + transactionId;
+        if (fields != null) {
+            relativeUrl = relativeUrl + "?fields=" + fields;
+        }
 
         br.setRequestId(Long.valueOf(RandomStringUtils.randomNumeric(5)));
         br.setRelativeUrl(relativeUrl);


### PR DESCRIPTION
## Description

The generated client for LoanTransactionsApi#retrieveTransaction has not the capability to specify the query parameters to control the behavior of the API.

<img width="1639" alt="Screen Shot 2022-06-18 at 0 55 04" src="https://user-images.githubusercontent.com/44206706/174424996-035dc559-ea73-4865-ab5c-bc6f9ab794f4.png">

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
