### PR TITLE
FINERACT-1686: Auditor fix - Detached Auditor entity was not persisted during cascade persisting

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JPAConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JPAConfig.java
@@ -25,7 +25,6 @@ import org.apache.fineract.infrastructure.core.persistence.DatabaseSelectingPers
 import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
 import org.apache.fineract.infrastructure.core.service.RoutingDataSource;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
-import org.apache.fineract.useradministration.domain.AppUser;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.orm.jpa.EntityManagerFactoryBuilderCustomizer;
@@ -96,7 +95,7 @@ public class JPAConfig extends JpaBaseConfiguration {
     }
 
     @Bean
-    public AuditorAware<AppUser> auditorAware() {
+    public AuditorAware<Long> auditorAware() {
         return new AuditorAwareImpl();
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AbstractAuditableCustom.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AbstractAuditableCustom.java
@@ -22,13 +22,9 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import javax.persistence.Column;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import org.apache.fineract.useradministration.domain.AppUser;
 import org.springframework.data.domain.Auditable;
 import org.springframework.data.jpa.domain.AbstractAuditable;
 
@@ -44,33 +40,31 @@ import org.springframework.data.jpa.domain.AbstractAuditable;
  *            the type of the auditing type's identifier
  */
 @MappedSuperclass
-public abstract class AbstractAuditableCustom extends AbstractPersistableCustom implements Auditable<AppUser, Long, Instant> {
+public abstract class AbstractAuditableCustom extends AbstractPersistableCustom implements Auditable<Long, Long, Instant> {
 
     private static final long serialVersionUID = 141481953116476081L;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "createdby_id")
-    private AppUser createdBy;
+    @Column(name = "createdby_id")
+    private Long createdBy;
 
     @Column(name = "created_date")
     @Temporal(TemporalType.TIMESTAMP)
     private Date createdDate;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "lastmodifiedby_id")
-    private AppUser lastModifiedBy;
+    @Column(name = "lastmodifiedby_id")
+    private Long lastModifiedBy;
 
     @Column(name = "lastmodified_date")
     @Temporal(TemporalType.TIMESTAMP)
     private Date lastModifiedDate;
 
     @Override
-    public Optional<AppUser> getCreatedBy() {
+    public Optional<Long> getCreatedBy() {
         return Optional.ofNullable(this.createdBy);
     }
 
     @Override
-    public void setCreatedBy(final AppUser createdBy) {
+    public void setCreatedBy(final Long createdBy) {
         this.createdBy = createdBy;
     }
 
@@ -85,12 +79,12 @@ public abstract class AbstractAuditableCustom extends AbstractPersistableCustom 
     }
 
     @Override
-    public Optional<AppUser> getLastModifiedBy() {
+    public Optional<Long> getLastModifiedBy() {
         return Optional.ofNullable(this.lastModifiedBy);
     }
 
     @Override
-    public void setLastModifiedBy(final AppUser lastModifiedBy) {
+    public void setLastModifiedBy(final Long lastModifiedBy) {
         this.lastModifiedBy = lastModifiedBy;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
@@ -27,29 +27,29 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-public class AuditorAwareImpl implements AuditorAware<AppUser> {
+public class AuditorAwareImpl implements AuditorAware<Long> {
 
     @Autowired
     private AppUserRepository userRepository;
 
     @Override
-    public Optional<AppUser> getCurrentAuditor() {
-        Optional<AppUser> currentUser;
+    public Optional<Long> getCurrentAuditor() {
+        Optional<Long> currentUserId;
         final SecurityContext securityContext = SecurityContextHolder.getContext();
         if (securityContext != null) {
             final Authentication authentication = securityContext.getAuthentication();
             if (authentication != null) {
-                currentUser = Optional.ofNullable((AppUser) authentication.getPrincipal());
+                currentUserId = Optional.ofNullable(((AppUser) authentication.getPrincipal()).getId());
             } else {
-                currentUser = retrieveSuperUser();
+                currentUserId = retrieveSuperUser();
             }
         } else {
-            currentUser = retrieveSuperUser();
+            currentUserId = retrieveSuperUser();
         }
-        return currentUser;
+        return currentUserId;
     }
 
-    private Optional<AppUser> retrieveSuperUser() {
-        return this.userRepository.findById(Long.valueOf("1"));
+    private Optional<Long> retrieveSuperUser() {
+        return Optional.of(1L);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteria.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteria.java
@@ -69,9 +69,9 @@ public class ProvisioningCriteria extends AbstractAuditableCustom {
     public ProvisioningCriteria(String criteriaName, AppUser createdBy, ZonedDateTime createdDate, AppUser lastModifiedBy,
             ZonedDateTime lastModifiedDate) {
         this.criteriaName = criteriaName;
-        setCreatedBy(createdBy);
+        setCreatedBy(createdBy.getId());
         setCreatedDate(Instant.ofEpochMilli(createdDate.toInstant().toEpochMilli()));
-        setLastModifiedBy(lastModifiedBy);
+        setLastModifiedBy(lastModifiedBy.getId());
         setLastModifiedDate(Instant.ofEpochMilli(lastModifiedDate.toInstant().toEpochMilli()));
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanRepaymentScheduleHistory.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanRepaymentScheduleHistory.java
@@ -31,7 +31,6 @@ import javax.persistence.TemporalType;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest;
-import org.apache.fineract.useradministration.domain.AppUser;
 
 @Entity
 @Table(name = "m_loan_repayment_schedule_history")
@@ -72,13 +71,11 @@ public class LoanRepaymentScheduleHistory extends AbstractPersistableCustom {
     @Column(name = "created_date")
     private Date createdOnDate;
 
-    @ManyToOne
-    @JoinColumn(name = "createdby_id")
-    private AppUser createdByUser;
+    @Column(name = "createdby_id")
+    private Long createdByUser;
 
-    @ManyToOne
-    @JoinColumn(name = "lastmodifiedby_id")
-    private AppUser lastModifiedByUser;
+    @Column(name = "lastmodifiedby_id")
+    private Long lastModifiedByUser;
 
     @Temporal(TemporalType.DATE)
     @Column(name = "lastmodified_date")
@@ -98,7 +95,7 @@ public class LoanRepaymentScheduleHistory extends AbstractPersistableCustom {
     private LoanRepaymentScheduleHistory(final Loan loan, final LoanRescheduleRequest loanRescheduleRequest,
             final Integer installmentNumber, final Date fromDate, final Date dueDate, final BigDecimal principal,
             final BigDecimal interestCharged, final BigDecimal feeChargesCharged, final BigDecimal penaltyCharges, final Date createdOnDate,
-            final AppUser createdByUser, final AppUser lastModifiedByUser, final Date lastModifiedOnDate, final Integer version) {
+            final Long createdByUser, final Long lastModifiedByUser, final Date lastModifiedOnDate, final Integer version) {
 
         this.loan = loan;
         this.loanRescheduleRequest = loanRescheduleRequest;
@@ -122,7 +119,7 @@ public class LoanRepaymentScheduleHistory extends AbstractPersistableCustom {
     public static LoanRepaymentScheduleHistory instance(final Loan loan, final LoanRescheduleRequest loanRescheduleRequest,
             final Integer installmentNumber, final Date fromDate, final Date dueDate, final BigDecimal principal,
             final BigDecimal interestCharged, final BigDecimal feeChargesCharged, final BigDecimal penaltyCharges, final Date createdOnDate,
-            final AppUser createdByUser, final AppUser lastModifiedByUser, final Date lastModifiedOnDate, final Integer version) {
+            final Long createdByUser, final Long lastModifiedByUser, final Date lastModifiedOnDate, final Integer version) {
 
         return new LoanRepaymentScheduleHistory(loan, loanRescheduleRequest, installmentNumber, fromDate, dueDate, principal,
                 interestCharged, feeChargesCharged, penaltyCharges, createdOnDate, createdByUser, lastModifiedByUser, lastModifiedOnDate,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleHistoryWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleHistoryWritePlatformServiceImpl.java
@@ -29,7 +29,6 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleIns
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepaymentScheduleHistory;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepaymentScheduleHistoryRepository;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest;
-import org.apache.fineract.useradministration.domain.AppUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,8 +78,8 @@ public class LoanScheduleHistoryWritePlatformServiceImpl implements LoanSchedule
                 createdOnDate = Date.from(repaymentScheduleInstallment.getCreatedDate().get()); // NOSONAR
             }
 
-            final AppUser createdByUser = repaymentScheduleInstallment.getCreatedBy().orElse(null);
-            final AppUser lastModifiedByUser = repaymentScheduleInstallment.getLastModifiedBy().orElse(null);
+            final Long createdByUser = repaymentScheduleInstallment.getCreatedBy().orElse(null);
+            final Long lastModifiedByUser = repaymentScheduleInstallment.getLastModifiedBy().orElse(null);
 
             Date lastModifiedOnDate = null;
 


### PR DESCRIPTION
## Description

While the AppUser (entity) was the auditor, the Spring JPA Auditing was not working perfectly. When a detached entity was saved through assosication the AppUser auditor was not set and it was null in the DB.

Example:
- Find Loan by id
- Create a new transaction
- Add the loan transaction to the Loan
- Save the Loan entity

Outcome:
- Loan transaction created by id was null

Solution

The AppUser entity was changed to be just the AppUser id. It is working just fine now, and anyway the AppUser was never used and was unnecessary anyway to be fetched.
 
Similar issue:
https://stackoverflow.com/questions/38828189/spring-data-jpa-auditing-fails-when-persisting-detached-entity

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
