### PR TITLE
FINERACT-1724 - Fix testcases failing on the end of the month due to missing timezone configuration

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/FixedDepositTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/FixedDepositTest.java
@@ -114,8 +114,6 @@ public class FixedDepositTest {
     // and then to compare the exact results
     public static final Float THRESHOLD = 1.0f;
 
-    private TimeZone systemTimeZone;
-
     @BeforeEach
     public void setup() {
         Utils.initializeRESTAssured();
@@ -125,8 +123,7 @@ public class FixedDepositTest {
         this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
         this.journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
         this.financialActivityAccountHelper = new FinancialActivityAccountHelper(this.requestSpec);
-
-        this.systemTimeZone = TimeZone.getTimeZone(Utils.TENANT_TIME_ZONE);
+        TimeZone.setDefault(TimeZone.getTimeZone(Utils.TENANT_TIME_ZONE));
     }
 
     /***

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
@@ -38,6 +38,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 import org.apache.fineract.accounting.common.AccountingConstants.FinancialActivity;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
@@ -123,6 +124,7 @@ public class RecurringDepositTest {
         this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
         this.journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
         this.financialActivityAccountHelper = new FinancialActivityAccountHelper(this.requestSpec);
+        TimeZone.setDefault(TimeZone.getTimeZone(Utils.TENANT_TIME_ZONE));
     }
 
     /***


### PR DESCRIPTION

## Description

Testcases may fail at the end of the month. It is happening because of the testcase’s TZ is might not be in align with the servers timezone. 
It is explained below using the testFixedDepositAccountWithPrematureClosureTypeWithdrawal_WITH_HOLD_TAX teastcase

Scenario #1, Tesctase running in UTC, time is 2023.08.31, 08:00 PM, Server is in Asia/Kolkata, so there the time is 2023.09.01 01:30 AM (UTC +5.5)
Fixed Deposit Account will be created with ACTIVATION_DATE = 2023.07.31, (Client time - 1 month)
Then client will trigger the posting of the interest
Server will calculate the interests, there is on 2023-08-01 and another on 2023-09-01
Testcase only expects a single interest in the expense ledger account, but we have two, so it will FAIL.


Scenario #2, Tesctase running in Asia/Kolkata, time is 2023.08.31, 08:00 PM, Server is in Asia/Kolkata, so there the time is 2023.08.31 08:00 PM
Fixed Deposit Account will be created with ACTIVATION_DATE = 2023.07.31, (Client time - 1 month)
Then client will trigger the posting of the interest
Server will calculate a single interest, there is on 2023-08-01 
Testcase only expects a single interest and the amount is matching. PASS


Scenario #3, Tesctase running in UTC, time is 2023.09.01 02:00 AM, Server is in Asia/Kolkata, so there the time is 2023.09.01 07:30 AM (UTC +5.5)
Fixed Deposit Account will be created with ACTIVATION_DATE = 2023.08.1, (Client time - 1 month)
Then client will trigger the posting of the interest
Server will calculate the interests, there is on 2023-09-01
Testcase only expects a single interest be there, so it will PASS.

 

Scenario #4, Tesctase running in Asia/Kolkata, time is 2023.09.01 02:00 AM, Server is in Asia/Kolkata, so there the time is 2023.09.01 02:00 AM
Fixed Deposit Account will be created with ACTIVATION_DATE = 2023.08.1, (Client time - 1 month)
Then client will trigger the posting of the interest
Server will calculate the interests, there is on 2023-09-01
Testcase only expects a single interest be there, so it will PASS.

=> We need to make sure that client is always running using Asia/Kolkata TZ and the clock is in align with the server clock. 
=> Server has a default tenant running using Asia/Kolkata TZ 


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
