### PR TITLE
FINERACT-1689: Fix job mismatched logic

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobRegisterServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobRegisterServiceImpl.java
@@ -188,7 +188,7 @@ public class JobRegisterServiceImpl implements JobRegisterService, ApplicationLi
                 final List<ScheduledJobDetail> scheduledJobDetails = this.schedularWritePlatformService
                         .retrieveAllJobs(fineractProperties.getNodeId());
                 for (final ScheduledJobDetail jobDetail : scheduledJobDetails) {
-                    if (jobDetail.isTriggerMisfired()) {
+                    if (jobDetail.isTriggerMisfired() || jobDetail.getIsMismatchedJob()) {
                         if (jobDetail.isActiveSchedular()) {
                             executeJob(jobDetail, SchedulerServiceConstants.TRIGGER_TYPE_CRON);
                             jobDetail.setIsMismatchedJob(false);
@@ -240,6 +240,8 @@ public class JobRegisterServiceImpl implements JobRegisterService, ApplicationLi
 
         if (nodeIdStored.equals(fineractProperties.getNodeId()) || nodeIdStored.equals("0")) {
             executeJob(scheduledJobDetail, null);
+            scheduledJobDetail.setIsMismatchedJob(false);
+            this.schedularWritePlatformService.saveOrUpdate(scheduledJobDetail);
         } else {
             scheduledJobDetail.setIsMismatchedJob(true);
             this.schedularWritePlatformService.saveOrUpdate(scheduledJobDetail);

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0015_add_business_date.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0015_add_business_date.xml
@@ -79,6 +79,7 @@
         </insert>
     </changeSet>
     <changeSet id="4" author="fineract">
+        <validCheckSum>8:f7e5e697680e1e81eca6566f2481b879</validCheckSum>
         <insert tableName="job">
             <column name="name" value="Increase Business Date by 1 day"/>
             <column name="display_name" value="Increase Business Date by 1 day"/>
@@ -95,10 +96,11 @@
             <column name="scheduler_group" valueNumeric="0"/>
             <column name="is_misfired" valueBoolean="false"/>
             <column name="node_id" valueNumeric="1"/>
-            <column name="is_mismatched_job" valueBoolean="true"/>
+            <column name="is_mismatched_job" valueBoolean="false"/>
         </insert>
     </changeSet>
     <changeSet id="5" author="fineract">
+        <validCheckSum>8:cb7f67c27941deda1e83d317bd78dabd</validCheckSum>
         <insert tableName="job">
             <column name="name" value="Increase COB Date by 1 day"/>
             <column name="display_name" value="Increase COB Date by 1 day"/>
@@ -115,7 +117,7 @@
             <column name="scheduler_group" valueNumeric="0"/>
             <column name="is_misfired" valueBoolean="false"/>
             <column name="node_id" valueNumeric="1"/>
-            <column name="is_mismatched_job" valueBoolean="true"/>
+            <column name="is_mismatched_job" valueBoolean="false"/>
         </insert>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Description

In short about the issue: We marked the jobs as mismatched if they were triggered from the “wrong” node, however when they were executed on the “right” node, the “isMismatched” flag was not lifted

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
