### PR TITLE
[FINERACT-1953] Matured on date fix

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -7124,7 +7124,7 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom {
     }
 
     public void handleMaturityDateActivate() {
-        if (this.expectedMaturityDate != null && this.actualMaturityDate == null) {
+        if (this.expectedMaturityDate != null && !this.expectedMaturityDate.equals(this.actualMaturityDate)) {
             this.actualMaturityDate = this.expectedMaturityDate;
         }
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionChargebackTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionChargebackTest.java
@@ -293,6 +293,8 @@ public class LoanTransactionChargebackTest {
             getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
             assertNotNull(getLoansLoanIdResponse);
             loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
+            assertNotNull(getLoansLoanIdResponse.getTimeline());
+            assertEquals(todaysDate, getLoansLoanIdResponse.getTimeline().getActualMaturityDate());
 
             reviewLoanTransactionRelations(loanId, transactionId, 0, Double.valueOf("0.00"));
 
@@ -307,6 +309,10 @@ public class LoanTransactionChargebackTest {
             loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.active");
 
             loanTransactionHelper.validateLoanPrincipalOustandingBalance(getLoansLoanIdResponse, Double.valueOf("500.00"));
+
+            assertNotNull(getLoansLoanIdResponse.getTimeline());
+            assertEquals(getLoansLoanIdResponse.getTimeline().getExpectedMaturityDate(),
+                    getLoansLoanIdResponse.getTimeline().getActualMaturityDate());
 
             // N+1 Scenario
             loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
@@ -397,6 +403,11 @@ public class LoanTransactionChargebackTest {
         loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.active");
 
         loanTransactionHelper.validateLoanPrincipalOustandingBalance(getLoansLoanIdResponse, Double.valueOf("100.00"));
+
+        assertNotNull(getLoansLoanIdResponse.getTimeline());
+        assertEquals(getLoansLoanIdResponse.getTimeline().getExpectedMaturityDate(),
+                getLoansLoanIdResponse.getTimeline().getActualMaturityDate());
+
         GetJournalEntriesTransactionIdResponse journalEntries = journalEntryHelper
                 .getJournalEntries("L" + chargebackTransactionId.toString());
         assertEquals(3L, journalEntries.getTotalFilteredRecords());


### PR DESCRIPTION
## Description

If the loan is closed or overpaid and becomes active again, the `Actual Maturity Date` needs to be the same as the `Expected Maturiy Date`