### PR TITLE
FINERACT-1477: Change the logging level for InsufficientAccountBalanceException in batch job

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/jobs/transferinteresttosavings/TransferInterestToSavingsTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/jobs/transferinteresttosavings/TransferInterestToSavingsTasklet.java
@@ -53,7 +53,7 @@ public class TransferInterestToSavingsTasklet implements Tasklet {
                         accountTransferDTO.getToAccountId(), e);
                 errors.add(e);
             } catch (final InsufficientAccountBalanceException e) {
-                log.error("InsufficientAccountBalanceException while trasfering Interest from {} to {} ",
+                log.warn("InsufficientAccountBalanceException while trasfering Interest from {} to {} ",
                         accountTransferDTO.getFromAccountId(), accountTransferDTO.getToAccountId(), e);
                 errors.add(e);
             }


### PR DESCRIPTION
Changed the logging level for InsufficientAccountBalanceException in batch job from error to warn.
Removed errors.add(e) to avoid abrupt stopping of batch job due to this exception.