### PR TITLE
FINERACT-2020: Added currency to LoanAccountSummaryData

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/data/LoanAccountSummaryData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/data/LoanAccountSummaryData.java
@@ -40,6 +40,7 @@ public class LoanAccountSummaryData {
     private final String productName;
     private final String shortProductName;
     private final LoanStatusEnumData status;
+    private final CurrencyData currency;
     private final EnumOptionData loanType;
     private final Integer loanCycle;
     private final LoanApplicationTimelineData timeline;
@@ -49,7 +50,7 @@ public class LoanAccountSummaryData {
     private final BigDecimal amountPaid;
 
     public LoanAccountSummaryData(final Long id, final String accountNo, final String externalId, final Long productId,
-            final String loanProductName, final String shortLoanProductName, final LoanStatusEnumData loanStatus,
+            final String loanProductName, final String shortLoanProductName, final LoanStatusEnumData loanStatus, final CurrencyData currency,
             final EnumOptionData loanType, final Integer loanCycle, final LoanApplicationTimelineData timeline, final Boolean inArrears,
             final BigDecimal originalLoan, final BigDecimal loanBalance, final BigDecimal amountPaid) {
         this.id = id;
@@ -60,6 +61,7 @@ public class LoanAccountSummaryData {
         this.productName = loanProductName;
         this.shortProductName = shortLoanProductName;
         this.status = loanStatus;
+        this.currency = currency;
         this.loanType = loanType;
         this.loanCycle = loanCycle;
         this.timeline = timeline;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/service/AccountDetailsReadPlatformServiceJpaRepositoryImpl.java
@@ -452,6 +452,11 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
 
                     .append(" l.loan_product_counter as loanCycle,")
 
+                    .append("l.currency_code as currencyCode, l.currency_digits as currencyDigits, l.currency_multiplesof as inMultiplesOf,")
+
+                    .append("curr.name as currencyName, curr.internationalized_name_code as currencyNameCode,")
+                    .append("curr.display_symbol as currencyDisplaySymbol,")
+
                     .append(" l.submittedon_date as submittedOnDate,")
                     .append(" sbu.username as submittedByUsername, sbu.firstname as submittedByFirstname, sbu.lastname as submittedByLastname,")
 
@@ -474,6 +479,7 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
                     .append(" l.charged_off_on_date as chargedOffOnDate, cobu.username as chargedOffByUsername, ")
                     .append(" cobu.firstname as chargedOffByFirstname, cobu.lastname as chargedOffByLastname ").append(" from m_loan l ")
                     .append("LEFT JOIN m_product_loan AS lp ON lp.id = l.product_id")
+                    .append(" join m_currency curr on curr.code = l.currency_code")
                     .append(" left join m_appuser sbu on sbu.id = l.created_by")
                     .append(" left join m_appuser rbu on rbu.id = l.rejectedon_userid")
                     .append(" left join m_appuser wbu on wbu.id = l.withdrawnon_userid")
@@ -502,6 +508,15 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
             final Integer loanTypeId = JdbcSupport.getInteger(rs, "loanType");
             final EnumOptionData loanType = AccountEnumerations.loanType(loanTypeId);
             final Integer loanCycle = JdbcSupport.getInteger(rs, "loanCycle");
+
+            final String currencyCode = rs.getString("currencyCode");
+            final String currencyName = rs.getString("currencyName");
+            final String currencyNameCode = rs.getString("currencyNameCode");
+            final String currencyDisplaySymbol = rs.getString("currencyDisplaySymbol");
+            final Integer currencyDigits = JdbcSupport.getInteger(rs, "currencyDigits");
+            final Integer inMultiplesOf = JdbcSupport.getInteger(rs, "inMultiplesOf");
+
+            final CurrencyData currency = new CurrencyData(currencyCode,currencyName,currencyDigits,inMultiplesOf,currencyDisplaySymbol,currencyNameCode);
 
             final LocalDate submittedOnDate = JdbcSupport.getLocalDate(rs, "submittedOnDate");
             final String submittedByUsername = rs.getString("submittedByUsername");
@@ -561,7 +576,7 @@ public class AccountDetailsReadPlatformServiceJpaRepositoryImpl implements Accou
                     chargedOffOnDate, chargedOffByUsername, chargedOffByFirstname, chargedOffByLastname);
 
             return new LoanAccountSummaryData(id, accountNo, parentAccountNumber, externalId, productId, loanProductName,
-                    shortLoanProductName, loanStatus, loanType, loanCycle, timeline, inArrears, originalLoan, loanBalance, amountPaid);
+                    shortLoanProductName, loanStatus, currency, loanType, loanCycle, timeline, inArrears, originalLoan, loanBalance, amountPaid);
         }
 
     }


### PR DESCRIPTION
We want the loan account summary data to contain currency as we will like to know the currencies tied to different loan products during setup.
The client account endpoint https://baseurl/fineract-provider/api/v1/clients/23/accounts returns a payload containing both savings and loan account, the savings account summary contains currency while the loan account summary does not contain currency.
The aim is to replicate what already exist on the savings account summary for the loan account summary by bringing in currency.
This Jira ticket [FINERACT-2020](https://issues.apache.org/jira/browse/FINERACT-2020) contains more vivid description.