### PR TITLE
FINERACT-1789: retrieveSchedulerDetail fails if no records founds

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobRegisterServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobRegisterServiceImpl.java
@@ -146,7 +146,7 @@ public class JobRegisterServiceImpl implements JobRegisterService, ApplicationLi
 
     @Override
     public void pauseScheduler() {
-        final SchedulerDetail schedulerDetail = this.schedularWritePlatformService.retriveSchedulerDetail();
+        final SchedulerDetail schedulerDetail = this.schedularWritePlatformService.retrieveSchedulerDetail();
         if (!schedulerDetail.isSuspended()) {
             schedulerDetail.setSuspended(true);
             this.schedularWritePlatformService.updateSchedulerDetail(schedulerDetail);
@@ -155,7 +155,7 @@ public class JobRegisterServiceImpl implements JobRegisterService, ApplicationLi
 
     @Override
     public void startScheduler() {
-        final SchedulerDetail schedulerDetail = this.schedularWritePlatformService.retriveSchedulerDetail();
+        final SchedulerDetail schedulerDetail = this.schedularWritePlatformService.retrieveSchedulerDetail();
         if (schedulerDetail.isSuspended()) {
             schedulerDetail.setSuspended(false);
             this.schedularWritePlatformService.updateSchedulerDetail(schedulerDetail);
@@ -227,7 +227,7 @@ public class JobRegisterServiceImpl implements JobRegisterService, ApplicationLi
 
     @Override
     public boolean isSchedulerRunning() {
-        return !this.schedularWritePlatformService.retriveSchedulerDetail().isSuspended();
+        return !this.schedularWritePlatformService.retrieveSchedulerDetail().isSuspended();
     }
 
     /**

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobSchedulerServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/JobSchedulerServiceImpl.java
@@ -67,7 +67,7 @@ public class JobSchedulerServiceImpl implements ApplicationListener<ContextRefre
                 jobDetails.setTriggerMisfired(false);
                 schedularWritePlatformService.saveOrUpdate(jobDetails);
             }
-            final SchedulerDetail schedulerDetail = schedularWritePlatformService.retriveSchedulerDetail();
+            final SchedulerDetail schedulerDetail = schedularWritePlatformService.retrieveSchedulerDetail();
             if (schedulerDetail.isResetSchedulerOnBootup()) {
                 schedulerDetail.setSuspended(false);
                 schedularWritePlatformService.updateSchedulerDetail(schedulerDetail);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformService.java
@@ -41,7 +41,7 @@ public interface SchedularWritePlatformService {
 
     CommandProcessingResult updateJobDetail(Long jobId, JsonCommand command);
 
-    SchedulerDetail retriveSchedulerDetail();
+    SchedulerDetail retrieveSchedulerDetail();
 
     void updateSchedulerDetail(SchedulerDetail schedulerDetail);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
@@ -34,8 +34,11 @@ import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetail;
 import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetailRepository;
 import org.apache.fineract.infrastructure.jobs.exception.JobNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 public class SchedularWritePlatformServiceJpaRepositoryImpl implements SchedularWritePlatformService {
@@ -104,12 +107,10 @@ public class SchedularWritePlatformServiceJpaRepositoryImpl implements Schedular
 
     @Override
     public SchedulerDetail retrieveSchedulerDetail() {
-        SchedulerDetail schedulerDetail = null;
-        final List<SchedulerDetail> schedulerDetailList = this.schedulerDetailRepository.findAll();
-        if (schedulerDetailList != null && schedulerDetailList.size() > 0) {
-            schedulerDetail = schedulerDetailList.get(0);
-        }
-        return schedulerDetail;
+        final Page<SchedulerDetail> schedulerDetailPage =
+                this.schedulerDetailRepository.findAll(PageRequest.of(0, 1));
+
+        return schedulerDetailPage.stream().findAny().orElse(null);
     }
 
     @Transactional

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
@@ -103,10 +103,10 @@ public class SchedularWritePlatformServiceJpaRepositoryImpl implements Schedular
     }
 
     @Override
-    public SchedulerDetail retriveSchedulerDetail() {
+    public SchedulerDetail retrieveSchedulerDetail() {
         SchedulerDetail schedulerDetail = null;
         final List<SchedulerDetail> schedulerDetailList = this.schedulerDetailRepository.findAll();
-        if (schedulerDetailList != null) {
+        if (schedulerDetailList != null && schedulerDetailList.size() > 0) {
             schedulerDetail = schedulerDetailList.get(0);
         }
         return schedulerDetail;
@@ -142,7 +142,7 @@ public class SchedularWritePlatformServiceJpaRepositoryImpl implements Schedular
                 && scheduledJobDetail.getNextRunTime().after(new Date()))) {
             isStopExecution = true;
         }
-        final SchedulerDetail schedulerDetail = retriveSchedulerDetail();
+        final SchedulerDetail schedulerDetail = retrieveSchedulerDetail();
         if (triggerType.equals(SchedulerServiceConstants.TRIGGER_TYPE_CRON) && schedulerDetail.isSuspended()) {
             scheduledJobDetail.setTriggerMisfired(true);
             isStopExecution = true;

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImplTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.jobs.service;
+
+import org.apache.fineract.infrastructure.jobs.data.JobDetailDataValidator;
+import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobDetailRepository;
+import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobRunHistoryRepository;
+import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetail;
+import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetailRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SchedularWritePlatformServiceJpaRepositoryImplTest {
+
+    @Mock
+    private ScheduledJobDetailRepository scheduledJobDetailsRepository;
+
+    @Mock
+    private ScheduledJobRunHistoryRepository scheduledJobRunHistoryRepository;
+
+    @Mock
+    private SchedulerDetailRepository schedulerDetailRepository;
+
+    @Mock
+    private JobDetailDataValidator dataValidator;
+
+    @InjectMocks
+    private  SchedularWritePlatformServiceJpaRepositoryImpl schedularWritePlatformService;
+
+    @Test
+    void testRetrieveSchedulerDetail_handle_null_response() {
+        // given
+        given(schedulerDetailRepository.findAll()).willReturn(null);
+
+        // when
+        final var result = schedularWritePlatformService.retrieveSchedulerDetail();
+
+        // then
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void testRetrieveSchedulerDetail_handle_empty_response() {
+        // given
+        given(schedulerDetailRepository.findAll()).willReturn(Collections.emptyList());
+
+        // when
+        final var result = schedularWritePlatformService.retrieveSchedulerDetail();
+
+        // then
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void testRetrieveSchedulerDetail_handle_not_empty_response() {
+        // given
+        SchedulerDetail schedulerDetail = new SchedulerDetail();
+        given(schedulerDetailRepository.findAll()).willReturn(List.of(schedulerDetail));
+
+        // when
+        final var result = schedularWritePlatformService.retrieveSchedulerDetail();
+
+        // then
+        Assertions.assertEquals(schedulerDetail, result);
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImplTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.fineract.infrastructure.jobs.service;
 
-import org.apache.fineract.infrastructure.jobs.data.JobDetailDataValidator;
-import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobDetailRepository;
-import org.apache.fineract.infrastructure.jobs.domain.ScheduledJobRunHistoryRepository;
 import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetail;
 import org.apache.fineract.infrastructure.jobs.domain.SchedulerDetailRepository;
 import org.junit.jupiter.api.Assertions;
@@ -31,6 +28,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.Collections;
 import java.util.List;
@@ -42,36 +41,16 @@ import static org.mockito.BDDMockito.given;
 class SchedularWritePlatformServiceJpaRepositoryImplTest {
 
     @Mock
-    private ScheduledJobDetailRepository scheduledJobDetailsRepository;
-
-    @Mock
-    private ScheduledJobRunHistoryRepository scheduledJobRunHistoryRepository;
-
-    @Mock
     private SchedulerDetailRepository schedulerDetailRepository;
-
-    @Mock
-    private JobDetailDataValidator dataValidator;
 
     @InjectMocks
     private  SchedularWritePlatformServiceJpaRepositoryImpl schedularWritePlatformService;
 
     @Test
-    void testRetrieveSchedulerDetail_handle_null_response() {
-        // given
-        given(schedulerDetailRepository.findAll()).willReturn(null);
-
-        // when
-        final var result = schedularWritePlatformService.retrieveSchedulerDetail();
-
-        // then
-        Assertions.assertNull(result);
-    }
-
-    @Test
     void testRetrieveSchedulerDetail_handle_empty_response() {
         // given
-        given(schedulerDetailRepository.findAll()).willReturn(Collections.emptyList());
+        given(schedulerDetailRepository.findAll(PageRequest.of(0, 1)))
+                .willReturn(new PageImpl<>(Collections.emptyList()));
 
         // when
         final var result = schedularWritePlatformService.retrieveSchedulerDetail();
@@ -84,7 +63,8 @@ class SchedularWritePlatformServiceJpaRepositoryImplTest {
     void testRetrieveSchedulerDetail_handle_not_empty_response() {
         // given
         SchedulerDetail schedulerDetail = new SchedulerDetail();
-        given(schedulerDetailRepository.findAll()).willReturn(List.of(schedulerDetail));
+        given(schedulerDetailRepository.findAll(PageRequest.of(0, 1)))
+                .willReturn(new PageImpl<>(List.of(schedulerDetail)));
 
         // when
         final var result = schedularWritePlatformService.retrieveSchedulerDetail();


### PR DESCRIPTION
Also fixed typo in name

## Description

org.apache.fineract.infrastructure.jobs.service.SchedularWritePlatformServiceJpaRepositoryImpl#retrieveSchedulerDetail retrieve ScheduleDetail using findAll backed by JPA.

Then checks:
```
        final List<SchedulerDetail> schedulerDetailList = this.schedulerDetailRepository.findAll();
        if (schedulerDetailList != null) {
            schedulerDetail = schedulerDetailList.get(0);
        }

```
If the `findAll()` returns an empty list instead of a null, the core fails with a `IndexOutOfBoundException`.

The change added the check for empty list: `if (schedulerDetailList != null && schedulerDetailList.size() > 0) {`

Also renamed `retriveSchedulerDetail` to `retrieveSchedulerDetail` to fix typo.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
