### PR TITLE
FINERACT-1761: Loan Product repayment due event values set by default…

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
@@ -146,6 +146,7 @@ public interface LoanProductConstants {
     // repayment events related
     String DUE_DAYS_FOR_REPAYMENT_EVENT = "dueDaysForRepaymentEvent";
     String OVER_DUE_DAYS_FOR_REPAYMENT_EVENT = "overDueDaysForRepaymentEvent";
+    String USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS = "useDueForRepaymentsConfigurations";
 
     // down-payment related
     String ENABLE_DOWN_PAYMENT = "enableDownPayment";

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
@@ -217,6 +217,9 @@ public class LoanProduct extends AbstractPersistableCustom {
     @Column(name = "overdue_days_for_repayment_event")
     private Integer overDueDaysForRepaymentEvent;
 
+    @Column(name = "use_due_for_repayments_configurations", nullable = false)
+    private boolean useDueForRepaymentsConfigurations = true;
+
     @Column(name = "repayment_start_date_type_enum", nullable = false)
     private RepaymentStartDateType repaymentStartDateType;
 
@@ -399,9 +402,14 @@ public class LoanProduct extends AbstractPersistableCustom {
 
         final Integer overAppliedNumber = command.integerValueOfParameterNamed(LoanProductConstants.OVER_APPLIED_NUMBER);
 
-        final Integer dueDaysForRepaymentEvent = command.integerValueOfParameterNamed(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT);
-        final Integer overDueDaysForRepaymentEvent = command
-                .integerValueOfParameterNamed(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT);
+        Integer dueDaysForRepaymentEvent = null;
+        Integer overDueDaysForRepaymentEvent = null;
+        final boolean useDueForRepaymentsConfigurations = command
+                .booleanPrimitiveValueOfParameterNamed(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS);
+        if (!useDueForRepaymentsConfigurations) {
+            dueDaysForRepaymentEvent = command.integerValueOfParameterNamed(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT);
+            overDueDaysForRepaymentEvent = command.integerValueOfParameterNamed(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT);
+        }
 
         final boolean enableDownPayment = command.booleanPrimitiveValueOfParameterNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT);
         final BigDecimal disbursedAmountPercentageDownPayment = command
@@ -436,7 +444,7 @@ public class LoanProduct extends AbstractPersistableCustom {
                 disallowExpectedDisbursements, allowApprovedDisbursedAmountsOverApplied, overAppliedCalculationType, overAppliedNumber,
                 dueDaysForRepaymentEvent, overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment,
                 enableAutoRepaymentForDownPayment, repaymentStartDateType, disableScheduleExtensionForDownPayment,
-                enableInstallmentLevelDelinquency, loanScheduleType);
+                enableInstallmentLevelDelinquency, loanScheduleType, useDueForRepaymentsConfigurations);
 
     }
 
