### PR TITLE
FINERACT-1724: Closing JMS sessions explicitly to avoid memory leaking for multi external event producer

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/producer/jms/JMSMultiExternalEventProducer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/producer/jms/JMSMultiExternalEventProducer.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
@@ -34,6 +35,8 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.messaging.jms.MessageFactory;
 import org.apache.fineract.infrastructure.core.service.HashingService;
@@ -73,8 +76,12 @@ public class JMSMultiExternalEventProducer implements ExternalEventProducer {
     public void sendEvents(Map<Long, List<byte[]>> partitions) throws AcknowledgementTimeoutException {
         Map<Integer, List<byte[]>> indexedPartitions = mapPartitionsToProducers(partitions);
         measure(() -> {
-            List<Future<?>> tasks = sendPartitions(indexedPartitions);
+            List<Pair<Session, MessageProducer>> producersWithSessions = obtainProducers();
+            List<MessageProducer> producers = producersWithSessions.stream().map(Pair::getRight).collect(Collectors.toList());
+            List<Session> sessions = producersWithSessions.stream().map(Pair::getLeft).collect(Collectors.toList());
+            List<Future<?>> tasks = sendPartitions(indexedPartitions, producers);
             waitForSendingCompletion(tasks);
+            closeSessions(sessions);
         }, timeTaken -> {
             if (log.isDebugEnabled()) {
                 int eventCount = partitions.values().stream().map(Collection::size).reduce(0, Integer::sum);
@@ -84,8 +91,20 @@ public class JMSMultiExternalEventProducer implements ExternalEventProducer {
         });
     }
 
-    private List<MessageProducer> obtainProducers() {
-        List<MessageProducer> result = new ArrayList<>();
+    private void closeSessions(List<Session> sessions) {
+        // The sessions retrieved from a CachingConnectionFactory needs to be explicitly closed, otherwise we're making
+        // orphan sessions, leaking memory
+        for (Session session : sessions) {
+            try {
+                session.close();
+            } catch (JMSException e) {
+                log.error("Exception while trying to close sessions", e);
+            }
+        }
+    }
+
+    private List<Pair<Session, MessageProducer>> obtainProducers() {
+        List<Pair<Session, MessageProducer>> result = new ArrayList<>();
         int producerCount = getProducerCount();
         try {
             // No need to close the connection since it's a pooled one
@@ -96,7 +115,7 @@ public class JMSMultiExternalEventProducer implements ExternalEventProducer {
                 // producers
                 Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
                 MessageProducer producer = session.createProducer(destination);
-                result.add(producer);
+                result.add(new ImmutablePair<>(session, producer));
             }
         } catch (JMSException e) {
             throw new RuntimeException("Error while obtaining message producers", e);
@@ -104,8 +123,7 @@ public class JMSMultiExternalEventProducer implements ExternalEventProducer {
         return result;
     }
 
-    private List<Future<?>> sendPartitions(Map<Integer, List<byte[]>> indexedPartitions) {
-        List<MessageProducer> producers = obtainProducers();
+    private List<Future<?>> sendPartitions(Map<Integer, List<byte[]>> indexedPartitions, List<MessageProducer> producers) {
         List<Future<?>> tasks = new ArrayList<>();
         for (Map.Entry<Integer, List<byte[]>> entry : indexedPartitions.entrySet()) {
             Integer producerIndex = entry.getKey();

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/producer/jms/JMSMultiExternalEventProducerTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/producer/jms/JMSMultiExternalEventProducerTest.java
@@ -37,6 +37,7 @@ import org.apache.fineract.avro.MessageV1;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.messaging.jms.MessageFactory;
 import org.apache.fineract.infrastructure.core.service.HashingService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,6 +108,13 @@ class JMSMultiExternalEventProducerTest {
         given(session1.createProducer(destination)).willReturn(producer1);
         given(session2.createProducer(destination)).willReturn(producer2);
         given(session3.createProducer(destination)).willReturn(producer3);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        verify(session1).close();
+        verify(session2).close();
+        verify(session3).close();
     }
 
     @Test


### PR DESCRIPTION


## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
