### PR TITLE
FINERACT-1795: Improve resilience of command processing service

### DIFF
--- a/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
+++ b/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
@@ -187,5 +187,7 @@ dependencyManagement {
         dependency 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
         dependency "org.apache.avro:avro:1.11.1"
+
+        dependency "io.github.resilience4j:resilience4j-spring-boot2:1.7.1"
     }
 }

--- a/fineract-doc/src/docs/en/chapters/resilience/command.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/command.adoc
@@ -1,0 +1,23 @@
+= Command
+
+== `CommandProcessingService`
+
+TBD
+
+.Retry-able service function `executeCommand`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java[lines=73..151]
+----
+
+.Fallback function `fallbackExecuteCommand`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java[lines=166..174]
+----
+
+.Retry configuration for `executeCommand`
+[source,properties]
+----
+include::{rootdir}/fineract-provider/src/main/resources/application.properties[lines=169..174]
+----

--- a/fineract-doc/src/docs/en/chapters/resilience/index.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/index.adoc
@@ -1,0 +1,11 @@
+= Resilience
+
+include::intro.adoc[leveloffset=+1]
+
+include::command.adoc[leveloffset=+1]
+
+include::job.adoc[leveloffset=+1]
+
+include::loan.adoc[leveloffset=+1]
+
+include::saving.adoc[leveloffset=+1]

--- a/fineract-doc/src/docs/en/chapters/resilience/intro.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/intro.adoc
@@ -1,0 +1,84 @@
+= Introduction Resilience
+
+Fineract had handcrafted retry loops in place for the longest time. A typical retry code would have looked like this:
+
+.Legacy retry code
+[source,java]
+----
+    @Override
+    @SuppressWarnings("AvoidHidingCauseException")
+    @SuppressFBWarnings(value = {
+            "DMI_RANDOM_USED_ONLY_ONCE" }, justification = "False positive for random object created and used only once")
+    public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
+
+        boolean isApprovedByChecker = false;
+        // check if is update of own account details
+        if (wrapper.isUpdateOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+            // then allow this operation to proceed.
+            // maker checker doesnt mean anything here.
+            isApprovedByChecker = true; // set to true in case permissions have
+                                        // been maker-checker enabled by
+                                        // accident.
+        } else {
+            // if not user changing their own details - check user has
+            // permission to perform specific task.
+            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+        }
+        validateIsUpdateAllowed();
+
+        final String json = wrapper.getJson();
+        CommandProcessingResult result = null;
+        JsonCommand command;
+        int numberOfRetries = 0; // <1>
+        int maxNumberOfRetries = ThreadLocalContextUtil.getTenant().getConnection().getMaxRetriesOnDeadlock();
+        int maxIntervalBetweenRetries = ThreadLocalContextUtil.getTenant().getConnection().getMaxIntervalBetweenRetries();
+        final JsonElement parsedCommand = this.fromApiJsonHelper.parse(json);
+        command = JsonCommand.from(json, parsedCommand, this.fromApiJsonHelper, wrapper.getEntityName(), wrapper.getEntityId(),
+                wrapper.getSubentityId(), wrapper.getGroupId(), wrapper.getClientId(), wrapper.getLoanId(), wrapper.getSavingsId(),
+                wrapper.getTransactionId(), wrapper.getHref(), wrapper.getProductId(), wrapper.getCreditBureauId(),
+                wrapper.getOrganisationCreditBureauId(), wrapper.getJobName());
+        while (numberOfRetries <= maxNumberOfRetries) { // <2>
+            try {
+                result = this.processAndLogCommandService.executeCommand(wrapper, command, isApprovedByChecker);
+                numberOfRetries = maxNumberOfRetries + 1; // <3>
+            } catch (CannotAcquireLockException | ObjectOptimisticLockingFailureException exception) {
+                log.debug("The following command {} has been retried  {} time(s)", command.json(), numberOfRetries);
+                /***
+                 * Fail if the transaction has been retired for maxNumberOfRetries
+                 **/
+                if (numberOfRetries >= maxNumberOfRetries) {
+                    log.warn("The following command {} has been retried for the max allowed attempts of {} and will be rolled back",
+                            command.json(), numberOfRetries);
+                    throw exception;
+                }
+                /***
+                 * Else sleep for a random time (between 1 to 10 seconds) and continue
+                 **/
+                try {
+                    int randomNum = RANDOM.nextInt(maxIntervalBetweenRetries + 1);
+                    Thread.sleep(1000 + (randomNum * 1000));
+                    numberOfRetries = numberOfRetries + 1; // <4>
+                } catch (InterruptedException e) {
+                    throw exception;
+                }
+            } catch (final RollbackTransactionAsCommandIsNotApprovedByCheckerException e) {
+                numberOfRetries = maxNumberOfRetries + 1; // <3>
+                result = this.processAndLogCommandService.logCommand(e.getCommandSourceResult());
+            }
+        }
+
+        return result;
+    }
+----
+<1> counter
+<2> `while` loop
+<3> increment to abort
+<4> increment
+
+For better code quality and readability we introduced https://resilience4j.readme.io/docs[Resilience4j]:
+
+.Annotation based retry
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java[lines=49..76]
+----

