### PR TITLE
FINERACT-1854: Undo last disbursal function deletes all disbursals on…

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -50,6 +50,7 @@ import org.apache.fineract.client.models.GetLoansApprovalTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdCollectionData;
+import org.apache.fineract.client.models.GetLoansLoanIdDisbursementDetails;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentSchedule;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
@@ -1615,6 +1616,18 @@ public class LoanTransactionHelper extends IntegrationTest {
             log.info("Loan with Total Outstanding Balance {} expected {}", getLoansLoanIdSummary.getTotalOutstanding(), amountExpected);
             assertEquals(amountExpected, getLoansLoanIdSummary.getTotalOutstanding());
         }
+    }
+
+    public void evaluateLoanDisbursementDetails(GetLoansLoanIdResponse getLoansLoanIdResponse, Integer numItems, Double amountExpected) {
+        log.info("Disbursement details items: {}", getLoansLoanIdResponse.getDisbursementDetails().size());
+        assertEquals(numItems, getLoansLoanIdResponse.getDisbursementDetails().size());
+        Double amount = Double.valueOf("0.0");
+        for (GetLoansLoanIdDisbursementDetails disbursementDetails : getLoansLoanIdResponse.getDisbursementDetails()) {
+            amount = amount + disbursementDetails.getPrincipal();
+            log.info("Disbursement details with principal {} {}", disbursementDetails.getExpectedDisbursementDate(),
+                    disbursementDetails.getPrincipal());
+        }
+        assertEquals(amountExpected, amount);
     }
 
     public Long applyChargebackTransaction(final Integer loanId, final Long transactionId, final String amount,


### PR DESCRIPTION
… the last date

## Description

When a loan with multitranches have two (or more) disbursals on it, and we call the` /loans/{loanId}?command=undolastdisbursal` or `/loans/external-id/{externalId}?command=undolastdisbursal `API it will look for only the last DATE, not the last disbursal itself. So if the last two disbursal was on the same day, it will undo both of them.

[FINERACT-1854](https://issues.apache.org/jira/browse/FINERACT-1854)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
