### PR TITLE
FINERACT-1856: Fix to update datatable entry is failing after column added lately

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
@@ -2059,7 +2059,13 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
                 sql += sqlGenerator.escape(key) + " = " + pValueWrite;
             } else {
                 if (key.equalsIgnoreCase(DataTableApiConstant.UPDATEDAT_FIELD_NAME)) {
-                    sql += ", " + sqlGenerator.escape(key) + " = " + sqlGenerator.currentTenantDateTime();
+                    if (firstColumn) {
+                        sql += " set ";
+                        firstColumn = false;
+                    } else {
+                        sql += ", ";
+                    }
+                    sql += sqlGenerator.escape(key) + " = " + sqlGenerator.currentTenantDateTime();
                 }
             }
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import org.apache.fineract.client.models.GetDataTablesResponse;
+import org.apache.fineract.client.models.PostDataTablesAppTableIdResponse;
 import org.apache.fineract.client.models.PostDataTablesRequest;
 import org.apache.fineract.client.models.PostDataTablesResponse;
 import org.apache.fineract.client.models.PutDataTablesAppTableIdDatatableIdResponse;
@@ -73,6 +74,13 @@ public class DatatableHelper extends IntegrationTest {
                 + "?genericResultSet=" + genericResultSet + "&" + Utils.TENANT_IDENTIFIER, json, "");
     }
 
+    public PostDataTablesAppTableIdResponse addDatatableEntry(final String datatableName, final Integer apptableId,
+            final boolean genericResultSet, final String json) {
+        final String response = Utils.performServerPost(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/"
+                + apptableId + "?genericResultSet=" + genericResultSet + "&" + Utils.TENANT_IDENTIFIER, json);
+        return GSON.fromJson(response, PostDataTablesAppTableIdResponse.class);
+    }
+
     public <T> T updateDatatableEntry(final String datatableName, final Integer apptableId, final boolean genericResultSet,
             final String json) {
         return Utils.performServerPut(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/" + apptableId
@@ -89,6 +97,13 @@ public class DatatableHelper extends IntegrationTest {
             final Integer entryId, final String json) {
         final String response = Utils.performServerPut(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/"
                 + apptableId + "/" + entryId + "?genericResultSet=false&" + Utils.TENANT_IDENTIFIER, json, null);
+        return GSON.fromJson(response, PutDataTablesAppTableIdDatatableIdResponse.class);
+    }
+
+    public PutDataTablesAppTableIdDatatableIdResponse updateDatatableEntry(final String datatableName, final Integer apptableId,
+            final String json) {
+        final String response = Utils.performServerPut(this.requestSpec, this.responseSpec,
+                DATATABLE_URL + "/" + datatableName + "/" + apptableId + "?genericResultSet=false&" + Utils.TENANT_IDENTIFIER, json, null);
         return GSON.fromJson(response, PutDataTablesAppTableIdDatatableIdResponse.class);
     }
 
@@ -251,6 +266,18 @@ public class DatatableHelper extends IntegrationTest {
 
     public PutDataTablesResponse updateDatatable(String dataTableName, PutDataTablesRequest request) {
         return ok(fineract().dataTables.updateDatatable(dataTableName, request));
+    }
+
+    public PostDataTablesResponse createDatatable(final String json) {
+        final String response = Utils.performServerPost(this.requestSpec, this.responseSpec, DATATABLE_URL + "?" + Utils.TENANT_IDENTIFIER,
+                json);
+        return GSON.fromJson(response, PostDataTablesResponse.class);
+    }
+
+    public PutDataTablesResponse updateDatatable(String dataTableName, final String json) {
+        final String response = Utils.performServerPut(this.requestSpec, this.responseSpec,
+                DATATABLE_URL + "/" + dataTableName + "?" + Utils.TENANT_IDENTIFIER, json);
+        return GSON.fromJson(response, PutDataTablesResponse.class);
     }
 
 }


### PR DESCRIPTION
## Description

Fix to update datatable entry is failing after column added lately

[FINERACT-1856](https://issues.apache.org/jira/browse/FINERACT-1856)

<img width="1584" alt="Screenshot 2023-01-13 at 18 16 12" src="https://user-images.githubusercontent.com/44206706/212440453-058d8f28-0c5e-4fab-bb14-e131630735d3.png">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
