### PR TITLE
FINERACT-1816: Create client with datatable subentity type

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResource.java
@@ -73,7 +73,7 @@ public class BulkImportApiResource {
         this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSION);
         Collection<ImportData> importData = new ArrayList<>();
         if (entityType.equals(GlobalEntityType.CLIENT.getCode())) {
-            final Collection<ImportData> importForClientEntity = this.bulkImportWorkbookService.getImports(GlobalEntityType.CLIENTS_ENTTTY);
+            final Collection<ImportData> importForClientEntity = this.bulkImportWorkbookService.getImports(GlobalEntityType.CLIENTS_ENTITY);
             final Collection<ImportData> importForClientPerson = this.bulkImportWorkbookService.getImports(GlobalEntityType.CLIENTS_PERSON);
             if (importForClientEntity != null) {
                 importData.addAll(importForClientEntity);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/data/GlobalEntityType.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/data/GlobalEntityType.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public enum GlobalEntityType {
 
-    INVALID(0, "invalid"), CLIENTS_PERSON(1, "clients.person"), CLIENTS_ENTTTY(2, "clients.entity"), GROUPS(3, "groups"), CENTERS(4,
+    INVALID(0, "invalid"), CLIENTS_PERSON(1, "clients.person"), CLIENTS_ENTITY(2, "clients.entity"), GROUPS(3, "groups"), CENTERS(4,
             "centers"), OFFICES(5, "offices"), STAFF(6, "staff"), USERS(7, "users"), SMS(8, "sms"), DOCUMENTS(9, "documents"), TEMPLATES(10,
                     "templates"), NOTES(11, "templates"), CALENDAR(12, "calendar"), MEETINGS(13, "meetings"), HOLIDAYS(14,
                             "holidays"), LOANS(15, "loans"), LOAN_PRODUCTS(16, "loancharges"), LOAN_TRANSACTIONS(18,

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportEventListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportEventListener.java
@@ -80,7 +80,7 @@ public class BulkImportEventListener implements ApplicationListener<BulkImportEv
             case CHART_OF_ACCOUNTS:
                 importHandler = this.applicationContext.getBean("chartOfAccountsImportHandler", ImportHandler.class);
             break;
-            case CLIENTS_ENTTTY:
+            case CLIENTS_ENTITY:
                 importHandler = this.applicationContext.getBean("clientEntityImportHandler", ImportHandler.class);
             break;
             case CLIENTS_PERSON:

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookPopulatorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookPopulatorServiceImpl.java
@@ -180,7 +180,7 @@ public class BulkImportWorkbookPopulatorServiceImpl implements BulkImportWorkboo
         final Workbook workbook = new HSSFWorkbook();
         if (entityType != null) {
             if (entityType.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_PERSON.toString())
-                    || entityType.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTTTY.toString())) {
+                    || entityType.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTITY.toString())) {
                 populator = populateClientWorkbook(entityType, officeId, staffId);
             } else if (entityType.trim().equalsIgnoreCase(GlobalEntityType.CENTERS.toString())) {
                 populator = populateCenterWorkbook(officeId, staffId);
@@ -241,7 +241,7 @@ public class BulkImportWorkbookPopulatorServiceImpl implements BulkImportWorkboo
             return new ClientPersonWorkbookPopulator(new OfficeSheetPopulator(offices), new PersonnelSheetPopulator(staff, offices),
                     clientTypeCodeValues, genderCodeValues, clientClassification, addressTypesCodeValues, stateProvinceCodeValues,
                     countryCodeValues);
-        } else if (entityType.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTTTY.toString())) {
+        } else if (entityType.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTITY.toString())) {
             List<CodeValueData> constitutionCodeValues = fetchCodeValuesByCodeName("Constitution");
             List<CodeValueData> mainBusinessline = fetchCodeValuesByCodeName("Main Business Line");
             return new ClientEntityWorkbookPopulator(new OfficeSheetPopulator(offices), new PersonnelSheetPopulator(staff, offices),

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -110,8 +110,8 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                 if (entity.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_PERSON.toString())) {
                     entityType = GlobalEntityType.CLIENTS_PERSON;
                     primaryColumn = 0;
-                } else if (entity.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTTTY.toString())) {
-                    entityType = GlobalEntityType.CLIENTS_ENTTTY;
+                } else if (entity.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_ENTITY.toString())) {
+                    entityType = GlobalEntityType.CLIENTS_ENTITY;
                     primaryColumn = 0;
                 } else if (entity.trim().equalsIgnoreCase(GlobalEntityType.CENTERS.toString())) {
                     entityType = GlobalEntityType.CENTERS;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResource.java
@@ -38,6 +38,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
+import lombok.AllArgsConstructor;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
@@ -50,37 +51,19 @@ import org.apache.fineract.infrastructure.dataqueries.data.EntityDataTableChecks
 import org.apache.fineract.infrastructure.dataqueries.data.EntityDataTableChecksTemplateData;
 import org.apache.fineract.infrastructure.dataqueries.data.GenericResultsetData;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksReadService;
-import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
-import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Path("/entityDatatableChecks")
+@AllArgsConstructor
 @Component
 @Scope("singleton")
 @Tag(name = "Entity Data Table", description = "This defines Entity-Datatable Check.")
 public class EntityDatatableChecksApiResource {
 
-    private final PlatformSecurityContext context;
-    private final GenericDataService genericDataService;
     private final EntityDatatableChecksReadService readEntityDatatableChecksService;
     private final ToApiJsonSerializer<GenericResultsetData> toApiJsonSerializer;
     private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(EntityDatatableChecksApiResource.class);
-
-    @Autowired
-    public EntityDatatableChecksApiResource(final PlatformSecurityContext context, final GenericDataService genericDataService,
-            final EntityDatatableChecksReadService readEntityDatatableChecksService,
-            final ToApiJsonSerializer<GenericResultsetData> toApiJsonSerializer,
-            final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService) {
-        this.context = context;
-        this.genericDataService = genericDataService;
-        this.readEntityDatatableChecksService = readEntityDatatableChecksService;
-        this.toApiJsonSerializer = toApiJsonSerializer;
-        this.commandsSourceWritePlatformService = commandsSourceWritePlatformService;
-    }
 
     @GET
     @Consumes({ MediaType.APPLICATION_JSON })

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/EntityDatatableChecks.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/EntityDatatableChecks.java
@@ -21,12 +21,17 @@ package org.apache.fineract.infrastructure.dataqueries.domain;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 @Entity
 @Table(name = "m_entity_datatable_check")
-
 public class EntityDatatableChecks extends AbstractPersistableCustom {
 
     @Column(name = "application_table_name", nullable = false)
@@ -43,18 +48,6 @@ public class EntityDatatableChecks extends AbstractPersistableCustom {
 
     @Column(name = "product_id", nullable = true)
     private Long productId;
-
-    public EntityDatatableChecks() {}
-
-    public EntityDatatableChecks(final String entity, final String datatableName, final Long status, final boolean systemDefined,
-            final Long productId) {
-
-        this.entity = entity;
-        this.status = status;
-        this.datatableName = datatableName;
-        this.systemDefined = systemDefined;
-        this.productId = productId;
-    }
 
     public static EntityDatatableChecks fromJson(final JsonCommand command) {
 
@@ -78,23 +71,8 @@ public class EntityDatatableChecks extends AbstractPersistableCustom {
 
     }
 
-    public String getEntity() {
-        return this.entity;
-    }
-
-    public Long getStatus() {
-        return this.status;
-    }
-
-    public String getDatatableName() {
-        return this.datatableName;
-    }
-
     public boolean isSystemDefined() {
         return this.systemDefined;
     }
 
-    public Long getProductId() {
-        return productId;
-    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/EntityDatatableChecksRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/EntityDatatableChecksRepository.java
@@ -27,7 +27,17 @@ import org.springframework.data.repository.query.Param;
 public interface EntityDatatableChecksRepository
         extends JpaRepository<EntityDatatableChecks, Long>, JpaSpecificationExecutor<EntityDatatableChecks> {
 
-    List<EntityDatatableChecks> findByEntityAndStatus(String entityName, Long status);
+    List<EntityDatatableChecks> findByEntityAndStatus(String entityName, Integer status);
+
+    @Query("""
+                SELECT dt
+                FROM EntityDatatableChecks dt
+                INNER JOIN RegisteredDatatable rdt ON rdt.datatableName = dt.datatableName
+                WHERE dt.entity = :entity
+                AND dt.status = :status
+                AND rdt.subtype = :subtype
+            """)
+    List<EntityDatatableChecks> findByEntityAndStatusAndSubtype(String entity, Integer status, String subtype);
 
     @Query("select t from  EntityDatatableChecks t WHERE t.status =:status and t.entity=:entity and t.productId = :productId ")
     List<EntityDatatableChecks> findByEntityStatusAndProduct(@Param("entity") String entity, @Param("status") Long status,

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/RegisteredDatatable.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/RegisteredDatatable.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Entity
+@Table(name = "x_registered_table")
+public class RegisteredDatatable extends AbstractPersistableCustom {
+
+    @Column(name = "registered_table_name", nullable = false)
+    private String datatableName;
+
+    @Column(name = "application_table_name", nullable = false)
+    private String entity;
+
+    @Column(name = "entity_subtype", nullable = true)
+    private String subtype;
+
+    @Column(name = "category", nullable = false)
+    private int category;
+
+    public RegisteredDatatable() {}
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/RegisteredDatatableRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/domain/RegisteredDatatableRepository.java
@@ -16,22 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.dataqueries.service;
+package org.apache.fineract.infrastructure.dataqueries.domain;
 
-import com.google.gson.JsonArray;
-import org.apache.fineract.infrastructure.core.api.JsonCommand;
-import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface EntityDatatableChecksWritePlatformService {
-
-    CommandProcessingResult createCheck(JsonCommand command);
-
-    CommandProcessingResult deleteCheck(Long entityDatatableCheckId);
-
-    void runTheCheck(Long entityId, String entityName, Integer statusCode, String foreignKeyColumn, String entitySubtype);
-
-    void runTheCheckForProduct(Long entityId, String entityName, Long statusCode, String foreignKeyColumn, long productLoanId);
-
-    boolean saveDatatables(Long status, String entity, Long entityId, Long productId, JsonArray data);
+public interface RegisteredDatatableRepository
+        extends JpaRepository<RegisteredDatatable, Long>, JpaSpecificationExecutor<RegisteredDatatable> {
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerManagementReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerManagementReadPlatformServiceImpl.java
@@ -66,7 +66,6 @@ public class TellerManagementReadPlatformServiceImpl implements TellerManagement
     private final JdbcTemplate jdbcTemplate;
     private final PlatformSecurityContext context;
     private final TellerLookupMapper lookupMapper = new TellerLookupMapper();
-    private final TellerInOfficeHierarchyMapper tellerInOfficeHierarchyMapper = new TellerInOfficeHierarchyMapper();
     private final OfficeReadPlatformService officeReadPlatformService;
     private final StaffReadPlatformService staffReadPlatformService;
     private final CurrencyReadPlatformService currencyReadPlatformService;
@@ -110,33 +109,6 @@ public class TellerManagementReadPlatformServiceImpl implements TellerManagement
 
             return TellerData.instance(id, officeId, debitAccountId, creditAccountId, tellerName, description, startDate, endDate,
                     tellerStatus, officeName, null, null);
-        }
-    }
-
-    private static final class TellerInOfficeHierarchyMapper implements RowMapper<TellerData> {
-
-        @Override
-        public TellerData mapRow(final ResultSet rs, final int rowNum) throws SQLException {
-
-            final Long id = rs.getLong("id");
-            final String tellerName = rs.getString("teller_name");
-            final String description = rs.getString("description");
-            final String officeName = rs.getString("office_name");
-            final Long officeId = rs.getLong("office_id");
-            TellerStatus tellerStatus = null;
-            final Integer status = rs.getInt("status");
-            if (status != null) {
-                tellerStatus = TellerStatus.fromInt(status);
-            }
-            final Long debitAccountId = rs.getLong("debit_account_id");
-            final Long creditAccountId = rs.getLong("credit_account_id");
-
-            final LocalDate startDate = JdbcSupport.getLocalDate(rs, "start_date");
-            final LocalDate endDate = JdbcSupport.getLocalDate(rs, "end_date");
-
-            return TellerData.instance(id, officeId, debitAccountId, creditAccountId, tellerName, description, startDate, endDate,
-                    tellerStatus, officeName, null, null);
-
         }
     }
 
@@ -377,8 +349,6 @@ public class TellerManagementReadPlatformServiceImpl implements TellerManagement
         if (tellerData != null) {
             tellerName = tellerData.getName();
         }
-
-        final Collection<OfficeData> offices = this.officeReadPlatformService.retrieveAllOfficesForDropdown();
 
         Collection<StaffData> staffOptions = null;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/LegalForm.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/LegalForm.java
@@ -18,29 +18,26 @@
  */
 package org.apache.fineract.portfolio.client.domain;
 
+import lombok.Getter;
+
 /**
  * Type used to differentiate the type of client
  */
+@Getter
 public enum LegalForm {
 
-    PERSON(1, "legalFormType.person"),
+    PERSON(1, "legalFormType.person", "Person"),
 
-    ENTITY(2, "legalFormType.entity");
+    ENTITY(2, "legalFormType.entity", "Entity");
 
     private final Integer value;
     private final String code;
+    private final String label;
 
-    LegalForm(final Integer value, final String code) {
+    LegalForm(final Integer value, final String code, final String label) {
         this.value = value;
         this.code = code;
-    }
-
-    public Integer getValue() {
-        return this.value;
-    }
-
-    public String getCode() {
-        return this.code;
+        this.label = label;
     }
 
     public static LegalForm fromInt(final Integer type) {
@@ -63,5 +60,10 @@ public enum LegalForm {
 
     public boolean isEntity() {
         return this.value.equals(LegalForm.ENTITY.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return this.label;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/CenterReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/CenterReadPlatformServiceImpl.java
@@ -23,7 +23,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,7 +54,6 @@ import org.apache.fineract.organisation.staff.data.StaffData;
 import org.apache.fineract.organisation.staff.service.StaffReadPlatformService;
 import org.apache.fineract.portfolio.calendar.data.CalendarData;
 import org.apache.fineract.portfolio.calendar.service.CalendarEnumerations;
-import org.apache.fineract.portfolio.calendar.service.CalendarReadPlatformService;
 import org.apache.fineract.portfolio.calendar.service.CalendarUtils;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.domain.ClientEnumerations;
@@ -86,8 +84,6 @@ public class CenterReadPlatformServiceImpl implements CenterReadPlatformService 
     private final StaffReadPlatformService staffReadPlatformService;
     private final CodeValueReadPlatformService codeValueReadPlatformService;
     private final ConfigurationDomainService configurationDomainService;
-    private final CalendarReadPlatformService calendarReadPlatformService;
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final ColumnValidator columnValidator;
 
     // data mappers

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
@@ -207,7 +207,7 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
                 }
 
                 this.entityDatatableChecksWritePlatformService.runTheCheck(newGroup.getId(), EntityTables.GROUP.getName(),
-                        StatusEnum.CREATE.getCode().longValue(), EntityTables.GROUP.getForeignKeyColumnNameOnDatatable());
+                        StatusEnum.CREATE.getCode(), EntityTables.GROUP.getForeignKeyColumnNameOnDatatable(), null);
             }
 
             return new CommandProcessingResultBuilder() //
@@ -323,8 +323,8 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
         if (!isGroupClientCountValid) {
             throw new GroupMemberCountNotInPermissibleRangeException(group.getId(), minClients, maxClients);
         }
-        entityDatatableChecksWritePlatformService.runTheCheck(group.getId(), EntityTables.GROUP.getName(),
-                StatusEnum.ACTIVATE.getCode().longValue(), EntityTables.GROUP.getForeignKeyColumnNameOnDatatable());
+        entityDatatableChecksWritePlatformService.runTheCheck(group.getId(), EntityTables.GROUP.getName(), StatusEnum.ACTIVATE.getCode(),
+                EntityTables.GROUP.getForeignKeyColumnNameOnDatatable(), null);
     }
 
     public void validateGroupRulesBeforeClientAssociation(final Group group) {
@@ -595,8 +595,8 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
 
         validateLoansAndSavingsForGroupOrCenterClose(group, closureDate);
 
-        entityDatatableChecksWritePlatformService.runTheCheck(groupId, EntityTables.GROUP.getName(), StatusEnum.CLOSE.getCode().longValue(),
-                EntityTables.GROUP.getForeignKeyColumnNameOnDatatable());
+        entityDatatableChecksWritePlatformService.runTheCheck(groupId, EntityTables.GROUP.getName(), StatusEnum.CLOSE.getCode(),
+                EntityTables.GROUP.getForeignKeyColumnNameOnDatatable(), null);
 
         group.close(currentUser, closureReason, closureDate);
 
@@ -670,8 +670,8 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
 
         validateLoansAndSavingsForGroupOrCenterClose(center, closureDate);
 
-        entityDatatableChecksWritePlatformService.runTheCheck(centerId, EntityTables.GROUP.getName(),
-                StatusEnum.ACTIVATE.getCode().longValue(), EntityTables.GROUP.getForeignKeyColumnNameOnDatatable());
+        entityDatatableChecksWritePlatformService.runTheCheck(centerId, EntityTables.GROUP.getName(), StatusEnum.ACTIVATE.getCode(),
+                EntityTables.GROUP.getForeignKeyColumnNameOnDatatable(), null);
 
         center.close(currentUser, closureReason, closureDate);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/bulkimport/importhandler/client/ClientEntityImportHandlerTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/bulkimport/importhandler/client/ClientEntityImportHandlerTest.java
@@ -97,7 +97,7 @@ public class ClientEntityImportHandlerTest {
         CodeHelper.retrieveOrCreateCodeValue(25, requestSpec, responseSpec);
 
         ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        Workbook workbook = clientHelper.getClientEntityWorkbook(GlobalEntityType.CLIENTS_ENTTTY, "dd MMMM yyyy");
+        Workbook workbook = clientHelper.getClientEntityWorkbook(GlobalEntityType.CLIENTS_ENTITY, "dd MMMM yyyy");
 
         // insert dummy data into client entity sheet
         Sheet clientEntitySheet = workbook.getSheet(TemplatePopulateImportConstants.CLIENT_ENTITY_SHEET_NAME);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/bulkimport/populator/client/ClientEntityWorkbookPopulatorTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/bulkimport/populator/client/ClientEntityWorkbookPopulatorTest.java
@@ -65,7 +65,7 @@ public class ClientEntityWorkbookPopulatorTest {
         Assertions.assertNotNull(outcome_office_creation, "Could not create office");
 
         ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        Workbook workbook = clientHelper.getClientEntityWorkbook(GlobalEntityType.CLIENTS_ENTTTY, "dd MMMM yyyy");
+        Workbook workbook = clientHelper.getClientEntityWorkbook(GlobalEntityType.CLIENTS_ENTITY, "dd MMMM yyyy");
         Sheet officeSheet = workbook.getSheet(TemplatePopulateImportConstants.OFFICE_SHEET_NAME);
         Row firstOfficeRow = officeSheet.getRow(1);
         Assertions.assertNotNull(firstOfficeRow.getCell(1), "No offices found for given OfficeId ");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -156,6 +157,15 @@ public class ClientHelper extends IntegrationTest {
                 "clientId");
     }
 
+    public static PostClientsResponse createClientAsPersonWithDatatable(final RequestSpecification requestSpec,
+            final ResponseSpecification responseSpec, final String activationDate, final String officeId,
+            final HashMap<String, Object> datatables) {
+        log.info("---------------------------------CREATING A CLIENT PERSON WITH DATATABLE---------------------------------------------");
+        final String response = Utils.performServerPost(requestSpec, responseSpec, CREATE_CLIENT_URL,
+                getTestPersonClientAsJSON(activationDate, officeId, datatables), null);
+        return GSON.fromJson(response, PostClientsResponse.class);
+    }
+
     public static Integer createClientAsEntity(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
         return createClientAsEntity(requestSpec, responseSpec, "04 March 2011");
     }
@@ -276,6 +286,25 @@ public class ClientHelper extends IntegrationTest {
         map.put("active", "true");
         map.put("activationDate", dateOfJoining);
         map.put("legalFormId", 1);
+
+        log.info("map :  {}", map);
+        return GSON.toJson(map);
+    }
+
+    public static String getTestPersonClientAsJSON(final String dateOfJoining, final String officeId,
+            final HashMap<String, Object> datatables) {
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put("officeId", officeId);
+        map.put("fullname", Utils.randomNameGenerator("Client_FullName_", 5));
+        map.put("externalId", randomIDGenerator("ID_", 7));
+        map.put("dateFormat", Utils.DATE_FORMAT);
+        map.put("locale", "en");
+        map.put("active", "true");
+        map.put("activationDate", dateOfJoining);
+        map.put("legalFormId", 1);
+        if (datatables != null) {
+            map.put("datatables", Arrays.asList(datatables));
+        }
 
         log.info("map :  {}", map);
         return GSON.toJson(map);
@@ -665,7 +694,7 @@ public class ClientHelper extends IntegrationTest {
     public String importClientEntityTemplate(File file) {
         String locale = "en";
         String dateFormat = "dd MMMM yyyy";
-        String legalFormType = GlobalEntityType.CLIENTS_ENTTTY.toString();
+        String legalFormType = GlobalEntityType.CLIENTS_ENTITY.toString();
         requestSpec.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA);
         return Utils.performServerTemplatePost(requestSpec, responseSpec, CLIENT_URL + "/uploadtemplate" + "?" + Utils.TENANT_IDENTIFIER,
                 legalFormType, file, locale, dateFormat);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/Utils.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/Utils.java
@@ -210,6 +210,7 @@ public final class Utils {
 
     public static <T> T performServerPost(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String postURL, final String jsonBodyToSend, final String jsonAttributeToGetBack) {
+        LOG.info("JSON {}", jsonBodyToSend);
         final String json = given().spec(requestSpec).body(jsonBodyToSend).expect().spec(responseSpec).log().ifError().when().post(postURL)
                 .andReturn().asString();
         if (jsonAttributeToGetBack == null) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/organisation/EntityDatatableChecksHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/organisation/EntityDatatableChecksHelper.java
@@ -22,6 +22,8 @@ import com.google.gson.Gson;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
+import org.apache.fineract.client.models.PostEntityDatatableChecksTemplateResponse;
+import org.apache.fineract.client.util.JSON;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +36,8 @@ public class EntityDatatableChecksHelper {
 
     private static final String DATATABLE_CHECK_URL = "/fineract-provider/api/v1/entityDatatableChecks";
 
+    private static final Gson GSON = new JSON().getGson();
+
     public EntityDatatableChecksHelper(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
         this.requestSpec = requestSpec;
         this.responseSpec = responseSpec;
@@ -43,6 +47,14 @@ public class EntityDatatableChecksHelper {
             final Integer productId) {
         return Utils.performServerPost(this.requestSpec, this.responseSpec, DATATABLE_CHECK_URL + "?" + Utils.TENANT_IDENTIFIER,
                 getTestEdcAsJSON(apptableName, datatableName, status, productId), "resourceId");
+    }
+
+    public PostEntityDatatableChecksTemplateResponse addEntityDatatableCheck(final String apptableName, final String datatableName,
+            final int status, final Integer productId) {
+        final String response = Utils.performServerPost(this.requestSpec, this.responseSpec,
+                DATATABLE_CHECK_URL + "?" + Utils.TENANT_IDENTIFIER, getTestEdcAsJSON(apptableName, datatableName, status, productId),
+                null);
+        return GSON.fromJson(response, PostEntityDatatableChecksTemplateResponse.class);
     }
 
     public Integer deleteEntityDatatableCheck(final Integer entityDatatableCheckId) {


### PR DESCRIPTION
## Description

When a datatable is linked to Client creation it will be visible regardless of its subtype and the set Legal type
So for eg. we have two datatables, one for PERSON and one for ENTITY, both will be visible upon client creation wether the Legal form is set to PERSON or ENTITY

[FINERACT-1816](https://issues.apache.org/jira/browse/FINERACT-1816)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
