### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/.github/workflows/build-docker-mariadb.yml
+++ b/.github/workflows/build-docker-mariadb.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/build-docker-postgresql.yml
+++ b/.github/workflows/build-docker-postgresql.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -7,6 +7,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -27,6 +27,7 @@ jobs:
 
     env:
         TZ: Asia/Kolkata
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -27,6 +27,7 @@ jobs:
 
     env:
         TZ: Asia/Kolkata
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -28,6 +28,7 @@ jobs:
 
     env:
         TZ: Asia/Kolkata
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -17,6 +17,7 @@ jobs:
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # tag=v3

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+plugins {
+    id 'com.gradle.enterprise' version '3.12.5'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+}
+
+def isCI = System.getenv('JENKINS_URL') != null
+
+gradleEnterprise {
+    server = "https://ge.apache.org"
+    buildScan {
+        capture { taskInputFiles = true }
+        uploadInBackground = !isCI
+        publishAlways()
+        publishIfAuthenticated()
+        obfuscation {
+            ipAddresses { addresses ->
+                addresses.collect { address ->
+                    "0.0.0.0"
+                }
+            }
+        }
+    }
+}
+
+buildCache {
+    local {
+        enabled = !isCI
+    }
+}
+
 rootProject.name='fineract'
 include ':fineract-provider'
 include ':fineract-war'


### PR DESCRIPTION
## Description

This change will generate and publish Gradle Build Scans to https://ge.apache.org for increased ability to troubleshoot build failures. The changes in this PR do not affect the outcome of the build, but rather produce deeper insights into what is happening in the build itself.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
