### PR TITLE
FINERACT-1971: Add urlEncoder for build.gradle file in fineract-client module

### DIFF
--- a/fineract-client/build.gradle
+++ b/fineract-client/build.gradle
@@ -33,7 +33,8 @@ openApiMeta {
 }
 
 openApiValidate {
-    inputSpec = "file:///$swaggerFile"
+    def encodedUrl = "file:///$swaggerFile".replaceAll(" ","%20")
+    inputSpec = "$encodedUrl"
     recommend = true
 }
 
@@ -42,7 +43,8 @@ task buildJavaSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateT
     verbose = false
     validateSpec = false
     skipValidateSpec = true
-    inputSpec = "file:///$swaggerFile"
+    def encodedUrl = "file:///$swaggerFile".replaceAll(" ","%20")
+    inputSpec = "$encodedUrl"
     outputDir = "$buildDir/generated/temp-java".toString()
     templateDir = "$projectDir/src/main/resources/templates/java"
     groupId = 'org.apache.fineract'
@@ -66,7 +68,8 @@ task buildTypescriptAngularSdk(type: org.openapitools.generator.gradle.plugin.ta
     verbose = false
     validateSpec = false
     skipValidateSpec = true
-    inputSpec = "file:///$swaggerFile"
+    def encodedUrl = "file:///$swaggerFile".replaceAll(" ","%20")
+    inputSpec = "$encodedUrl"
     outputDir = "$buildDir/generated/typescript".toString()
     apiPackage = 'apache-fineract-client/services'
     invokerPackage = 'apache-fineract-client/invoker'
@@ -86,7 +89,8 @@ task buildAsciidoc(type: org.openapitools.generator.gradle.plugin.tasks.Generate
     verbose = false
     validateSpec = false
     skipValidateSpec = true
-    inputSpec = "file:///$swaggerFile"
+    def encodedUrl = "file:///$swaggerFile".replaceAll(" ","%20")
+    inputSpec = "$encodedUrl"
     outputDir = "$buildDir/generated/asciidoc".toString()
     apiPackage = 'org.apache.fineract.client.services'
     invokerPackage = 'org.apache.fineract.client'


### PR DESCRIPTION
The line inputSpec = "file:///$swaggerFile" in build.gradle file was not able to handle spaces in the file path. Hence, encoded the URL properly to handle spaces in the file path.

Refer images below for details:
![123456](https://github.com/apache/fineract/assets/147911928/fdc88504-7553-498f-8f9c-4afd930001af)
