### PR TITLE
FINERACT-1815: Fix datatable put call with resource id

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/handler/UpdateOneToManyDatatableEntryCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/handler/UpdateOneToManyDatatableEntryCommandHandler.java
@@ -21,7 +21,6 @@ package org.apache.fineract.infrastructure.dataqueries.handler;
 import org.apache.fineract.commands.handler.NewCommandSourceHandler;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
-import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.dataqueries.service.ReadWriteNonCoreDataService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -41,18 +40,8 @@ public class UpdateOneToManyDatatableEntryCommandHandler implements NewCommandSo
     @Override
     public CommandProcessingResult processCommand(final JsonCommand command) {
 
-        final CommandProcessingResult commandProcessingResult = this.writePlatformService
-                .updateDatatableEntryOneToMany(command.entityName(), command.entityId(), command.subentityId(), command);
+        return this.writePlatformService.updateDatatableEntryOneToMany(command.entityName(), command.entityId(), command.subentityId(),
+                command);
 
-        return new CommandProcessingResultBuilder() //
-                .withCommandId(command.commandId()) //
-                .withEntityId(command.entityId()) //
-                .withOfficeId(commandProcessingResult.getOfficeId()) //
-                .withGroupId(commandProcessingResult.getGroupId()) //
-                .withClientId(commandProcessingResult.getClientId()) //
-                .withSavingsId(commandProcessingResult.getSavingsId()) //
-                .withLoanId(commandProcessingResult.getLoanId()) //
-                .with(commandProcessingResult.getChanges()) //
-                .build();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
@@ -1415,14 +1415,14 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
             }
         }
 
-        return new CommandProcessingResultBuilder() //
+        return new CommandProcessingResultBuilder().withCommandId(command.commandId()) //
+                .withEntityId(datatableId != null ? command.subentityId() : command.entityId()) //
                 .withOfficeId(commandProcessingResult.getOfficeId()) //
                 .withGroupId(commandProcessingResult.getGroupId()) //
                 .withClientId(commandProcessingResult.getClientId()) //
                 .withSavingsId(commandProcessingResult.getSavingsId()) //
                 .withLoanId(commandProcessingResult.getLoanId()) //
-                .with(changes) //
-                .build();
+                .with(changes).build();
     }
 
     @Transactional
@@ -1477,7 +1477,8 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
         SQLInjectionValidator.validateSQLInput(whereClause);
         String sql = "select * from " + sqlGenerator.escape(dataTableName) + " where " + whereClause;
 
-        // id only used for reading a specific entry that belongs to appTableId (in a one to many datatable)
+        // id only used for reading a specific entry that belongs to appTableId (in a
+        // one to many datatable)
         if (multiRow && id != null) {
             sql = sql + " and id = " + id;
         }
@@ -1503,7 +1504,8 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
         SQLInjectionValidator.validateSQLInput(whereClause);
         String sql = "select * from " + sqlGenerator.escape(dataTableName) + " where " + whereClause;
 
