### PR TITLE
FINERACT-1724 native support for arm64 (Apple m1, m2) 

### DIFF
--- a/custom/docker/build.gradle
+++ b/custom/docker/build.gradle
@@ -25,6 +25,12 @@ apply from: "${rootDir}/buildSrc/src/main/groovy/org.apache.fineract.dependencie
 jib {
     from {
         image = 'azul/zulu-openjdk-alpine:17'
+        platforms {
+            platform {
+                architecture = System.getProperty("os.arch").equals("aarch64")?"arm64":"amd64"
+                os = 'linux'
+            }
+        }
     }
 
     to {

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -244,6 +244,12 @@ bootJar {
 jib {
     from {
         image = 'azul/zulu-openjdk-alpine:17'
+        platforms {
+            platform {
+                architecture = System.getProperty("os.arch").equals("aarch64")?"arm64":"amd64"
+                os = 'linux'
+            }
+        }
     }
 
     to {


### PR DESCRIPTION
 Add support for M1/M2 or other ARM64. Docker image will be based on AMR64 images, for the rest of the architectures it falls back to amd64.

It was tested on:
- amd64 windows
- amd64 linux
- arm64 linux
- m1 macos (arm64)

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
