### PR TITLE
[FINERACT-1683] Webhook trigger execution fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/WebHookService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/WebHookService.java
@@ -38,22 +38,22 @@ public interface WebHookService {
     String API_KEY_HEADER = "X-Fineract-API-Key";
 
     // Ping
-    @GET("/")
+    @GET(".")
     Call<Void> sendEmptyRequest();
 
     // Template - Web
-    @POST("/")
+    @POST(".")
     Call<Void> sendJsonRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(ENDPOINT_HEADER) String endpointHeader, @Body JsonObject result);
 
     @FormUrlEncoded
-    @POST("/")
+    @POST(".")
     Call<Void> sendFormRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(ENDPOINT_HEADER) String endpointHeader,
             @FieldMap Map<String, String> params);
 
     // Template - SMS Bridge
-    @POST("/")
+    @POST(".")
     Call<Void> sendSmsBridgeRequest(@Header(ENTITY_HEADER) String entityHeader, @Header(ACTION_HEADER) String actionHeader,
             @Header(TENANT_HEADER) String tenantHeader, @Header(API_KEY_HEADER) String apiKeyHeader, @Body JsonObject result);
 


### PR DESCRIPTION
for the base URL to be the full path you can use `"."` instead of `"\"` . This would declare that your final URL is the same as your base URL.

## Description
When a webhook is created against an event such as `CLIENT CREATE/CLOSE/ACTIVATE` the configured webhook URL is never called and it is because the retrofit2 request annotations had an invalid string in it, `"\"` which should have been `"."`

Once changing the annotation value from `\` to `.` the webhook URL was executed successfully.

Describe the changes made and why they were made.
This issue was a bug as webhooks were not being triggered. I guess there is no real way to write tests for this particular component.


Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
