### PR TITLE
FINERACT-1708 migration fails when upgrading from 1.6.0 to 1.7.0

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0016_changed_unique_constraint_of_ref_no.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0016_changed_unique_constraint_of_ref_no.xml
@@ -26,6 +26,6 @@
         <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="m_savings_account_transaction_ref_no_key"/>
     </changeSet>
     <changeSet author="fineract" id="1" context="mysql">
-        <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="ref_no"/>
+        <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="transaction_ref_no"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
the unique constraint name in `fineract_default` database `m_savings_account_transaction` is `transaction_ref_no` instead of `ref_no` which cause migration to fail.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
