### PR TITLE
FINERACT-1805 - Treat share transactions separately

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
@@ -204,7 +204,12 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
                 }
                 Long transaction = null;
                 if (entityType != null) {
-                    transaction = Long.parseLong(transactionId.substring(1).trim());
+                    if (transactionId.substring(0, 2).equalsIgnoreCase("SH")) {
+                        transaction = Long.parseLong(transactionId.substring(2).trim());
+                    } else {
+                        transaction = Long.parseLong(transactionId.substring(1).trim());
+                    }
+
                 }
 
                 TransactionTypeEnumData transactionTypeEnumData = null;


### PR DESCRIPTION
## Description

Loan and Savings transactionIds start with a single capital letter (L and S repectively) but share transactions start with 2 capital letters (SH). Originally all transactionIds had been assumed to start with a single which threw a NumberFormatException. The edit addresses this by treating share transactions separately from other entity transactions.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
