### PR TITLE
FINERACT-1693: Fix null handling of datatables

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
@@ -1540,7 +1540,7 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
             final String key = pColumnHeader.getColumnName();
             if (affectedColumns.containsKey(key)) {
                 pValue = String.valueOf(affectedColumns.get(key));
-                if (StringUtils.isEmpty(pValue)) {
+                if (StringUtils.isEmpty(pValue) || "null".equalsIgnoreCase(pValue)) {
                     pValueWrite = "null";
                 } else {
                     if ("bit".equalsIgnoreCase(pColumnHeader.getColumnType())) {
@@ -1605,7 +1605,7 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
         for (final String key : affectedColumns.keySet()) {
             pValue = String.valueOf(affectedColumns.get(key));
 
-            if (StringUtils.isEmpty(pValue)) {
+            if (StringUtils.isEmpty(pValue) || "null".equalsIgnoreCase(pValue)) {
                 pValueWrite = "null";
             } else {
                 pValueWrite = singleQuote + this.genericDataService.replace(pValue, singleQuote, singleQuote + singleQuote) + singleQuote;
@@ -1860,6 +1860,8 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
                             dataValidationErrors);
                 }
             }
+        } else {
+            paramValue = null;
         }
         return paramValue;
     }


### PR DESCRIPTION
## Description

When new datatable entry was posted, the null value handling was not properly handled:
If there were a field, where explicitly null was passed, the system was not processing properly and failed during saving with SQL syntax error.

**Example**:
```
{ 
    "amount": null
}
```

Added test scenarios to cover:


- Add null values as initial values: null and empty string as well

**During update**

- if it was null and the provided value is empty string it should not consider it as a change 



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
