### PR TITLE
Fix to use only loan transaction type 2 in getLastRepaymentTransaction

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -4946,7 +4946,7 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom {
 
     public LoanTransaction getLastRepaymentTransaction() {
         for (final LoanTransaction loanTransaction : this.loanTransactions) {
-            if (!loanTransaction.isReversed() && loanTransaction.isRepaymentType()) {
+            if (!loanTransaction.isReversed() && loanTransaction.isRepayment()) {
                 return loanTransaction;
             }
         }


### PR DESCRIPTION
## Description

Fix to use only loan transaction type 2 (_REPAYMENT_) in `getLastRepaymentTransaction` instead of the other repayment types like Merchant Issued Refund, Payout Refund, Goodwill Credit, Charge Refund or Charge Adjustment

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
