### PR TITLE
FINERACT-1724 overrides default statusListener in integration tests with NopStatusListener

### DIFF
--- a/integration-tests/src/test/resources/logback.xml
+++ b/integration-tests/src/test/resources/logback.xml
@@ -20,6 +20,7 @@
 
 -->
 <configuration scan="false">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" /> <!-- this hides the warning related to jansi in windows -->
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>false</resetJUL>
     </contextListener>


### PR DESCRIPTION
Overrides default statusListener with NopStatusListener so jansi related missing class exception will not be shown. (The exception is irrelevant because intellij and windows terminal can already handle ansi color codes)

- putting jansi jar on the classpath resulted in not colored logs in the output, but in that case the exception was not shown
- removing <withJansi>true<withJansi> also resulted in monochrome output.
- It looks like newer windows and also intellij seems to be able to display ansi colored output without any kind of wrapper, so it seems to be safe to add a Noop  statusListener so the exception won't be printed during initialization

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
