### PR TITLE
FINERACT-1724 - No more 'Could not open the public key ring.' during regular builds

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/fineract/gradle/FineractPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/fineract/gradle/FineractPlugin.groovy
@@ -66,7 +66,6 @@ class FineractPlugin implements Plugin<Project> {
             this.confluenceService = new ConfluenceService(extension.config.confluence)
             this.subversionService = new SubversionService(extension.config.subversion)
             this.emailService = new EmailService(extension.config.smtp)
-            this.gpgService = new GpgService(extension.config.gpg)
             this.gitService = new GitService(extension.config.git, extension.config.gpg)
             this.context = context(project)
         }
@@ -331,7 +330,7 @@ class FineractPlugin implements Plugin<Project> {
         project.tasks.register("fineractReleaseStep7") {
             doFirst {
                 FineractPluginExtension.FineractPluginStep step = step(extension, "step7")
-
+                gpgService = new GpgService(extension.config.gpg)
                 gpgService.sign(step.gpg)
 
                 step.gpg.files.findAll {


### PR DESCRIPTION
 GPG Service initialization is moved to step7 of the release script. This should reduce the build time and removes noise during normal (non release) builds.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
