### PR TITLE
FINERACT-1757: Uppercase letters in the datatable name is failing on …

### DIFF
--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImplTest.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonObject;
 import java.util.Collections;
 import java.util.List;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.dataqueries.data.ResultsetColumnHeaderData;
 import org.apache.fineract.infrastructure.security.utils.SQLInjectionException;
@@ -51,6 +52,9 @@ public class ReadWriteNonCoreDataServiceImplTest {
 
     @Mock
     private DatabaseTypeResolver databaseTypeResolver;
+
+    @Mock
+    private DatabaseSpecificSQLGenerator sqlGenerator;
 
     @InjectMocks
     private ReadWriteNonCoreDataServiceImpl underTest;
@@ -81,6 +85,7 @@ public class ReadWriteNonCoreDataServiceImplTest {
                 .thenReturn(sqlRS);
         when(sqlRS.next()).thenReturn(true).thenReturn(false);
         when(sqlRS.getObject(ArgumentMatchers.anyString())).thenReturn("value1").thenReturn("value2");
+        when(sqlGenerator.escape(ArgumentMatchers.anyString())).thenReturn("rc1").thenReturn("rc2").thenReturn("table").thenReturn("cf1");
         when(databaseTypeResolver.isPostgreSQL()).thenReturn(true);
 
         ResultsetColumnHeaderData cf1 = ResultsetColumnHeaderData.detailed("cf1", "text", 10L, false, false, null, null, false, false);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/DatatableHelper.java
@@ -158,6 +158,12 @@ public class DatatableHelper extends IntegrationTest {
         return Utils.performServerDelete(this.requestSpec, this.responseSpec, deleteEntryUrl, jsonAttributeToGetBack);
     }
 
+    public String runDatatableQuery(final String datatableName, final String columnFilter, final String valueFilter,
+            final String resultColumns) {
+        return Utils.performServerGet(this.requestSpec, this.responseSpec, DATATABLE_URL + "/" + datatableName + "/query" + "?columnFilter="
+                + columnFilter + "&valueFilter=" + valueFilter + "&resultColumns=" + resultColumns + "&" + Utils.TENANT_IDENTIFIER);
+    }
+
     public static void verifyDatatableCreatedOnServer(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String generatedDatatableName) {
         LOG.info("------------------------------CHECK DATATABLE DETAILS------------------------------------\n");


### PR DESCRIPTION
…postgres

## Description

There is no restriction on the datatables whether they can contain uppercase letters.

It was working just fine with Mysql and Mariadb as it was automatically converted all of them on saving and looking up.

However postgres is working differently. It will fail on the lookup if the provided table names contains uppercase letters.

[FINERACT-1757](https://issues.apache.org/jira/browse/FINERACT-1757)

- SQL samble generated with the table name `scaped` 
<img width="1734" alt="Screenshot 2023-04-14 at 0 11 50" src="https://user-images.githubusercontent.com/44206706/231958768-649542c8-f051-413e-b708-244eba9fa887.png">

- Datatable API call using the `query` option to filter results
<img width="1000" alt="Screenshot 2023-04-14 at 0 19 29" src="https://user-images.githubusercontent.com/44206706/231959292-60c816b3-1a7d-4395-9746-26ce7a7993cc.png">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
