### PR TITLE
FINERACT-2021: migrate fund resource to MVC

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/domain/CommandTypeWrapper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/domain/CommandTypeWrapper.java
@@ -1,0 +1,304 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.domain;
+
+import java.util.Objects;
+import lombok.Getter;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.useradministration.api.PasswordPreferencesApiConstants;
+
+@Getter
+public class CommandTypeWrapper<T> {
+
+    private final Long commandId;
+    @SuppressWarnings("unused")
+    private final Long officeId;
+    private final Long groupId;
+    private final Long clientId;
+    private final Long loanId;
+    private final Long savingsId;
+    private final String actionName;
+    private final String entityName;
+    private final String taskPermissionName;
+    private final Long entityId;
+    private final Long subentityId;
+    private final String href;
+    private final T request;
+    private CommandWrapper jsonWrapper; // TODO: Remove after MVC migration
+    private final String transactionId;
+    private final Long productId;
+    private final Long creditBureauId;
+    private final Long organisationCreditBureauId;
+    private final String jobName;
+
+    private final String idempotencyKey;
+
+    @SuppressWarnings("unused")
+    private Long templateId;
+
+    public static <T> CommandTypeWrapper<T> wrap(final String actionName, final String entityName, final Long resourceId,
+            final Long subresourceId) {
+        return new CommandTypeWrapper<>(null, actionName, entityName, resourceId, subresourceId, null, null);
+    }
+
+    public static <T> CommandTypeWrapper<T> fromExistingCommand(final Long commandId, final String actionName, final String entityName,
+            final Long resourceId, final Long subresourceId, final String resourceGetUrl, final Long productId, final Long officeId,
+            final Long groupId, final Long clientId, final Long loanId, final Long savingsId, final String transactionId,
+            final Long creditBureauId, final Long organisationCreditBureauId, final String idempotencyKey) {
+        return new CommandTypeWrapper<>(commandId, actionName, entityName, resourceId, subresourceId, resourceGetUrl, productId, officeId,
+                groupId, clientId, loanId, savingsId, transactionId, creditBureauId, organisationCreditBureauId, idempotencyKey);
+    }
+
+    private CommandTypeWrapper(final Long commandId, final String actionName, final String entityName, final Long resourceId,
+            final Long subresourceId, final String resourceGetUrl, final Long productId) {
+        this.commandId = commandId;
+        this.officeId = null;
+        this.groupId = null;
+        this.clientId = null;
+        this.loanId = null;
+        this.savingsId = null;
+        this.actionName = actionName;
+        this.entityName = entityName;
+        this.taskPermissionName = actionName + "_" + entityName;
+        this.entityId = resourceId;
+        this.subentityId = subresourceId;
+        this.href = resourceGetUrl;
+        this.request = null;
+        this.transactionId = null;
+        this.productId = productId;
+        this.creditBureauId = null;
+        this.organisationCreditBureauId = null;
+        this.jobName = null;
+        this.idempotencyKey = null;
+    }
+
+    public CommandTypeWrapper(final Long officeId, final Long groupId, final Long clientId, final Long loanId, final Long savingsId,
+            final String actionName, final String entityName, final Long entityId, final Long subentityId, final String href,
+            final T request, final String transactionId, final Long productId, final Long templateId, final Long creditBureauId,
+            final Long organisationCreditBureauId, final String jobName, final String idempotencyKey) {
+
+        this.commandId = null;
+        this.officeId = officeId;
+        this.groupId = groupId;
+        this.clientId = clientId;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.actionName = actionName;
+        this.entityName = entityName;
+        this.taskPermissionName = actionName + "_" + entityName;
+        this.entityId = entityId;
+        this.subentityId = subentityId;
+        this.href = href;
+        this.request = request;
+        this.transactionId = transactionId;
+        this.productId = productId;
+        this.templateId = templateId;
+        this.creditBureauId = creditBureauId;
+        this.organisationCreditBureauId = organisationCreditBureauId;
+        this.jobName = jobName;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    private CommandTypeWrapper(final Long commandId, final String actionName, final String entityName, final Long resourceId,
+            final Long subresourceId, final String resourceGetUrl, final Long productId, final Long officeId, final Long groupId,
+            final Long clientId, final Long loanId, final Long savingsId, final String transactionId, final Long creditBureauId,
+            final Long organisationCreditBureauId, final String idempotencyKey) {
+
+        this.commandId = commandId;
+        this.officeId = officeId;
+        this.groupId = groupId;
+        this.clientId = clientId;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.actionName = actionName;
+        this.entityName = entityName;
+        this.taskPermissionName = actionName + "_" + entityName;
+        this.entityId = resourceId;
+        this.subentityId = subresourceId;
+        this.href = resourceGetUrl;
+        this.request = null;
+        this.transactionId = transactionId;
+        this.productId = productId;
+        this.creditBureauId = creditBureauId;
+        this.organisationCreditBureauId = organisationCreditBureauId;
+        this.jobName = null;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public boolean isCreate() {
+        return this.actionName.equalsIgnoreCase("CREATE");
+    }
+
+    public boolean isCreateDatatable() {
+        return this.actionName.equalsIgnoreCase("CREATE") && this.href.startsWith("/datatables/") && this.entityId == null;
+    }
+
+    public boolean isDeleteDatatable() {
+        return this.actionName.equalsIgnoreCase("DELETE") && this.href.startsWith("/datatables/") && this.entityId == null;
+    }
+
+    public boolean isUpdateDatatable() {
+        return this.actionName.equalsIgnoreCase("UPDATE") && this.href.startsWith("/datatables/") && this.entityId == null;
+    }
+
+    public boolean isDatatableResource() {
+        return this.href.startsWith("/datatables/");
+    }
+
+    public boolean isDeleteOneToOne() {
+        /* also covers case of deleting all of a one to many */
+        return isDatatableResource() && isDeleteOperation() && this.subentityId == null;
+    }
+
+    public boolean isDeleteMultiple() {
+        return isDatatableResource() && isDeleteOperation() && this.subentityId != null;
+    }
+
+    public boolean isUpdateOneToOne() {
+        return isDatatableResource() && isUpdateOperation() && this.subentityId == null;
+    }
+
+    public boolean isUpdateMultiple() {
+        return isDatatableResource() && isUpdateOperation() && this.subentityId != null;
+    }
+
+    public boolean isRegisterDatatable() {
+        return this.actionName.equalsIgnoreCase("REGISTER") && this.href.startsWith("/datatables/") && this.entityId == null;
+    }
+
+    public boolean isNoteResource() {
+        boolean isnoteResource = false;
+        if (this.entityName.equalsIgnoreCase("CLIENTNOTE") || this.entityName.equalsIgnoreCase("LOANNOTE")
+                || this.entityName.equalsIgnoreCase("LOANTRANSACTIONNOTE") || this.entityName.equalsIgnoreCase("SAVINGNOTE")
+                || this.entityName.equalsIgnoreCase("GROUPNOTE")) {
+            isnoteResource = true;
+        }
+        return isnoteResource;
+    }
+
+    public boolean isUpdateOfOwnUserDetails(final Long loggedInUserId) {
+        return isUserResource() && isUpdate() && loggedInUserId.equals(this.entityId);
+    }
+
+    public boolean isUpdate() {
+        // permissions resource has special update which involves no resource.
+        return (isPermissionResource() && isUpdateOperation()) || (isCurrencyResource() && isUpdateOperation())
+                || (isCacheResource() && isUpdateOperation()) || (isWorkingDaysResource() && isUpdateOperation())
+                || (isPasswordPreferencesResource() && isUpdateOperation()) || (isUpdateOperation() && (this.entityId != null));
+    }
+
+    public boolean isCacheResource() {
+        return this.entityName.equalsIgnoreCase("CACHE");
+    }
+
+    public boolean isUpdateOperation() {
+        return this.actionName.equalsIgnoreCase("UPDATE");
+    }
+
+    public boolean isDelete() {
+        return isDeleteOperation() && this.entityId != null;
+    }
+
+    public boolean isDeleteOperation() {
+        return this.actionName.equalsIgnoreCase("DELETE");
+    }
+
+    public boolean isSurveyResource() {
+        return this.href.startsWith("/survey/");
+    }
+
+    public boolean isRegisterSurvey() {
+        return this.actionName.equalsIgnoreCase("REGISTER");
+    }
+
+    public boolean isFullFilSurvey() {
+        return this.actionName.equalsIgnoreCase("CREATE");
+    }
+
+    public boolean isWorkingDaysResource() {
+        return this.entityName.equalsIgnoreCase("WORKINGDAYS");
+    }
+
+    public boolean isPasswordPreferencesResource() {
+        return this.entityName.equalsIgnoreCase(PasswordPreferencesApiConstants.ENTITY_NAME);
+    }
+
+    public Long commandId() {
+        return this.commandId;
+    }
+
+    public String actionName() {
+        return this.actionName;
+    }
+
+    public String entityName() {
+        return this.entityName;
+    }
+
+    public Long resourceId() {
+        return this.entityId;
+    }
+
+    public Long subresourceId() {
+        return this.subentityId;
+    }
+
+    public String taskPermissionName() {
+        return this.actionName + "_" + this.entityName;
+    }
+
+    public boolean isPermissionResource() {
+        return this.entityName.equalsIgnoreCase("PERMISSION");
+    }
+
+    public boolean isUserResource() {
+        return this.entityName.equalsIgnoreCase("USER");
+    }
+
+    public boolean isCurrencyResource() {
+        return this.entityName.equalsIgnoreCase("CURRENCY");
+    }
+
+    public String commandName() {
+        return this.actionName + "_" + this.entityName;
+    }
+
+    public boolean isLoanDisburseDetailResource() {
+        return this.entityName.equalsIgnoreCase("DISBURSEMENTDETAIL");
+    }
+
+    public boolean isUpdateDisbursementDate() {
+        return this.actionName.equalsIgnoreCase("UPDATE") && this.entityName.equalsIgnoreCase("DISBURSEMENTDETAIL")
+                && this.entityId != null;
+    }
+
+    public boolean addAndDeleteDisbursementDetails() {
+        return this.actionName.equalsIgnoreCase("UPDATE") && this.entityName.equalsIgnoreCase("DISBURSEMENTDETAIL")
+                && this.entityId == null;
+    }
+
+    public CommandTypeWrapper<T> setJsonWrapper(CommandWrapper jsonWrapper) {
+        this.jsonWrapper = Objects.requireNonNull(jsonWrapper);
+        return this;
+    }
+
+    public CommandWrapper getJsonWrapper() {
+        return Objects.requireNonNull(this.jsonWrapper);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/handler/NewCommandSourceHandlerType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/handler/NewCommandSourceHandlerType.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.handler;
+
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+public interface NewCommandSourceHandlerType<T> {
+
+    CommandProcessingResult processCommand(TypeCommand<T> command);
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/provider/CommandHandlerProvider.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/provider/CommandHandlerProvider.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.provider;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.exception.UnsupportedCommandException;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.commands.mvc.handler.NewCommandSourceHandlerType;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link CommandHandlerProvider} provides {@link NewCommandSourceHandler}s for a given entity and action. <br>
+ * <br>
+ * A {@link NewCommandSourceHandler} can be registered and the annotation {@link CommandType} is used to determine the
+ * entity and the action the handler is capable to process.
+ *
+ * @author Markus Geiss
+ * @version 1.0
+ * @since 15.06
+ * @see NewCommandSourceHandler
+ * @see CommandType
+ */
+@ProfileMvc
+@Component("mvcCommandHandlerProvider")
+@NoArgsConstructor
+@Slf4j
+public class CommandHandlerProvider implements ApplicationContextAware, InitializingBean {
+
+    private final HashMap<String, String> registeredHandlers = new HashMap<>();
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        initializeHandlerRegistry();
+    }
+
+    private void initializeHandlerRegistry() {
+        final String[] commandHandlerBeans = applicationContext.getBeanNamesForAnnotation(CommandType.class);
+        if (ArrayUtils.isNotEmpty(commandHandlerBeans)) {
+            for (final String commandHandlerName : commandHandlerBeans) {
+                log.debug("Register command handler '{}' ...", commandHandlerName);
+                final CommandType commandType = applicationContext.findAnnotationOnBean(commandHandlerName, CommandType.class);
+                try {
+                    if (commandType != null) {
+                        registeredHandlers.put(commandType.entity() + "|" + commandType.action(), commandHandlerName);
+                    } else {
+                        log.error("Unable to register command handler '{}'!", commandHandlerName);
+                    }
+                } catch (final Throwable th) {
+                    log.error("Unable to register command handler '{}'!", commandHandlerName, th);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns a handler for the given entity and action.<br>
+     * <br>
+     * Throws an {@link UnsupportedCommandException} if no handler for the given entity, action combination can be
+     * found.
+     *
+     * @param entity
+     *            the entity to lookup the handler, must be given.
+     * @param action
+     *            the action to lookup the handler, must be given.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> NewCommandSourceHandlerType<T> getHandler(final String entity, final String action) {
+        Preconditions.checkArgument(StringUtils.isNoneEmpty(entity), "An entity must be given!");
+        Preconditions.checkArgument(StringUtils.isNoneEmpty(action), "An action must be given!");
+
+        final String key = entity + "|" + action;
+        if (!registeredHandlers.containsKey(key)) {
+            throw new UnsupportedCommandException(key);
+        }
+        return (NewCommandSourceHandlerType<T>) applicationContext.getBean(registeredHandlers.get(key));
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandProcessingService.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.useradministration.domain.AppUser;
+
+public interface CommandProcessingService {
+
+    <T> CommandProcessingResult executeCommand(CommandTypeWrapper<T> wrapper, TypeCommand<T> command, boolean isApprovedByChecker);
+
+    boolean validateRollbackCommand(CommandTypeWrapper<?> commandWrapper, AppUser user);
+
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandSourceService.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import static org.apache.fineract.commands.domain.CommandProcessingResultType.UNDER_PROCESSING;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.batch.exception.ErrorInfo;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandSourceRepository;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.exception.CommandNotFoundException;
+import org.apache.fineract.commands.exception.RollbackTransactionNotApprovedException;
+import org.apache.fineract.commands.mvc.handler.NewCommandSourceHandlerType;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Two phase transactional command processing: save initial...work...finish/failed to handle idempotent requests. As the
+ * default isolation level for MYSQL is REPEATABLE_READ and a lower value READ_COMMITED for postgres, we can force to
+ * use the same for both database backends to be consistent.
+ */
+@ProfileMvc
+@Component("mvcCommandSourceService")
+@RequiredArgsConstructor
+public class CommandSourceService {
+
+    private final CommandSourceRepository commandSourceRepository;
+    private final ErrorHandler errorHandler;
+
+    @NotNull
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
+    public CommandSource saveInitialNewTransaction(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
+        return saveInitial(wrapper, jsonCommand, maker, idempotencyKey);
+    }
+
+    @NotNull
+    @Transactional(propagation = Propagation.REQUIRED)
+    public CommandSource saveInitialSameTransaction(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
+        return saveInitial(wrapper, jsonCommand, maker, idempotencyKey);
+    }
+
+    @NotNull
+    private CommandSource saveInitial(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
+        CommandSource initialCommandSource = getInitialCommandSource(wrapper, jsonCommand, maker, idempotencyKey);
+        return commandSourceRepository.saveAndFlush(initialCommandSource);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
+    public CommandSource saveResultNewTransaction(@NotNull CommandSource commandSource) {
+        return saveResult(commandSource);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public CommandSource saveResultSameTransaction(@NotNull CommandSource commandSource) {
+        return saveResult(commandSource);
+    }
+
+    @NotNull
+    private CommandSource saveResult(@NotNull CommandSource commandSource) {
+        return commandSourceRepository.saveAndFlush(commandSource);
+    }
+
+    public ErrorInfo generateErrorInfo(Throwable t) {
+        return errorHandler.handle(ErrorHandler.getMappable(t));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public CommandSource getCommandSource(Long commandSourceId) {
+        return commandSourceRepository.findById(commandSourceId).orElseThrow(() -> new CommandNotFoundException(commandSourceId));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public CommandSource findCommandSource(CommandWrapper wrapper, String idempotencyKey) {
+        return commandSourceRepository.findByActionNameAndEntityNameAndIdempotencyKey(wrapper.actionName(), wrapper.entityName(),
+                idempotencyKey);
+    }
+
+    public CommandSource getInitialCommandSource(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
+        CommandSource commandSourceResult = CommandSource.fullEntryFrom(wrapper, jsonCommand, maker, idempotencyKey,
+                UNDER_PROCESSING.getValue());
+        if (commandSourceResult.getCommandJson() == null) {
+            commandSourceResult.setCommandJson("{}");
+        }
+        return commandSourceResult;
+    }
+
+    @Transactional
+    public <T> CommandProcessingResult processCommand(NewCommandSourceHandlerType<T> handler, TypeCommand<T> command,
+            CommandSource commandSource, AppUser user, boolean isApprovedByChecker, boolean isMakerChecker) {
+        final CommandProcessingResult result = handler.processCommand(command);
+        boolean isRollback = !isApprovedByChecker && !user.isCheckerSuperUser() && (isMakerChecker || result.isRollbackTransaction());
+        if (isRollback) {
+            commandSource.markAsAwaitingApproval();
+            throw new RollbackTransactionNotApprovedException(commandSource.getId(), commandSource.getResourceId());
+        }
+        return result;
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandTypeWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/CommandTypeWrapperBuilder.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+
+public class CommandTypeWrapperBuilder<T> {
+
+    private Long officeId;
+    private Long groupId;
+    private Long clientId;
+    private Long loanId;
+    private Long savingsId;
+    private String actionName;
+    private String entityName;
+    private Long entityId;
+    private Long subentityId;
+    private String href;
+    private T request;
+    private CommandWrapper jsonWrapper;
+    private String transactionId;
+    private Long productId;
+    private Long templateId;
+    private Long creditBureauId;
+    private Long organisationCreditBureauId;
+    private String jobName;
+    private String idempotencyKey;
+
+    public CommandTypeWrapperBuilder() {}
+
+    @SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD", justification = "TODO: fix this!")
+    public CommandTypeWrapper<T> build() {
+        return new CommandTypeWrapper<>(this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId, this.actionName,
+                this.entityName, this.entityId, this.subentityId, this.href, this.request, this.transactionId, this.productId,
+                this.templateId, this.creditBureauId, this.organisationCreditBureauId, this.jobName, this.idempotencyKey)
+                .setJsonWrapper(this.jsonWrapper); // TODO: Remove after MVC migration
+    }
+
+    public CommandTypeWrapperBuilder<T> createFund() {
+        this.actionName = "CREATE";
+        this.entityName = "FUND";
+        this.entityId = null;
+        this.href = "/funds/template";
+        return this;
+    }
+
+    public CommandTypeWrapperBuilder<T> updateFund(final Long fundId) {
+        this.actionName = "UPDATE";
+        this.entityName = "FUND";
+        this.entityId = fundId;
+        this.href = "/funds/" + fundId;
+        return this;
+    }
+
+    public CommandTypeWrapperBuilder<T> withRequest(final T request) {
+        this.request = request;
+        return this;
+    }
+
+    // TODO: This method is temporarily added to support the use of old jsonCommand during the migration process from
+    // jsonCommand to typeCommand.
+    // Some logic still uses jsonCommand. Once the migration is complete and all logic has been updated to use
+    // typeCommand, this method should be removed.
+    public CommandTypeWrapperBuilder<T> withJsonCommand(final CommandWrapper jsonWrapper) {
+        this.jsonWrapper = jsonWrapper;
+        return this;
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/PortfolioCommandSourceWritePlatformService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/PortfolioCommandSourceWritePlatformService.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+public interface PortfolioCommandSourceWritePlatformService {
+
+    <T> CommandProcessingResult logCommandSource(CommandTypeWrapper<T> commandRequest);
+
+    CommandProcessingResult approveEntry(Long id);
+
+    Long rejectEntry(Long id);
+
+    Long deleteEntry(Long makerCheckerId);
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import com.google.gson.JsonElement;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandSourceRepository;
+import org.apache.fineract.commands.exception.CommandNotAwaitingApprovalException;
+import org.apache.fineract.commands.exception.CommandNotFoundException;
+import org.apache.fineract.commands.exception.UnsupportedCommandException;
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.jobs.service.SchedulerJobRunnerReadService;
+import org.apache.fineract.infrastructure.security.service.mvc.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ProfileMvc
+@Service("mvcPortfolioCommandSourceWritePlatformService")
+@RequiredArgsConstructor
+@Slf4j
+public class PortfolioCommandSourceWritePlatformServiceImpl implements PortfolioCommandSourceWritePlatformService {
+
+    private final PlatformSecurityContext context;
+    private final CommandSourceRepository commandSourceRepository;
+    private final FromJsonHelper fromApiJsonHelper;
+    private final CommandProcessingService processAndLogCommandService;
+    private final SchedulerJobRunnerReadService schedulerJobRunnerReadService;
+    private final ConfigurationDomainService configurationService;
+
+    @Override
+    public <T> CommandProcessingResult logCommandSource(final CommandTypeWrapper<T> wrapper) {
+        boolean isApprovedByChecker = false;
+
+        // check if is update of own account details
+        if (wrapper.isUpdateOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+            // then allow this operation to proceed.
+            // maker checker doesnt mean anything here.
+            isApprovedByChecker = true; // set to true in case permissions have
+            // been maker-checker enabled by
+            // accident.
+        } else {
+            // if not user changing their own details - check user has
+            // permission to perform specific task.
+            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+        }
+        validateIsUpdateAllowed();
+
+        TypeCommand<T> command = TypeCommand.from(wrapper.getRequest(), wrapper.getEntityName(), wrapper.getEntityId(),
+                wrapper.getSubentityId(), wrapper.getGroupId(), wrapper.getClientId(), wrapper.getLoanId(), wrapper.getSavingsId(),
+                wrapper.getTransactionId(), wrapper.getHref(), wrapper.getProductId(), wrapper.getCreditBureauId(),
+                wrapper.getOrganisationCreditBureauId(), wrapper.getJobName());
+
+        // TODO: This is temporarily added to support the use of old jsonCommand during the migration process from
+        // jsonCommand to typeCommand.
+        // Some logic still uses jsonCommand. Once the migration is complete and all logic has been updated to use
+        // typeCommand, this method should be removed.
+        command.setJsonCommand(getJsonCommand(wrapper));
+        return this.processAndLogCommandService.executeCommand(wrapper, command, isApprovedByChecker);
+
+    }
+
+    @Override
+    public CommandProcessingResult approveEntry(final Long makerCheckerId) {
+        // TODO: This method hasn't been rewritten due to an implementation challenge.
+        // It requires the correct type from the database to deserialize the correct request body.
+        // Currently, this is not possible because CommandSource does not have the request type, only the JSON body.
+        // This method needs to be updated once a solution for the deserialization issue is found.
+        throw new UnsupportedOperationException("Approve entry is not implemented yet.");
+    }
+
+    @Transactional
+    @Override
+    public Long deleteEntry(final Long makerCheckerId) {
+
+        validateMakerCheckerTransaction(makerCheckerId);
+        validateIsUpdateAllowed();
+
+        this.commandSourceRepository.deleteById(makerCheckerId);
+
+        return makerCheckerId;
+    }
+
+    private CommandSource validateMakerCheckerTransaction(final Long makerCheckerId) {
+        final CommandSource commandSource = this.commandSourceRepository.findById(makerCheckerId)
+                .orElseThrow(() -> new CommandNotFoundException(makerCheckerId));
+        if (!commandSource.isMarkedAsAwaitingApproval()) {
+            throw new CommandNotAwaitingApprovalException(makerCheckerId);
+        }
+        AppUser appUser = this.context.authenticatedUser();
+        String permissionCode = commandSource.getPermissionCode();
+        appUser.validateHasCheckerPermissionTo(permissionCode);
+        if (!configurationService.isSameMakerCheckerEnabled() && !appUser.isCheckerSuperUser()) {
+            AppUser maker = commandSource.getMaker();
+            if (maker == null) {
+                throw new UnsupportedCommandException(permissionCode, "Maker user is missing.");
+            }
+            if (Objects.equals(appUser.getId(), maker.getId())) {
+                throw new UnsupportedCommandException(permissionCode, "Can not be checked by the same user.");
+            }
+        }
+        return commandSource;
+    }
+
+    private void validateIsUpdateAllowed() {
+        this.schedulerJobRunnerReadService.isUpdatesAllowed();
+    }
+
+    @Override
+    public Long rejectEntry(final Long makerCheckerId) {
+        final CommandSource commandSourceInput = validateMakerCheckerTransaction(makerCheckerId);
+        validateIsUpdateAllowed();
+        final AppUser maker = this.context.authenticatedUser();
+        commandSourceInput.markAsRejected(maker);
+        this.commandSourceRepository.save(commandSourceInput);
+        return makerCheckerId;
+    }
+
+    // TODO: Remove after MVC migration
+    private JsonCommand getJsonCommand(CommandTypeWrapper<?> wrapper) {
+        final String json = wrapper.getJsonWrapper().getJson();
+        final JsonElement parsedCommand = this.fromApiJsonHelper.parse(json);
+        return JsonCommand.from(json, parsedCommand, this.fromApiJsonHelper, wrapper.getEntityName(), wrapper.getEntityId(),
+                wrapper.getSubentityId(), wrapper.getGroupId(), wrapper.getClientId(), wrapper.getLoanId(), wrapper.getSavingsId(),
+                wrapper.getTransactionId(), wrapper.getHref(), wrapper.getProductId(), wrapper.getCreditBureauId(),
+                wrapper.getOrganisationCreditBureauId(), wrapper.getJobName());
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/mvc/service/SynchronousCommandProcessingService.java
@@ -1,0 +1,337 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.mvc.service;
+
+import static org.apache.fineract.commands.domain.CommandProcessingResultType.ERROR;
+import static org.apache.fineract.commands.domain.CommandProcessingResultType.PROCESSED;
+import static org.apache.http.HttpStatus.SC_OK;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.github.resilience4j.retry.annotation.Retry;
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.batch.exception.ErrorInfo;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.exception.UnsupportedCommandException;
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.commands.mvc.handler.NewCommandSourceHandlerType;
+import org.apache.fineract.commands.mvc.provider.CommandHandlerProvider;
+import org.apache.fineract.commands.service.IdempotencyKeyResolver;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.domain.BatchRequestContextHolder;
+import org.apache.fineract.infrastructure.core.domain.FineractRequestContextHolder;
+import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessFailedException;
+import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessSucceedException;
+import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.GoogleGsonSerializerHelper;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.hooks.event.HookEvent;
+import org.apache.fineract.infrastructure.hooks.event.HookEventSource;
+import org.apache.fineract.infrastructure.security.service.mvc.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+@ProfileMvc
+@Service("mvcSynchronousCommandProcessingService")
+@Slf4j
+@RequiredArgsConstructor
+public class SynchronousCommandProcessingService implements CommandProcessingService {
+
+    public static final String IDEMPOTENCY_KEY_STORE_FLAG = "idempotencyKeyStoreFlag";
+
+    public static final String IDEMPOTENCY_KEY_ATTRIBUTE = "IdempotencyKeyAttribute";
+    public static final String COMMAND_SOURCE_ID = "commandSourceId";
+    private final PlatformSecurityContext context;
+    private final ApplicationContext applicationContext;
+    private final ToApiJsonSerializer<Map<String, Object>> toApiJsonSerializer;
+    private final ToApiJsonSerializer<CommandProcessingResult> toApiResultJsonSerializer;
+    private final ConfigurationDomainService configurationDomainService;
+    private final CommandHandlerProvider commandHandlerProvider;
+    private final IdempotencyKeyResolver idempotencyKeyResolver;
+    private final CommandSourceService commandSourceService;
+
+    private final FineractRequestContextHolder fineractRequestContextHolder;
+    private final Gson gson = GoogleGsonSerializerHelper.createSimpleGson();
+
+    @Override
+    @Retry(name = "executeCommand", fallbackMethod = "fallbackExecuteCommand")
+    public <T> CommandProcessingResult executeCommand(final CommandTypeWrapper<T> typeWrapper, final TypeCommand<T> typeCommand,
+            final boolean isApprovedByChecker) {
+        final CommandWrapper wrapper = typeWrapper.getJsonWrapper(); // TODO: Remove after MVC migration
+        final JsonCommand command = typeCommand.getJsonCommand();
+        // Do not store the idempotency key because of the exception handling
+        setIdempotencyKeyStoreFlag(false);
+
+        Long commandId = (Long) fineractRequestContextHolder.getAttribute(COMMAND_SOURCE_ID, null);
+        boolean isRetry = commandId != null;
+        boolean isEnclosingTransaction = BatchRequestContextHolder.isEnclosingTransaction();
+
+        CommandSource commandSource = null;
+        String idempotencyKey;
+        if (isRetry) {
+            commandSource = commandSourceService.getCommandSource(commandId);
+            idempotencyKey = commandSource.getIdempotencyKey();
+        } else if ((commandId = command.commandId()) != null) { // action on the command itself
+            commandSource = commandSourceService.getCommandSource(commandId);
+            idempotencyKey = commandSource.getIdempotencyKey();
+        } else {
+            idempotencyKey = idempotencyKeyResolver.resolve(wrapper);
+        }
+        exceptionWhenTheRequestAlreadyProcessed(wrapper, idempotencyKey, isRetry);
+
+        AppUser user = context.authenticatedUser(typeWrapper);
+        if (commandSource == null) {
+            if (isEnclosingTransaction) {
+                commandSource = commandSourceService.getInitialCommandSource(wrapper, command, user, idempotencyKey);
+            } else {
+                commandSource = commandSourceService.saveInitialNewTransaction(wrapper, command, user, idempotencyKey);
+                commandId = commandSource.getId();
+            }
+        }
+        if (commandId != null) {
+            storeCommandIdInContext(commandSource); // Store command id as a request attribute
+        }
+
+        boolean isMakerChecker = configurationDomainService.isMakerCheckerEnabledForTask(wrapper.taskPermissionName());
+        if (isApprovedByChecker || (isMakerChecker && user.isCheckerSuperUser())) {
+            commandSource.markAsChecked(user);
+        }
+        setIdempotencyKeyStoreFlag(true);
+
+        final CommandProcessingResult result;
+        try {
+            result = commandSourceService.processCommand(findCommandHandler(typeWrapper), typeCommand, commandSource, user,
+                    isApprovedByChecker, isMakerChecker);
+        } catch (Throwable t) { // NOSONAR
+            RuntimeException mappable = ErrorHandler.getMappable(t);
+            ErrorInfo errorInfo = commandSourceService.generateErrorInfo(mappable);
+            Integer statusCode = errorInfo.getStatusCode();
+            commandSource.setResultStatusCode(statusCode);
+            commandSource.setResult(errorInfo.getMessage());
+            if (statusCode != SC_OK) {
+                commandSource.setStatus(ERROR);
+            }
+            if (!isEnclosingTransaction) { // TODO: temporary solution
+                commandSource = commandSourceService.saveResultNewTransaction(commandSource);
+            }
+            // must not throw any exception; must persist in new transaction as the current transaction was already
+            // marked as rollback
+            publishHookErrorEvent(wrapper, command, errorInfo);
+            throw mappable;
+        }
+
+        commandSource.setResultStatusCode(SC_OK);
+        commandSource.updateForAudit(result);
+        commandSource.setResult(toApiJsonSerializer.serializeResult(result));
+        commandSource.setStatus(PROCESSED);
+        commandSource = commandSourceService.saveResultSameTransaction(commandSource);
+        storeCommandIdInContext(commandSource); // Store command id as a request attribute
+
+        result.setRollbackTransaction(null);
+        publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, result); // TODO must be performed in a
+                                                                                       // new transaction
+        return result;
+    }
+
+    private void storeCommandIdInContext(CommandSource savedCommandSource) {
+        if (savedCommandSource.getId() == null) {
+            throw new IllegalStateException("Command source not saved");
+        }
+        // Idempotency filters and retry need this
+        fineractRequestContextHolder.setAttribute(COMMAND_SOURCE_ID, savedCommandSource.getId());
+    }
+
+    private void publishHookErrorEvent(CommandWrapper wrapper, JsonCommand command, ErrorInfo errorInfo) {
+        publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, gson.toJson(errorInfo));
+    }
+
+    private void exceptionWhenTheRequestAlreadyProcessed(CommandWrapper wrapper, String idempotencyKey, boolean retry) {
+        CommandSource command = commandSourceService.findCommandSource(wrapper, idempotencyKey);
+        if (command == null) {
+            return;
+        }
+        CommandProcessingResultType status = CommandProcessingResultType.fromInt(command.getStatus());
+        switch (status) {
+            case UNDER_PROCESSING -> throw new IdempotentCommandProcessUnderProcessingException(wrapper, idempotencyKey);
+            case PROCESSED -> throw new IdempotentCommandProcessSucceedException(wrapper, idempotencyKey, command);
+            case ERROR -> {
+                if (!retry) {
+                    throw new IdempotentCommandProcessFailedException(wrapper, idempotencyKey, command);
+                }
+            }
+            default -> {
+            }
+        }
+    }
+
+    private void setIdempotencyKeyStoreFlag(boolean flag) {
+        fineractRequestContextHolder.setAttribute(IDEMPOTENCY_KEY_STORE_FLAG, flag);
+    }
+
+    @SuppressWarnings("unused")
+    public CommandProcessingResult fallbackExecuteCommand(Exception e) {
+        throw ErrorHandler.getMappable(e);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> NewCommandSourceHandlerType<T> findCommandHandler(final CommandTypeWrapper<T> wrapper) {
+        NewCommandSourceHandlerType<T> handler;
+
+        if (wrapper.isDatatableResource()) {
+            if (wrapper.isCreateDatatable()) {
+                handler = applicationContext.getBean("createDatatableCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isDeleteDatatable()) {
+                handler = applicationContext.getBean("deleteDatatableCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isUpdateDatatable()) {
+                handler = applicationContext.getBean("updateDatatableCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isCreate()) {
+                handler = applicationContext.getBean("createDatatableEntryCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isUpdateMultiple()) {
+                handler = applicationContext.getBean("updateOneToManyDatatableEntryCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isUpdateOneToOne()) {
+                handler = applicationContext.getBean("updateOneToOneDatatableEntryCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isDeleteMultiple()) {
+                handler = applicationContext.getBean("deleteOneToManyDatatableEntryCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isDeleteOneToOne()) {
+                handler = applicationContext.getBean("deleteOneToOneDatatableEntryCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isRegisterDatatable()) {
+                handler = applicationContext.getBean("registerDatatableCommandHandler", NewCommandSourceHandlerType.class);
+            } else {
+                throw new UnsupportedCommandException(wrapper.commandName());
+            }
+        } else if (wrapper.isNoteResource()) {
+            if (wrapper.isCreate()) {
+                handler = applicationContext.getBean("createNoteCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isUpdate()) {
+                handler = applicationContext.getBean("updateNoteCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isDelete()) {
+                handler = applicationContext.getBean("deleteNoteCommandHandler", NewCommandSourceHandlerType.class);
+            } else {
+                throw new UnsupportedCommandException(wrapper.commandName());
+            }
+        } else if (wrapper.isSurveyResource()) {
+            if (wrapper.isRegisterSurvey()) {
+                handler = applicationContext.getBean("registerSurveyCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.isFullFilSurvey()) {
+                handler = applicationContext.getBean("fullFilSurveyCommandHandler", NewCommandSourceHandlerType.class);
+            } else {
+                throw new UnsupportedCommandException(wrapper.commandName());
+            }
+        } else if (wrapper.isLoanDisburseDetailResource()) {
+            if (wrapper.isUpdateDisbursementDate()) {
+                handler = applicationContext.getBean("updateLoanDisburseDateCommandHandler", NewCommandSourceHandlerType.class);
+            } else if (wrapper.addAndDeleteDisbursementDetails()) {
+                handler = applicationContext.getBean("addAndDeleteLoanDisburseDetailsCommandHandler", NewCommandSourceHandlerType.class);
+            } else {
+                throw new UnsupportedCommandException(wrapper.commandName());
+            }
+        } else {
+            handler = commandHandlerProvider.getHandler(wrapper.entityName(), wrapper.actionName());
+        }
+
+        return handler;
+    }
+
+    @Override
+    public boolean validateRollbackCommand(final CommandTypeWrapper<?> commandWrapper, final AppUser user) {
+        user.validateHasPermissionTo(commandWrapper.getTaskPermissionName());
+        boolean isMakerChecker = configurationDomainService.isMakerCheckerEnabledForTask(commandWrapper.taskPermissionName());
+        return isMakerChecker && !user.isCheckerSuperUser();
+    }
+
+    protected void publishHookEvent(final String entityName, final String actionName, JsonCommand command, final Object result) {
+
+        final AppUser appUser = context.authenticatedUser(CommandTypeWrapper.wrap(actionName, entityName, null, null));
+
+        final HookEventSource hookEventSource = new HookEventSource(entityName, actionName);
+
+        // TODO: Add support for publishing array events
+        if (command.json() != null) {
+            Type type = new TypeToken<Map<String, Object>>() {
+
+            }.getType();
+
+            Map<String, Object> myMap;
+
+            try {
+                myMap = gson.fromJson(command.json(), type);
+            } catch (Exception e) {
+                throw new PlatformApiDataValidationException("error.msg.invalid.json", "The provided JSON is invalid.", new ArrayList<>(),
+                        e);
+            }
+
+            Map<String, Object> reqmap = new HashMap<>();
+            reqmap.put("entityName", entityName);
+            reqmap.put("actionName", actionName);
+            reqmap.put("createdBy", context.authenticatedUser().getId());
+            reqmap.put("createdByName", context.authenticatedUser().getUsername());
+            reqmap.put("createdByFullName", context.authenticatedUser().getDisplayName());
+
+            reqmap.put("request", myMap);
+            if (result instanceof CommandProcessingResult) {
+                CommandProcessingResult resultCopy = CommandProcessingResult.fromCommandProcessingResult((CommandProcessingResult) result);
+
+                reqmap.put("officeId", resultCopy.getOfficeId());
+                reqmap.put("clientId", resultCopy.getClientId());
+                resultCopy.setOfficeId(null);
+                reqmap.put("response", resultCopy);
+            } else if (result instanceof ErrorInfo ex) {
+                reqmap.put("status", "Exception");
+
+                Map<String, Object> errorMap = new HashMap<>();
+
+                try {
+                    errorMap = gson.fromJson(ex.getMessage(), type);
+                } catch (Exception e) {
+                    errorMap.put("errorMessage", ex.getMessage());
+                }
+
+                errorMap.put("errorCode", ex.getErrorCode());
+                errorMap.put("statusCode", ex.getStatusCode());
+
+                reqmap.put("response", errorMap);
+            }
+
+            reqmap.put("timestamp", Instant.now().toString());
+
+            final String serializedResult = toApiResultJsonSerializer.serialize(reqmap);
+
+            final HookEvent applicationEvent = new HookEvent(hookEventSource, serializedResult, appUser,
+                    ThreadLocalContextUtil.getContext());
+
+            applicationContext.publishEvent(applicationEvent);
+        }
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/ApiRequestParameterHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/ApiRequestParameterHelper.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.ApiParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * <p>
+ * Used to process the query parameters provided in a API request to see features of the RESTful API are being asked for
+ * such as:
+ * </p>
+ * <ul>
+ * <li>Pretty printing through pretty=true, defaults to false</li>
+ * <li>Partial response through fields=id, name etc, when empty, the full data is returned by default.</li>
+ * </ul>
+ */
+@ProfileMvc
+@Component("mvcApiRequestParameterHelper")
+@RequiredArgsConstructor
+public class ApiRequestParameterHelper {
+
+    public static final String RESPONSE_PARAMETERS_ATTRIBUTE = "responseParameters";
+
+    private final ServletRequest servletRequest;
+
+    public ApiRequestJsonSerializationSettings process(final Set<String> mandatoryResponseParameters) {
+        final MultivaluedMap<String, String> queryParameters = getQueryParameters();
+
+        final Set<String> responseParameters = ApiParameterHelper.extractFieldsForResponseIfProvided(queryParameters);
+        if (!responseParameters.isEmpty()) {
+            responseParameters.addAll(mandatoryResponseParameters);
+        }
+        setResponseParameters(responseParameters);
+
+        final boolean prettyPrint = ApiParameterHelper.prettyPrint(queryParameters);
+        final boolean template = ApiParameterHelper.template(queryParameters);
+        final boolean makerCheckerable = ApiParameterHelper.makerCheckerable(queryParameters);
+        final boolean includeJson = ApiParameterHelper.includeJson(queryParameters);
+
+        return ApiRequestJsonSerializationSettings.from(prettyPrint, responseParameters, template, makerCheckerable, includeJson);
+
+    }
+
+    public ApiRequestJsonSerializationSettings process() {
+        final MultivaluedMap<String, String> queryParameters = getQueryParameters();
+
+        final Set<String> responseParameters = ApiParameterHelper.extractFieldsForResponseIfProvided(queryParameters);
+        setResponseParameters(responseParameters);
+        final boolean prettyPrint = ApiParameterHelper.prettyPrint(queryParameters);
+        final boolean template = ApiParameterHelper.template(queryParameters);
+        final boolean makerCheckerable = ApiParameterHelper.makerCheckerable(queryParameters);
+        final boolean includeJson = ApiParameterHelper.includeJson(queryParameters);
+
+        return ApiRequestJsonSerializationSettings.from(prettyPrint, responseParameters, template, makerCheckerable, includeJson);
+    }
+
+    private MultivaluedMap<String, String> getQueryParameters() {
+        final MultivaluedMap<String, String> uriInfoParameters = new MultivaluedHashMap<>();
+        servletRequest.getParameterMap().forEach(uriInfoParameters::addAll);
+        return uriInfoParameters;
+    }
+
+    private void setResponseParameters(final Set<String> responseParameters) {
+        Objects.requireNonNull(RequestContextHolder.getRequestAttributes()).setAttribute(RESPONSE_PARAMETERS_ATTRIBUTE, responseParameters,
+                RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonExternalIdExcludeFilter.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonExternalIdExcludeFilter.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
+
+/**
+ * Filters empty ExternalId instances during JSON serialization with Jackson.
+ */
+public class JacksonExternalIdExcludeFilter {
+
+    @Override
+    @SuppressFBWarnings(value = { "EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS",
+            "EQ_UNUSUAL" }, justification = "The equals method is only designed to exclude empty ExternalId by Jackson.")
+
+    public boolean equals(final Object obj) {
+        return obj == null || (obj instanceof ExternalId externalId && externalId.isEmpty());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonPartialResponseFilter.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonPartialResponseFilter.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * This class is responsible for handling partial response. If the filter is present, take the required parameters from
+ * the request and apply the filter.
+ */
+@ProfileMvc
+@ControllerAdvice
+public class JacksonPartialResponseFilter implements ResponseBodyAdvice<Object> {
+
+    public static final String PARTIAL_RESPONSE = "partialResponse";
+
+    @Override
+    public boolean supports(@NotNull MethodParameter returnType, @NotNull Class<? extends HttpMessageConverter<?>> converterType) {
+        if (Collection.class.isAssignableFrom(returnType.getParameterType())) {
+            return isFilterPresentInCollection(returnType);
+        } else {
+            return Arrays.stream(returnType.getParameterType().getAnnotations())
+                    .anyMatch(ann -> ann instanceof JsonFilter jFilter && jFilter.value().equals(PARTIAL_RESPONSE));
+        }
+    }
+
+    @Override
+    public Object beforeBodyWrite(final Object body, @NotNull final MethodParameter returnType,
+            @NotNull final MediaType selectedContentType, @NotNull final Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            @NotNull final ServerHttpRequest request, @NotNull final ServerHttpResponse response) {
+        if (body == null) {
+            throw new IllegalArgumentException("Partial response body cannot be null");
+        }
+        return new JacksonPartialResponseMappingValue<>(body, getResponseParameters());
+    }
+
+    private boolean isFilterPresentInCollection(@NotNull MethodParameter returnType) {
+        final boolean filterPresent;
+        final Type genericParameterType = returnType.getGenericParameterType();
+        final ParameterizedType parameterType = (ParameterizedType) genericParameterType;
+        final Type[] actualTypeArguments = parameterType.getActualTypeArguments();
+        if (actualTypeArguments.length != 0 && actualTypeArguments[0] instanceof Class<?> responseClass) {
+            filterPresent = Arrays.stream(responseClass.getAnnotations())
+                    .anyMatch(ann -> ann instanceof JsonFilter jFilter && jFilter.value().equals(PARTIAL_RESPONSE));
+        } else {
+            filterPresent = false;
+        }
+        return filterPresent;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getResponseParameters() {
+        final Object responseParameters = Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
+                .getAttribute(ApiRequestParameterHelper.RESPONSE_PARAMETERS_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+
+        if (responseParameters instanceof Set<?> parametersSet) {
+            return (Set<String>) parametersSet;
+        } else {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonPartialResponseMappingValue.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/JacksonPartialResponseMappingValue.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import java.util.Set;
+import org.springframework.http.converter.json.MappingJacksonValue;
+
+public class JacksonPartialResponseMappingValue<T> extends MappingJacksonValue {
+
+    public JacksonPartialResponseMappingValue(final T value, final Set<String> filters) {
+        super(value);
+        setFilters(new SimpleFilterProvider().addFilter(JacksonPartialResponseFilter.PARTIAL_RESPONSE,
+                filters.isEmpty() ? SimpleBeanPropertyFilter.serializeAll() : SimpleBeanPropertyFilter.filterOutAllExcept(filters)));
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/MvcDuplicateBeanFilter.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/MvcDuplicateBeanFilter.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import jakarta.ws.rs.Path;
+import java.util.HashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Excludes JAX-RS beans that are already migrated to MVC based on their annotations.
+ */
+@ProfileMvc
+@Slf4j
+@Component
+public class MvcDuplicateBeanFilter implements BeanFactoryPostProcessor {
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        final HashMap<String, String> mvcPath = new HashMap<>();
+        final HashMap<String, String> jerseyPath = new HashMap<>();
+        final HashMap<CommandType, String> mvcCommand = new HashMap<>();
+        final HashMap<CommandType, String> jerseyCommand = new HashMap<>();
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            AbstractBeanDefinition beanDefinition = ((AbstractBeanDefinition) beanFactory.getBeanDefinition(beanName));
+            final Class<?> beanClass;
+            try {
+                beanClass = beanDefinition.getBeanClassName() != null ? Class.forName(beanDefinition.getBeanClassName()) : null;
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+            if (beanClass == null) {
+                continue;
+            }
+
+            if (beanClass.isAnnotationPresent(RequestMapping.class)) {
+                mvcPath.put(beanClass.getAnnotation(RequestMapping.class).value()[0], beanName);
+            } else if (beanClass.isAnnotationPresent(Path.class)) {
+                jerseyPath.put(beanClass.getAnnotation(Path.class).value(), beanName);
+            }
+            if (beanClass.isAnnotationPresent(CommandType.class)) {
+                if (beanClass.isAnnotationPresent(ProfileMvc.class)) {
+                    mvcCommand.put(beanClass.getAnnotation(CommandType.class), beanName);
+                } else {
+                    jerseyCommand.put(beanClass.getAnnotation(CommandType.class), beanName);
+                }
+            }
+        }
+
+        mvcPath.forEach((path, beanName) -> {
+            final String jerseyBeanName = jerseyPath.get(path);
+            if (jerseyBeanName != null) {
+                log.info("Removing bean: {} with path: {} and request mapping: {}", jerseyBeanName, path, path);
+                ((DefaultListableBeanFactory) beanFactory).removeBeanDefinition(jerseyBeanName);
+            }
+        });
+        mvcCommand.forEach((command, beanName) -> {
+            final String jerseyBeanName = jerseyCommand.get(command);
+            if (jerseyBeanName != null) {
+                log.info("Removing bean: {} with command: {}", jerseyBeanName, command);
+                ((DefaultListableBeanFactory) beanFactory).removeBeanDefinition(jerseyBeanName);
+            }
+        });
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/ProfileMvc.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/ProfileMvc.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.context.annotation.Profile;
+
+@Profile("mvc")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProfileMvc {}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/SpringErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/SpringErrorHandler.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.mvc.validation.ValidationErrorConverter;
+import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
+import org.apache.fineract.infrastructure.core.exceptionmapper.UnsupportedParameterExceptionMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@ProfileMvc
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class SpringErrorHandler {
+
+    private final ErrorHandler errorHandler;
+    private final UnsupportedParameterExceptionMapper unsupportedParameterExceptionMapper;
+    private final ValidationErrorConverter validationErrorConverter;
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Object> toResponse(final RuntimeException exception) {
+        final Response response = getResponse(exception);
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.status(response.getStatus()).body(response.getEntity());
+    }
+
+    @ExceptionHandler(BindException.class)
+    public Object handleValidationException(final BindException exception) {
+        final Response response = validationErrorConverter.getResponse(exception.getBindingResult().getFieldErrors());
+        return ResponseEntity.status(response.getStatus()).body(response.getEntity());
+    }
+
+    private Response getResponse(RuntimeException exception) {
+        if (exception.getCause() instanceof UnrecognizedPropertyException ure) {
+            return unsupportedParameterExceptionMapper.toResponse(new UnsupportedParameterException(List.of(ure.getPropertyName())));
+        }
+        return errorHandler.findMostSpecificExceptionHandler(exception).toResponse(exception);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/TypeCommand.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/TypeCommand.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc;
+
+import java.util.Objects;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+
+/**
+ * Immutable representation of a command.
+ *
+ * Wraps the provided JSON with convenience functions for extracting parameter values and checking for changes against
+ * an existing value.
+ */
+public final class TypeCommand<T> {
+
+    private final T request;
+    private JsonCommand jsonCommandObject; // TODO: Remove after MVC migration
+    private final Long commandId;
+    private final Long resourceId;
+    private final Long subresourceId;
+    private final Long groupId;
+    private final Long clientId;
+    private final Long loanId;
+    private final Long savingsId;
+    private final String entityName;
+    private final String transactionId;
+    private final String url;
+    private final Long productId;
+    private final Long creditBureauId;
+    private final Long organisationCreditBureauId;
+    private final String jobName;
+
+    public static <T> TypeCommand<T> from(final T body, final String entityName, final Long resourceId, final Long subresourceId,
+            final Long groupId, final Long clientId, final Long loanId, final Long savingsId, final String transactionId, final String url,
+            final Long productId, final Long creditBureauId, final Long organisationCreditBureauId, final String jobName) {
+        return new TypeCommand<>(null, body, entityName, resourceId, subresourceId, groupId, clientId, loanId, savingsId, transactionId,
+                url, productId, creditBureauId, organisationCreditBureauId, jobName);
+
+    }
+
+    public TypeCommand(final Long commandId, final T request, final String entityName, final Long resourceId, final Long subresourceId,
+            final Long groupId, final Long clientId, final Long loanId, final Long savingsId, final String transactionId, final String url,
+            final Long productId, final Long creditBureauId, final Long organisationCreditBureauId, final String jobName) {
+
+        this.commandId = commandId;
+        this.request = request;
+        this.entityName = entityName;
+        this.resourceId = resourceId;
+        this.subresourceId = subresourceId;
+        this.groupId = groupId;
+        this.clientId = clientId;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.transactionId = transactionId;
+        this.url = url;
+        this.productId = productId;
+        this.creditBureauId = creditBureauId;
+        this.organisationCreditBureauId = organisationCreditBureauId;
+        this.jobName = jobName;
+    }
+
+    public Long getOrganisationCreditBureauId() {
+        return this.organisationCreditBureauId;
+    }
+
+    public Long getCreditBureauId() {
+        return this.creditBureauId;
+    }
+
+    public T getRequest() {
+        return this.request;
+    }
+
+    public Long commandId() {
+        return this.commandId;
+    }
+
+    public String entityName() {
+        return this.entityName;
+    }
+
+    public Long entityId() {
+        return this.resourceId;
+    }
+
+    public Long subentityId() {
+        return this.subresourceId;
+    }
+
+    public Long getGroupId() {
+        return this.groupId;
+    }
+
+    public Long getClientId() {
+        return this.clientId;
+    }
+
+    public Long getLoanId() {
+        return this.loanId;
+    }
+
+    public Long getSavingsId() {
+        return this.savingsId;
+    }
+
+    public String getTransactionId() {
+        return this.transactionId;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public Long getProductId() {
+        return this.productId;
+    }
+
+    public String getJobName() {
+        return this.jobName;
+    }
+
+    public boolean differenceExists(final String baseValue, final String workingCopyValue) {
+        return !Objects.equals(baseValue, workingCopyValue);
+    }
+
+    // TODO: Remove after MVC migration
+    public void setJsonCommand(JsonCommand jsonCommandObject) {
+        this.jsonCommandObject = jsonCommandObject;
+    }
+
+    public JsonCommand getJsonCommand() {
+        return Objects.requireNonNull(jsonCommandObject);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/MaxSize.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/MaxSize.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.OverridesAttribute;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Size(message = "exceeds max length of {max}")
+@Target({ ElementType.FIELD, ElementType.TYPE_USE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@ReportAsSingleViolation
+public @interface MaxSize {
+
+    @OverridesAttribute(constraint = Size.class, name = "max")
+    int max() default Integer.MAX_VALUE;
+
+    String message() default "exceeds max length of {max}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/ResourceName.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/ResourceName.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for resource name in validation error codes.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResourceName {
+
+    String value();
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/ValidationErrorConverter.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/mvc/validation/ValidationErrorConverter.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.api.mvc.validation;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.ws.rs.core.Response;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exceptionmapper.PlatformApiDataValidationExceptionMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+
+@ProfileMvc
+@Component
+@RequiredArgsConstructor
+public final class ValidationErrorConverter {
+
+    private static final Map<Class<? extends Annotation>, String> annotationCodes = Map.of(NotBlank.class, "cannot.be.blank", MaxSize.class,
+            "exceeds.max.length");
+
+    private final PlatformApiDataValidationExceptionMapper validationExceptionMapper;
+
+    public Response getResponse(final List<FieldError> fieldErrors) {
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        for (final FieldError fieldError : fieldErrors) {
+            dataValidationErrors.add(generateParameterError(fieldError));
+        }
+        return validationExceptionMapper.toResponse(new PlatformApiDataValidationException(dataValidationErrors));
+    }
+
+    private ApiParameterError generateParameterError(FieldError fieldError) {
+        final ConstraintViolation<?> constraint = fieldError.unwrap(ConstraintViolation.class);
+
+        final Class<? extends Annotation> annotationType = constraint.getConstraintDescriptor().getAnnotation().annotationType();
+        final String validationErrorCode = getValidationErrorCode(constraint.getRootBeanClass(), fieldError.getField(), annotationType);
+        final String realParameterName = fieldError.getField();
+        final String defaultEnglishMessage = "The parameter `%s` %s.".formatted(realParameterName, fieldError.getDefaultMessage());
+        final Object[] arguments = getArguments(fieldError, constraint, annotationType);
+
+        return ApiParameterError.parameterError(validationErrorCode, defaultEnglishMessage, realParameterName, arguments);
+    }
+
+    private String getValidationErrorCode(Class<?> requestClass, String fieldName, Class<? extends Annotation> annotation) {
+        final String resourceName = requestClass.getAnnotation(ResourceName.class).value();
+        return "validation.msg.%s.%s.%s".formatted(resourceName, fieldName, annotationCodes.get(annotation));
+    }
+
+    private Object[] getArguments(FieldError fieldError, ConstraintViolation<?> constraint, Class<? extends Annotation> annotationType) {
+        final Map<String, Object> attributes = constraint.getConstraintDescriptor().getAttributes();
+        final ArrayList<Object> arguments = new ArrayList<>();
+        arguments.add(fieldError.getRejectedValue());
+        if (MaxSize.class == annotationType) {
+            arguments.add(attributes.get("max"));
+        }
+        return arguments.toArray();
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.infrastructure.core.data;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import java.io.Serializable;
 import java.util.Map;
 import lombok.Getter;
@@ -145,6 +146,13 @@ public class CommandProcessingResult implements Serializable {
             checkIfEmpty = this.changes;
         }
         return checkIfEmpty;
+    }
+
+    // TODO: Jackson uses getters to serialize fields. getChanges() never returns empty Map.
+    // Remove when getChanges() starts returning empty Map
+    @JsonGetter("changes")
+    public Map<String, Object> getChangesJacksonSerialization() {
+        return this.changes;
     }
 
     public boolean hasChanges() {

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/service/mvc/PlatformSecurityContext.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/service/mvc/PlatformSecurityContext.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.service.mvc;
+
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.infrastructure.security.service.PlatformUserRightsContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+
+public interface PlatformSecurityContext extends PlatformUserRightsContext {
+
+    AppUser authenticatedUser();
+
+    /**
+     * Convenience method returns null (does not throw an exception) if an authenticated user is not present
+     *
+     * To be used only in service layer methods that can be triggered via both the API and batch Jobs (which do not have
+     * an authenticated user)
+     *
+     * @return
+     */
+    AppUser getAuthenticatedUserIfPresent();
+
+    void validateAccessRights(String resourceOfficeHierarchy);
+
+    String officeHierarchy();
+
+    boolean doesPasswordHasToBeRenewed(AppUser currentUser);
+
+    AppUser authenticatedUser(CommandTypeWrapper<?> commandWrapper);
+}

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/domain/Fund.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/domain/Fund.java
@@ -24,11 +24,15 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 
 @Entity
+@Getter
+@Setter
 @Table(name = "m_fund", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }, name = "fund_name_org"),
         @UniqueConstraint(columnNames = { "external_id" }, name = "fund_externalid_org") })
 public class Fund extends AbstractPersistableCustom {
@@ -50,7 +54,7 @@ public class Fund extends AbstractPersistableCustom {
         return new Fund(name, externalId);
     }
 
-    protected Fund() {
+    public Fund() {
         //
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/mvc/MvcJacksonConverterConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/mvc/MvcJacksonConverterConfig.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.mvc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.api.mvc.JacksonExternalIdExcludeFilter;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.infrastructure.core.jersey.converter.JsonConverter;
+import org.apache.fineract.infrastructure.core.jersey.serializer.JacksonDeserializerAdapter;
+import org.apache.fineract.infrastructure.core.jersey.serializer.JacksonSerializerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+@ProfileMvc
+@Configuration
+public class MvcJacksonConverterConfig {
+
+    @Primary
+    @Bean
+    public MappingJackson2HttpMessageConverter jacksonHttpConverter(final ObjectMapper objectMapper) {
+        return new MappingJackson2HttpMessageConverter(objectMapper);
+    }
+
+    @Primary
+    @Bean
+    public ObjectMapper objectMapper(List<JsonSerializer<?>> serializers, List<JsonDeserializer<?>> deserializers,
+            List<JsonConverter<?>> jsonConverters) {
+        List<JsonSerializer<?>> mergedSerializers = new ArrayList<>(serializers);
+        mergedSerializers.addAll(jsonConverters.stream().map(JacksonSerializerAdapter::new).toList());
+
+        List<JsonDeserializer<?>> mergedDeserializers = new ArrayList<>(deserializers);
+        mergedDeserializers.addAll(jsonConverters.stream().map(JacksonDeserializerAdapter::new).toList());
+
+        final ObjectMapper objectMapper = new Jackson2ObjectMapperBuilder().indentOutput(true)
+                .serializers(mergedSerializers.toArray(new JsonSerializer[0]))
+                .deserializers(mergedDeserializers.toArray(new JsonDeserializer[0])).serializationInclusion(JsonInclude.Include.NON_NULL)
+                .failOnUnknownProperties(true).featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .modulesToInstall(new ParameterNamesModule()).build();
+
+        objectMapper.configOverride(ExternalId.class)
+                .setInclude(JsonInclude.Value.empty().withValueFilter(JacksonExternalIdExcludeFilter.class));
+
+        return objectMapper;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/mvc/MvcRoutingFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/mvc/MvcRoutingFilter.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.mvc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Forwards JAX-RS requests to Spring MVC if a handler exists.
+ */
+@ProfileMvc
+@Component
+@RequiredArgsConstructor
+public class MvcRoutingFilter extends OncePerRequestFilter {
+
+    private static final String SPRING_MVC_SERVLET = DispatcherServletAutoConfiguration.DEFAULT_DISPATCHER_SERVLET_BEAN_NAME;
+    private final ServletContext servletContext;
+    @Qualifier("requestMappingHandlerMapping")
+    private final RequestMappingHandlerMapping handlerMapping;
+
+    @Override
+    protected boolean shouldNotFilter(@NotNull HttpServletRequest request) {
+        try {
+            return handlerMapping.getHandler(request) == null;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to get handler for request", e);
+        }
+    }
+
+    @Override
+    protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response,
+            @NotNull FilterChain filterChain) throws ServletException, IOException {
+        servletContext.getNamedDispatcher(SPRING_MVC_SERVLET).forward(request, response);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/mvc/SpringSecurityPlatformSecurityContext.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/mvc/SpringSecurityPlatformSecurityContext.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.service.mvc;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.commands.service.CommandWrapperBuilder;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.exception.ResetPasswordException;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Wrapper around spring security's {@link SecurityContext} for extracted the current authenticated {@link AppUser}.
+ */
+
+@Primary
+@ProfileMvc
+@Service("mvcSpringSecurityPlatformSecurityContext")
+public class SpringSecurityPlatformSecurityContext implements PlatformSecurityContext {
+
+    // private static final Logger LOG =
+    // LoggerFactory.getLogger(SpringSecurityPlatformSecurityContext.class);
+
+    private final ConfigurationDomainService configurationDomainService;
+
+    protected static final List<CommandWrapper> EXEMPT_FROM_PASSWORD_RESET_CHECK = new ArrayList<CommandWrapper>(
+            List.of(new CommandWrapperBuilder().updateUser(null).build()));
+
+    @Autowired
+    SpringSecurityPlatformSecurityContext(final ConfigurationDomainService configurationDomainService) {
+        this.configurationDomainService = configurationDomainService;
+    }
+
+    @Override
+    public AppUser authenticatedUser() {
+
+        AppUser currentUser = null;
+        final SecurityContext context = SecurityContextHolder.getContext();
+        if (context != null) {
+            final Authentication auth = context.getAuthentication();
+            if (auth != null) {
+                currentUser = (AppUser) auth.getPrincipal();
+            }
+        }
+
+        if (currentUser == null) {
+            throw new UnAuthenticatedUserException();
+        }
+
+        if (this.doesPasswordHasToBeRenewed(currentUser)) {
+            throw new ResetPasswordException(currentUser.getId());
+        }
+
+        return currentUser;
+    }
+
+    @Override
+    public void isAuthenticated() {
+        authenticatedUser();
+    }
+
+    @Override
+    public AppUser getAuthenticatedUserIfPresent() {
+
+        AppUser currentUser = null;
+        final SecurityContext context = SecurityContextHolder.getContext();
+        if (context != null) {
+            final Authentication auth = context.getAuthentication();
+            if (auth != null) {
+                currentUser = (AppUser) auth.getPrincipal();
+            }
+        }
+
+        if (currentUser == null) {
+            return null;
+        }
+
+        if (this.doesPasswordHasToBeRenewed(currentUser)) {
+            throw new ResetPasswordException(currentUser.getId());
+        }
+
+        return currentUser;
+    }
+
+    @Override
+    public AppUser authenticatedUser(CommandTypeWrapper<?> commandWrapper) {
+
+        AppUser currentUser = null;
+        final SecurityContext context = SecurityContextHolder.getContext();
+        if (context != null) {
+            final Authentication auth = context.getAuthentication();
+            if (auth != null) {
+                currentUser = (AppUser) auth.getPrincipal();
+            }
+        }
+
+        if (currentUser == null) {
+            throw new UnAuthenticatedUserException();
+        }
+
+        if (this.shouldCheckForPasswordForceReset(commandWrapper) && this.doesPasswordHasToBeRenewed(currentUser)) {
+            throw new ResetPasswordException(currentUser.getId());
+        }
+
+        return currentUser;
+
+    }
+
+    @Override
+    public void validateAccessRights(final String resourceOfficeHierarchy) {
+
+        final AppUser user = authenticatedUser();
+        final String userOfficeHierarchy = user.getOffice().getHierarchy();
+
+        if (!resourceOfficeHierarchy.startsWith(userOfficeHierarchy)) {
+            throw new NoAuthorizationException("The user doesn't have enough permissions to access the resource.");
+        }
+
+    }
+
+    @Override
+    public String officeHierarchy() {
+        return authenticatedUser().getOffice().getHierarchy();
+    }
+
+    @Override
+    public boolean doesPasswordHasToBeRenewed(AppUser currentUser) {
+
+        if (this.configurationDomainService.isPasswordForcedResetEnable() && !currentUser.getPasswordNeverExpires()) {
+
+            Long passwordDurationDays = this.configurationDomainService.retrievePasswordLiveTime();
+            final LocalDate passWordLastUpdateDate = currentUser.getLastTimePasswordUpdated();
+
+            final LocalDate passwordExpirationDate = passWordLastUpdateDate.plusDays(passwordDurationDays);
+
+            if (DateUtils.isBeforeTenantDate(passwordExpirationDate)) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+    private boolean shouldCheckForPasswordForceReset(CommandTypeWrapper<?> commandWrapper) {
+        for (CommandWrapper commandItem : EXEMPT_FROM_PASSWORD_RESET_CHECK) {
+            if (commandItem.actionName().equals(commandWrapper.actionName())
+                    && commandItem.getEntityName().equals(commandWrapper.getEntityName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/api/FundsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/api/FundsApiResource.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.mvc.domain.CommandTypeWrapper;
+import org.apache.fineract.commands.mvc.service.CommandTypeWrapperBuilder;
+import org.apache.fineract.commands.mvc.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.commands.service.CommandWrapperBuilder;
+import org.apache.fineract.infrastructure.core.api.mvc.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.fund.data.FundData;
+import org.apache.fineract.portfolio.fund.mvc.data.FundResponse;
+import org.apache.fineract.portfolio.fund.mvc.data.PostFundsRequest;
+import org.apache.fineract.portfolio.fund.mvc.data.PutFundsRequest;
+import org.apache.fineract.portfolio.fund.service.FundReadPlatformService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ProfileMvc
+@RestController("mvcFundsApiResource")
+@RequestMapping("/v1/funds")
+@Tag(name = "Funds")
+@RequiredArgsConstructor
+public class FundsApiResource {
+
+    private static final String RESOURCE_NAME_FOR_PERMISSIONS = "FUND";
+
+    private final PlatformSecurityContext context;
+    private final FundReadPlatformService readPlatformService;
+    private final ApiRequestParameterHelper apiRequestParameterHelper;
+    private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    private final ObjectMapper mapper;
+
+    @GetMapping
+    @Operation(summary = "Retrieve Funds", description = "Returns the list of funds.\n" + "\n" + "Example Requests:\n" + "\n" + "funds")
+    public List<FundResponse> retrieveFunds() {
+        context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+        final Collection<FundData> funds = readPlatformService.retrieveAllFunds();
+        apiRequestParameterHelper.process();
+        return funds.stream().map(fundData -> new FundResponse(fundData.getId(), fundData.getName(), fundData.getExternalId())).toList();
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a Fund", description = "Creates a Fund")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = FundsApiResourceSwagger.PostFundsResponse.class))) })
+    public CommandProcessingResult createFund(@Valid @RequestBody final PostFundsRequest apiRequestBody) {
+        final String withJson = getJsonRequest(apiRequestBody);
+
+        final CommandWrapper commandJsonRequest = new CommandWrapperBuilder().createFund().withJson(withJson).build();
+
+        final CommandTypeWrapper<PostFundsRequest> commandRequest = new CommandTypeWrapperBuilder<PostFundsRequest>() //
+                .createFund() //
+                .withRequest(apiRequestBody) //
+                .withJsonCommand(commandJsonRequest) //
+                .build(); //
+
+        return commandsSourceWritePlatformService.logCommandSource(commandRequest);
+    }
+
+    @GetMapping("/{fundId}")
+    @Operation(summary = "Retrieve a Fund", description = "Returns the details of a Fund.\n" + "\n" + "Example Requests:\n" + "\n"
+            + "funds/1")
+    public FundResponse retrieveFund(@PathVariable @Parameter(description = "fundId") final Long fundId) {
+        context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+        final FundData fund = readPlatformService.retrieveFund(fundId);
+        apiRequestParameterHelper.process();
+        return new FundResponse(fund.getId(), fund.getName(), fund.getExternalId());
+    }
+
+    @PutMapping("/{fundId}")
+    @Operation(summary = "Update a Fund", description = "Updates the details of a fund.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = FundsApiResourceSwagger.PutFundsFundIdResponse.class))) })
+    public CommandProcessingResult updateFund(@PathVariable @Parameter(description = "fundId") final Long fundId,
+            @Valid @RequestBody final PutFundsRequest apiRequestBody) {
+        final String withJson = getJsonRequest(apiRequestBody);
+
+        final CommandWrapper commandJsonRequest = new CommandWrapperBuilder().updateFund(fundId).withJson(withJson).build();
+
+        final CommandTypeWrapper<PutFundsRequest> commandRequest = new CommandTypeWrapperBuilder<PutFundsRequest>() //
+                .updateFund(fundId) //
+                .withRequest(apiRequestBody) //
+                .withJsonCommand(commandJsonRequest) //
+                .build(); //
+
+        return commandsSourceWritePlatformService.logCommandSource(commandRequest);
+    }
+
+    // TODO: Remove after MVC migration
+    private String getJsonRequest(Object apiRequestBody) {
+        final String withJson;
+        try {
+            withJson = mapper.writeValueAsString(apiRequestBody);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return withJson;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/api/FundsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/api/FundsApiResourceSwagger.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Created by Chirag Gupta on 12/08/17.
+ */
+final class FundsApiResourceSwagger {
+
+    private FundsApiResourceSwagger() {}
+
+    @Schema(description = "PostFundsResponse")
+    public static final class PostFundsResponse {
+
+        private PostFundsResponse() {}
+
+        @Schema(example = "1")
+        public Long resourceId;
+    }
+
+    @Schema(description = "PutFundsFundIdRequest")
+    public static final class PutFundsFundIdRequest {
+
+        private PutFundsFundIdRequest() {}
+
+        @Schema(example = "EU Agri Fund (2010-2020)")
+        public String name;
+        @Schema(example = "123")
+        public String externalId;
+    }
+
+    @Schema(description = "PutFundsFundIdResponse")
+    public static final class PutFundsFundIdResponse {
+
+        private PutFundsFundIdResponse() {}
+
+        @Schema(example = "1")
+        public Long resourceId;
+        public PutFundsFundIdRequest changes;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/FundResponse.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/FundResponse.java
@@ -16,41 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.portfolio.fund.data;
+package org.apache.fineract.portfolio.fund.mvc.data;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.fineract.infrastructure.core.api.mvc.JacksonPartialResponseFilter;
 
 /**
  * Immutable data object to represent fund data.
  */
-public final class FundData implements Serializable {
-
-    @SuppressWarnings("unused")
-    private final Long id;
-    @SuppressWarnings("unused")
-    private final String name;
-    @SuppressWarnings("unused")
-    private final String externalId;
-
-    public static FundData instance(final Long id, final String name, final String externalId) {
-        return new FundData(id, name, externalId);
-    }
-
-    private FundData(final Long id, final String name, final String externalId) {
-        this.id = id;
-        this.name = name;
-        this.externalId = externalId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getExternalId() {
-        return externalId;
-    }
+@JsonFilter(JacksonPartialResponseFilter.PARTIAL_RESPONSE)
+public record FundResponse(@Schema(example = "1") Long id, @Schema(example = "EU Agri Fund") String name,
+        @Schema(example = "123") String externalId) {
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/PostFundsRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/PostFundsRequest.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.apache.fineract.infrastructure.core.api.mvc.validation.MaxSize;
+import org.apache.fineract.infrastructure.core.api.mvc.validation.ResourceName;
+
+@ResourceName("fund")
+public record PostFundsRequest(@NotBlank(message = "is mandatory") @MaxSize(max = 100) @Schema(example = "EU Agri Fund") String name,
+        @MaxSize(max = 100) @Schema(example = "123") String externalId) {
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/PutFundsRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/data/PutFundsRequest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+import org.apache.fineract.infrastructure.core.api.mvc.validation.MaxSize;
+import org.apache.fineract.infrastructure.core.api.mvc.validation.ResourceName;
+
+@ResourceName("fund")
+@FieldNameConstants
+@Getter
+@Setter
+public class PutFundsRequest {
+
+    // TODO: Using validation on a generic type like Optional will lead to duplicate validation errors.
+    @Schema(example = "EU Agri Fund")
+    private Optional<@NotBlank(message = "is mandatory") @MaxSize(max = 100) String> name;
+
+    @Schema(example = "123")
+    private Optional<@Size(max = 100) String> externalId;
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/handler/CreateFundCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/handler/CreateFundCommandHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.mvc.handler.NewCommandSourceHandlerType;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.fund.mvc.data.PostFundsRequest;
+import org.apache.fineract.portfolio.fund.mvc.service.FundWritePlatformService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ProfileMvc
+@Service("mvcCreateFundCommandHandler")
+@CommandType(entity = "FUND", action = "CREATE")
+@RequiredArgsConstructor
+public class CreateFundCommandHandler implements NewCommandSourceHandlerType<PostFundsRequest> {
+
+    private final FundWritePlatformService writePlatformService;
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final TypeCommand<PostFundsRequest> command) {
+        return this.writePlatformService.createFund(command);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/handler/UpdateFundCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/handler/UpdateFundCommandHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.mvc.handler.NewCommandSourceHandlerType;
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.fund.mvc.data.PutFundsRequest;
+import org.apache.fineract.portfolio.fund.mvc.service.FundWritePlatformService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ProfileMvc
+@Service("mvcUpdateFundCommandHandler")
+@CommandType(entity = "FUND", action = "UPDATE")
+@RequiredArgsConstructor
+public class UpdateFundCommandHandler implements NewCommandSourceHandlerType<PutFundsRequest> {
+
+    private final FundWritePlatformService writePlatformService;
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final TypeCommand<PutFundsRequest> command) {
+        return this.writePlatformService.updateFund(command.entityId(), command);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/service/FundWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/service/FundWritePlatformService.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.service;
+
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.fund.mvc.data.PostFundsRequest;
+import org.apache.fineract.portfolio.fund.mvc.data.PutFundsRequest;
+
+public interface FundWritePlatformService {
+
+    CommandProcessingResult createFund(TypeCommand<PostFundsRequest> command);
+
+    CommandProcessingResult updateFund(Long fundId, TypeCommand<PutFundsRequest> command);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/service/FundWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/service/FundWritePlatformServiceJpaRepositoryImpl.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.service;
+
+import jakarta.persistence.PersistenceException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.fineract.infrastructure.core.api.mvc.TypeCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.fund.domain.Fund;
+import org.apache.fineract.portfolio.fund.domain.FundRepository;
+import org.apache.fineract.portfolio.fund.exception.FundNotFoundException;
+import org.apache.fineract.portfolio.fund.mvc.data.PostFundsRequest;
+import org.apache.fineract.portfolio.fund.mvc.data.PutFundsRequest;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FundWritePlatformServiceJpaRepositoryImpl implements FundWritePlatformService {
+
+    private final PlatformSecurityContext context;
+    private final FundRepository fundRepository;
+
+    @Transactional
+    @Override
+    @CacheEvict(value = "funds", key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('fn')")
+    public CommandProcessingResult createFund(final TypeCommand<PostFundsRequest> command) {
+
+        final PostFundsRequest request = command.getRequest();
+        try {
+            this.context.authenticatedUser();
+
+            final Fund fund = new Fund();
+            fund.setName(request.name());
+            fund.setExternalId(request.externalId());
+
+            this.fundRepository.saveAndFlush(fund);
+
+            return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(fund.getId()).build();
+        } catch (final JpaSystemException | DataIntegrityViolationException dve) {
+            handleFundDataIntegrityIssues(request.externalId(), request.name(), dve.getMostSpecificCause(), dve);
+            return CommandProcessingResult.empty();
+        } catch (final PersistenceException dve) {
+            Throwable throwable = ExceptionUtils.getRootCause(dve.getCause());
+            handleFundDataIntegrityIssues(request.externalId(), request.name(), throwable, dve);
+            return CommandProcessingResult.empty();
+        }
+    }
+
+    @Transactional
+    @Override
+    @CacheEvict(value = "funds", key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('fn')")
+    public CommandProcessingResult updateFund(final Long fundId, final TypeCommand<PutFundsRequest> command) {
+
+        final PutFundsRequest request = command.getRequest();
+        try {
+            this.context.authenticatedUser();
+
+            final Fund fund = this.fundRepository.findById(fundId).orElseThrow(() -> new FundNotFoundException(fundId));
+
+            final Map<String, Object> changes = update(fund, command);
+            if (!changes.isEmpty()) {
+                this.fundRepository.saveAndFlush(fund);
+            }
+
+            return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(fund.getId()).with(changes).build();
+        } catch (final JpaSystemException | DataIntegrityViolationException dve) {
+            handleFundDataIntegrityIssues(request.getExternalId().orElse(null), request.getName().orElse(null), dve.getMostSpecificCause(),
+                    dve);
+            return CommandProcessingResult.empty();
+        } catch (final PersistenceException dve) {
+            Throwable throwable = ExceptionUtils.getRootCause(dve.getCause());
+            handleFundDataIntegrityIssues(request.getExternalId().orElse(null), request.getName().orElse(null), throwable, dve);
+            return CommandProcessingResult.empty();
+        }
+    }
+
+    public Map<String, Object> update(final Fund fund, final TypeCommand<PutFundsRequest> command) {
+        final PutFundsRequest request = command.getRequest();
+        final Map<String, Object> actualChanges = new LinkedHashMap<>(7);
+
+        if (request.getName() != null) {
+            final String name = request.getName().orElse(null);
+            if (command.differenceExists(fund.getName(), name)) {
+                actualChanges.put(PutFundsRequest.Fields.name, name);
+                fund.setName(name);
+            }
+        }
+
+        if (request.getExternalId() != null) {
+            final String externalId = request.getExternalId().orElse(null);
+            if (command.differenceExists(fund.getExternalId(), externalId)) {
+                actualChanges.put(PutFundsRequest.Fields.externalId, externalId);
+                fund.setExternalId(externalId);
+            }
+        }
+        return actualChanges;
+    }
+
+    /*
+     * Guaranteed to throw an exception no matter what the data integrity issue is.
+     */
+    private void handleFundDataIntegrityIssues(final String externalId, final String name, final Throwable realCause, final Exception dve) {
+        if (realCause.getMessage().contains("m_fund_external_id_key")) {
+            throw new PlatformDataIntegrityException("error.msg.fund.duplicate.externalId",
+                    "A fund with external id '" + externalId + "' already exists", "externalId", externalId);
+        } else if (realCause.getMessage().contains("m_fund_external_id_name")) {
+            throw new PlatformDataIntegrityException("error.msg.fund.duplicate.name", "A fund with name '" + name + "' already exists",
+                    "name", name);
+        }
+
+        log.error("Error occurred.", dve);
+        throw ErrorHandler.getMappable(dve, "error.msg.fund.unknown.data.integrity.issue",
+                "Unknown data integrity issue with resource: " + realCause.getMessage());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/starter/FundConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/mvc/starter/FundConfiguration.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.fund.mvc.starter;
+
+import org.apache.fineract.infrastructure.core.api.mvc.ProfileMvc;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.fund.domain.FundRepository;
+import org.apache.fineract.portfolio.fund.mvc.service.FundWritePlatformService;
+import org.apache.fineract.portfolio.fund.mvc.service.FundWritePlatformServiceJpaRepositoryImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@ProfileMvc
+@Configuration("mvcFundConfiguration")
+public class FundConfiguration {
+
+    @Bean("mvcFundWritePlatformService")
+    @ConditionalOnMissingBean(FundWritePlatformService.class)
+    public FundWritePlatformService fundWritePlatformService(PlatformSecurityContext context, FundRepository fundRepository) {
+        return new FundWritePlatformServiceJpaRepositoryImpl(context, fundRepository);
+    }
+}

--- a/fineract-provider/src/main/resources/application-mvc.properties
+++ b/fineract-provider/src/main/resources/application-mvc.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+springdoc.swagger-ui.url=
+springdoc.paths-to-match=/**


### PR DESCRIPTION
## Description

Initial PR on [FINERACT-2021](https://issues.apache.org/jira/browse/FINERACT-2021)
Migrated Fund resource.


#### Type-safe
- Each endpoint in Fund receives and returns a specific class instead of json.
- To keep the type-safe request until it reaches the target service, I added classes that mirror JsonCommand/Wrapper functionality but instead of json and JsonElement have the type-safe request.
- For this reason, I had to duplicate some services so that they could use these new classes.
- However, some of the classes that I duplicated, such as SynchronousCommandProcessingService have a lot of code that relies on JsonCommand/Wrapper. I didn't want to completely rewrite it and create even more duplicate classes just for the sake of it. That's why the new classes that mirror JsonCommand/Wrapper temporarily have JsonCommand/Wrapper inside. I can rewrite all the other classes completely in future PRs. However, the end classes like FundWritePlatformService only use my new class.

#### Errors
- All MVC errors are managed by SpringErrorHandler. To map to the correct response, it uses the existing jakarta ExceptionMapper and findMostSpecificExceptionHandler method. It also handles UnsupportedParameter errors that are thrown by Jackson failOnUnknownProperties(true).
- I migrated from manual validation to Spring's. To make the validation error response exactly as it was, I created ValidationErrorConverter to correctly map the message and the messageCode.

#### Features
- I migrated the partial parameter response (JacksonPartialResponseFilter).
- I didn't implement the prettyPrint flag. Currently the response is always pretty printed.
- The partial resource update looks a bit strange as it uses Optional, but I haven't found another way to implement it.

#### MVC
- To run the server in MVC mode, you need to add the "mvc" profile.
- Any bean classes I added or duplicated will only be initialized if the application has the "mvc" profile.
- To route requests to MVC, I created MvcRoutingFilter. If Spring can handle the request, it routes it to the Spring dispatcher.

#### Tests
- The integration tests will work in MVC if you run the cargo with the "mvc" profile.

#### Note
To work as the original classes, all duplicate classes must be up to date with the original.
Classes that I had to duplicate completely or to some extent in order to be able to use a type-safe API:
```
ApiRequestParameterHelper
CommandHandlerProvider
CommandProcessingService
SynchronousCommandProcessingService
CommandWrapper (CommandTypeWrapper)
CommandWrapperBuilder (CommandTypeWrapperBuilder)
JsonCommand (TypeCommand)
JacksonConverterConfig
PlatformSecurityContext
SpringSecurityPlatformSecurityContext
NewCommandSourceHandler (NewCommandSourceHandlerType)

FundsApiResource
FundsApiResourceSwagger
CreateFundCommandHandler
UpdateFundCommandHandler
FundWritePlatformService
FundWritePlatformServiceJpaRepositoryImpl
FundConfiguration
```



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