-        // id only used for reading a specific entry that belongs to appTableId (in a one to many datatable)
+        // id only used for reading a specific entry that belongs to appTableId (in a
+        // one to many datatable)
         if (multiRow && id != null) {
             sql = sql + " and id = " + id;
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DatatableIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DatatableIntegrationTest.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.fineract.client.models.PutDataTablesAppTableIdDatatableIdResponse;
 import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.integrationtests.client.IntegrationTest;
 import org.apache.fineract.integrationtests.common.ClientHelper;
@@ -419,10 +420,10 @@ public class DatatableIntegrationTest extends IntegrationTest {
         assertNull(((List) ((Map) ((List) items.get("data")).get(1)).get("row")).get(8));
         assertNull(((List) ((Map) ((List) items.get("data")).get(1)).get("row")).get(9));
 
-        HashMap<String, Object> updatedDatatableEntryResponse = this.datatableHelper.updateDatatableEntry(datatableName, loanID, 1, false,
-                datatableEntryRequestJsonString);
-
-        assertEquals(null, updatedDatatableEntryResponse.get("changes"));
+        PutDataTablesAppTableIdDatatableIdResponse updatedDatatableEntryResponse = this.datatableHelper.updateDatatableEntry(datatableName,
+                loanID, 1, datatableEntryRequestJsonString);
+        assertNotNull(updatedDatatableEntryResponse);
+        assertEquals(0, updatedDatatableEntryResponse.getChanges().size());
     }
 
     @Test
@@ -591,20 +592,25 @@ public class DatatableIntegrationTest extends IntegrationTest {
         datatabelEntryRequestJsonString = new GsonBuilder().serializeNulls().create().toJson(datatableEntryMap);
         LOG.info("map : {}", datatabelEntryRequestJsonString);
 
-        HashMap<String, Object> updatedDatatableEntryResponse = this.datatableHelper.updateDatatableEntry(datatableName, loanID, 1, false,
+        PutDataTablesAppTableIdDatatableIdResponse updatedDatatableEntryResponse = this.datatableHelper.updateDatatableEntry(datatableName,
+                loanID, 1, datatabelEntryRequestJsonString);
+        assertNotNull(updatedDatatableEntryResponse);
+        assertEquals(1L, updatedDatatableEntryResponse.getResourceId());
+        updatedDatatableEntryResponse = this.datatableHelper.updateDatatableEntry(datatableName, loanID, 2,
                 datatabelEntryRequestJsonString);
-        this.datatableHelper.updateDatatableEntry(datatableName, loanID, 2, false, datatabelEntryRequestJsonString);
+        assertNotNull(updatedDatatableEntryResponse);
+        assertEquals(2L, updatedDatatableEntryResponse.getResourceId());
 
-        assertEquals(loanID, updatedDatatableEntryResponse.get("loanId"));
+        assertEquals(Long.valueOf(loanID), updatedDatatableEntryResponse.getLoanId());
 
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsABoolean"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsADate"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsADecimal"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsADatetime"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get(tst_tst_tst + "_cd_itsADropdown"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsANumber"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsAString"));
-        assertEquals(null, ((Map) updatedDatatableEntryResponse.get("changes")).get("itsAText"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsABoolean"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsADate"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsADecimal"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsADatetime"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get(tst_tst_tst + "_cd_itsADropdown"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsANumber"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsAString"));
+        assertEquals(null, updatedDatatableEntryResponse.getChanges().get("itsAText"));
 
         items = this.datatableHelper.readDatatableEntry(datatableName, loanID, genericResultSet, null, "");
         assertNotNull(items);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
@@ -30,11 +30,15 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import org.apache.fineract.client.models.PutDataTablesAppTableIdDatatableIdResponse;
+import org.apache.fineract.client.util.JSON;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatatableHelper {
+
+    private static final Gson GSON = new JSON().getGson();
 
     private static final Logger LOG = LoggerFactory.getLogger(DatatableHelper.class);
     private final RequestSpecification requestSpec;
@@ -73,6 +77,13 @@ public class DatatableHelper {
             final boolean genericResultSet, final String json) {
         return Utils.performServerPut(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + apptableId + "/"
                 + entryId + "?genericResultSet=" + genericResultSet + "&" + Utils.TENANT_IDENTIFIER, json, "");
+    }
+
+    public PutDataTablesAppTableIdDatatableIdResponse updateDatatableEntry(final String datatableName, final Integer apptableId,
+            final Integer entryId, final String json) {
+        final String response = Utils.performServerPut(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/"
+                + apptableId + "/" + entryId + "?genericResultSet=false&" + Utils.TENANT_IDENTIFIER, json, null);
+        return GSON.fromJson(response, PutDataTablesAppTableIdDatatableIdResponse.class);
     }
 
     public Integer createDatatableEntry(final String apptableName, final String datatableName, final Integer apptableId,


### PR DESCRIPTION
## Description

Update Datatable One to Many Entry `PUT` for:

`resource_id` field in response is populated with `datatableEntryId`

[FINERACT-1815](https://issues.apache.org/jira/browse/FINERACT-1815)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
