### PR TITLE
FINERACT-1895 - Fixing the issue where Fineract doesn't start with spring profile activeMqEnabled

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/notification/config/MessagingConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/config/MessagingConfiguration.java
@@ -22,7 +22,7 @@ import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.fineract.infrastructure.core.condition.EnableFineractEventsCondition;
-import org.apache.fineract.notification.eventandlistener.NotificationEventListener;
+import org.apache.fineract.notification.eventandlistener.ActiveMQNotificationEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +44,7 @@ public class MessagingConfiguration {
     private Environment env;
 
     @Autowired
-    private NotificationEventListener notificationEventListener;
+    private ActiveMQNotificationEventListener notificationEventListener;
 
     @Bean
     public Logger loggerBean() {

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -37,6 +37,7 @@ fineract.tenant.description=${FINERACT_DEFAULT_TENANTDB_DESCRIPTION:Default Demo
 
 fineract.mode.read-enabled=${FINERACT_MODE_READ_ENABLED:true}
 fineract.mode.write-enabled=${FINERACT_MODE_WRITE_ENABLED:true}
+fineract.mode.batch-enabled=${FINERACT_MODE_BATCH_ENABLED:true}
 fineract.mode.batch-worker-enabled=${FINERACT_MODE_BATCH_WORKER_ENABLED:true}
 fineract.mode.batch-manager-enabled=${FINERACT_MODE_BATCH_MANAGER_ENABLED:true}
 


### PR DESCRIPTION
Using correct Listener for ActiveMQ
adding missing property fineract.mode.batch-enabled

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
