### PR TITLE
FINERACT-1805: Fix getting details of a share transactions

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
@@ -201,8 +201,11 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
                     noteData = new NoteData(noteId, null, null, null, null, null, null, null, note, null, null, null, null, null, null);
                 }
                 Long transaction = null;
-                if (entityType != null) {
-                    transaction = Long.parseLong(transactionId.substring(1).trim());
+                if (entityType != null && transactionId != null) {
+                    String numericPart = transactionId.replaceAll("[^\\d]", "");
+                    if (!numericPart.isEmpty()) {
+                        transaction = Long.parseLong(numericPart);
+                    }
                 }
 
                 TransactionTypeEnumData transactionTypeEnumData = null;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AccountingScenarioIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AccountingScenarioIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.gson.Gson;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
@@ -42,7 +43,9 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
+import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
@@ -68,6 +71,10 @@ import org.apache.fineract.integrationtests.common.recurringdeposit.RecurringDep
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
+import org.apache.fineract.integrationtests.common.shares.ShareAccountHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareAccountTransactionHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareProductHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareProductTransactionHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -341,7 +348,7 @@ public class AccountingScenarioIntegrationTest {
 
         this.savingsAccountHelper.addChargesForSavings(savingsID, withdrawalChargeId, false);
         ArrayList<HashMap> chargesPendingState = this.savingsAccountHelper.getSavingsCharges(savingsID);
-        Assertions.assertEquals(1, chargesPendingState.size());
+        assertEquals(1, chargesPendingState.size());
         HashMap savingsChargeForPay = chargesPendingState.get(0);
         HashMap paidCharge = this.savingsAccountHelper.getSavingsCharge(savingsID, (Integer) savingsChargeForPay.get("id"));
         Float chargeAmount = (Float) paidCharge.get("amount");
@@ -1113,6 +1120,73 @@ public class AccountingScenarioIntegrationTest {
 
     private LocalDate getDateAsLocalDate(String dateAsString) {
         return LocalDate.parse(dateAsString, Utils.dateFormatter);
+    }
+
+    @Test
+    public void checkAccountingWithSharingFlow() {
+        this.savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+
+        final Account assetAccount = this.accountHelper.createAssetAccount();
+        final Account incomeAccount = this.accountHelper.createIncomeAccount();
+        final Account equityAccount = this.accountHelper.createEquityAccount();
+        final Account liabilityAccount = this.accountHelper.createLiabilityAccount();
+
+        final Integer shareProductID = createSharesProduct(assetAccount, incomeAccount, equityAccount, liabilityAccount);
+
+        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, DATE_OF_JOINING);
+        Assertions.assertNotNull(clientID);
+        final Integer savingsAccountId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, clientID, "1000");
+        Assertions.assertNotNull(savingsAccountId);
+        final Integer shareAccountId = createShareAccount(clientID, shareProductID, savingsAccountId);
+        Assertions.assertNotNull(shareAccountId);
+        final Map<String, Object> shareAccountData = ShareAccountTransactionHelper.retrieveShareAccount(shareAccountId, requestSpec,
+                responseSpec);
+        Assertions.assertNotNull(shareAccountData);
+        // Approve share Account
+        final Map<String, Object> approveMap = new HashMap<>();
+        approveMap.put("note", "Share Account Approval Note");
+        approveMap.put("dateFormat", "dd MMMM yyyy");
+        approveMap.put("approvedDate", "01 Jan 2016");
+        approveMap.put("locale", "en");
+        final String approve = new Gson().toJson(approveMap);
+        ShareAccountTransactionHelper.postCommand("approve", shareAccountId, approve, requestSpec, responseSpec);
+        // Activate Share Account
+        final Map<String, Object> activateMap = new HashMap<>();
+        activateMap.put("dateFormat", "dd MMMM yyyy");
+        activateMap.put("activatedDate", "01 Jan 2016");
+        activateMap.put("locale", "en");
+        final String activateJson = new Gson().toJson(activateMap);
+        ShareAccountTransactionHelper.postCommand("activate", shareAccountId, activateJson, requestSpec, responseSpec);
+
+        // Checking sharing entries.
+        final JournalEntry[] assetAccountEntry = { new JournalEntry(Float.parseFloat("200"), JournalEntry.TransactionType.DEBIT) };
+        final JournalEntry[] liabilityAccountEntry = { new JournalEntry(Float.parseFloat("200"), JournalEntry.TransactionType.CREDIT) };
+        final JournalEntry[] checkJournalEntryForEquityAccount = {
+                new JournalEntry(Float.parseFloat("200"), JournalEntry.TransactionType.CREDIT) };
+        this.journalEntryHelper.checkJournalEntryForAssetAccount(assetAccount, "01 Jan 2016", assetAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForLiabilityAccount(liabilityAccount, "01 Jan 2016", liabilityAccountEntry);
+        this.journalEntryHelper.checkJournalEntryForEquityAccount(equityAccount, "01 Jan 2016", checkJournalEntryForEquityAccount);
+
+        final String transactionId = this.journalEntryHelper.getJournalEntryTransactionIdByAccount(assetAccount, "01 Jan 2016",
+                assetAccountEntry);
+        Assertions.assertNotEquals("", transactionId);
+
+        final GetJournalEntriesTransactionIdResponse journalEntriesTransactionIdResponse = this.journalEntryHelper
+                .getJournalEntries(transactionId);
+        Assertions.assertNotNull(journalEntriesTransactionIdResponse);
+    }
+
+    public static Integer createSharesProduct(final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW SHARE PRODUCT ---------------------------------------");
+        final String shareProductJSON = new ShareProductHelper().withCashBasedAccounting(accounts).build();
+        return ShareProductTransactionHelper.createShareProduct(shareProductJSON, requestSpec, responseSpec);
+    }
+
+    private Integer createShareAccount(final Integer clientId, final Integer productId, final Integer savingsAccountId) {
+        final String shareAccountJSON = new ShareAccountHelper().withClientId(String.valueOf(clientId))
+                .withProductId(String.valueOf(productId)).withExternalId("External1").withSavingsAccountId(String.valueOf(savingsAccountId))
+                .withSubmittedDate("01 Jan 2016").withApplicationDate("01 Jan 2016").withRequestedShares("100").build();
+        return ShareAccountTransactionHelper.createShareAccount(shareAccountJSON, requestSpec, responseSpec);
     }
 
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/accounting/AccountHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/accounting/AccountHelper.java
@@ -69,6 +69,13 @@ public class AccountHelper extends IntegrationTest {
         return new Account(accountID, Account.AccountType.LIABILITY);
     }
 
+    public Account createEquityAccount() {
+        final String equityAccountJSON = new GLAccountBuilder().withAccountTypeAsAsEquity().build();
+        final Integer accountID = Utils.performServerPost(this.requestSpec, this.responseSpec, CREATE_GL_ACCOUNT_URL, equityAccountJSON,
+                GL_ACCOUNT_ID_RESPONSE);
+        return new Account(accountID, Account.AccountType.EQUITY);
+    }
+
     public ArrayList getAccountingWithRunningBalances() {
         final String GET_RUNNING_BALANCE_URL = "/fineract-provider/api/v1/glaccounts?fetchRunningBalance=true";
         final ArrayList<HashMap> accountRunningBalance = Utils.performServerGet(this.requestSpec, this.responseSpec,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/accounting/JournalEntryHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/accounting/JournalEntryHelper.java
@@ -61,6 +61,10 @@ public class JournalEntryHelper {
         checkJournalEntry(null, liabilityAccount, date, accountEntries);
     }
 
+    public void checkJournalEntryForEquityAccount(final Account equityAccount, final String date, final JournalEntry... accountEntries) {
+        checkJournalEntry(null, equityAccount, date, accountEntries);
+    }
+
     public void checkJournalEntryForLiabilityAccount(final Integer officeId, final Account liabilityAccount, final String date,
             final JournalEntry... accountEntries) {
         checkJournalEntry(officeId, liabilityAccount, date, accountEntries);
@@ -70,6 +74,10 @@ public class JournalEntryHelper {
         ArrayList<HashMap> transactions = getJournalEntriesByTransactionId(transactionId);
         assertTrue(transactions.isEmpty(), "Tranasactions are is not empty");
 
+    }
+
+    public String getJournalEntryTransactionIdByAccount(final Account account, final String date, final JournalEntry... accountEntries) {
+        return getJournalEntryTransactionId(account, date, accountEntries);
     }
 
     private void checkJournalEntry(final Integer officeId, final Account account, final String date, final JournalEntry... accountEntries) {
@@ -87,6 +95,22 @@ public class JournalEntryHelper {
             }
             Assertions.assertTrue(matchFound, "Journal Entry not found");
         }
+    }
+
+    private String getJournalEntryTransactionId(final Account account, final String date, final JournalEntry... accountEntries) {
+        final String url = createURLForGettingAccountEntries(account, date, null);
+        final ArrayList<HashMap> response = Utils.performServerGet(this.requestSpec, this.responseSpec, url, "pageItems");
+
+        for (JournalEntry entry : accountEntries) {
+            for (HashMap map : response) {
+                final HashMap entryType = (HashMap) map.get("entryType");
+                if (entry.getTransactionType().equals(entryType.get("value")) && entry.getTransactionAmount().equals(map.get("amount"))) {
+                    return map.get("transactionId").toString();
+                }
+            }
+        }
+
+        return "";
     }
 
     private String createURLForGettingAccountEntries(final Account account, final String date, final Integer officeId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/shares/ShareProductHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/shares/ShareProductHelper.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,7 @@ public class ShareProductHelper {
 
     private List<Map<String, String>> charges = null;
     private List<Map<String, String>> marketPrices = null;
+    private Account[] accountList = null;
 
     public String build() {
         final HashMap<String, Object> map = new HashMap<>();
@@ -93,6 +95,10 @@ public class ShareProductHelper {
             map.put("marketPricePeriods", marketPrices);
         }
 
+        if (this.accountingRule.equals(CASH_BASED)) {
+            map.putAll(getAccountMappingForCashBased());
+        }
+
         String shareProductCreateJson = new Gson().toJson(map);
         LOG.info("{}", shareProductCreateJson);
         return shareProductCreateJson;
@@ -100,6 +106,12 @@ public class ShareProductHelper {
 
     public ShareProductHelper withCashBasedAccounting() {
         this.accountingRule = CASH_BASED;
+        return this;
+    }
+
+    public ShareProductHelper withCashBasedAccounting(final Account[] account_list) {
+        this.accountingRule = CASH_BASED;
+        this.accountList = account_list;
         return this;
     }
 
@@ -196,5 +208,30 @@ public class ShareProductHelper {
         // ArrayList<Map<String, String>> marketPrices = (ArrayList<Map<String,
         // String>>)shareProductData.get("marketPricePeriods") ;
 
+    }
+
+    private Map<String, String> getAccountMappingForCashBased() {
+        final Map<String, String> map = new HashMap<>();
+        if (accountList != null) {
+            for (int i = 0; i < this.accountList.length; i++) {
+                if (this.accountList[i].getAccountType().equals(Account.AccountType.ASSET)) {
+                    final String ID = this.accountList[i].getAccountID().toString();
+                    map.put("shareReferenceId", ID);
+                }
+                if (this.accountList[i].getAccountType().equals(Account.AccountType.LIABILITY)) {
+                    final String ID = this.accountList[i].getAccountID().toString();
+                    map.put("shareSuspenseId", ID);
+                }
+                if (this.accountList[i].getAccountType().equals(Account.AccountType.EQUITY)) {
+                    final String ID = this.accountList[i].getAccountID().toString();
+                    map.put("shareEquityId", ID);
+                }
+                if (this.accountList[i].getAccountType().equals(Account.AccountType.INCOME)) {
+                    final String ID = this.accountList[i].getAccountID().toString();
+                    map.put("incomeFromFeeAccountId", ID);
+                }
+            }
+        }
+        return map;
     }
 }


### PR DESCRIPTION
## Description

Loan and Savings transactionIds start with a single capital letter (L and S repectively) but share transactions start with 2 capital letters (SH). Originally all transactionIds had been assumed to start with a single which threw a NumberFormatException.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket]
JIRA ticket - https://issues.apache.org/jira/browse/FINERACT-1805


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
