### PR TITLE
FINERACT-1964: Add functionality to calculate maturity amount before creating FD account

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
@@ -112,6 +112,11 @@ public final class DepositsApiConstants {
     public static final String routingCodeParamName = "routingCode";
     public static final String receiptNumberParamName = "receiptNumber";
     public static final String bankNumberParamName = "bankNumber";
+    public static final String principalAmountParamName = "principalAmount";
+    public static final String annualInterestRateParamName = "annualInterestRate";
+    public static final String interestPostingPeriodInMonthsParamName = "interestPostingPeriodInMonths";
+    public static final String tenureInMonthsParamName = "tenureInMonths";
+    public static final String interestCompoundingPeriodInMonthsParamName = "interestCompoundingPeriodInMonths";
 
     // Preclosure parameters
     public static final String preClosurePenalApplicableParamName = "preClosurePenalApplicable";
@@ -307,9 +312,21 @@ public final class DepositsApiConstants {
 
     public static final Set<String> FIXED_DEPOSIT_ACCOUNT_REQUEST_DATA_PARAMETERS = fixedDepositAccountRequestData();
     public static final Set<String> FIXED_DEPOSIT_ACCOUNT_RESPONSE_DATA_PARAMETERS = fixedDepositAccountResponseData();
-
+    public static final Set<String> FIXED_DEPOSIT_ACCOUNT_INTEREST_CALCULATION_PARAMETERS = fixedDepositInterestCalculationData();
     public static final Set<String> RECURRING_DEPOSIT_ACCOUNT_REQUEST_DATA_PARAMETERS = recurringDepositAccountRequestData();
     public static final Set<String> RECURRING_DEPOSIT_ACCOUNT_RESPONSE_DATA_PARAMETERS = recurringDepositAccountResponseData();
+
+    private static Set<String> fixedDepositInterestCalculationData() {
+        final Set<String> fixedDepositInterestCalculationData = new HashSet<>();
+        fixedDepositInterestCalculationData.add(principalAmountParamName);
+        fixedDepositInterestCalculationData.add(annualInterestRateParamName);
+        fixedDepositInterestCalculationData.add(tenureInMonthsParamName);
+        fixedDepositInterestCalculationData.add(interestPostingPeriodInMonthsParamName);
+        fixedDepositInterestCalculationData.add(interestCompoundingPeriodInMonthsParamName);
+
+        return fixedDepositInterestCalculationData;
+
+    }
 
     private static Set<String> fixedDepositAccountRequestData() {
         final Set<String> fixedDepositRequestData = new HashSet<>();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResourceSwagger.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.savings.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 
@@ -254,6 +255,36 @@ final class FixedDepositAccountsApiResourceSwagger {
         @Schema(example = "6")
         public Integer depositPeriod;
         public GetFixedDepositAccountsDepositPeriodFrequency depositPeriodFrequency;
+    }
+
+    @Schema(description = "CalculateFixedDepositInterestRequest")
+    public static final class CalculateFixedDepositInterestRequest {
+
+        private CalculateFixedDepositInterestRequest() {}
+
+        @Schema(example = "10000")
+        public BigDecimal principalAmount;
+        @Schema(example = "5")
+        public BigDecimal annualInterestRate;
+        @Schema(example = "12")
+        public Long tenureInMonths;
+        @Schema(example = "3")
+        public Long interestPostingPeriodInMonths;
+        @Schema(example = "1")
+        public Long interestCompoundingPeriodInMonths;
+
+    }
+
+    @Schema(description = "CalculateFixedDepositInterestResponse")
+    public static final class CalculateFixedDepositInterestResponse {
+
+        private CalculateFixedDepositInterestResponse() {}
+
+        @Schema(example = "10511.61")
+        public BigDecimal maturityAmount;
+
+        @Schema(example = "Accuracy Warning")
+        public String warning;
     }
 
     @Schema(description = "PostFixedDepositAccountsRequest")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationService.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.portfolio.savings.service;
+
+import java.util.HashMap;
+import org.apache.fineract.infrastructure.core.api.JsonQuery;
+
+public interface FixedDepositAccountInterestCalculationService {
+
+    HashMap calculateInterest(JsonQuery query);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationServiceImpl.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.portfolio.savings.service;
+
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.annualInterestRateParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.interestCompoundingPeriodInMonthsParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.principalAmountParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.tenureInMonthsParamName;
+
+import com.google.gson.JsonElement;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.HashMap;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.JsonQuery;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.savings.data.DepositAccountDataValidator;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FixedDepositAccountInterestCalculationServiceImpl implements FixedDepositAccountInterestCalculationService {
+
+    private final DepositAccountDataValidator depositAccountDataValidator;
+    private final FromJsonHelper fromApiJsonHelper;
+
+    @Override
+    public HashMap calculateInterest(JsonQuery query) {
+        depositAccountDataValidator.validateFixedDepositForInterestCalculation(query.json());
+        JsonElement element = query.parsedJson();
+        BigDecimal principalAmount = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(principalAmountParamName, element);
+        BigDecimal annualInterestRate = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(annualInterestRateParamName, element);
+        Long tenureInMonths = this.fromApiJsonHelper.extractLongNamed(tenureInMonthsParamName, element);
+        Long interestCompoundingPeriodInMonths = this.fromApiJsonHelper.extractLongNamed(interestCompoundingPeriodInMonthsParamName,
+                element);
+        BigDecimal maturityAmount = this.calculateInterestInternal(principalAmount, annualInterestRate, tenureInMonths,
+                interestCompoundingPeriodInMonths);
+        String warning = "This is an approximate calculated amount - it may vary slightly when the account is created";
+
+        HashMap result = new HashMap<>();
+        result.put("maturityAmount", maturityAmount);
+        result.put("warning", warning);
+
+        return result;
+    }
+
+    public BigDecimal calculateInterestInternal(BigDecimal principalAmount, BigDecimal annualInterestRate, Long tenureInMonths,
+            Long interestCompoundingPeriodInMonths) {
+        BigDecimal numberOfCompoundingsPerAnnum = BigDecimal.valueOf(12).divide(BigDecimal.valueOf(interestCompoundingPeriodInMonths));
+        Long totalNumberOfCompoundings = tenureInMonths / interestCompoundingPeriodInMonths;
+        MathContext mc = MoneyHelper.getMathContext();
+        BigDecimal exponentialTerm = annualInterestRate.divide(numberOfCompoundingsPerAnnum, mc).divide(BigDecimal.valueOf(100), mc)
+                .add(BigDecimal.valueOf(1)).pow(Math.toIntExact(totalNumberOfCompoundings));
+        return principalAmount.multiply(exponentialTerm);
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/FixedDepositAccountInterestCalculationServiceImplTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.savings.data.DepositAccountDataValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FixedDepositAccountInterestCalculationServiceImplTest {
+
+    private FixedDepositAccountInterestCalculationServiceImpl service;
+
+    @Mock
+    private DepositAccountDataValidator depositAccountDataValidator;
+    @Mock
+    private FromJsonHelper fromApiJsonHelper;
+    private MockedStatic<MoneyHelper> moneyHelperStatic;
+
+    @BeforeEach
+    public void setUp() {
+        moneyHelperStatic = Mockito.mockStatic(MoneyHelper.class);
+        moneyHelperStatic.when(() -> MoneyHelper.getMathContext()).thenReturn(new MathContext(12, RoundingMode.UP));
+        service = new FixedDepositAccountInterestCalculationServiceImpl(depositAccountDataValidator, fromApiJsonHelper);
+    }
+
+    @AfterEach
+    public void deregister() {
+        moneyHelperStatic.close();
+    }
+
+    @Test
+    public void testCalculateInterestInternal1() {
+
+        // Calculate interest
+        BigDecimal expectedInterest = new BigDecimal("10509.4533691406250000"); // Expected interest calculated based
+                                                                                // on provided values
+        BigDecimal calculatedInterest = service.calculateInterestInternal(BigDecimal.valueOf(10000), BigDecimal.valueOf(5), 12L, 3L);
+
+        // Verify the result
+        assertEquals(expectedInterest, calculatedInterest);
+    }
+
+    @Test
+    public void testCalculateInterestInternal2() {
+
+        // Calculate interest
+        BigDecimal expectedInterest = new BigDecimal("105.062500"); // Expected interest calculated based on provided
+                                                                    // values
+        BigDecimal calculatedInterest = service.calculateInterestInternal(BigDecimal.valueOf(100), BigDecimal.valueOf(5), 12L, 6L);
+
+        // Verify the result
+        assertEquals(expectedInterest, calculatedInterest);
+    }
+
+}


### PR DESCRIPTION
Created a functionality to calculate maturity amount. I have tried to follow all the best practices in my knowledge. Please let me know if any changes need to be done. Also, please feel free to check business logic to calculate the amount and the validation operations on the input, because I used my own knowledge and some research to write them.

**Current Business logic to calculate the interest:**

Maturity amount = P* ((1+ r/n) ^nt))

Where -

A  denotes the future valuation of the investment made

P  denotes the Principal amount

r   denotes the interest rate

n  denotes the number of times interest gets compounded per period

t   denotes the time period the money was invested

**Current Applied validations on input data:**

1) All input fields (Principal Amount, annualInterestRate, tenureInMonths, interestPostingPeriodInMonths, interestCompoundingPeriodInMonths) must be greater than 0 and cannot be null.
2) 0 < interestCompoundingPeriodInMonths <= 12


Thanks!