### PR TITLE
  FINERACT-1694-External-event-producer-batch-size-configuration

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -133,4 +133,5 @@ public interface ConfigurationDomainService {
 
     boolean isCOBBulkEventEnabled();
 
+    Long retrieveExternalEventBatchSize();
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
@@ -48,6 +48,7 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
     private static final String ENABLE_EXTERNAL_ID_AUTO_GENERATION = "enable-auto-generated-external-id";
     private static final String ENABLE_ADDRESS = "Enable-Address";
     private static final String ENABLE_COB_BULK_EVENT = "enable-cob-bulk-event";
+    private static final String EXTERNAL_EVENT_BATCH_SIZE = "external-event-batch-size";
 
     private final PermissionRepository permissionRepository;
     private final GlobalConfigurationRepositoryWrapper globalConfigurationRepository;
@@ -503,6 +504,12 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
     public boolean isCOBBulkEventEnabled() {
         final GlobalConfigurationPropertyData property = getGlobalConfigurationPropertyData(ENABLE_COB_BULK_EVENT);
         return property.isEnabled();
+    }
+
+    @Override
+    public Long retrieveExternalEventBatchSize() {
+        final GlobalConfigurationPropertyData property = getGlobalConfigurationPropertyData(EXTERNAL_EVENT_BATCH_SIZE);
+        return property.getValue();
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -152,7 +152,6 @@ public class FineractProperties {
     @Setter
     public static class FineractExternalEventsProducerProperties {
 
-        private int readBatchSize;
         private FineractExternalEventsProducerJmsProperties jms;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/jobs/SendAsynchronousEventsTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/jobs/SendAsynchronousEventsTasklet.java
@@ -23,6 +23,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.avro.MessageV1;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.event.external.producer.ExternalEventProducer;
@@ -49,6 +50,7 @@ public class SendAsynchronousEventsTasklet implements Tasklet {
     private final ExternalEventProducer eventProducer;
     private final MessageFactory messageFactory;
     private final ByteBufferConverter byteBufferConverter;
+    private final ConfigurationDomainService configurationDomainService;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
@@ -85,7 +87,8 @@ public class SendAsynchronousEventsTasklet implements Tasklet {
     }
 
     private int getBatchSize() {
-        return fineractProperties.getEvents().getExternal().getProducer().getReadBatchSize();
+        Long externalEventBatchSize = configurationDomainService.retrieveExternalEventBatchSize();
+        return externalEventBatchSize.intValue();
     }
 
 }

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -56,7 +56,6 @@ fineract.remote-job-message-handler.jms.broker-username=${FINERACT_REMOTE_JOB_ME
 fineract.remote-job-message-handler.jms.broker-password=${FINERACT_REMOTE_JOB_MESSAGE_HANDLER_JMS_BROKER_PASSWORD:}
 
 fineract.events.external.enabled=${FINERACT_EXTERNAL_EVENTS_ENABLED:false}
-fineract.events.external.producer.read-batch-size=${FINERACT_EXTERNAL_EVENTS_PRODUCER_READ_BATCH_SIZE:1000}
 fineract.events.external.producer.jms.enabled=${FINERACT_EXTERNAL_EVENTS_PRODUCER_JMS_ENABLED:false}
 fineract.events.external.producer.jms.event-queue-name=${FINERACT_EXTERNAL_EVENTS_PRODUCER_JMS_QUEUE_NAME:}
 fineract.events.external.producer.jms.event-topic-name=${FINERACT_EXTERNAL_EVENTS_PRODUCER_JMS_TOPIC_NAME:}

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -100,4 +100,5 @@
     <include file="parts/0078_add_configuration_cob_bulk_event.xml" relativeToChangelogFile="true" />
     <include file="parts/0079_add_charge_off_details_to_loan.xml" relativeToChangelogFile="true" />
     <include file="parts/0080_add_external_event_configuration_for_stayed_locked_loans_business_event.xml" relativeToChangelogFile="true" />
+    <include file="parts/0081_add_configuration_event_producer_batch_size.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0081_add_configuration_event_producer_batch_size.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0081_add_configuration_event_producer_batch_size.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1" context="postgresql">
+        <sql>
+            SELECT SETVAL('c_configuration_id_seq', COALESCE(MAX(id), 0)+1, false ) FROM c_configuration;
+        </sql>
+    </changeSet>
+    <changeSet author="fineract" id="2">
+        <insert tableName="c_configuration">
+            <column name="name" value="external-event-batch-size"/>
+            <column name="value" valueNumeric="1000"/>
+            <column name="date_value"/>
+            <column name="string_value"/>
+            <column name="enabled" valueBoolean="false"/>
+            <column name="is_trap_door" valueBoolean="false"/>
+            <column name="description" value="External event producer batch size"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
@@ -119,9 +119,9 @@ public class GlobalConfigurationHelper {
         ArrayList<HashMap> expectedGlobalConfigurations = getAllDefaultGlobalConfigurations();
         ArrayList<HashMap> actualGlobalConfigurations = getAllGlobalConfigurations(requestSpec, responseSpec);
 
-        // There are currently 47 global configurations.
-        Assertions.assertEquals(47, expectedGlobalConfigurations.size());
-        Assertions.assertEquals(47, actualGlobalConfigurations.size());
+        // There are currently 48 global configurations.
+        Assertions.assertEquals(48, expectedGlobalConfigurations.size());
+        Assertions.assertEquals(48, actualGlobalConfigurations.size());
 
         for (int i = 0; i < expectedGlobalConfigurations.size(); i++) {
 
@@ -532,6 +532,14 @@ public class GlobalConfigurationHelper {
         isCOBBulkEventEnabled.put("enabled", false);
         isCOBBulkEventEnabled.put("trapDoor", false);
         defaults.add(isCOBBulkEventEnabled);
+
+        HashMap<String, Object> externalEventBatchSize = new HashMap<>();
+        externalEventBatchSize.put("id", 53);
+        externalEventBatchSize.put("name", "external-event-batch-size");
+        externalEventBatchSize.put("value", 1000);
+        externalEventBatchSize.put("enabled", false);
+        externalEventBatchSize.put("trapDoor", false);
+        defaults.add(externalEventBatchSize);
         return defaults;
     }
 


### PR DESCRIPTION
## Description
1.Removed static configuration(environment variable) for event batch read size for producer.
2.Introduced new global configuration "external-event-batch-size" to configure batch size dynamically
3.Modified SendExternalEvent job to read batch size from global configuration.
4.Modified tests.

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
