### PR TITLE
FINERACT-2015: NPE on fee charge when performing account transfer on savings account

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/AccountTransfersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/AccountTransfersApiResourceSwagger.java
@@ -170,6 +170,8 @@ final class AccountTransfersApiResourceSwagger {
         public Float transferAmount;
         @Schema(example = "A description of the transfer")
         public String transferDescription;
+        @Schema(example = "1")
+        public Integer paymentType;
     }
 
     @Schema(description = "PostAccountTransfersResponse")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/data/AccountTransferDTO.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/data/AccountTransferDTO.java
@@ -56,6 +56,7 @@ public class AccountTransferDTO {
     private final SavingsAccount fromSavingsAccount;
     private final Boolean isRegularTransaction;
     private final Boolean isExceptionForBalanceCheck;
+    private final Integer paymentTypeId;
 
     public AccountTransferDTO(final LocalDate transactionDate, final BigDecimal transactionAmount,
             final PortfolioAccountType fromAccountType, final PortfolioAccountType toAccountType, final Long fromAccountId,
@@ -89,6 +90,7 @@ public class AccountTransferDTO {
         this.fromSavingsAccount = fromSavingsAccount;
         this.isRegularTransaction = isRegularTransaction;
         this.isExceptionForBalanceCheck = isExceptionForBalanceCheck;
+        this.paymentTypeId = null;
     }
 
     public AccountTransferDTO(final LocalDate transactionDate, final BigDecimal transactionAmount,
@@ -121,6 +123,42 @@ public class AccountTransferDTO {
         this.fromSavingsAccount = null;
         this.isRegularTransaction = null;
         this.isExceptionForBalanceCheck = null;
+        this.paymentTypeId = null;
+    }
+
+    public AccountTransferDTO(final LocalDate transactionDate, final BigDecimal transactionAmount,
+            final PortfolioAccountType fromAccountType, final PortfolioAccountType toAccountType, final Long fromAccountId,
+            final Long toAccountId, final String description, final Locale locale, final DateTimeFormatter fmt,
+            final PaymentDetail paymentDetail, final Integer fromTransferType, final Integer toTransferType, final Long chargeId,
+            Integer loanInstallmentNumber, Integer transferType, final AccountTransferDetails accountTransferDetails, final String noteText,
+            final ExternalId txnExternalId, final Loan loan, SavingsAccount toSavingsAccount, final SavingsAccount fromSavingsAccount,
+            final Boolean isRegularTransaction, Boolean isExceptionForBalanceCheck, Integer paymentTypeId) {
+        this.transactionDate = transactionDate;
+        this.transactionAmount = transactionAmount;
+        this.fromAccountType = fromAccountType;
+        this.toAccountType = toAccountType;
+        this.fromAccountId = fromAccountId;
+        this.toAccountId = toAccountId;
+        this.description = description;
+        this.locale = locale;
+        this.fmt = fmt;
+        this.paymentDetail = paymentDetail;
+        this.fromTransferType = fromTransferType;
+        this.toTransferType = toTransferType;
+        this.chargeId = chargeId;
+        this.loanInstallmentNumber = loanInstallmentNumber;
+        this.transferType = transferType;
+        this.accountTransferDetails = accountTransferDetails;
+        this.noteText = noteText;
+        this.txnExternalId = txnExternalId;
+        this.loan = loan;
+        this.fromLoan = null;
+        this.toLoan = null;
+        this.toSavingsAccount = toSavingsAccount;
+        this.fromSavingsAccount = fromSavingsAccount;
+        this.isRegularTransaction = isRegularTransaction;
+        this.isExceptionForBalanceCheck = isExceptionForBalanceCheck;
+        this.paymentTypeId = paymentTypeId;
     }
 
     public LocalDate getTransactionDate() {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -31,8 +31,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -51,6 +53,7 @@ import org.apache.fineract.portfolio.account.domain.AccountTransferDetails;
 import org.apache.fineract.portfolio.account.domain.AccountTransferRepository;
 import org.apache.fineract.portfolio.account.domain.AccountTransferTransaction;
 import org.apache.fineract.portfolio.account.domain.AccountTransferType;
+import org.apache.fineract.portfolio.paymentdetail.service.PaymentDetailWritePlatformService;
 import org.apache.fineract.portfolio.account.exception.DifferentCurrenciesException;
 import org.apache.fineract.portfolio.loanaccount.data.HolidayDetailDTO;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
@@ -88,6 +91,7 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
     private final ConfigurationDomainService configurationDomainService;
     private final ExternalIdFactory externalIdFactory;
     private final FineractProperties fineractProperties;
+    private final PaymentDetailWritePlatformService paymentDetailWritePlatformService;
 
     @Transactional
     @Override
@@ -108,7 +112,8 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
         final Integer toAccountTypeId = command.integerValueSansLocaleOfParameterNamed(toAccountTypeParamName);
         final PortfolioAccountType toAccountType = PortfolioAccountType.fromInt(toAccountTypeId);
 
-        final PaymentDetail paymentDetail = null;
+        Map<String, Object> changes = new HashMap<>();
+        final PaymentDetail paymentDetail = paymentDetailWritePlatformService.createAndPersistPaymentDetail(command, changes);
         Long fromSavingsAccountId = null;
         Long transferDetailId = null;
         boolean isInterestTransfer = false;
@@ -572,7 +577,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
         final CommandProcessingResultBuilder builder = new CommandProcessingResultBuilder().withEntityId(transferTransactionId);
 
         // if (fromAccountType.isSavingsAccount()) {
-
         builder.withSavingsId(toSavingsAccountId);
         // }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
@@ -88,11 +88,11 @@ public class AccountConfiguration {
             LoanAccountDomainService loanAccountDomainService, SavingsAccountWritePlatformService savingsAccountWritePlatformService,
             AccountTransferDetailRepository accountTransferDetailRepository, LoanReadPlatformService loanReadPlatformService,
             GSIMRepositoy gsimRepository, ConfigurationDomainService configurationDomainService, ExternalIdFactory externalIdFactory,
-            FineractProperties fineractProperties) {
+            FineractProperties fineractProperties, PaymentDetailWritePlatformService paymentDetailWritePlatformService;) {
         return new AccountTransfersWritePlatformServiceImpl(accountTransfersDataValidator, accountTransferAssembler,
                 accountTransferRepository, savingsAccountAssembler, savingsAccountDomainService, loanAccountAssembler,
                 loanAccountDomainService, savingsAccountWritePlatformService, accountTransferDetailRepository, loanReadPlatformService,
-                gsimRepository, configurationDomainService, externalIdFactory, fineractProperties);
+                gsimRepository, configurationDomainService, externalIdFactory, fineractProperties, paymentDetailWritePlatformService);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
@@ -46,6 +46,7 @@ import org.apache.fineract.portfolio.account.service.StandingInstructionReadPlat
 import org.apache.fineract.portfolio.account.service.StandingInstructionReadPlatformServiceImpl;
 import org.apache.fineract.portfolio.account.service.StandingInstructionWritePlatformService;
 import org.apache.fineract.portfolio.account.service.StandingInstructionWritePlatformServiceImpl;
+import org.apache.fineract.portfolio.paymentdetail.service.PaymentDetailWritePlatformService;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
 import org.apache.fineract.portfolio.common.service.DropdownReadPlatformService;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanAccountDomainService;
@@ -88,7 +89,7 @@ public class AccountConfiguration {
             LoanAccountDomainService loanAccountDomainService, SavingsAccountWritePlatformService savingsAccountWritePlatformService,
             AccountTransferDetailRepository accountTransferDetailRepository, LoanReadPlatformService loanReadPlatformService,
             GSIMRepositoy gsimRepository, ConfigurationDomainService configurationDomainService, ExternalIdFactory externalIdFactory,
-            FineractProperties fineractProperties, PaymentDetailWritePlatformService paymentDetailWritePlatformService;) {
+            FineractProperties fineractProperties, PaymentDetailWritePlatformService paymentDetailWritePlatformService) {
         return new AccountTransfersWritePlatformServiceImpl(accountTransfersDataValidator, accountTransferAssembler,
                 accountTransferRepository, savingsAccountAssembler, savingsAccountDomainService, loanAccountAssembler,
                 loanAccountDomainService, savingsAccountWritePlatformService, accountTransferDetailRepository, loanReadPlatformService,

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/account/SavingsAccountTransfersApiTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/account/SavingsAccountTransfersApiTest.java
@@ -1,0 +1,76 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package org.apache.fineract.portfolio.savings.account;
+
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.portfolio.account.api.AccountTransfersApiResource;
+import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ *
+ * @author daviestobialex
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SavingsAccountTransfersApiTest {
+
+    @Mock
+    private ApiRequestParameterHelper parameterHelper;
+
+    @Mock
+    private PlatformSecurityContext securityContext;
+
+    @Mock
+    private PortfolioCommandSourceWritePlatformService commandWritePlatformService;
+
+    @Mock
+    private AccountTransfersReadPlatformService accountTransfersReadPlatformService;
+
+    private ApiRequestJsonSerializationSettings apiRequestJsonSerializationSettings;
+
+    @InjectMocks
+    private AccountTransfersApiResource underTest;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        apiRequestJsonSerializationSettings = new ApiRequestJsonSerializationSettings(false, null, false, false, false);
+        given(parameterHelper.process(Mockito.any())).willReturn(apiRequestJsonSerializationSettings);
+    }
+
+    @Test
+    void accountTransfer_ChargeWithdrawalFeeWithPaymentType_Test() {
+        AppUser appUser = Mockito.mock(AppUser.class);
+        CommandProcessingResult response = Mockito.mock(CommandProcessingResult.class);
+        // given
+        Mockito.doNothing().when(appUser).validateHasUpdatePermission("BUSINESS_DATE");
+        given(securityContext.authenticatedUser()).willReturn(appUser);
+        given(commandWritePlatformService.logCommandSource(Mockito.any())).willReturn(response);
+
+        // when
+        underTest.create("{}");
+
+        // then
+        verify(commandWritePlatformService, Mockito.times(1)).logCommandSource(Mockito.any());
+
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/account/transfers/SavingsAccountTransfersApiTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/account/transfers/SavingsAccountTransfersApiTest.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package org.apache.fineract.portfolio.savings.account;
+package org.apache.fineract.portfolio.savings.account.transfers;
 
 import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
 import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;


### PR DESCRIPTION
## Description

A savings account can not transfer to another savings account when a withdrawal fee is applied. When the is_witdrawal_fee_on_transfer is set to true, a null pointer exception occurs causing the transaction to fail.

linked stale PR from version 1.8.4 (https://github.com/apache/fineract/pull/3600).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