--- a/fineract-doc/src/docs/en/chapters/resilience/job.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/job.adoc
@@ -1,0 +1,25 @@
+= Jobs
+
+== `SchedularWritePlatformService`
+
+WARNING: This service has a typo and should be called `SchedulerWritePlatformService`.
+
+TBD
+
+.Retry-able service function `processJobDetailForExecution`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java[lines=135..155]
+----
+
+.Fallback function `fallbackProcessJobDetailForExecution`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java[lines=156..159]
+----
+
+.Retry configuration for `processJobDetailForExecution`
+[source,properties]
+----
+include::{rootdir}/fineract-provider/src/main/resources/application.properties[lines=175..179]
+----

--- a/fineract-doc/src/docs/en/chapters/resilience/loan.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/loan.adoc
@@ -1,0 +1,23 @@
+= Loan
+
+== `LoanWritePlatformService`
+
+TBD
+
+.Retry-able service function `recalculateInterest`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java[lines=3217..3247]
+----
+
+.Fallback function `fallbackRecalculateInterest`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java[lines=3255..3266]
+----
+
+.Retry configuration for `recalculateInterest`
+[source,properties]
+----
+include::{rootdir}/fineract-provider/src/main/resources/application.properties[lines=180..185]
+----

--- a/fineract-doc/src/docs/en/chapters/resilience/saving.adoc
+++ b/fineract-doc/src/docs/en/chapters/resilience/saving.adoc
@@ -1,0 +1,23 @@
+= Savings
+
+== `SavingsAccountWritePlatformService`
+
+TBD
+
+.Retry-able service function `postInterest`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java[lines=586..627]
+----
+
+.Fallback function `fallbackPostInterest`
+[source,java]
+----
+include::{rootdir}/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java[lines=1402..1414]
+----
+
+.Retry configuration for `postInterest`
+[source,properties]
+----
+include::{rootdir}/fineract-provider/src/main/resources/application.properties[lines=186..191]
+----

--- a/fineract-doc/src/docs/en/index.adoc
+++ b/fineract-doc/src/docs/en/index.adoc
@@ -39,6 +39,8 @@ include::chapters/development/index.adoc[leveloffset=+1]
 
 include::chapters/custom/index.adoc[leveloffset=+1]
 
