### PR TITLE
FINERACT-1694-External-events-date-unit-change-to-milliseconds

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
@@ -66,6 +66,11 @@ public final class DateUtils {
         return OffsetDateTime.now(zone).truncatedTo(ChronoUnit.SECONDS);
     }
 
+    public static OffsetDateTime getOffsetDateTimeOfTenantWithMilliseconds() {
+        final ZoneId zone = getDateTimeZoneOfTenant();
+        return OffsetDateTime.now(zone).truncatedTo(ChronoUnit.MILLIS);
+    }
+
     public static LocalDateTime getLocalDateTimeOfSystem() {
         return LocalDateTime.now(ZoneId.systemDefault()).truncatedTo(ChronoUnit.SECONDS);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/jobs/SendAsynchronousEventsTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/jobs/SendAsynchronousEventsTasklet.java
@@ -98,7 +98,7 @@ public class SendAsynchronousEventsTasklet implements Tasklet {
     }
 
     private void markEventsAsSent(List<Long> eventIds) {
-        OffsetDateTime sentAt = DateUtils.getOffsetDateTimeOfTenant();
+        OffsetDateTime sentAt = DateUtils.getOffsetDateTimeOfTenantWithMilliseconds();
 
         // Partitioning dataset to avoid exception: PreparedStatement can have at most 65,535 parameters
         List<List<Long>> partitions = Lists.partition(eventIds, 5_000);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/repository/domain/ExternalEvent.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/repository/domain/ExternalEvent.java
@@ -79,7 +79,7 @@ public class ExternalEvent extends AbstractPersistableCustom {
         this.schema = schema;
         this.data = data;
         this.idempotencyKey = idempotencyKey;
-        this.createdAt = DateUtils.getOffsetDateTimeOfTenant();
+        this.createdAt = DateUtils.getOffsetDateTimeOfTenantWithMilliseconds();
         this.status = ExternalEventStatus.TO_BE_SENT;
         this.businessDate = DateUtils.getBusinessLocalDate();
     }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -115,4 +115,5 @@
     <include file="parts/0093_update_general_accounting_table_reports.xml" relativeToChangelogFile="true" />
     <include file="parts/0094_add_external_event_default_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0095_add_delinquency_and_arrears_display_configuration.xml" relativeToChangelogFile="true" />
+    <include file="parts/0096_modify_created_and_sent_at_date_external_events.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0096_modify_created_and_sent_at_date_external_events.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0096_modify_created_and_sent_at_date_external_events.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet id="1" author="fineract">
+        <modifyDataType columnName="created_at"
+                        newDataType="timestamp(6)"
+                        tableName="m_external_event"/>
+    </changeSet>
+    <changeSet author="fineract" id="2-postgres" context="postgresql">
+        <modifyDataType columnName="sent_at"
+                        newDataType="timestamp(6)"
+                        tableName="m_external_event"/>
+    </changeSet>
+    <changeSet author="fineract" id="2-mysql" context="mysql">
+        <modifyDataType columnName="sent_at"
+                        newDataType="timestamp(6) NULL"
+                        tableName="m_external_event"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Description
Changes made to include milliseconds for created_at and sent_at dates for external events.

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
