### PR TITLE
FINERACT-1724: Add indexes to assets and jobs

### DIFF
--- a/fineract-investor/src/main/resources/db/changelog/tenant/module/investor/module-changelog-master.xml
+++ b/fineract-investor/src/main/resources/db/changelog/tenant/module/investor/module-changelog-master.xml
@@ -33,4 +33,5 @@
   <include relativeToChangelogFile="true" file="parts/0009_add_loan_ownership_transfer_events.xml"/>
   <include relativeToChangelogFile="true" file="parts/0010_external_transafer_status_external_transfer_id_constraints.xml"/>
   <include relativeToChangelogFile="true" file="parts/0011_set_datetime_precision.xml"/>
+  <include relativeToChangelogFile="true" file="parts/0012_add_external_asset_owner_transfer_index.xml"/>
 </databaseChangeLog>

--- a/fineract-investor/src/main/resources/db/changelog/tenant/module/investor/parts/0012_add_external_asset_owner_transfer_index.xml
+++ b/fineract-investor/src/main/resources/db/changelog/tenant/module/investor/parts/0012_add_external_asset_owner_transfer_index.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1" context="mysql">
+        <createIndex tableName="m_external_asset_owner_transfer" indexName="external_asset_owner_transfer_loan_id">
+            <column name="loan_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -141,4 +141,5 @@
     <include file="parts/0119_add_loan_product_down_payment_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0120_transaction_summary_with_asset_owner_report_typo_fix.xml" relativeToChangelogFile="true" />
     <include file="parts/0121_transaction_summary_with_asset_owner_report_typo_fix_2.xml" relativeToChangelogFile="true" />
+    <include file="parts/0122_add_batch_job_execution_params_index.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0122_add_batch_job_execution_params_index.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0122_add_batch_job_execution_params_index.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <createIndex tableName="BATCH_JOB_EXECUTION_PARAMS" indexName="ind_batch_job_execution_params">
+            <column name="JOB_EXECUTION_ID"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
FINERACT-1724: Add indexes to assets and jobs
- [x] Add `loan_id` as indexed field on the `m_external_asset_owner_transfer`
- [x] Add `job_execution_id` as indexed field on the `batch_job_execution_params` table
