### PR TITLE
[FINERACT-1842] Wrong entityId is returned upon disbursing a loan

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -506,23 +506,24 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
 
         businessEventNotifierService.notifyPostBusinessEvent(new LoanDisbursalBusinessEvent(loan));
 
-        Long entityId = loan.getId();
-        ExternalId externalId = loan.getExternalId();
+        Long disbursalTransactionId = null;
+        ExternalId disbursalTransactionExternalId = null;
 
-        // During a disbursement, the entityId should be the disbursement transaction id
         if (!isAccountTransfer) {
             // If accounting is not periodic accrual, the last transaction might be the accrual not the disbursement
             LoanTransaction disbursalTransaction = Lists.reverse(loan.getLoanTransactions()).stream()
                     .filter(e -> LoanTransactionType.DISBURSEMENT.equals(e.getTypeOf())).findFirst().orElseThrow();
-            entityId = disbursalTransaction.getId();
-            externalId = disbursalTransaction.getExternalId();
+            disbursalTransactionId = disbursalTransaction.getId();
+            disbursalTransactionExternalId = disbursalTransaction.getExternalId();
             businessEventNotifierService.notifyPostBusinessEvent(new LoanDisbursalTransactionBusinessEvent(disbursalTransaction));
         }
 
         return new CommandProcessingResultBuilder() //
                 .withCommandId(command.commandId()) //
-                .withEntityId(entityId) //
-                .withEntityExternalId(externalId) //
+                .withEntityId(loan.getId()) //
+                .withEntityExternalId(loan.getExternalId()) //
+                .withSubEntityId(disbursalTransactionId) //
+                .withSubEntityExternalId(disbursalTransactionExternalId) //
                 .withOfficeId(loan.getOfficeId()) //
                 .withClientId(loan.getClientId()) //
                 .withGroupId(loan.getGroupId()) //

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
@@ -1034,7 +1034,7 @@ public class BatchApiTest {
         final BatchRequest batchRequest3 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
 
         // Create a getTransaction Request
-        final BatchRequest batchRequest4 = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, disburseLoanRequestId, false);
+        final BatchRequest batchRequest4 = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, disburseLoanRequestId, true);
 
         final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalIdSupportIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalIdSupportIntegrationTest.java
@@ -140,7 +140,7 @@ public class ExternalIdSupportIntegrationTest extends IntegrationTest {
         final HashMap disbursedLoanResult = this.loanTransactionHelper.disburseLoan("03 September 2022", loanId, "1000", txnExternalIdStr);
 
         // Check whether the provided external id was retrieved
-        assertEquals(txnExternalIdStr, disbursedLoanResult.get("resourceExternalId"));
+        assertEquals(txnExternalIdStr, disbursedLoanResult.get("subResourceExternalId"));
 
         LocalDate targetDate = LocalDate.of(2022, 9, 7);
         final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
@@ -523,7 +523,7 @@ public class ExternalIdSupportIntegrationTest extends IntegrationTest {
         final HashMap disbursedLoanWithInterestResult = this.loanTransactionHelper.disburseLoan(formattedDate, loanWithInterestId, "1000",
                 null);
         // Check whether an external id was generated
-        assertNotNull(disbursedLoanWithInterestResult.get("resourceExternalId"));
+        assertNotNull(disbursedLoanWithInterestResult.get("subResourceExternalId"));
         LocalDate aMonthBeforePlus3Days = aMonthBefore.plusDays(3);
         formattedDate = dateFormatter.format(aMonthBeforePlus3Days);
 
@@ -718,7 +718,7 @@ public class ExternalIdSupportIntegrationTest extends IntegrationTest {
         final HashMap disbursedLoanResult = this.loanTransactionHelper.disburseLoan("03 September 2022", loanId, "1000", txnExternalIdStr);
 
         // Check whether the provided external id was retrieved
-        assertEquals(txnExternalIdStr, disbursedLoanResult.get("resourceExternalId"));
+        assertEquals(txnExternalIdStr, disbursedLoanResult.get("subResourceExternalId"));
 
         // Second loan
         final HashMap loan2 = applyForLoanApplication(client.getClientId().intValue(), loanProductID, null);
@@ -906,14 +906,14 @@ public class ExternalIdSupportIntegrationTest extends IntegrationTest {
                     txnExternalIdStr);
 
             // Check whether the provided external id was retrieved
-            assertEquals(txnExternalIdStr, disbursedLoanResult.get("resourceExternalId"));
+            assertEquals(txnExternalIdStr, disbursedLoanResult.get("subResourceExternalId"));
 
             String txnExternalIdStr2 = UUID.randomUUID().toString();
             final HashMap disbursedLoanResult2 = this.loanTransactionHelper.disburseLoan("04 September 2022", loanId, "1000",
                     txnExternalIdStr2);
 
             // Check whether the provided external id was retrieved
-            assertEquals(txnExternalIdStr2, disbursedLoanResult2.get("resourceExternalId"));
+            assertEquals(txnExternalIdStr2, disbursedLoanResult2.get("subResourceExternalId"));
 
             PutLoansLoanIdResponse markLoanAsFraudResult = this.loanTransactionHelper.modifyLoanApplication(loanExternalIdStr,
                     "markAsFraud", new PutLoansLoanIdRequest().fraud(true));


### PR DESCRIPTION
## Description

Disbursing loan API response changes:
- entityId in the HTTP response is the Loan ID now.
- entityExternalId in the HTTP response is the Loan external ID now.
- subEntityId in the HTTP response is the Disbursement Transaction ID now.
- subEntityExternalId in the HTTP response is the Disbursement Transaction external ID now.
