### PR TITLE
FINERACT-1791: Remove Travis CI from documentation and syncronize the MariaDB version to version 10.9 in all the documents

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,7 +35,7 @@ ports:
 tasks:
 - command: |
       # NB MySQL on GitPod.io is currently quite slow.
-      # similar to .travis.yml, but using authentication_string= instead of password= due to mysql major version difference
+      # Using authentication_string= instead of password= due to mysql major version difference
       mysql -e "USE mysql;\nUPDATE user SET authentication_string=PASSWORD('mysql') WHERE user='root';\nFLUSH PRIVILEGES;\n"
       ./gradlew createDB -PdbName=fineract_tenants
       ./gradlew createDB -PdbName=fineract_default

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ If you are interested in contributing to this project, but perhaps don't quite k
 
 Requirements
 ============
-* Java >= 17 (OpenJDK JVM is tested by our CI on Travis)
-* MariaDB 10.6
+* Java >= 17 (Azul Zulu JVM is tested by our CI on GitHub Actions)
+* MariaDB 10.9
 
 You can run the required version of the database server in a container, instead of having to install it, like this:
 
-    docker run --name mariadb-10.8 -p 3306:3306 -e MARIADB_ROOT_PASSWORD=mysql -d mariadb:10.8
+    docker run --name mariadb-10.9 -p 3306:3306 -e MARIADB_ROOT_PASSWORD=mysql -d mariadb:10.9
 
 and stop and destroy it like this:
 
-    docker rm -f mariadb-10.8
+    docker rm -f mariadb-10.9
 
 Beware that this database container database keeps its state inside the container and not on the host filesystem.  It is lost when you destroy (rm) this container.  This is typically fine for development.  See [Caveats: Where to Store Data on the database container documentation](https://hub.docker.com/_/mariadb) re. how to make it persistent instead of ephemeral.
 
@@ -145,7 +145,7 @@ Instructions to execute Integration Tests
 ============
 > Note that if this is the first time to access MySQL DB, then you may need to reset your password.
 
-Run the following commands, very similarly to how [.travis.yml](.travis.yml) does:
+Run the following commands:
 1. `./gradlew createDB -PdbName=fineract_tenants`
 1. `./gradlew createDB -PdbName=fineract_default`
 1. `./gradlew clean test`

--- a/custom/docker/docker-compose.yml
+++ b/custom/docker/docker-compose.yml
@@ -16,8 +16,7 @@
 # under the License.
 #
 
-# NB: Travis CI (dist: bionic) supports up to v3.7
-# (unless we'd install a more recent version in .travis.yml)
+# You can replace and test a more recent version of docker compose
 version: '3.7'
 services:
   # Backend service

--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -16,8 +16,7 @@
 # under the License.
 #
 
-# NB: Travis CI (dist: bionic) supports up to v3.7
-# (unless we'd install a more recent version in .travis.yml)
+# You can replace and test a more recent version of docker compose
 version: '3.7'
 services:
   # Backend service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,7 @@
 # under the License.
 #
 
-# NB: Travis CI (dist: bionic) supports up to v3.7
-# (unless we'd install a more recent version in .travis.yml)
+# You can replace and test a more recent version of docker compose
 version: '3.7'
 services:
   # Backend service

--- a/fineract-client/.openapi-generator-ignore
+++ b/fineract-client/.openapi-generator-ignore
@@ -2,7 +2,6 @@
 **/pom.xml
 **/build.sbt
 **/*.gradle
-**/.travis.yml
 **/.gitignore
 **/git_push.sh
 **/api/*

--- a/fineract-war/build.gradle
+++ b/fineract-war/build.gradle
@@ -90,7 +90,7 @@ distributions {
         distributionBaseName = 'apache-fineract-src'
         contents {
             from "$rootDir/"
-            exclude '**/build' , '.git', '**/.gradle', '.github', '**/.settings', '**/.project', '**/.classpath', '.idea', 'out', '._.DS_Store', '.DS_Store', 'WebContent', '**/.externalToolbuilders', '.theia', '.gitpod.yml', '.travis.yml', 'LICENSE_RELEASE', 'NOTICE_RELEASE', '**/licenses', '*.class', '**/bin', '*.log', '.dockerignore', '**/.gitkeep'
+            exclude '**/build' , '.git', '**/.gradle', '.github', '**/.settings', '**/.project', '**/.classpath', '.idea', 'out', '._.DS_Store', '.DS_Store', 'WebContent', '**/.externalToolbuilders', '.theia', '.gitpod.yml', 'LICENSE_RELEASE', 'NOTICE_RELEASE', '**/licenses', '*.class', '**/bin', '*.log', '.dockerignore', '**/.gitkeep'
             rename ('LICENSE_SOURCE', 'LICENSE')
             rename ('NOTICE_SOURCE', 'NOTICE')
         }

--- a/kubernetes/fineractmysql-deployment.yml
+++ b/kubernetes/fineractmysql-deployment.yml
@@ -86,7 +86,7 @@ spec:
         tier: fineractmysql
     spec:
       containers:
-        - image: mariadb:10.6
+        - image: mariadb:10.9
           name: mysql
           resources:
             requests:


### PR DESCRIPTION
## Description

- Travis CI text has been replaced to reflect the current use of GitHub Actions
- MariaDB version has been updated to version 10.9

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X ] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