+include::chapters/resilience/index.adoc[leveloffset=+1]
+
 include::chapters/security/index.adoc[leveloffset=+1]
 
 include::chapters/testing/index.adoc[leveloffset=+1]

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -84,6 +84,8 @@ dependencies {
             'org.springdoc:springdoc-openapi-common',
             'org.springdoc:springdoc-openapi-security',
             'org.mapstruct:mapstruct',
+
+            'io.github.resilience4j:resilience4j-spring-boot2',
             )
 
     implementation ('org.apache.commons:commons-email') {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
@@ -54,8 +54,6 @@ public class FineractPlatformTenantConnection implements Serializable {
     private final int suspectTimeout;
     private final int timeBetweenEvictionRunsMillis;
     private final int minEvictableIdleTimeMillis;
-    private final int maxRetriesOnDeadlock;
-    private final int maxIntervalBetweenRetries;
     private final boolean testOnBorrow;
 
     public FineractPlatformTenantConnection(final Long connectionId, final String schemaName, String schemaServer,
@@ -63,10 +61,9 @@ public class FineractPlatformTenantConnection implements Serializable {
             final String schemaPassword, final boolean autoUpdateEnabled, final int initialSize, final long validationInterval,
             final boolean removeAbandoned, final int removeAbandonedTimeout, final boolean logAbandoned,
             final int abandonWhenPercentageFull, final int maxActive, final int minIdle, final int maxIdle, final int suspectTimeout,
-            final int timeBetweenEvictionRunsMillis, final int minEvictableIdleTimeMillis, final int maxRetriesOnDeadlock,
-            final int maxIntervalBetweenRetries, final boolean tesOnBorrow, final String readOnlySchemaServer,
-            final String readOnlySchemaServerPort, final String readOnlySchemaName, final String readOnlySchemaUsername,
-            final String readOnlySchemaPassword, final String readOnlySchemaConnectionParameters) {
+            final int timeBetweenEvictionRunsMillis, final int minEvictableIdleTimeMillis, final boolean tesOnBorrow,
+            final String readOnlySchemaServer, final String readOnlySchemaServerPort, final String readOnlySchemaName,
+            final String readOnlySchemaUsername, final String readOnlySchemaPassword, final String readOnlySchemaConnectionParameters) {
 
         this.connectionId = connectionId;
         this.schemaName = schemaName;
@@ -88,8 +85,6 @@ public class FineractPlatformTenantConnection implements Serializable {
         this.suspectTimeout = suspectTimeout;
         this.timeBetweenEvictionRunsMillis = timeBetweenEvictionRunsMillis;
         this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;
-        this.maxRetriesOnDeadlock = maxRetriesOnDeadlock;
-        this.maxIntervalBetweenRetries = maxIntervalBetweenRetries;
         this.testOnBorrow = tesOnBorrow;
         this.readOnlySchemaServer = readOnlySchemaServer;
         this.readOnlySchemaServerPort = readOnlySchemaServerPort;
@@ -169,14 +164,6 @@ public class FineractPlatformTenantConnection implements Serializable {
 
     public int getMinEvictableIdleTimeMillis() {
         return this.minEvictableIdleTimeMillis;
-    }
-
-    public int getMaxRetriesOnDeadlock() {
-        return this.maxRetriesOnDeadlock;
-    }
-
-    public int getMaxIntervalBetweenRetries() {
-        return this.maxIntervalBetweenRetries;
     }
 
     public boolean isTestOnBorrow() {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/SchedularWritePlatformServiceJpaRepositoryImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.infrastructure.jobs.service;
 
+import io.github.resilience4j.retry.annotation.Retry;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,7 @@ public class SchedularWritePlatformServiceJpaRepositoryImpl implements Schedular
 
     @Transactional
     @Override
+    @Retry(name = "processJobDetailForExecution", fallbackMethod = "fallbackProcessJobDetailForExecution")
     public boolean processJobDetailForExecution(final String jobKey, final String triggerType) {
         boolean isStopExecution = false;
         final ScheduledJobDetail scheduledJobDetail = this.scheduledJobDetailsRepository.findByJobKeyWithLock(jobKey);
@@ -149,6 +151,11 @@ public class SchedularWritePlatformServiceJpaRepositoryImpl implements Schedular
         }
         this.scheduledJobDetailsRepository.save(scheduledJobDetail);
         return isStopExecution;
+    }
+
+    @SuppressWarnings("unused")
+    private boolean fallbackProcessJobDetailForExecution(Exception e) {
+        return false;
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TenantMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TenantMapper.java
@@ -37,7 +37,6 @@ public final class TenantMapper implements RowMapper<FineractPlatformTenant> {
             + " ts.pool_max_active as poolMaxActive, ts.pool_min_idle as poolMinIdle, ts.pool_max_idle as poolMaxIdle,"
             + " ts.pool_suspect_timeout as poolSuspectTimeout, ts.pool_time_between_eviction_runs_millis as poolTimeBetweenEvictionRunsMillis,"
             + " ts.pool_min_evictable_idle_time_millis as poolMinEvictableIdleTimeMillis,"
-            + " ts.deadlock_max_retries as maxRetriesOnDeadlock," + " ts.deadlock_max_retry_interval as maxIntervalBetweenRetries,"
             + " ts.readonly_schema_server as readOnlySchemaServer, " + " ts.readonly_schema_server_port as readOnlySchemaServerPort, "
             + " ts.readonly_schema_name as readOnlySchemaName, " + " ts.readonly_schema_username as readOnlySchemaUsername, "
             + " ts.readonly_schema_password as readOnlySchemaPassword, "
@@ -99,26 +98,11 @@ public final class TenantMapper implements RowMapper<FineractPlatformTenant> {
         final int suspectTimeout = rs.getInt("poolSuspectTimeout");
         final int timeBetweenEvictionRunsMillis = rs.getInt("poolTimeBetweenEvictionRunsMillis");
         final int minEvictableIdleTimeMillis = rs.getInt("poolMinEvictableIdleTimeMillis");
-        int maxRetriesOnDeadlock = rs.getInt("maxRetriesOnDeadlock");
-        int maxIntervalBetweenRetries = rs.getInt("maxIntervalBetweenRetries");
-
-        maxRetriesOnDeadlock = bindValueInMinMaxRange(maxRetriesOnDeadlock, 0, 15);
-        maxIntervalBetweenRetries = bindValueInMinMaxRange(maxIntervalBetweenRetries, 1, 15);
 
         return new FineractPlatformTenantConnection(connectionId, schemaName, schemaServer, schemaServerPort, schemaConnectionParameters,
                 schemaUsername, schemaPassword, autoUpdateEnabled, initialSize, validationInterval, removeAbandoned, removeAbandonedTimeout,
                 logAbandoned, abandonWhenPercentageFull, maxActive, minIdle, maxIdle, suspectTimeout, timeBetweenEvictionRunsMillis,
-                minEvictableIdleTimeMillis, maxRetriesOnDeadlock, maxIntervalBetweenRetries, testOnBorrow, readOnlySchemaServer,
-                readOnlySchemaServerPort, readOnlySchemaName, readOnlySchemaUsername, readOnlySchemaPassword,
-                readOnlySchemaConnectionParameters);
-    }
-
-    private int bindValueInMinMaxRange(final int value, int min, int max) {
-        if (value < min) {
-            return min;
-        } else if (value > max) {
-            return max;
-        }
-        return value;
+                minEvictableIdleTimeMillis, testOnBorrow, readOnlySchemaServer, readOnlySchemaServerPort, readOnlySchemaName,
+                readOnlySchemaUsername, readOnlySchemaPassword, readOnlySchemaConnectionParameters);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/RecalculateInterestPoster.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/RecalculateInterestPoster.java
@@ -18,19 +18,14 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.jobs.exception.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
-import org.springframework.dao.CannotAcquireLockException;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,7 +33,6 @@ import org.springframework.stereotype.Component;
 public class RecalculateInterestPoster implements Callable<Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecalculateInterestPoster.class);
-    private static final SecureRandom random = new SecureRandom();
 
     private Collection<Long> loanIds;
     private LoanWritePlatformService loanWritePlatformService;
@@ -52,52 +46,16 @@ public class RecalculateInterestPoster implements Callable<Void> {
     }
 
     @Override
-    @SuppressFBWarnings(value = {
-            "DMI_RANDOM_USED_ONLY_ONCE" }, justification = "False positive for random object created and used only once")
     public Void call() throws JobExecutionException {
-        Integer maxNumberOfRetries = ThreadLocalContextUtil.getTenant().getConnection().getMaxRetriesOnDeadlock();
-        Integer maxIntervalBetweenRetries = ThreadLocalContextUtil.getTenant().getConnection().getMaxIntervalBetweenRetries();
-
-        int i = 0;
         if (!loanIds.isEmpty()) {
             List<Throwable> errors = new ArrayList<>();
             for (Long loanId : loanIds) {
                 LOG.debug("Loan ID {}", loanId);
-                Integer numberOfRetries = 0;
-                while (numberOfRetries <= maxNumberOfRetries) {
-                    try {
-                        this.loanWritePlatformService.recalculateInterest(loanId);
-                        numberOfRetries = maxNumberOfRetries + 1;
-                    } catch (CannotAcquireLockException | ObjectOptimisticLockingFailureException exception) {
-                        LOG.debug("Recalculate interest job has been retried {} time(s)", numberOfRetries);
-                        // Fail if the transaction has been retired for
-                        // maxNumberOfRetries
-                        if (numberOfRetries >= maxNumberOfRetries) {
-                            LOG.error(
-                                    "Recalculate interest job has been retried for the max allowed attempts of {} and will be rolled back",
-                                    numberOfRetries);
-                            errors.add(exception);
-                            break;
-                        }
-                        // Else sleep for a random time (between 1 to 10
-                        // seconds) and continue
-                        try {
-                            int randomNum = random.nextInt(maxIntervalBetweenRetries + 1);
-                            Thread.sleep(1000 + (randomNum * 1000));
-                            numberOfRetries = numberOfRetries + 1;
-                        } catch (InterruptedException e) {
-                            LOG.error("Interest recalculation for loans retry failed due to InterruptedException", e);
-                            errors.add(e);
-                            break;
-                        }
-                    } catch (Exception e) {
-                        LOG.error("Interest recalculation for loans failed for account {}", loanId, e);
-                        numberOfRetries = maxNumberOfRetries + 1;
-                        errors.add(e);
-                    }
-                    i++;
+                try {
+                    loanWritePlatformService.recalculateInterest(loanId);
+                } catch (Exception e) {
+                    errors.add(e);
                 }
-                LOG.debug("Loans count {}", i);
             }
             if (!errors.isEmpty()) {
                 throw new JobExecutionException(errors);

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -73,17 +73,18 @@ fineract.loan.transactionprocessor.error-not-found-fail=${FINERACT_LOAN_TRANSACT
 # Logging pattern for the console
 logging.pattern.console=${CONSOLE_LOG_PATTERN:%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(%replace([%X{correlationId}]){'\\[\\]', ''}) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}}
 
-management.health.jms.enabled=false
+management.health.jms.enabled=${FINERACT_MANAGEMENT_HEALTH_JMS_ENABLED:false}
 
 # FINERACT 1296
 management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 
+management.health.ratelimiters.enabled=${FINERACT_MANAGEMENT_HEALTH_RATELIMITERS_ENABLED:false}
+
 # FINERACT-883
 management.info.git.mode=FULL
-management.endpoints.web.exposure.include=health,info
-
+management.endpoints.web.exposure.include=${FINERACT_MANAGEMENT_ENDPOINT_WEB_EXPOSURE_INCLUDE:health,info}
 # FINERACT-914
 server.forward-headers-strategy=framework
 server.port=${FINERACT_SERVER_PORT:8443}
@@ -164,3 +165,26 @@ spring.main.allow-bean-definition-overriding=true
 spring.batch.initialize-schema=NEVER
 # Disabling Spring Batch jobs on startup
 spring.batch.job.enabled=false
+
+resilience4j.retry.instances.executeCommand.max-attempts=${FINERACT_COMMAND_PROCESSING_RETRY_MAX_ATTEMPTS:3}
+resilience4j.retry.instances.executeCommand.wait-duration=${FINERACT_COMMAND_PROCESSING_RETRY_WAIT_DURATION:1s}
+resilience4j.retry.instances.executeCommand.enable-exponential-backoff=${FINERACT_COMMAND_PROCESSING_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
+resilience4j.retry.instances.executeCommand.exponential-backoff-multiplier=${FINERACT_COMMAND_PROCESSING_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
+resilience4j.retry.instances.executeCommand.retryExceptions=${FINERACT_COMMAND_PROCESSING_RETRY_EXCEPTIONS:org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException}
+
+resilience4j.retry.instances.processJobDetailForExecution.max-attempts=${FINERACT_PROCESS_JOB_DETAIL_RETRY_MAX_ATTEMPTS:3}
+resilience4j.retry.instances.processJobDetailForExecution.wait-duration=${FINERACT_PROCESS_JOB_DETAIL_RETRY_WAIT_DURATION:1s}
+resilience4j.retry.instances.processJobDetailForExecution.enable-exponential-backoff=${FINERACT_PROCESS_JOB_DETAIL_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
+resilience4j.retry.instances.processJobDetailForExecution.exponential-backoff-multiplier=${FINERACT_PROCESS_JOB_DETAIL_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
+
+resilience4j.retry.instances.recalculateInterest.max-attempts=${FINERACT_PROCESS_RECALCULATE_INTEREST_RETRY_MAX_ATTEMPTS:3}
+resilience4j.retry.instances.recalculateInterest.wait-duration=${FINERACT_PROCESS_RECALCULATE_INTEREST_RETRY_WAIT_DURATION:1s}
+resilience4j.retry.instances.recalculateInterest.enable-exponential-backoff=${FINERACT_PROCESS_RECALCULATE_INTEREST_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
+resilience4j.retry.instances.recalculateInterest.exponential-backoff-multiplier=${FINERACT_PROCESS_RECALCULATE_INTEREST_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
+resilience4j.retry.instances.recalculateInterest.retryExceptions=${FINERACT_PROCESS_RECALCULATE_INTEREST_RETRY_EXCEPTIONS:org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException}
+
+resilience4j.retry.instances.postInterest.max-attempts=${FINERACT_PROCESS_POST_INTEREST_RETRY_MAX_ATTEMPTS:3}
+resilience4j.retry.instances.postInterest.wait-duration=${FINERACT_PROCESS_POST_INTEREST_RETRY_WAIT_DURATION:1s}
+resilience4j.retry.instances.postInterest.enable-exponential-backoff=${FINERACT_PROCESS_POST_INTEREST_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
+resilience4j.retry.instances.postInterest.exponential-backoff-multiplier=${FINERACT_PROCESS_POST_INTEREST_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
+resilience4j.retry.instances.postInterest.retryExceptions=${FINERACT_PROCESS_POST_INTEREST_RETRY_EXCEPTIONS:org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException}

--- a/fineract-provider/src/main/resources/db/changelog/tenant-store/parts/0006_drop_retry_parameter_columns.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant-store/parts/0006_drop_retry_parameter_columns.xml
@@ -22,8 +22,8 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-     <include file="parts/0003_reset_postgresql_sequences.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0004_readonly_database_connection.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0005_jdbc_connection_string.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0006_drop_retry_parameter_columns.xml" relativeToChangelogFile="true"/>
+    <changeSet author="fineract" id="1" context="tenant_store_db">
+        <dropColumn tableName="tenant_server_connections" columnName="deadlock_max_retries" />
+        <dropColumn tableName="tenant_server_connections" columnName="deadlock_max_retry_interval" />
+    </changeSet>
 </databaseChangeLog>

--- a/fineract-provider/src/test/java/org/apache/fineract/commands/service/CommandServiceStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/commands/service/CommandServiceStepDefinitions.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.cucumber.java8.En;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.event.RetryEvent;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.exception.RollbackTransactionAsCommandIsNotApprovedByCheckerException;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+public class CommandServiceStepDefinitions implements En {
+
+    private static final Logger log = LoggerFactory.getLogger(CommandServiceStepDefinitions.class);
+
+    @Autowired
+    private CommandProcessingService processAndLogCommandService;
+
+    @Autowired
+    private RetryRegistry retryRegistry;
+
+    private PortfolioCommandSourceWritePlatformService commandSourceWritePlatformService;
+
+    private DummyCommand command;
+
+    private RetryEvent retryEvent;
+
+    public CommandServiceStepDefinitions() {
+        Given("/^A command source write service$/", () -> {
+            this.commandSourceWritePlatformService = new DummyCommandSourceWriteService(processAndLogCommandService);
+            this.command = new DummyCommand();
+            this.retryRegistry.retry("executeCommand").getEventPublisher().onRetry(event -> {
+                log.warn("... retry event: {}", event);
+
+                CommandServiceStepDefinitions.this.retryEvent = event;
+            });
+
+        });
+
+        When("/^The user executes the command via a command write service with exceptions$/", () -> {
+            try {
+                this.commandSourceWritePlatformService.logCommandSource(command);
+            } catch (Exception e) {
+                // TODO: this exception is OK for now; we need to fix the whole tenant based data source setup
+                log.warn("At the moment mocking data access is so incredibly hard... it's easier to just ignore this exception: {}",
+                        e.getMessage());
+            }
+        });
+
+        Then("/^The command processing service should fallback as expected$/", () -> {
+            assertNotNull(retryEvent);
+            assertEquals("executeCommand", retryEvent.getName());
+            assertEquals(2, retryEvent.getNumberOfRetryAttempts());
+        });
+
+        Then("/^The command processing service execute function should be called 3 times$/", () -> {
+            assertEquals(3, command.getCount());
+        });
+    }
+
+    public static class DummyCommand extends CommandWrapper {
+
+        private AtomicInteger counter = new AtomicInteger();
+
+        public DummyCommand() {
+            super(null, null, null, null, null, null, null, null, null, null, "{}", null, null, null, null, null, null,
+                    UUID.randomUUID().toString());
+        }
+
+        @Override
+        public String taskPermissionName() {
+            // NOTE: simulating a failure scenario that triggers retries; using this function, because it is the first
+            // called in the command processing service
+
+            int step = counter.incrementAndGet();
+
+            log.warn("Round: {}", step);
+
+            if (step == 1) {
+                throw new CannotAcquireLockException("BLOW IT UP!!!");
+            } else if (step == 2) {
+                throw new ObjectOptimisticLockingFailureException("Dummy", new RuntimeException("BLOW IT UP!!!"));
+            } else if (step == 3) {
+                throw new RollbackTransactionAsCommandIsNotApprovedByCheckerException(new DummyCommandSource());
+            }
+
+            return "dummy";
+        }
+
+        @Override
+        public String actionName() {
+            return "dummy";
+        }
+
+        public int getCount() {
+            return counter.get();
+        }
+    }
+
+    public static class DummyCommandSourceWriteService implements PortfolioCommandSourceWritePlatformService {
+
+        private final CommandProcessingService processAndLogCommandService;
+
+        public DummyCommandSourceWriteService(CommandProcessingService processAndLogCommandService) {
+            this.processAndLogCommandService = processAndLogCommandService;
+        }
+
+        @Override
+        public CommandProcessingResult logCommandSource(CommandWrapper wrapper) {
+            final String json = wrapper.getJson();
+            JsonCommand command = JsonCommand.from(json, null, null, wrapper.getEntityName(), wrapper.getEntityId(),
+                    wrapper.getSubentityId(), wrapper.getGroupId(), wrapper.getClientId(), wrapper.getLoanId(), wrapper.getSavingsId(),
+                    wrapper.getTransactionId(), wrapper.getHref(), wrapper.getProductId(), wrapper.getCreditBureauId(),
+                    wrapper.getOrganisationCreditBureauId(), wrapper.getJobName());
+
+            return this.processAndLogCommandService.executeCommand(wrapper, command, true);
+        }
+
+        @Override
+        public CommandProcessingResult approveEntry(Long id) {
+            return null;
+        }
+
+        @Override
+        public Long rejectEntry(Long id) {
+            return null;
+        }
+
+        @Override
+        public Long deleteEntry(Long makerCheckerId) {
+            return null;
+        }
+    }
+
+    @Entity
+    @Table(name = "m_portfolio_command_source")
+    public static class DummyCommandSource extends CommandSource {
+
+        public DummyCommandSource() {
+            setId(1L);
+        }
+    }
+}

--- a/fineract-provider/src/test/resources/application-test.properties
+++ b/fineract-provider/src/test/resources/application-test.properties
@@ -111,3 +111,26 @@ spring.main.allow-bean-definition-overriding=true
 spring.batch.initialize-schema=NEVER
 # Disabling Spring Batch jobs on startup
 spring.batch.job.enabled=false
+
+resilience4j.retry.instances.executeCommand.max-attempts=3
+resilience4j.retry.instances.executeCommand.wait-duration=1s
+resilience4j.retry.instances.executeCommand.enable-exponential-backoff=true
+resilience4j.retry.instances.executeCommand.exponential-backoff-multiplier=2
+resilience4j.retry.instances.executeCommand.retryExceptions=org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException
+
+resilience4j.retry.instances.processJobDetailForExecution.max-attempts=3
+resilience4j.retry.instances.processJobDetailForExecution.wait-duration=1s
+resilience4j.retry.instances.processJobDetailForExecution.enable-exponential-backoff=true
+resilience4j.retry.instances.processJobDetailForExecution.exponential-backoff-multiplier=2
+
+resilience4j.retry.instances.recalculateInterest.max-attempts=3
+resilience4j.retry.instances.recalculateInterest.wait-duration=1s
+resilience4j.retry.instances.recalculateInterest.enable-exponential-backoff=true
+resilience4j.retry.instances.recalculateInterest.exponential-backoff-multiplier=2
+resilience4j.retry.instances.recalculateInterest.retryExceptions=org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException
+
+resilience4j.retry.instances.postInterest.max-attempts=3
+resilience4j.retry.instances.postInterest.wait-duration=1s
+resilience4j.retry.instances.postInterest.enable-exponential-backoff=true
+resilience4j.retry.instances.postInterest.exponential-backoff-multiplier=2
+resilience4j.retry.instances.postInterest.retryExceptions=org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException

--- a/fineract-provider/src/test/resources/features/commands/commands.service.feature
+++ b/fineract-provider/src/test/resources/features/commands/commands.service.feature
@@ -17,23 +17,11 @@
 # under the License.
 #
 
-Feature: Commands Provider
+Feature: Commands Service
 
-  @template
-  Scenario Outline: Verify that command providers are injected
-    Given A command handler for entity <entity> and action <action>
-    When The user processes the command with ID <id>
-    Then The command ID matches <id>
+  Scenario: Verify that command source write service are working with fallback function
+    Given A command source write service
+    When The user executes the command via a command write service with exceptions
+    Then The command processing service should fallback as expected
+    Then The command processing service execute function should be called 3 times
 
-    Examples:
-      | id  | entity | action |
-      | 815 | HUMAN  | UPDATE |
-
-  @template
-  Scenario Outline: Verify that command no command handler is provided
-    Given A missing command handler for entity <entity> and action <action>
-    Then The system should throw an exception
-
-    Examples:
-      | entity   | action      |
-      | WHATEVER | DOSOMETHING |

--- a/fineract-provider/src/test/resources/logback.xml
+++ b/fineract-provider/src/test/resources/logback.xml
@@ -34,6 +34,7 @@
     <logger name="org.springframework.transaction" level="INFO" />
     <logger name="org.springframework.data.convert" level="ERROR" />
     <logger name="org.springframework.http.converter.json" level="ERROR" />
+    <logger name="io.github.resilience4j.retry" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Improve the resilience of the command processing service and make retry (and other parameters) configurable (provide reasonable defaults).

The current retry mechanics in place are causing various congestion issues in high traffic deployments. Besides that, we always have to lookup the tenant to retrieve the retry configuration; Spring Boot's application.properties are the proper place for that.

Retries are used currently with 4 service function calls and the code used to implement retries is very repetitive and not very adjustable.