### PR TITLE
FINERACT-2035: Client Trend For Day Scale is not work Due to BadSqlGrammar Error

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0087_update_dashboard_table_reports.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0087_update_dashboard_table_reports.xml
@@ -75,7 +75,7 @@
             FROM m_office o LEFT JOIN m_client cl on o.id = cl.office_id
                 LEFT JOIN m_loan ln on cl.id = ln.client_id
             WHERE o.hierarchy like concat((select ino.hierarchy from m_office ino where ino.id = ${officeId}),'%' )
-                AND (ln.disbursedon_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 12 DAY) AND DATE(NOW()- INTERVAL '1 DAY'))
+                AND (ln.disbursedon_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 12 DAY) AND DATE(NOW()- INTERVAL 1 DAY))
             GROUP BY days
             "/>
             <where>id='152' AND report_name = 'LoanTrendsByDay'</where>


### PR DESCRIPTION
Issue: [FINERACT-2035](https://issues.apache.org/jira/browse/FINERACT-2035)
Client Trend For Day Scale is not work Due to BadSqlGrammar Error

This error is happened due to bucket 1 Day is inside single quotation in 0087_update_dashboard_table_reports.xml file which is responsible for storing SQL query in DB that SQL query is responsible for the BadSQLGrammar Error. I check the other queries related to this query but, all of them are working fine.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
