### PR TITLE
FINERACT-1866 Avoid StackOverflow Exception because an Infinite Lookup of WorkingDay

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonElement;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -123,17 +122,17 @@ public final class CalendarUtils {
     }
 
     private static LocalDateTime getNextRecurringDate(final Recur recur, final LocalDateTime seedDate, final LocalDateTime startDate) {
-        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atZone(ZoneId.systemDefault()).toInstant()));
+        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atZone(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Date seed = convertToiCal4JCompatibleDate(seedDate);
         final Date nextRecDate = recur.getNextDate(seed, periodStart);
-        return nextRecDate == null ? null : LocalDateTime.ofInstant(nextRecDate.toInstant(), DateUtils.getSystemZoneId());
+        return nextRecDate == null ? null : LocalDateTime.ofInstant(nextRecDate.toInstant(), DateUtils.getDateTimeZoneOfTenant());
     }
 
     private static LocalDate getNextRecurringDate(final Recur recur, final LocalDate seedDate, final LocalDate startDate) {
-        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
         final Date nextRecDate = recur.getNextDate(seed, periodStart);
-        return nextRecDate == null ? null : LocalDate.ofInstant(nextRecDate.toInstant(), DateUtils.getSystemZoneId());
+        return nextRecDate == null ? null : LocalDate.ofInstant(nextRecDate.toInstant(), DateUtils.getDateTimeZoneOfTenant());
     }
 
     private static Date convertToiCal4JCompatibleDate(final LocalDateTime inputDate) {
@@ -184,10 +183,10 @@ public final class CalendarUtils {
         if (recur == null) {
             return null;
         }
+        
         final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
-        final DateTime periodStart = new DateTime(java.util.Date.from(periodStartDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-        final DateTime periodEnd = new DateTime(java.util.Date.from(periodEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-
+        final DateTime periodStart = new DateTime(java.util.Date.from(periodStartDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
+        final DateTime periodEnd = new DateTime(java.util.Date.from(periodEndDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Value value = new Value(Value.DATE.getValue());
         final DateList recurringDates = recur.getDates(seed, periodStart, periodEnd, value, maxCount);
         return convertToLocalDateList(recurringDates, seedDate, getMeetingPeriodFrequencyType(recur), isSkippMeetingOnFirstDay,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonElement;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -123,17 +122,18 @@ public final class CalendarUtils {
     }
 
     private static LocalDateTime getNextRecurringDate(final Recur recur, final LocalDateTime seedDate, final LocalDateTime startDate) {
-        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atZone(ZoneId.systemDefault()).toInstant()));
+        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atZone(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Date seed = convertToiCal4JCompatibleDate(seedDate);
         final Date nextRecDate = recur.getNextDate(seed, periodStart);
-        return nextRecDate == null ? null : LocalDateTime.ofInstant(nextRecDate.toInstant(), DateUtils.getSystemZoneId());
+        return nextRecDate == null ? null : LocalDateTime.ofInstant(nextRecDate.toInstant(), DateUtils.getDateTimeZoneOfTenant());
     }
 
     private static LocalDate getNextRecurringDate(final Recur recur, final LocalDate seedDate, final LocalDate startDate) {
-        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        final DateTime periodStart = new DateTime(
+                java.util.Date.from(startDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
         final Date nextRecDate = recur.getNextDate(seed, periodStart);
-        return nextRecDate == null ? null : LocalDate.ofInstant(nextRecDate.toInstant(), DateUtils.getSystemZoneId());
+        return nextRecDate == null ? null : LocalDate.ofInstant(nextRecDate.toInstant(), DateUtils.getDateTimeZoneOfTenant());
     }
 
     private static Date convertToiCal4JCompatibleDate(final LocalDateTime inputDate) {
@@ -184,10 +184,12 @@ public final class CalendarUtils {
         if (recur == null) {
             return null;
         }
-        final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
-        final DateTime periodStart = new DateTime(java.util.Date.from(periodStartDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-        final DateTime periodEnd = new DateTime(java.util.Date.from(periodEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
 
+        final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
+        final DateTime periodStart = new DateTime(
+                java.util.Date.from(periodStartDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
+        final DateTime periodEnd = new DateTime(
+                java.util.Date.from(periodEndDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Value value = new Value(Value.DATE.getValue());
         final DateList recurringDates = recur.getDates(seed, periodStart, periodEnd, value, maxCount);
         return convertToLocalDateList(recurringDates, seedDate, getMeetingPeriodFrequencyType(recur), isSkippMeetingOnFirstDay,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
@@ -129,7 +129,8 @@ public final class CalendarUtils {
     }
 
     private static LocalDate getNextRecurringDate(final Recur recur, final LocalDate seedDate, final LocalDate startDate) {
-        final DateTime periodStart = new DateTime(java.util.Date.from(startDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
+        final DateTime periodStart = new DateTime(
+                java.util.Date.from(startDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
         final Date nextRecDate = recur.getNextDate(seed, periodStart);
         return nextRecDate == null ? null : LocalDate.ofInstant(nextRecDate.toInstant(), DateUtils.getDateTimeZoneOfTenant());
@@ -183,10 +184,12 @@ public final class CalendarUtils {
         if (recur == null) {
             return null;
         }
-        
+
         final Date seed = convertToiCal4JCompatibleDate(seedDate.atStartOfDay());
-        final DateTime periodStart = new DateTime(java.util.Date.from(periodStartDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
-        final DateTime periodEnd = new DateTime(java.util.Date.from(periodEndDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
+        final DateTime periodStart = new DateTime(
+                java.util.Date.from(periodStartDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
+        final DateTime periodEnd = new DateTime(
+                java.util.Date.from(periodEndDate.atStartOfDay(DateUtils.getDateTimeZoneOfTenant()).toInstant()));
         final Value value = new Value(Value.DATE.getValue());
         final DateList recurringDates = recur.getDates(seed, periodStart, periodEnd, value, maxCount);
         return convertToLocalDateList(recurringDates, seedDate, getMeetingPeriodFrequencyType(recur), isSkippMeetingOnFirstDay,


### PR DESCRIPTION
…p of WorkingDay

## Description

Avoid StackOverflow Exception because an Infinite Lookup of WorkingDay using the Tenant Time Zone instead of System Time Zone.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
