### PR TITLE
Update fineract image source in docker-compose.yml to pull the correct `fineract` image artifact 

### DIFF
--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -39,7 +39,7 @@ services:
     ports:
       - "5432:5432"
   fineract-server:
-    image: fineract:latest
+    image: apache/fineract:latest
     volumes:
       - ./fineract-provider/build/data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - "3306:3306"
   fineract-server:
-    image: fineract:latest
+    image: apache/fineract:latest
     volumes:
       - ./fineract-provider/build/data:/data
     healthcheck:


### PR DESCRIPTION
## Description

I updated the line in the docker-compose.yml that is supposed to reference the docker image for `fineract` from `fineract` to `apache/fineract`.


