### PR TITLE
FINERACT-1724 Fixing fragile givenEventsForPurgeWhenTaskExecutionThenEventsPurgeForDaysCriteria test

### DIFF
--- a/fineract-provider/src/test/java/org/apache/fineract/commands/jobs/PurgeProcessedCommandsTaskletTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/commands/jobs/PurgeProcessedCommandsTaskletTest.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,7 +83,7 @@ public class PurgeProcessedCommandsTaskletTest {
         verify(repository).deleteOlderEventsWithStatus(Mockito.any(), dateCriteriaCaptor.capture());
         OffsetDateTime expectedDateForPurgeCriteriaTest = DateUtils.getOffsetDateTimeOfTenant().minusDays(2);
         OffsetDateTime actualDateForPurgeCriteria = dateCriteriaCaptor.getValue();
-        assertEquals(expectedDateForPurgeCriteriaTest, actualDateForPurgeCriteria);
+        assertTrue(expectedDateForPurgeCriteriaTest.toEpochSecond() - actualDateForPurgeCriteria.toEpochSecond() <= 1);
         assertEquals(RepeatStatus.FINISHED, resultStatus);
     }
 


### PR DESCRIPTION
 - Fixing fragile givenEventsForPurgeWhenTaskExecutionThenEventsPurgeForDaysCriteria failed here: https://github.com/apache/fineract/actions/runs/6576359375/job/17865569282

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
