### PR TITLE
[FINERACT-1852] Swagger schema inconsistency for Business Step Config

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/data/ConfiguredJobNamesDTO.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/data/ConfiguredJobNamesDTO.java
@@ -16,23 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.core.exception;
+package org.apache.fineract.cob.data;
 
-import org.apache.fineract.commands.domain.CommandWrapper;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-/**
- * Exception thrown when command is sent with same action, entity and idempotency key
- */
-public class IdempotentCommandProcessSucceedException extends AbstractIdempotentCommandException {
+@Data
+@AllArgsConstructor
+public class ConfiguredJobNamesDTO {
 
-    private final Integer statusCode;
-
-    public IdempotentCommandProcessSucceedException(CommandWrapper wrapper, String response, Integer statusCode) {
-        super(wrapper.actionName(), wrapper.entityName(), wrapper.getIdempotencyKey(), response);
-        this.statusCode = statusCode;
-    }
-
-    public Integer getStatusCode() {
-        return statusCode;
-    }
+    private List<String> businessJobs;
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -165,7 +165,7 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
                     command -> new IdempotentCommandProcessUnderProcessingException(wrapper));
             idempotentExceptionByStatus(ERROR, existingCommand, command -> new IdempotentCommandProcessFailedException(wrapper, command));
             idempotentExceptionByStatus(PROCESSED, existingCommand,
-                    command -> new IdempotentCommandProcessSucceedException(wrapper, command.getResult()));
+                    command -> new IdempotentCommandProcessSucceedException(wrapper, command.getResult(), command.getResultStatusCode()));
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/IdempotentCommandProcessSucceedExceptionMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/IdempotentCommandProcessSucceedExceptionMapper.java
@@ -20,7 +20,6 @@ package org.apache.fineract.infrastructure.core.exceptionmapper;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +35,11 @@ public class IdempotentCommandProcessSucceedExceptionMapper implements Exception
     @Override
     public Response toResponse(final IdempotentCommandProcessSucceedException exception) {
         log.debug("Idempotent processing success request: {}", exception.getMessage());
-        return Response.status(Status.OK).entity(exception.getResponse())
-                .header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER, "true").type(MediaType.APPLICATION_JSON).build();
+        Response.ResponseBuilder responseBuilder = Response.status(exception.getStatusCode());
+        if (exception.getResponse() != null) {
+            responseBuilder.entity(exception.getResponse());
+        }
+        return responseBuilder.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER, "true").type(MediaType.APPLICATION_JSON)
+                .build();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BusinessConfigurationApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BusinessConfigurationApiTest.java
@@ -83,12 +83,13 @@ public class BusinessConfigurationApiTest {
 
     @Test
     public void shouldUpdateStepOrder() {
+        ResponseSpecification updateResponseSpec = new ResponseSpecBuilder().expectStatusCode(204).build();
         JobBusinessStepConfigData originalStepConfig = BusinessStepConfigurationHelper.getConfiguredBusinessStepsByJobName(requestSpec,
                 responseSpec, LOAN_JOB_NAME);
 
         List<BusinessStep> requestBody = new ArrayList<>();
         requestBody.add(getBusinessSteps(1L, APPLY_CHARGE_TO_OVERDUE_LOANS));
-        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 BusinessStepConfigurationHelper.toJsonString(requestBody));
 
         JobBusinessStepConfigData newStepConfig = BusinessStepConfigurationHelper.getConfiguredBusinessStepsByJobName(requestSpec,
@@ -100,7 +101,7 @@ public class BusinessConfigurationApiTest {
 
         requestBody.add(getBusinessSteps(2L, LOAN_DELINQUENCY_CLASSIFICATION));
 
-        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 BusinessStepConfigurationHelper.toJsonString(requestBody));
         newStepConfig = BusinessStepConfigurationHelper.getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, LOAN_JOB_NAME);
         applyChargeStep = newStepConfig.getBusinessSteps().stream()
@@ -112,7 +113,7 @@ public class BusinessConfigurationApiTest {
         assertEquals(2L, loanDelinquencyStep.getOrder());
 
         requestBody.remove(1);
-        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 BusinessStepConfigurationHelper.toJsonString(requestBody));
 
         newStepConfig = BusinessStepConfigurationHelper.getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, LOAN_JOB_NAME);
@@ -121,7 +122,7 @@ public class BusinessConfigurationApiTest {
         assertEquals(1, newStepConfig.getBusinessSteps().size());
         assertEquals(1L, applyChargeStep.getOrder());
 
-        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        BusinessStepConfigurationHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 BusinessStepConfigurationHelper.toJsonString(originalStepConfig.getBusinessSteps()));
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/IdempotencyTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/IdempotencyTest.java
@@ -58,6 +58,7 @@ public class IdempotencyTest {
 
     @Test
     public void shouldUpdateStepOrder() {
+        ResponseSpecification updateResponseSpec = new ResponseSpecBuilder().expectStatusCode(204).build();
         JobBusinessStepConfigData originalStepConfig = IdempotencyHelper.getConfiguredBusinessStepsByJobName(requestSpec, responseSpec,
                 LOAN_JOB_NAME);
 
@@ -65,9 +66,9 @@ public class IdempotencyTest {
 
         List<BusinessStep> requestBody = new ArrayList<>();
         requestBody.add(getBusinessSteps(1L, APPLY_CHARGE_TO_OVERDUE_LOANS));
-        Response response = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        Response response = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
-        Response responseSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        Response responseSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
         Assertions.assertEquals(response.getBody().asString(), responseSecond.getBody().asString());
         Assertions.assertNull(response.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER));
@@ -84,9 +85,9 @@ public class IdempotencyTest {
 
         requestBody.add(getBusinessSteps(2L, LOAN_DELINQUENCY_CLASSIFICATION));
 
-        Response update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        Response update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
-        Response updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        Response updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
         Assertions.assertNull(update.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER));
         Assertions.assertNotNull(updateSecond.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER));
@@ -103,9 +104,9 @@ public class IdempotencyTest {
 
         requestBody.remove(1);
         idempotencyKeyHeader = UUID.randomUUID().toString();
-        update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
-        updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(requestBody), idempotencyKeyHeader);
 
         Assertions.assertNull(update.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER));
@@ -120,9 +121,9 @@ public class IdempotencyTest {
 
         idempotencyKeyHeader = UUID.randomUUID().toString();
 
-        update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        update = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(originalStepConfig.getBusinessSteps()), idempotencyKeyHeader);
-        updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, responseSpec, LOAN_JOB_NAME,
+        updateSecond = IdempotencyHelper.updateBusinessStepOrder(requestSpec, updateResponseSpec, LOAN_JOB_NAME,
                 IdempotencyHelper.toJsonString(originalStepConfig.getBusinessSteps()), idempotencyKeyHeader);
 
         Assertions.assertNull(update.header(AbstractIdempotentCommandException.IDEMPOTENT_CACHE_HEADER));


### PR DESCRIPTION
## Description

Swagger schema provides the correct response type for the following APIs:
 - GET /jobs/names
 - GET /jobs/{jobName}/steps
 - PUT /jobs/{jobName}/available-steps
 - GET /jobs/{jobName}/steps