### PR TITLE
Datatables datetime fields management

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetRowData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/ResultsetRowData.java
@@ -22,17 +22,17 @@ import java.util.List;
 
 public final class ResultsetRowData {
 
-    private final List<String> row;
+    private final List<Object> row;
 
-    public static ResultsetRowData create(final List<String> rowValues) {
+    public static ResultsetRowData create(final List<Object> rowValues) {
         return new ResultsetRowData(rowValues);
     }
 
-    private ResultsetRowData(final List<String> rowValues) {
+    private ResultsetRowData(final List<Object> rowValues) {
         this.row = rowValues;
     }
 
-    public List<String> getRow() {
+    public List<Object> getRow() {
         return this.row;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -115,7 +115,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         writer.append('\n');
 
         final List<ResultsetRowData> data = result.getData();
-        List<String> row;
+        List<Object> row;
         Integer rSize;
         // String currCol;
         String currColType;
@@ -129,7 +129,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
             for (int j = 0; j < rSize; j++) {
                 // currCol = columnHeaders.get(j).getColumnName();
                 currColType = columnHeaders.get(j).getColumnType();
-                currVal = row.get(j);
+                currVal = (String) row.get(j);
                 if (currVal != null) {
                     if (currColType.equals("DECIMAL") || currColType.equals("DOUBLE") || currColType.equals("BIGINT")
                             || currColType.equals("SMALLINT") || currColType.equals("INT")) {
@@ -252,7 +252,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
 
             final List<ResultsetColumnHeaderData> columnHeaders = result.getColumnHeaders();
             final List<ResultsetRowData> data = result.getData();
-            List<String> row;
+            List<Object> row;
 
             log.info("NO. of Columns: {}", columnHeaders.size());
             final Integer chSize = columnHeaders.size();
@@ -282,7 +282,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
                 rSize = row.size();
                 for (int j = 0; j < rSize; j++) {
                     currColType = columnHeaders.get(j).getColumnType();
-                    currVal = row.get(j);
+                    currVal = (String) row.get(j);
                     if (currVal != null) {
                         if (currColType.equals("DECIMAL") || currColType.equals("DOUBLE") || currColType.equals("BIGINT")
                                 || currColType.equals("SMALLINT") || currColType.equals("INT")) {

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0019_refactor_loan_transaction.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0019_refactor_loan_transaction.xml
@@ -22,8 +22,8 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-    <changeSet author="fineract" id="1">
-        <validCheckSum>8:4500ffb68c695d72caba498deff75643</validCheckSum>
+    <changeSet author="fineract" id="1" onValidationFail="MARK_RAN">
+        <validCheckSum>8:177f2e2cbac12752ede2182bbbfde6ae</validCheckSum>
         <addColumn tableName="m_loan_transaction">
             <column name="createdby_id" type="BIGINT" valueComputed="appuser_id"/>
             <column name="lastmodifiedby_id" type="BIGINT"/>


### PR DESCRIPTION
## Description

Since we moved to support 3 databases (MySql, MariaDB and Postgres) and an issue arised, Fetching `datetime` field of datatables as `string` gives back different dates format:

- MySQL: `YYYY-MM-DD hh:mm:ss`
- Postgres: `YYYY-MM-DDThh:mm:ss`

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
