### PR TITLE
FINERACT-1787: Fineract using wrong business date due to lack of resetting the ActionContext

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/COBBusinessStepServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/COBBusinessStepServiceImpl.java
@@ -54,6 +54,7 @@ public class COBBusinessStepServiceImpl implements COBBusinessStepService {
         businessEventNotifierService.startExternalEventRecording();
         for (String businessStep : executionMap.values()) {
             try {
+                ThreadLocalContextUtil.setActionContext(ActionContext.COB);
                 COBBusinessStep<S> businessStepBean = (COBBusinessStep<S>) applicationContext.getBean(businessStep);
                 item = businessStepBean.execute(item);
             } catch (Exception e) {

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/common/ResetContextTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/common/ResetContextTasklet.java
@@ -22,30 +22,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.domain.ActionContext;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
-import org.apache.fineract.useradministration.domain.AppUser;
-import org.apache.fineract.useradministration.domain.AppUserRepositoryWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @Slf4j
 @RequiredArgsConstructor
-public class InitialisationTasklet implements Tasklet {
-
-    private final AppUserRepositoryWrapper userRepository;
+public class ResetContextTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(@NotNull StepContribution contribution, @NotNull ChunkContext chunkContext) throws Exception {
-        AppUser user = userRepository.fetchSystemUser();
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, user.getPassword(),
-                new NullAuthoritiesMapper().mapAuthorities(user.getAuthorities()));
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        ThreadLocalContextUtil.setActionContext(ActionContext.COB);
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
         return RepeatStatus.FINISHED;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/InlineLoanCOBBuildExecutionContextTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/InlineLoanCOBBuildExecutionContextTasklet.java
@@ -26,7 +26,9 @@ import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.COBBusinessStepService;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
 import org.apache.fineract.infrastructure.core.serialization.GoogleGsonSerializerHelper;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.jobs.domain.CustomJobParameter;
 import org.apache.fineract.infrastructure.jobs.domain.CustomJobParameterRepository;
 import org.apache.fineract.infrastructure.springbatch.SpringBatchJobConstants;
@@ -54,6 +56,7 @@ public class InlineLoanCOBBuildExecutionContextTasklet implements Tasklet, Initi
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        ThreadLocalContextUtil.setActionContext(ActionContext.COB);
         TreeMap<Long, String> cobBusinessStepMap = cobBusinessStepService.getCOBBusinessStepMap(LoanCOBBusinessStep.class,
                 LoanCOBConstant.LOAN_COB_JOB_NAME);
         contribution.getStepExecution().getExecutionContext().put(LoanCOBConstant.LOAN_IDS, getLoanIdsFromJobParameters(chunkContext));

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.fineract.cob.loan;
 
 import org.apache.fineract.cob.COBBusinessStepService;
 import org.apache.fineract.cob.common.InitialisationTasklet;
+import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.domain.LoanAccountLockRepository;
 import org.apache.fineract.cob.listener.ChunkProcessingLoanItemListener;
 import org.apache.fineract.infrastructure.jobs.service.JobName;
@@ -74,7 +75,7 @@ public class LoanCOBWorkerConfiguration {
     @Bean
     public Flow flow() {
         return new FlowBuilder<Flow>("cobFlow").start(initialisationStep(null)).next(applyLockStep(null)).next(loanBusinessStep(null))
-                .build();
+                .next(resetContextStep(null)).build();
     }
 
     @Bean
@@ -100,6 +101,12 @@ public class LoanCOBWorkerConfiguration {
     }
 
     @Bean
+    @StepScope
+    public Step resetContextStep(@Value("#{stepExecutionContext['partition']}") String partitionName) {
+        return localStepBuilderFactory.get("Reset context - Step:" + partitionName).tasklet(resetContext()).build();
+    }
+
+    @Bean
     public InitialisationTasklet initialiseContext() {
         return new InitialisationTasklet(userRepository);
     }
@@ -112,6 +119,11 @@ public class LoanCOBWorkerConfiguration {
     @Bean
     public ApplyLoanLockTasklet applyLock() {
         return new ApplyLoanLockTasklet(accountLockRepository);
+    }
+
+    @Bean
+    public ResetContextTasklet resetContext() {
+        return new ResetContextTasklet();
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.cob.loan;
 
 import org.apache.fineract.cob.COBBusinessStepService;
+import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.domain.LoanAccountLockRepository;
 import org.apache.fineract.cob.listener.InlineCOBLoanItemListener;
 import org.apache.fineract.infrastructure.core.serialization.GoogleGsonSerializerHelper;
@@ -83,7 +84,7 @@ public class LoanInlineCOBConfig {
     @Bean(name = "loanInlineCOBJob")
     public Job loanInlineCOBJob() {
         return jobBuilderFactory.get(LoanCOBConstant.INLINE_LOAN_COB_JOB_NAME) //
-                .start(inlineCOBBuildExecutionContextStep()).next(inlineLoanCOBStep()) //
+                .start(inlineCOBBuildExecutionContextStep()).next(inlineLoanCOBStep()).next(inlineCOBResetContextStep()) //
                 .incrementer(new RunIdIncrementer()) //
                 .build();
     }
@@ -99,6 +100,11 @@ public class LoanInlineCOBConfig {
     }
 
     @Bean
+    public Step inlineCOBResetContextStep() {
+        return stepBuilderFactory.get("Reset context - Step").tasklet(inlineCOBResetContext()).build();
+    }
+
+    @Bean
     public InlineCOBLoanItemWriter inlineCobWorkerItemWriter() {
         InlineCOBLoanItemWriter repositoryItemWriter = new InlineCOBLoanItemWriter(accountLockRepository);
         repositoryItemWriter.setRepository(loanRepository);
@@ -108,6 +114,11 @@ public class LoanInlineCOBConfig {
     @Bean
     public InlineCOBLoanItemListener inlineCobLoanItemListener() {
         return new InlineCOBLoanItemListener(accountLockRepository, transactionTemplate);
+    }
+
+    @Bean
+    public ResetContextTasklet inlineCOBResetContext() {
+        return new ResetContextTasklet();
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/ThreadLocalContextUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/ThreadLocalContextUtil.java
@@ -116,4 +116,12 @@ public final class ThreadLocalContextUtil {
         setBusinessDates(fineractContext.getBusinessDateContext());
         setActionContext(fineractContext.getActionContext());
     }
+
+    public static void reset() {
+        contextHolder.remove();
+        tenantContext.remove();
+        authTokenContext.remove();
+        businessDateContext.remove();
+        actionContext.remove();
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobSchedulerServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobSchedulerServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobDetail;
@@ -57,6 +58,7 @@ public class JobSchedulerServiceImpl implements ApplicationListener<ContextRefre
         for (final FineractPlatformTenant tenant : allTenants) {
             ThreadLocalContextUtil.setTenant(tenant);
             HashMap<BusinessDateType, LocalDate> businessDates = businessDateReadPlatformService.getBusinessDates();
+            ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
             ThreadLocalContextUtil.setBusinessDates(businessDates);
             final List<ScheduledJobDetail> scheduledJobDetails = schedularWritePlatformService
                     .retrieveAllJobs(fineractProperties.getNodeId());

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerJobListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerJobListener.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobDetail;
 import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobRunHistory;
@@ -67,6 +68,7 @@ public class SchedulerJobListener implements JobListener {
                 authoritiesMapper.mapAuthorities(user.getAuthorities()));
         SecurityContextHolder.getContext().setAuthentication(auth);
         HashMap<BusinessDateType, LocalDate> businessDates = businessDateReadPlatformService.getBusinessDates();
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
         ThreadLocalContextUtil.setBusinessDates(businessDates);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerTriggerListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedulerTriggerListener.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.security.service.TenantDetailsService;
@@ -69,6 +70,7 @@ public class SchedulerTriggerListener implements TriggerListener {
         final String tenantIdentifier = trigger.getJobDataMap().getString(SchedulerServiceConstants.TENANT_IDENTIFIER);
         final FineractPlatformTenant tenant = this.tenantDetailsService.loadTenantById(tenantIdentifier);
         ThreadLocalContextUtil.setTenant(tenant);
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
         HashMap<BusinessDateType, LocalDate> businessDates = businessDateReadPlatformService.getBusinessDates();
         ThreadLocalContextUtil.setBusinessDates(businessDates);
         final JobKey key = trigger.getJobKey();

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareBasicAuthenticationFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareBasicAuthenticationFilter.java
@@ -103,7 +103,7 @@ public class TenantAwareBasicAuthenticationFilter extends BasicAuthenticationFil
         task.start();
 
         try {
-
+            ThreadLocalContextUtil.reset();
             if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
                 // ignore to allow 'preflight' requests from AJAX applications
                 // in different origin (domain name)
@@ -157,6 +157,7 @@ public class TenantAwareBasicAuthenticationFilter extends BasicAuthenticationFil
             response.addHeader("WWW-Authenticate", "Basic realm=\"" + "Fineract Platform API" + "\"");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         } finally {
+            ThreadLocalContextUtil.reset();
             task.stop();
             final PlatformRequestLog log = PlatformRequestLog.from(task, request);
             LOG.debug("{}", this.toApiJsonSerializer.serialize(log));

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareTenantIdentifierFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareTenantIdentifierFilter.java
@@ -88,7 +88,7 @@ public class TenantAwareTenantIdentifierFilter extends GenericFilterBean {
         task.start();
 
         try {
-
+            ThreadLocalContextUtil.reset();
             // allows for Cross-Origin
             // Requests (CORs) to be performed against the platform API.
             response.setHeader("Access-Control-Allow-Origin", "*"); // NOSONAR
@@ -148,6 +148,7 @@ public class TenantAwareTenantIdentifierFilter extends GenericFilterBean {
             response.addHeader("WWW-Authenticate", "Basic realm=\"" + "Fineract Platform API" + "\"");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         } finally {
+            ThreadLocalContextUtil.reset();
             task.stop();
             final PlatformRequestLog logRequest = PlatformRequestLog.from(task, request);
             log.debug("{}", this.toApiJsonSerializer.serialize(logRequest));


### PR DESCRIPTION
ActionContext (ThreadLocalContextUtil) is responsible to decide which business date to be used.
A bug was reported where it seemed the ActionContext was not reset after COB job execution and inadvertently inherited the previous value.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
