### PR TITLE
FINERACT-1724 - Fix JPA error on COB message redelivery

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemReader.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemReader.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.common.CustomJobParameterResolver;
 import org.apache.fineract.cob.data.LoanCOBParameter;
 import org.apache.fineract.cob.domain.LoanAccountLock;
@@ -33,6 +34,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.item.ExecutionContext;
 
+@Slf4j
 public class LoanItemReader extends AbstractLoanItemReader {
 
     private final RetrieveLoanIdService retrieveLoanIdService;
@@ -61,9 +63,10 @@ public class LoanItemReader extends AbstractLoanItemReader {
             loanIds = retrieveLoanIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter,
                     customJobParameterResolver.getCustomJobParameterById(stepExecution, LoanCOBConstant.IS_CATCH_UP_PARAMETER_NAME)
                             .map(Boolean::parseBoolean).orElse(false));
-
-            List<Long> lockedByCOBChunkProcessingAccountIds = getLoanIdsLockedWithChunkProcessingLock(loanIds);
-            loanIds.retainAll(lockedByCOBChunkProcessingAccountIds);
+            if (loanIds.size() > 0) {
+                List<Long> lockedByCOBChunkProcessingAccountIds = getLoanIdsLockedWithChunkProcessingLock(loanIds);
+                loanIds.retainAll(lockedByCOBChunkProcessingAccountIds);
+            }
         }
         setRemainingData(new LinkedBlockingQueue<>(loanIds));
     }

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
@@ -102,6 +102,27 @@ class LoanItemReaderTest {
     }
 
     @Test
+    public void testLoanItemReadNoOpenLoansFound() throws Exception {
+        // given
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "test", "UTC", null));
+        LoanItemReader loanItemReader = new LoanItemReader(loanRepository, retrieveLoanIdService, customJobParameterResolver,
+                loanLockingService);
+        when(stepExecution.getExecutionContext()).thenReturn(executionContext);
+        LoanCOBParameter loanCOBParameter = new LoanCOBParameter(1L, 5L);
+        when(executionContext.get(LoanCOBConstant.LOAN_COB_PARAMETER)).thenReturn(loanCOBParameter);
+        when(retrieveLoanIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter, false))
+                .thenReturn(new ArrayList<>(List.of()));
+
+        // when + then
+        loanItemReader.beforeStep(stepExecution);
+        Loan myLoan = loanItemReader.read();
+        Assertions.assertNull(myLoan);
+
+        Mockito.verifyNoMoreInteractions(loanRepository);
+        Mockito.verifyNoInteractions(loanLockingService);
+    }
+
+    @Test
     public void testLoanItemReaderMultiThreadRead() throws Exception {
         // given
         ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "test", "UTC", null));


### PR DESCRIPTION
Fixes the JPA exception which is raised when a message was redelivered and earlier all the loans got closed for that given partition.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
