### PR TITLE
FINERACT-1971: Fix Delinquency bucket error upon Loan product editing

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
@@ -209,7 +209,7 @@ public class LoanProduct extends AbstractPersistableCustom {
     private Integer overAppliedNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delinquency_bucket_id")
+    @JoinColumn(name = "delinquency_bucket_id", nullable = true)
     private DelinquencyBucket delinquencyBucket;
 
     @Column(name = "enable_installment_level_delinquency", nullable = false)

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -501,7 +501,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
             final boolean isRatesEnabled = false;
 
             // Delinquency Buckets
-            final Long delinquencyBucketId = rs.getLong("delinquencyBucketId");
+            final Long delinquencyBucketId = JdbcSupport.getLong(rs, "delinquencyBucketId");
             final String delinquencyBucketName = rs.getString("delinquencyBucketName");
             final DelinquencyBucketData delinquencyBucket = new DelinquencyBucketData(delinquencyBucketId, delinquencyBucketName,
                     new ArrayList<>());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
@@ -127,9 +127,8 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
                     loanRepaymentScheduleTransactionProcessorFactory.determineProcessor(loanTransactionProcessingStrategyCode).getName());
 
             if (command.parameterExists("delinquencyBucketId")) {
-                DelinquencyBucket delinquencyBucket = this.delinquencyBucketRepository
-                        .getReferenceById(command.longValueOfParameterNamed("delinquencyBucketId"));
-                loanProduct.setDelinquencyBucket(delinquencyBucket);
+                loanProduct
+                        .setDelinquencyBucket(findDelinquencyBucketIdIfProvided(command.longValueOfParameterNamed("delinquencyBucketId")));
             }
 
             this.loanProductRepository.saveAndFlush(loanProduct);
@@ -168,6 +167,15 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
         return fund;
     }
 
+    private DelinquencyBucket findDelinquencyBucketIdIfProvided(final Long delinquencyBucketId) {
+        DelinquencyBucket delinquencyBucket = null;
+        if (delinquencyBucketId != null) {
+            delinquencyBucket = delinquencyBucketRepository.findById(delinquencyBucketId)
+                    .orElseThrow(() -> new FundNotFoundException(delinquencyBucketId));
+        }
+        return delinquencyBucket;
+    }
+
     @Transactional
     @Override
     public CommandProcessingResult updateLoanProduct(final Long loanProductId, final JsonCommand command) {
@@ -201,9 +209,7 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
             }
 
             if (changes.containsKey("delinquencyBucketId")) {
-                final Long delinquencyBucketId = (Long) changes.get("delinquencyBucketId");
-                final DelinquencyBucket delinquencyBucket = this.delinquencyBucketRepository.getReferenceById(delinquencyBucketId);
-                product.setDelinquencyBucket(delinquencyBucket);
+                product.setDelinquencyBucket(findDelinquencyBucketIdIfProvided((Long) changes.get("delinquencyBucketId")));
             }
 
             if (changes.containsKey("transactionProcessingStrategyCode")) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
@@ -285,12 +285,20 @@ public class DelinquencyBucketsIntegrationTest {
         // Loan product creation without Delinquency bucket
         GetLoanProductsProductIdResponse getLoanProductResponse = createLoanProduct(loanTransactionHelper, null, null);
         assertNotNull(getLoanProductResponse);
+        assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
 
         // Loan product creation with Delinquency bucket
         getLoanProductResponse = createLoanProduct(loanTransactionHelper, Math.toIntExact(delinquencyBucket.getId()), null);
         assertNotNull(getLoanProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
+
+        // Update Loan product to remove the Delinquency bucket
+        final Long loanProductId = getLoanProductResponse.getId();
+        loanTransactionHelper.updateLoanProduct(loanProductId, "{delinquencyBucketId: null}");
+        getLoanProductResponse = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        assertNotNull(getLoanProductResponse);
+        assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -100,6 +100,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 public class LoanTransactionHelper extends IntegrationTest {
 
     public static final String DATE_TIME_FORMAT = "dd MMMM yyyy HH:mm";
+    private static final String LOAN_PRODUCTS_URL = "/fineract-provider/api/v1/loanproducts";
     private static final String CREATE_LOAN_PRODUCT_URL = "/fineract-provider/api/v1/loanproducts?" + Utils.TENANT_IDENTIFIER;
     private static final String APPLY_LOAN_URL = "/fineract-provider/api/v1/loans?" + Utils.TENANT_IDENTIFIER;
     private static final String LOAN_ACCOUNT_URL = "/fineract-provider/api/v1/loans";
@@ -1975,4 +1976,10 @@ public class LoanTransactionHelper extends IntegrationTest {
         final String ADD_CHARGES_URL = LOAN_ACCOUNT_URL + "/" + loanId + "/charges?" + Utils.TENANT_IDENTIFIER;
         return Utils.performServerPost(requestSpec, responseSpec, ADD_CHARGES_URL, request, jsonAttributeToGetBack);
     }
+
+    public Object updateLoanProduct(final Long loanProductId, final String request) {
+        final String UPDATE_LOAN_PRODUCT_URL = LOAN_PRODUCTS_URL + "/" + loanProductId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerPut(requestSpec, responseSpec, UPDATE_LOAN_PRODUCT_URL, request, null);
+    }
+
 }


### PR DESCRIPTION
## Description

Delinquency bucket error upon Loan product editing, In order to support null values in the delinquencyBucketId property, It was necessary to update the Loan Product creation and edition

[FINERACT-1971](https://issues.apache.org/jira/browse/FINERACT-1971)

<img width="1028" alt="Screenshot 2024-01-26 at 2 56 26 p m" src="https://github.com/apache/fineract/assets/154766431/a165a540-2d62-4f64-9566-843f45b70836">

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
