### PR TITLE
FINERACT-1724 - Suppress error messages related to invalid maven pom model version in old eclipse artifacts.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,12 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import static org.slf4j.LoggerFactory.*
+
 plugins {
     id 'io.spring.dependency-management' version '1.1.0'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'groovy-gradle-plugin'
 }
+
+//Suppress errors related to invalid org.eclipse.* maven poms versions.
+def loggerFactory = getILoggerFactory()
+def noOpMethod = getILoggerFactory().getClass().getDeclaredMethod("addNoOpLogger", String.class)
+noOpMethod.setAccessible(true)
+noOpMethod.invoke(loggerFactory, "io.spring.gradle.dependencymanagement.internal.maven.EffectiveModelBuilder")
 
 apply from: "${projectDir}/src/main/groovy/org.apache.fineract.dependencies.gradle"
 


### PR DESCRIPTION
## Description

- Fineract uses Spotless plugin to validate / enforce code formatting rules.
- The code formatting rules are described as eclipse formatting rules
- Fineract uses Spring Dependency Gradle Plugin to resolve artifact
- Spring Dependency Gradle Plugin seems to uses Maven to resolve the artifacts.  (So Gradle uses maven :))
- This has a validation rule to check the maven pom model version: https://github.com/apache/maven/blob/857a5e129ad8dad05495ba631818b55f1925d210/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java#L155
- When errors are found then they are reported here: https://github.com/spring-gradle-plugins/dependency-management-plugin/blob/main/src/main/java/io/spring/gradle/dependencymanagement/internal/maven/EffectiveModelBuilder.java#L101C10-L101C15


It looks spotless needs a newer version of [dev.equo.ide:solstice:1.3.1](https://github.com/diffplug/spotless/blob/b6e30f8eb3d8d2fc38b93761be94b342b3d88915/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java#L113)

But even the newest version [1.7.1](https://mvnrepository.com/artifact/dev.equo.ide/solstice/1.7.1) has the same old eclipse deps which are faulty.

The other funny thing is that in the solstice's pom file all transitive dependencies are excluded, but somehow they are still loaded and validated. I don't know why maven does this. 

![image](https://github.com/apache/fineract/assets/5830589/65c0c393-7c89-4dd5-8ae7-265db52a3c6d)



Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
