### PR TITLE
FINERACT-1724 fix flaky testCatchUpInLockedInstanceLastCOBDateIsNotNullTest

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
@@ -25,6 +25,7 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -193,6 +195,7 @@ public class LoanCOBAccountLockCatchupInlineCOBTest {
             loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
             loanAccountLockHelper = new LoanAccountLockHelper(requestSpec, new ResponseSpecBuilder().expectStatusCode(202).build());
 
+            // create client
             final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
             Assertions.assertNotNull(clientID);
 
@@ -200,6 +203,7 @@ public class LoanCOBAccountLockCatchupInlineCOBTest {
                     ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
             Assertions.assertNotNull(overdueFeeChargeId);
 
+            // create loan product
             final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
             Assertions.assertNotNull(loanProductID);
             HashMap loanStatusHashMap;
@@ -210,28 +214,39 @@ public class LoanCOBAccountLockCatchupInlineCOBTest {
             loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
             LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
 
+            // approve loan
             loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
             LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
 
             String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
+
+            // disburse loan
             loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
                     JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
             LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
 
+            // update business date 2020-03-02
             BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
 
+            // execute inline cob for the loan
             inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
             GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
             Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
 
+            // update business date to 2020-03-05
             BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
 
+            // apply lock on the loan
             loanAccountLockHelper.placeSoftLockOnLoanAccount(loanID, "LOAN_INLINE_COB_PROCESSING", "Sample error");
 
             loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+
+            // execute catchup which sets the last cob date first 2020-03-04 and then 2020-03-05, as this loan is two
+            // days behind
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
 
-            Utils.conditionalSleepWithMaxWait(30, 5, () -> loanCOBCatchUpHelper.isLoanCOBCatchUpRunning());
+            Awaitility.await().atMost(Duration.ofSeconds(30)).with().pollInterval(Duration.ofSeconds(5)) //
+                    .until(() -> loanCOBCatchUpHelper.isLoanCOBCatchUpFinishedFor(LocalDate.of(2020, 3, 4))); //
 
             loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
             Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanCOBCatchUpHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanCOBCatchUpHelper.java
@@ -18,12 +18,16 @@
  */
 package org.apache.fineract.integrationtests.common.loans;
 
+import java.time.LocalDate;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetOldestCOBProcessedLoanResponse;
 import org.apache.fineract.client.models.IsCatchUpRunningResponse;
 import org.apache.fineract.integrationtests.client.IntegrationTest;
+import org.jetbrains.annotations.NotNull;
 import retrofit2.Response;
 
+@Slf4j
 public class LoanCOBCatchUpHelper extends IntegrationTest {
 
     public LoanCOBCatchUpHelper() {}
@@ -31,6 +35,15 @@ public class LoanCOBCatchUpHelper extends IntegrationTest {
     public boolean isLoanCOBCatchUpRunning() {
         Response<IsCatchUpRunningResponse> response = executeGetLoanCatchUpStatus();
         return Boolean.TRUE.equals(Objects.requireNonNull(response.body()).getIsCatchUpRunning());
+    }
+
+    public boolean isLoanCOBCatchUpFinishedFor(@NotNull LocalDate cobBusinessDate) {
+        Response<IsCatchUpRunningResponse> response = executeGetLoanCatchUpStatus();
+        IsCatchUpRunningResponse isCatchUpRunningResponse = Objects.requireNonNull(response.body());
+        GetOldestCOBProcessedLoanResponse getOldestCOBProcessedLoanResponse = executeRetrieveOldestCOBProcessedLoan();
+
+        return !Boolean.TRUE.equals(isCatchUpRunningResponse.getIsCatchUpRunning())
+                && cobBusinessDate.equals(getOldestCOBProcessedLoanResponse.getCobProcessedDate());
     }
 
     public Response<Void> executeLoanCOBCatchUp() {


### PR DESCRIPTION
## Description

In nutshell the problem was that that the loan cob catchup job was two days behind therefore it had to run two consecutive jobs which are executed sequentially. The testcase was polling the state of the job every 5 seconds to check if the inline cob finished or not. In same cases this request was made between the two job executions and at that point (indeed) no inline cob was running, so the testcase went to the verification, but the loan was not yet closed by the second job yet. 

Repro steps: decrease the wait interval to 10ms...

The improved solution waits until the COB is not running anymore and queries the GetOldestCOBProcessedLoanResponse to figure out the last processed COB date. If both are OK, then the test can proceed to the verification of the loan. 

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
