### PR TITLE
FINERACT-1930 - Migration issue - upgrade from fineract 1.6.0 

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0001_initial_schema.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0001_initial_schema.xml
@@ -3871,7 +3871,7 @@
             <column defaultValueComputed="NULL" name="release_id_of_hold_amount" type="BIGINT"/>
             <column defaultValueComputed="NULL" name="is_loan_disbursement" type="boolean"/>
             <column name="ref_no" type="VARCHAR(128)">
-                <constraints unique="true"/>
+                <constraints uniqueConstraintName="transaction_ref_no" unique="true"/>
             </column>
         </createTable>
     </changeSet>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0016_changed_unique_constraint_of_ref_no.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0016_changed_unique_constraint_of_ref_no.xml
@@ -26,6 +26,6 @@
         <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="m_savings_account_transaction_ref_no_key"/>
     </changeSet>
     <changeSet author="fineract" id="1" context="mysql">
-        <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="ref_no"/>
+        <dropUniqueConstraint tableName="m_savings_account_transaction" constraintName="transaction_ref_no"/>
     </changeSet>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/upgrades/0000_upgrade_to_1.6.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/upgrades/0000_upgrade_to_1.6.xml
@@ -491,7 +491,7 @@
     <changeSet author="fineract" id="391">
         <addColumn tableName="m_savings_account_transaction">
             <column name="ref_no" type="VARCHAR(128)">
-                <constraints unique="true"/>
+                <constraints uniqueConstraintName="transaction_ref_no" unique="true"/>
             </column>
         </addColumn>
     </changeSet>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FINERACT-1930 

Fixing small migration issue while migrating from 1.6.0 schema. Changing unique constraint name to  'transaction_ref_no' as per V391__add_transaction_ref_column.sql to resolve the issue

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
