### PR TITLE
Fix no enum constant http methods

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBApiFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBApiFilter.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.infrastructure.jobs.filter;
 
 import com.google.common.base.Splitter;
-import com.sun.research.ws.wadl.HTTPMethods;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.GLIMAccountInfoRepositor
 import org.apache.fineract.portfolio.loanaccount.domain.GroupLoanIndividualMonitoringAccount;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.http.HttpStatus;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -50,7 +50,7 @@ public class LoanCOBApiFilter extends OncePerRequestFilter {
     private final GLIMAccountInfoRepository glimAccountInfoRepository;
     private final LoanAccountLockService loanAccountLockService;
 
-    private static final List<HTTPMethods> HTTP_METHODS = List.of(HTTPMethods.POST, HTTPMethods.PUT, HTTPMethods.DELETE);
+    private static final List<HttpMethod> HTTP_METHODS = List.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE);
     private static final Function<String, Boolean> URL_FUNCTION = s -> s.matches("/loans/\\d+.*") || s.matches("/loans/glimAccount/\\d+.*");
     private static final Integer LOAN_ID_INDEX_IN_URL = 2;
     private static final Integer GLIM_ID_INDEX_IN_URL = 3;
@@ -121,7 +121,7 @@ public class LoanCOBApiFilter extends OncePerRequestFilter {
         if (StringUtils.isBlank(request.getPathInfo())) {
             return false;
         }
-        return HTTP_METHODS.contains(HTTPMethods.fromValue(request.getMethod())) && URL_FUNCTION.apply(request.getPathInfo());
+        return HTTP_METHODS.contains(HttpMethod.valueOf(request.getMethod())) && URL_FUNCTION.apply(request.getPathInfo());
     }
 
     private boolean isGlim(Supplier<Stream<String>> streamSupplier) {


### PR DESCRIPTION
## Description

There was an `IllegalArgument` exception using the `HTTPMethods` instead of the `HttpMethod` from Spring

<img width="1777" alt="Screenshot 2022-10-28 at 13 40 10" src="https://user-images.githubusercontent.com/44206706/198845055-0a510c36-20a7-45af-9d53-aa8629c08c45.png">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