@@ -652,7 +660,7 @@ public class LoanProduct extends AbstractPersistableCustom {
             final boolean enableDownPayment, final BigDecimal disbursedAmountPercentageForDownPayment,
             final boolean enableAutoRepaymentForDownPayment, final RepaymentStartDateType repaymentStartDateType,
             final boolean disableScheduleExtensionForDownPayment, final boolean enableInstallmentLevelDelinquency,
-            final LoanScheduleType loanScheduleType) {
+            final LoanScheduleType loanScheduleType, final boolean useDueForRepaymentsConfigurations) {
         this.fund = fund;
         this.transactionProcessingStrategyCode = transactionProcessingStrategyCode;
 
@@ -746,6 +754,7 @@ public class LoanProduct extends AbstractPersistableCustom {
 
         this.dueDaysForRepaymentEvent = dueDaysForRepaymentEvent;
         this.overDueDaysForRepaymentEvent = overDueDaysForRepaymentEvent;
+        this.useDueForRepaymentsConfigurations = useDueForRepaymentsConfigurations;
         this.repaymentStartDateType = repaymentStartDateType;
 
         this.enableInstallmentLevelDelinquency = enableInstallmentLevelDelinquency;
@@ -1290,6 +1299,14 @@ public class LoanProduct extends AbstractPersistableCustom {
             this.overDueDaysForRepaymentEvent = newValue;
         }
 
+        if (command.isChangeInBooleanParameterNamed(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS,
+                isUseDueForRepaymentsConfigurations())) {
+            final boolean newValue = command
+                    .booleanPrimitiveValueOfParameterNamed(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS);
+            actualChanges.put(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS, newValue);
+            this.updateUseDueForRepaymentsConfigurations(newValue);
+        }
+
         if (command.isChangeInBooleanParameterNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT,
                 this.loanProductRelatedDetail.isEnableDownPayment())) {
             final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT);
@@ -1739,6 +1756,18 @@ public class LoanProduct extends AbstractPersistableCustom {
 
     public void updateEnableInstallmentLevelDelinquency(boolean enableInstallmentLevelDelinquency) {
         this.enableInstallmentLevelDelinquency = enableInstallmentLevelDelinquency;
+    }
+
+    public boolean isUseDueForRepaymentsConfigurations() {
+        return useDueForRepaymentsConfigurations;
+    }
+
+    public void updateUseDueForRepaymentsConfigurations(final boolean useDueForRepaymentsConfigurations) {
+        this.useDueForRepaymentsConfigurations = useDueForRepaymentsConfigurations;
+        if (useDueForRepaymentsConfigurations) {
+            dueDaysForRepaymentEvent = null;
+            overDueDaysForRepaymentEvent = null;
+        }
     }
 
 }

--- a/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/module-changelog-master.xml
+++ b/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/module-changelog-master.xml
@@ -34,4 +34,5 @@
   <include relativeToChangelogFile="true" file="parts/1009_refactor_loan_Installment_delinquency_tag.xml"/>
   <include relativeToChangelogFile="true" file="parts/1010_introduce_loan_schedule_type_configuration.xml"/>
   <include relativeToChangelogFile="true" file="parts/1011_add_delinquency_actions_table.xml"/>
+  <include relativeToChangelogFile="true" file="parts/1012_add_loan_product_days_for_repayments_flag.xml"/>
 </databaseChangeLog>

--- a/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/parts/1012_add_loan_product_days_for_repayments_flag.xml
+++ b/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/parts/1012_add_loan_product_days_for_repayments_flag.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_product_loan">
+            <column defaultValueBoolean="false" type="boolean" name="use_due_for_repayments_configurations">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/CheckLoanRepaymentDueBusinessStep.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/CheckLoanRepaymentDueBusinessStep.java
@@ -45,9 +45,11 @@ public class CheckLoanRepaymentDueBusinessStep implements LoanCOBBusinessStep {
     public Loan execute(Loan loan) {
         log.debug("start processing loan repayment due business step loan for loan with id [{}]", loan.getId());
         Long numberOfDaysBeforeDueDateToRaiseEvent = configurationDomainService.retrieveRepaymentDueDays();
-        if (loan.getLoanProduct().getDueDaysForRepaymentEvent() != null) {
-            if (loan.getLoanProduct().getDueDaysForRepaymentEvent() > 0) {
-                numberOfDaysBeforeDueDateToRaiseEvent = loan.getLoanProduct().getDueDaysForRepaymentEvent().longValue();
+        if (!loan.getLoanProduct().isUseDueForRepaymentsConfigurations()) {
+            if (loan.getLoanProduct().getDueDaysForRepaymentEvent() != null) {
+                if (loan.getLoanProduct().getDueDaysForRepaymentEvent() > 0) {
+                    numberOfDaysBeforeDueDateToRaiseEvent = loan.getLoanProduct().getDueDaysForRepaymentEvent().longValue();
+                }
             }
         }
         final LocalDate currentDate = DateUtils.getBusinessLocalDate();

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/CheckLoanRepaymentOverdueBusinessStep.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/CheckLoanRepaymentOverdueBusinessStep.java
@@ -42,9 +42,11 @@ public class CheckLoanRepaymentOverdueBusinessStep implements LoanCOBBusinessSte
     public Loan execute(Loan loan) {
         log.debug("start processing loan repayment overdue business step for loan with Id [{}]", loan.getId());
         Long numberOfDaysAfterDueDateToRaiseEvent = configurationDomainService.retrieveRepaymentOverdueDays();
-        if (loan.getLoanProduct().getOverDueDaysForRepaymentEvent() != null) {
-            if (loan.getLoanProduct().getOverDueDaysForRepaymentEvent() > 0) {
-                numberOfDaysAfterDueDateToRaiseEvent = loan.getLoanProduct().getOverDueDaysForRepaymentEvent().longValue();
+        if (!loan.getLoanProduct().isUseDueForRepaymentsConfigurations()) {
+            if (loan.getLoanProduct().getOverDueDaysForRepaymentEvent() != null) {
+                if (loan.getLoanProduct().getOverDueDaysForRepaymentEvent() > 0) {
+                    numberOfDaysAfterDueDateToRaiseEvent = loan.getLoanProduct().getOverDueDaysForRepaymentEvent().longValue();
+                }
             }
         }
         final LocalDate currentDate = DateUtils.getBusinessLocalDate();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
@@ -154,6 +154,8 @@ final class LoanProductsApiResourceSwagger {
         public Long delinquencyBucketId;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean useDueForRepaymentsConfigurations;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")
@@ -1248,6 +1250,8 @@ final class LoanProductsApiResourceSwagger {
         public Boolean enableInstallmentLevelDelinquency;
         @Schema(example = "true")
         public Boolean disallowExpectedDisbursements;
+        @Schema(example = "false")
+        public Boolean useDueForRepaymentsConfigurations;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")
@@ -1383,6 +1387,8 @@ final class LoanProductsApiResourceSwagger {
         public Long delinquencyBucketId;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean useDueForRepaymentsConfigurations;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
@@ -202,6 +202,7 @@ public class LoanProductData implements Serializable {
 
     private final Integer dueDaysForRepaymentEvent;
     private final Integer overDueDaysForRepaymentEvent;
+    private final boolean useDueForRepaymentsConfigurations;
 
     private final boolean enableDownPayment;
     private final BigDecimal disbursedAmountPercentageForDownPayment;
@@ -304,6 +305,7 @@ public class LoanProductData implements Serializable {
         final EnumOptionData repaymentStartDateType = null;
         final boolean disableScheduleExtensionForDownPayment = false;
         final boolean enableInstallmentLevelDelinquency = false;
+        final boolean useDueForRepaymentsConfigurations = false;
 
         return new LoanProductData(id, name, shortName, description, currency, principal, minPrincipal, maxPrincipal, tolerance,
                 numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, repaymentEvery, interestRatePerPeriod,
@@ -323,7 +325,8 @@ public class LoanProductData implements Serializable {
                 syncExpectedWithDisbursementDate, canUseForTopup, isEqualAmortization, rateOptions, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
-                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency);
+                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency,
+                useDueForRepaymentsConfigurations);
 
     }
 
@@ -420,6 +423,7 @@ public class LoanProductData implements Serializable {
         final EnumOptionData repaymentStartDateType = null;
         final boolean disableScheduleExtensionForDownPayment = false;
         final boolean enableInstallmentLevelDelinquency = false;
+        final boolean useDueForRepaymentsConfigurations = false;
 
         return new LoanProductData(id, name, shortName, description, currency, principal, minPrincipal, maxPrincipal, tolerance,
                 numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, repaymentEvery, interestRatePerPeriod,
@@ -439,7 +443,8 @@ public class LoanProductData implements Serializable {
                 syncExpectedWithDisbursementDate, canUseForTopup, isEqualAmortization, rateOptions, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
-                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency);
+                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency,
+                useDueForRepaymentsConfigurations);
 
     }
 
@@ -543,6 +548,7 @@ public class LoanProductData implements Serializable {
         final EnumOptionData repaymentStartDateType = LoanEnumerations.repaymentStartDateType(RepaymentStartDateType.DISBURSEMENT_DATE);
         final boolean disableScheduleExtensionForDownPayment = false;
         final boolean enableInstallmentLevelDelinquency = false;
+        final boolean useDueForRepaymentsConfigurations = false;
 
         return new LoanProductData(id, name, shortName, description, currency, principal, minPrincipal, maxPrincipal, tolerance,
                 numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, repaymentEvery, interestRatePerPeriod,
@@ -562,7 +568,8 @@ public class LoanProductData implements Serializable {
                 syncExpectedWithDisbursementDate, canUseForTopup, isEqualAmortization, rateOptions, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
-                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency);
+                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency,
+                useDueForRepaymentsConfigurations);
 
     }
 
@@ -660,6 +667,7 @@ public class LoanProductData implements Serializable {
         final EnumOptionData repaymentStartDateType = LoanEnumerations.repaymentStartDateType(RepaymentStartDateType.DISBURSEMENT_DATE);
         final boolean disableScheduleExtensionForDownPayment = false;
         final boolean enableInstallmentLevelDelinquency = false;
+        final boolean useDueForRepaymentsConfigurations = false;
 
         return new LoanProductData(id, name, shortName, description, currency, principal, minPrincipal, maxPrincipal, tolerance,
                 numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, repaymentEvery, interestRatePerPeriod,
@@ -679,7 +687,8 @@ public class LoanProductData implements Serializable {
                 syncExpectedWithDisbursementDate, canUseForTopup, isEqualAmortization, rateOptions, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
-                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency);
+                paymentAllocation, repaymentStartDateType, disableScheduleExtensionForDownPayment, enableInstallmentLevelDelinquency,
+                useDueForRepaymentsConfigurations);
     }
 
     public static LoanProductData withAccountingDetails(final LoanProductData productData, final Map<String, Object> accountingMappings,
@@ -728,7 +737,8 @@ public class LoanProductData implements Serializable {
             final Integer overDueDaysForRepaymentEvent, final boolean enableDownPayment,
             final BigDecimal disbursedAmountPercentageForDownPayment, final boolean enableAutoRepaymentForDownPayment,
             final Collection<AdvancedPaymentData> paymentAllocation, final EnumOptionData repaymentStartDateType,
-            final boolean disableScheduleExtensionForDownPayment, final boolean enableInstallmentLevelDelinquency) {
+            final boolean disableScheduleExtensionForDownPayment, final boolean enableInstallmentLevelDelinquency,
+            final boolean useDueForRepaymentsConfigurations) {
         this.id = id;
         this.name = name;
         this.shortName = shortName;
@@ -857,6 +867,7 @@ public class LoanProductData implements Serializable {
         this.advancedPaymentAllocationTypes = PaymentAllocationType.getValuesAsEnumOptionDataList();
         this.disableScheduleExtensionForDownPayment = disableScheduleExtensionForDownPayment;
         this.enableInstallmentLevelDelinquency = enableInstallmentLevelDelinquency;
+        this.useDueForRepaymentsConfigurations = useDueForRepaymentsConfigurations;
     }
 
     public LoanProductData(final LoanProductData productData, final Collection<ChargeData> chargeOptions,
@@ -1011,6 +1022,7 @@ public class LoanProductData implements Serializable {
         this.delinquencyBucket = productData.delinquencyBucket;
         this.dueDaysForRepaymentEvent = productData.dueDaysForRepaymentEvent;
         this.overDueDaysForRepaymentEvent = productData.overDueDaysForRepaymentEvent;
+        this.useDueForRepaymentsConfigurations = productData.useDueForRepaymentsConfigurations;
         this.enableDownPayment = productData.enableDownPayment;
         this.disbursedAmountPercentageForDownPayment = productData.disbursedAmountPercentageForDownPayment;
         this.enableAutoRepaymentForDownPayment = productData.enableAutoRepaymentForDownPayment;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -165,7 +165,7 @@ public final class LoanProductDataValidator {
             LoanProductConstants.ENABLE_DOWN_PAYMENT, LoanProductConstants.DISBURSED_AMOUNT_PERCENTAGE_DOWN_PAYMENT,
             LoanProductConstants.ENABLE_AUTO_REPAYMENT_DOWN_PAYMENT, LoanProductConstants.REPAYMENT_START_DATE_TYPE,
             LoanProductConstants.DISABLE_SCHEDULE_EXTENSION_FOR_DOWN_PAYMENT, LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY,
-            LoanProductConstants.LOAN_SCHEDULE_TYPE));
+            LoanProductConstants.LOAN_SCHEDULE_TYPE, LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS));
 
     private static final String[] SUPPORTED_LOAN_CONFIGURABLE_ATTRIBUTES = { LoanProductConstants.amortizationTypeParamName,
             LoanProductConstants.interestTypeParamName, LoanProductConstants.transactionProcessingStrategyCodeParamName,
@@ -743,12 +743,20 @@ public final class LoanProductDataValidator {
         final Integer dueDaysForRepaymentEvent = this.fromApiJsonHelper
                 .extractIntegerWithLocaleNamed(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT, element);
         baseDataValidator.reset().parameter(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT).value(dueDaysForRepaymentEvent)
-                .integerZeroOrGreater();
+                .ignoreIfNull().integerZeroOrGreater();
 
         final Integer overDueDaysForRepaymentEvent = this.fromApiJsonHelper
                 .extractIntegerWithLocaleNamed(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT, element);
         baseDataValidator.reset().parameter(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT).value(overDueDaysForRepaymentEvent)
-                .integerZeroOrGreater();
+                .ignoreIfNull().integerZeroOrGreater();
+
+        final boolean useDueForRepaymentsConfigurations = this.fromApiJsonHelper
+                .extractBooleanNamed(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS, element);
+        baseDataValidator.reset().parameter(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS)
+                .value(useDueForRepaymentsConfigurations).validateForBooleanValue();
+
+        validateDueDayForRepaymentsSettings(baseDataValidator, useDueForRepaymentsConfigurations, dueDaysForRepaymentEvent,
+                overDueDaysForRepaymentEvent);
 
         if (this.fromApiJsonHelper.parameterExists(LoanProductConstants.ENABLE_DOWN_PAYMENT, element)) {
             final Boolean enableDownPayment = this.fromApiJsonHelper.extractBooleanNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT, element);
@@ -1722,12 +1730,20 @@ public final class LoanProductDataValidator {
         final Integer dueDaysForRepaymentEvent = this.fromApiJsonHelper
                 .extractIntegerWithLocaleNamed(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT, element);
         baseDataValidator.reset().parameter(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT).value(dueDaysForRepaymentEvent)
-                .integerZeroOrGreater();
+                .ignoreIfNull().integerZeroOrGreater();
 
         final Integer overDueDaysForRepaymentEvent = this.fromApiJsonHelper
                 .extractIntegerWithLocaleNamed(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT, element);
         baseDataValidator.reset().parameter(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT).value(overDueDaysForRepaymentEvent)
-                .integerZeroOrGreater();
+                .ignoreIfNull().integerZeroOrGreater();
+
+        final boolean useDueForRepaymentsConfigurations = this.fromApiJsonHelper
+                .extractBooleanNamed(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS, element);
+        baseDataValidator.reset().parameter(LoanProductConstants.USE_DUE_DAYS_FOR_REPAYMENTS_CONFIGURATIONS)
+                .value(useDueForRepaymentsConfigurations).validateForBooleanValue();
+
+        validateDueDayForRepaymentsSettings(baseDataValidator, useDueForRepaymentsConfigurations, dueDaysForRepaymentEvent,
+                overDueDaysForRepaymentEvent);
 
         if (this.fromApiJsonHelper.parameterExists(LoanProductConstants.ENABLE_DOWN_PAYMENT, element)) {
             final Boolean enableDownPayment = this.fromApiJsonHelper.extractBooleanNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT, element);
@@ -2362,4 +2378,30 @@ public final class LoanProductDataValidator {
 
         }
     }
+
+    private void validateDueDayForRepaymentsSettings(final DataValidatorBuilder baseDataValidator,
+            final boolean useDueForRepaymentsConfigurations, final Integer dueDaysForRepaymentEvent,
+            final Integer overDueDaysForRepaymentEvent) {
+
+        if (useDueForRepaymentsConfigurations) {
+            if (dueDaysForRepaymentEvent != null) {
+                baseDataValidator.reset().parameter(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT)
+                        .failWithCode("use.event.global.settings.can.not.mixed.with.custom.value");
+            }
+            if (overDueDaysForRepaymentEvent != null) {
+                baseDataValidator.reset().parameter(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT)
+                        .failWithCode("use.event.global.settings.can.not.mixed.with.custom.value");
+            }
+        } else {
+            if (dueDaysForRepaymentEvent == null) {
+                baseDataValidator.reset().parameter(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT)
+                        .failWithCode("value.required.for.due.days.for.repayment.event");
+            }
+            if (overDueDaysForRepaymentEvent == null) {
+                baseDataValidator.reset().parameter(LoanProductConstants.OVER_DUE_DAYS_FOR_REPAYMENT_EVENT)
+                        .failWithCode("value.required.for.overdue.days.for.repayment.event");
+            }
+        }
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -221,7 +221,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
                     + "lp.repay_every as repaidEvery, lp.repayment_period_frequency_enum as repaymentPeriodFrequency, lp.number_of_repayments as numberOfRepayments, lp.min_number_of_repayments as minNumberOfRepayments, lp.max_number_of_repayments as maxNumberOfRepayments, "
                     + "lp.grace_on_principal_periods as graceOnPrincipalPayment, lp.recurring_moratorium_principal_periods as recurringMoratoriumOnPrincipalPeriods, lp.grace_on_interest_periods as graceOnInterestPayment, lp.grace_interest_free_periods as graceOnInterestCharged,lp.grace_on_arrears_ageing as graceOnArrearsAgeing,lp.overdue_days_for_npa as overdueDaysForNPA, "
                     + "lp.min_days_between_disbursal_and_first_repayment As minimumDaysBetweenDisbursalAndFirstRepayment, "
-                    + "lp.amortization_method_enum as amortizationMethod, lp.arrearstolerance_amount as tolerance, "
+                    + "lp.amortization_method_enum as amortizationMethod, lp.arrearstolerance_amount as tolerance, lp.use_due_for_repayments_configurations as useDueForRepaymentsConfigurations, "
                     + "lp.accounting_type as accountingType, lp.include_in_borrower_cycle as includeInBorrowerCycle,lp.use_borrower_cycle as useBorrowerCycle, lp.start_date as startDate, lp.close_date as closeDate,  "
                     + "lp.allow_multiple_disbursals as multiDisburseLoan, lp.max_disbursals as maxTrancheCount, lp.max_outstanding_loan_balance as outstandingLoanBalance, "
                     + "lp.disallow_expected_disbursements as disallowExpectedDisbursements, lp.allow_approved_disbursed_amounts_over_applied as allowApprovedDisbursedAmountsOverApplied, lp.over_applied_calculation_type as overAppliedCalculationType, over_applied_number as overAppliedNumber, "
@@ -360,6 +360,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
             final LocalDate closeDate = JdbcSupport.getLocalDate(rs, "closeDate");
             final Integer dueDaysForRepaymentEvent = JdbcSupport.getIntegerDefaultToNullIfZero(rs, "dueDaysForRepaymentEvent");
             final Integer overDueDaysForRepaymentEvent = JdbcSupport.getIntegerDefaultToNullIfZero(rs, "overDueDaysForRepaymentEvent");
+            final boolean useDueForRepaymentsConfigurations = rs.getBoolean("useDueForRepaymentsConfigurations");
             final boolean enableDownPayment = rs.getBoolean("enableDownPayment");
             final BigDecimal disbursedAmountPercentageForDownPayment = rs.getBigDecimal("disbursedAmountPercentageForDownPayment");
             final boolean enableAutoRepaymentForDownPayment = rs.getBoolean("enableAutoRepaymentForDownPayment");
@@ -525,7 +526,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
                     isRatesEnabled, fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket,
                     dueDaysForRepaymentEvent, overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageForDownPayment,
                     enableAutoRepaymentForDownPayment, advancedPaymentData, repaymentStartDateType, disableScheduleExtensionForDownPayment,
-                    enableInstallmentLevelDelinquency);
+                    enableInstallmentLevelDelinquency, useDueForRepaymentsConfigurations);
         }
     }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/CheckLoanRepaymentDueBusinessStepTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/CheckLoanRepaymentDueBusinessStepTest.java
@@ -87,7 +87,7 @@ public class CheckLoanRepaymentDueBusinessStepTest {
         List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = Arrays.asList(repaymentInstallment);
         when(repaymentInstallment.getDueDate()).thenReturn(loanInstallmentRepaymentDueDate);
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
-        when(loanProduct.getDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(true);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
         when(loanForProcessing.getLoanSummary()).thenReturn(loanSummary);
         when(loanForProcessing.getLoanSummary().getTotalOutstanding()).thenReturn(BigDecimal.ONE);
@@ -117,7 +117,7 @@ public class CheckLoanRepaymentDueBusinessStepTest {
                         loanInstallmentRepaymentDueDateAfter5Days, BigDecimal.valueOf(0.0), BigDecimal.valueOf(0.0),
                         BigDecimal.valueOf(0.0), BigDecimal.valueOf(0.0), false, new HashSet<>(), BigDecimal.valueOf(0.0)));
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
-        when(loanProduct.getDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(true);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
 
         // when
@@ -145,6 +145,7 @@ public class CheckLoanRepaymentDueBusinessStepTest {
         when(repaymentInstallment.getDueDate()).thenReturn(loanInstallmentRepaymentDueDate);
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
         // Loan Product setting overrides global settings
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(false);
         when(loanProduct.getDueDaysForRepaymentEvent()).thenReturn(1);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
         when(loanForProcessing.getLoanSummary()).thenReturn(loanSummary);

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/CheckLoanRepaymentOverdueBusinessStepTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/CheckLoanRepaymentOverdueBusinessStepTest.java
@@ -83,7 +83,7 @@ public class CheckLoanRepaymentOverdueBusinessStepTest {
                 BigDecimal.valueOf(0.0), BigDecimal.valueOf(0.0), false, new HashSet<>(), BigDecimal.valueOf(0.0));
         List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = Arrays.asList(repaymentInstallment);
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
-        when(loanProduct.getOverDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(true);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
 
         // when
@@ -107,7 +107,7 @@ public class CheckLoanRepaymentOverdueBusinessStepTest {
                         loanInstallmentRepaymentDueDateBefore5Days, BigDecimal.valueOf(0.0), BigDecimal.valueOf(0.0),
                         BigDecimal.valueOf(0.0), BigDecimal.valueOf(0.0), false, new HashSet<>(), BigDecimal.valueOf(0.0)));
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
-        when(loanProduct.getOverDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(true);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
         // when
         Loan processedLoan = underTest.execute(loanForProcessing);
@@ -132,7 +132,7 @@ public class CheckLoanRepaymentOverdueBusinessStepTest {
 
         List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = Arrays.asList(repaymentInstallmentPaidOff);
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
-        when(loanProduct.getOverDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(true);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
 
         // when
@@ -158,6 +158,7 @@ public class CheckLoanRepaymentOverdueBusinessStepTest {
         List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = Arrays.asList(repaymentInstallment);
         when(loanForProcessing.getLoanProduct()).thenReturn(loanProduct);
         // product configuration overrides global configuration
+        when(loanProduct.isUseDueForRepaymentsConfigurations()).thenReturn(false);
         when(loanProduct.getOverDueDaysForRepaymentEvent()).thenReturn(1);
         when(loanForProcessing.getRepaymentScheduleInstallments()).thenReturn(loanRepaymentScheduleInstallments);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductWithRepaymentDueEventConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductWithRepaymentDueEventConfigurationTest.java
@@ -113,7 +113,8 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
         Integer dueDaysForRepaymentEvent = 1;
         Integer overDueDaysForRepaymentEvent = 2;
         final PutLoanProductsProductIdRequest requestModifyLoan = new PutLoanProductsProductIdRequest()
-                .dueDaysForRepaymentEvent(dueDaysForRepaymentEvent).overDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).locale("en");
+                .useDueForRepaymentsConfigurations(false).dueDaysForRepaymentEvent(dueDaysForRepaymentEvent)
+                .overDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).locale("en");
         return loanTransactionHelper.updateLoanProduct(id, requestModifyLoan);
     }
 
@@ -127,7 +128,8 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
     private Integer createLoanProductWithDueDaysForRepaymentEvent(final LoanTransactionHelper loanTransactionHelper,
             final Integer delinquencyBucketId, Integer dueDaysForRepaymentEvent, Integer overDueDaysForRepaymentEvent) {
         final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withDueDaysForRepaymentEvent(dueDaysForRepaymentEvent)
-                .withOverDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).build(null, delinquencyBucketId);
+                .withOverDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).withUseDueForRepaymentsConfigurations(false)
+                .build(null, delinquencyBucketId);
         final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
         return loanProductId;
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanProductTestBuilder.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanProductTestBuilder.java
@@ -153,6 +153,7 @@ public class LoanProductTestBuilder {
     private Integer repaymentStartDateType = null;
     private boolean disableScheduleExtensionForDownPayment = false;
     private LoanScheduleType loanScheduleType = LoanScheduleType.CUMULATIVE;
+    private boolean useDueForRepaymentsConfigurations = false;
 
     public String build() {
         final HashMap<String, Object> map = build(null, null);
@@ -289,6 +290,9 @@ public class LoanProductTestBuilder {
             map.put("penaltyToIncomeAccountMappings", this.penaltyToIncomeAccountMappings);
         }
 
+        if (this.useDueForRepaymentsConfigurations) {
+            map.put("useDueForRepaymentsConfigurations", this.useDueForRepaymentsConfigurations);
+        }
         if (this.dueDaysForRepaymentEvent != null) {
             map.put("dueDaysForRepaymentEvent", this.dueDaysForRepaymentEvent);
         }
@@ -708,6 +712,11 @@ public class LoanProductTestBuilder {
 
     public LoanProductTestBuilder withFeeAndPenaltyAssetAccount(final Account account) {
         this.feeAndPenaltyAssetAccount = account;
+        return this;
+    }
+
+    public LoanProductTestBuilder withUseDueForRepaymentsConfigurations(final boolean useDueForRepaymentsConfigurations) {
+        this.useDueForRepaymentsConfigurations = useDueForRepaymentsConfigurations;
         return this;
     }
 


### PR DESCRIPTION
… from global configurations

## Description

As part of Loan Product enhancements in the create and edit actions some values are being used from the Global Configuration. In particular the Event (notifications) settings values, so those values must to be remarked to indicated the default value is set from the GLobal Configuration  

[FINERACT-1761](https://issues.apache.org/jira/browse/FINERACT-1761)

<img width="1306" alt="Screenshot 2023-10-29 at 5 52 18 p m" src="https://github.com/apache/fineract/assets/44206706/b7555558-f97f-4d43-95e4-7331373030d3">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
