### PR TITLE
Loan externalId unique validation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
@@ -161,4 +161,6 @@ public interface LoanRepository extends JpaRepository<Loan, Long>, JpaSpecificat
     @Query(FIND_BY_ACCOUNT_NUMBER)
     Loan findLoanAccountByAccountNumber(@Param("accountNumber") String accountNumber);
 
+    boolean existsByExternalId(@Param("externalId") String externalId);
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
@@ -240,6 +240,10 @@ public class LoanRepositoryWrapper {
         return this.repository.findNonClosedLoanByAccountNumber(accountNumber);
     }
 
+    public boolean existLoanByExternalId(final String externalId) {
+        return this.repository.existsByExternalId(externalId);
+    }
+
     // Looks like we need complete entity
     @Transactional(readOnly = true)
     public Loan findNonClosedLoanThatBelongsToClient(@Param("loanId") Long loanId, @Param("clientId") Long clientId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApplicationWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApplicationWritePlatformServiceJpaRepositoryImpl.java
@@ -303,6 +303,16 @@ public class LoanApplicationWritePlatformServiceJpaRepositoryImpl implements Loa
 
             this.fromApiJsonDeserializer.validateForCreate(command.json(), isMeetingMandatoryForJLGLoans, loanProduct);
 
+            // Validate If the externalId is already registered
+            final String externalId = this.fromJsonHelper.extractStringNamed("externalId", command.parsedJson());
+            if (StringUtils.isNotBlank(externalId)) {
+                final boolean existByExternalId = this.loanRepositoryWrapper.existLoanByExternalId(externalId);
+                if (existByExternalId) {
+                    throw new GeneralPlatformDomainRuleException("error.msg.loan.with.externalId.already.used",
+                            "Loan with externalId is already registered.");
+                }
+            }
+
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
             final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan");
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -123,6 +124,26 @@ public class ClientLoanIntegrationTest {
         final ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(this.requestSpec, this.responseSpec,
                 loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
+    }
+
+    @Test
+    public void validateClientLoanWithUniqueExternalId() {
+        // Given
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+        final ResponseSpecification responseSpec403 = new ResponseSpecBuilder().expectStatusCode(403).build();
+
+        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
+        final Integer loanProductID = createLoanProduct(false, NONE);
+
+        final String externalId = Utils.randomStringGenerator("qwerty", 10);
+
+        // When
+        final Integer loanID = applyForLoanApplicationWithExternalId(this.requestSpec, this.responseSpec, clientID, loanProductID,
+                "12,000.00", externalId);
+
+        // Then
+        assertNotNull(loanID);
+        applyForLoanApplicationWithExternalId(this.requestSpec, responseSpec403, clientID, loanProductID, "12,000.00", externalId);
     }
 
     @Test
@@ -1153,6 +1174,27 @@ public class ClientLoanIntegrationTest {
                 .withSubmittedOnDate("20 September 2011") //
                 .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
         return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    }
+
+    private Integer applyForLoanApplicationWithExternalId(RequestSpecification requestSpec, ResponseSpecification responseSpec,
+            final Integer clientID, final Integer loanProductID, String principal, final String externalId) {
+        LOG.info("------------------------APPLYING FOR LOAN APPLICATION WITH EXTERNALID------------------------");
+        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
+                .withPrincipal(principal) //
+                .withExternalId(externalId) //
+                .withLoanTermFrequency("4") //
+                .withLoanTermFrequencyAsMonths() //
+                .withNumberOfRepayments("4") //
+                .withRepaymentEveryAfter("1") //
+                .withRepaymentFrequencyTypeAsMonths() //
+                .withInterestRatePerPeriod("2") //
+                .withAmortizationTypeAsEqualInstallments() //
+                .withInterestTypeAsDecliningBalance() //
+                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
+                .withExpectedDisbursementDate("20 September 2011") //
+                .withSubmittedOnDate("20 September 2011") //
+                .build(clientID.toString(), loanProductID.toString(), null);
+        return this.loanTransactionHelper.getLoanId(loanApplicationJSON, requestSpec, responseSpec);
     }
 
     private Integer applyForLoanApplicationWithTranches(final Integer clientID, final Integer loanProductID, List<HashMap> charges,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanApplicationTestBuilder.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanApplicationTestBuilder.java
@@ -43,6 +43,7 @@ public class LoanApplicationTestBuilder {
     public static final String RBI_INDIA_STRATEGY = "4";
     public static final String INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY = "6";
 
+    private String externalId = null;
     private String principal = "10,000";
     private String glimPrincipal = "1000";
     private String loanTermFrequency = "";
@@ -124,7 +125,7 @@ public class LoanApplicationTestBuilder {
         if (this.glimPrincipal != null) {
             map.put("glimPrincipal", this.glimPrincipal);
         }
-        map.put("locale", "en_GB");
+        map.put("locale", LOCALE);
 
         String approvalFormData = new Gson().toJson(map);
         LOG.info("approvalFormData: {} ", approvalFormData);
@@ -152,6 +153,10 @@ public class LoanApplicationTestBuilder {
         map.put("loanType", this.loanType);
         map.put("collateral", this.collaterals);
         map.put("interestChargedFromDate", this.interestChargedFromDate);
+
+        if (this.externalId != null) {
+            map.put("externalId", this.externalId);
+        }
 
         if (repaymentsStartingFromDate != null) {
             map.put("repaymentsStartingFromDate", this.repaymentsStartingFromDate);
@@ -183,6 +188,11 @@ public class LoanApplicationTestBuilder {
         }
         LOG.info("Loan Application request : {} ", map);
         return new Gson().toJson(map);
+    }
+
+    public LoanApplicationTestBuilder withExternalId(final String externalId) {
+        this.externalId = externalId;
+        return this;
     }
 
     public LoanApplicationTestBuilder withPrincipal(final String principalAmount) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -81,7 +81,11 @@ public class LoanTransactionHelper {
     }
 
     public Integer getLoanId(final String loanApplicationJSON) {
-        return Utils.performServerPost(this.requestSpec, this.responseSpec, APPLY_LOAN_URL, loanApplicationJSON, "loanId");
+        return this.getLoanId(loanApplicationJSON, this.requestSpec, this.responseSpec);
+    }
+
+    public Integer getLoanId(final String loanApplicationJSON, RequestSpecification requestSpec, ResponseSpecification responseSpec) {
+        return Utils.performServerPost(requestSpec, responseSpec, APPLY_LOAN_URL, loanApplicationJSON, "loanId");
     }
 
     public HashMap<String, Integer> getGlimId(final String loanApplicationJSON) {


### PR DESCRIPTION
## Description

Loan creation - Data integrity issue in case the ExternalID was already used, now It returns a domain rule validation error with the developer code: `error.msg.loan.with.externalId.already.used`

- Error in the FrontEnd
<img width="1114" alt="Screen Shot 2022-06-30 at 19 29 14" src="https://user-images.githubusercontent.com/44206706/176809039-6b0a78f5-8f6a-456b-8c90-21f3893d485b.png">

- Error (detailed) in the Integration Test created
<img width="1009" alt="Screen Shot 2022-06-30 at 20 57 33" src="https://user-images.githubusercontent.com/44206706/176809013-ea92d4f5-653d-4ca0-ab6e-bb6be070b875.png">

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
