### PR TITLE
FINERACT-1834: Remove dependency on configuration service from conten…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -174,6 +174,7 @@ public class FineractProperties {
     @Setter
     public static class FineractContentFilesystemProperties {
 
+        private Boolean enabled;
         private String rootFolder;
     }
 
@@ -181,6 +182,7 @@ public class FineractProperties {
     @Setter
     public static class FineractContentS3Properties {
 
+        private Boolean enabled;
         private String bucketName;
         private String accessKey;
         private String secretKey;


### PR DESCRIPTION
The configuration of file system and S3 file storage was moved to application.properties already as part of the recent vulnerability fix, but there is still a left over in ContentRepositoryFactory which should also be properties based for consistency.

Does not affect patches for older releases, because we didn't replace the way how the configuration is done (patch policy).