### PR TITLE
FINERACT-1269: (fix) Validate the json we try to deserialize is valid.

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import io.github.resilience4j.retry.annotation.Retry;
 import java.lang.reflect.Type;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,7 @@ import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessFailedException;
 import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessSucceedException;
 import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.GoogleGsonSerializerHelper;
 import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
@@ -261,56 +263,67 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
         return isMakerChecker && !user.isCheckerSuperUser();
     }
 
-    private void publishHookEvent(final String entityName, final String actionName, JsonCommand command, final Object result) {
-        try {
-            final AppUser appUser = context.authenticatedUser(CommandWrapper.wrap(actionName, entityName, null, null));
+    protected void publishHookEvent(final String entityName, final String actionName, JsonCommand command, final Object result) {
 
-            final HookEventSource hookEventSource = new HookEventSource(entityName, actionName);
+        final AppUser appUser = context.authenticatedUser(CommandWrapper.wrap(actionName, entityName, null, null));
 
-            // TODO: Add support for publishing array events
-            if (command.json() != null && command.json().startsWith("{")) {
-                Type type = new TypeToken<Map<String, Object>>() {
+        final HookEventSource hookEventSource = new HookEventSource(entityName, actionName);
 
-                }.getType();
-                Map<String, Object> myMap = gson.fromJson(command.json(), type);
+        // TODO: Add support for publishing array events
+        if (command.json() != null) {
+            Type type = new TypeToken<Map<String, Object>>() {
 
-                Map<String, Object> reqmap = new HashMap<>();
-                reqmap.put("entityName", entityName);
-                reqmap.put("actionName", actionName);
-                reqmap.put("createdBy", context.authenticatedUser().getId());
-                reqmap.put("createdByName", context.authenticatedUser().getUsername());
-                reqmap.put("createdByFullName", context.authenticatedUser().getDisplayName());
+            }.getType();
 
-                reqmap.put("request", myMap);
-                if (result instanceof CommandProcessingResult) {
-                    CommandProcessingResult resultCopy = CommandProcessingResult
-                            .fromCommandProcessingResult((CommandProcessingResult) result);
+            Map<String, Object> myMap;
 
-                    reqmap.put("officeId", resultCopy.getOfficeId());
-                    reqmap.put("clientId", resultCopy.getClientId());
-                    resultCopy.setOfficeId(null);
-                    reqmap.put("response", resultCopy);
-                } else if (result instanceof ErrorInfo ex) {
-                    reqmap.put("status", "Exception");
+            try {
+                myMap = gson.fromJson(command.json(), type);
+            } catch (Exception e) {
+                throw new PlatformApiDataValidationException("error.msg.invalid.json", "The provided JSON is invalid.", new ArrayList<>(),
+                        e);
+            }
 
-                    Map<String, Object> errorMap = gson.fromJson(ex.getMessage(), type);
-                    errorMap.put("errorCode", ex.getErrorCode());
-                    errorMap.put("statusCode", ex.getStatusCode());
+            Map<String, Object> reqmap = new HashMap<>();
+            reqmap.put("entityName", entityName);
+            reqmap.put("actionName", actionName);
+            reqmap.put("createdBy", context.authenticatedUser().getId());
+            reqmap.put("createdByName", context.authenticatedUser().getUsername());
+            reqmap.put("createdByFullName", context.authenticatedUser().getDisplayName());
 
-                    reqmap.put("response", errorMap);
+            reqmap.put("request", myMap);
+            if (result instanceof CommandProcessingResult) {
+                CommandProcessingResult resultCopy = CommandProcessingResult.fromCommandProcessingResult((CommandProcessingResult) result);
+
+                reqmap.put("officeId", resultCopy.getOfficeId());
+                reqmap.put("clientId", resultCopy.getClientId());
+                resultCopy.setOfficeId(null);
+                reqmap.put("response", resultCopy);
+            } else if (result instanceof ErrorInfo ex) {
+                reqmap.put("status", "Exception");
+
+                Map<String, Object> errorMap = new HashMap<>();
+
+                try {
+                    errorMap = gson.fromJson(ex.getMessage(), type);
+                } catch (Exception e) {
+                    errorMap.put("errorMessage", ex.getMessage());
                 }
 
-                reqmap.put("timestamp", Instant.now().toString());
+                errorMap.put("errorCode", ex.getErrorCode());
+                errorMap.put("statusCode", ex.getStatusCode());
 
-                final String serializedResult = toApiResultJsonSerializer.serialize(reqmap);
-
-                final HookEvent applicationEvent = new HookEvent(hookEventSource, serializedResult, appUser,
-                        ThreadLocalContextUtil.getContext());
-
-                applicationContext.publishEvent(applicationEvent);
+                reqmap.put("response", errorMap);
             }
-        } catch (Exception e) {
-            log.error("Error", e);
+
+            reqmap.put("timestamp", Instant.now().toString());
+
+            final String serializedResult = toApiResultJsonSerializer.serialize(reqmap);
+
+            final HookEvent applicationEvent = new HookEvent(hookEventSource, serializedResult, appUser,
+                    ThreadLocalContextUtil.getContext());
+
+            applicationContext.publishEvent(applicationEvent);
         }
     }
 }


### PR DESCRIPTION
## Description

- Wrap the fromJson() method with try-catch block and throw proper exception.
- Add `publishHookEventHandlesInvalidJson()` method to test the invalid json is handled successfully.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
