### PR TITLE
FINERACT-2056: (chore) make use of builder pattern in saving module.

### DIFF
--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/GroupSavingsIndividualMonitoringAccountData.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/GroupSavingsIndividualMonitoringAccountData.java
@@ -20,7 +20,11 @@
 package org.apache.fineract.portfolio.savings.data;
 
 import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
 
+@Getter
+@Builder
 public final class GroupSavingsIndividualMonitoringAccountData {
 
     private final BigDecimal gsimId;
@@ -42,80 +46,4 @@ public final class GroupSavingsIndividualMonitoringAccountData {
     private final Long childAccountsCount;
 
     private final String savingsStatus;
-
-    private GroupSavingsIndividualMonitoringAccountData(final BigDecimal glimId, final BigDecimal groupId, final BigDecimal clientId,
-            final String accountNumber, final BigDecimal childAccountId, final String childAccountNumber, final BigDecimal childDeposit,
-            final BigDecimal parentDeposit, final Long childAccountsCount, final String savingsStatus) {
-        this.gsimId = glimId;
-        this.groupId = groupId;
-        this.clientId = clientId;
-        this.accountNumber = accountNumber;
-        this.childAccountId = childAccountId;
-        this.childAccountNumber = childAccountNumber;
-        this.childDeposit = childDeposit;
-        this.parentDeposit = parentDeposit;
-        this.childAccountsCount = childAccountsCount;
-        this.savingsStatus = savingsStatus;
-    }
-
-    public static GroupSavingsIndividualMonitoringAccountData getInstance(final BigDecimal glimId, final BigDecimal groupId,
-            final String accountNumber, final String childAccountNumber, final BigDecimal childDeposit, final BigDecimal parentDeposit,
-            final Long childAccountsCount, final String savingsStatus) {
-        return new GroupSavingsIndividualMonitoringAccountData(glimId, groupId, null, accountNumber, null, childAccountNumber, childDeposit,
-                parentDeposit, childAccountsCount, savingsStatus);
-    }
-
-    public static GroupSavingsIndividualMonitoringAccountData getInstance1(final BigDecimal glimId, final BigDecimal groupId,
-            final String accountNumber, final BigDecimal parentDeposit, final String savingsStatus) {
-        return new GroupSavingsIndividualMonitoringAccountData(glimId, groupId, null, accountNumber, null, null, null, parentDeposit, null,
-                savingsStatus);
-    }
-
-    public static GroupSavingsIndividualMonitoringAccountData getInstance2(final BigDecimal glimId, final BigDecimal groupId,
-            final BigDecimal clientId, final String accountNumber, final BigDecimal childAccountId, final String childAccountNumber,
-            final BigDecimal childDeposit, final BigDecimal parentDeposit, final Long childAccountsCount, final String savingsStatus) {
-        return new GroupSavingsIndividualMonitoringAccountData(glimId, groupId, clientId, accountNumber, childAccountId, childAccountNumber,
-                childDeposit, parentDeposit, childAccountsCount, savingsStatus);
-    }
-
-    public BigDecimal getGsimId() {
-        return gsimId;
-    }
-
-    public BigDecimal getGroupId() {
-        return groupId;
-    }
-
-    public BigDecimal getClientId() {
-        return clientId;
-    }
-
-    public String getAccountNumber() {
-        return accountNumber;
-    }
-
-    public BigDecimal getChildAccountId() {
-        return childAccountId;
-    }
-
-    public String getChildAccountNumber() {
-        return childAccountNumber;
-    }
-
-    public BigDecimal getChildDeposit() {
-        return childDeposit;
-    }
-
-    public BigDecimal getParentDeposit() {
-        return parentDeposit;
-    }
-
-    public Long getChildAccountsCount() {
-        return childAccountsCount;
-    }
-
-    public String getSavingsStatus() {
-        return savingsStatus;
-    }
-
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/GSIMReadPlatformServiceImpl.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/GSIMReadPlatformServiceImpl.java
@@ -73,8 +73,11 @@ public class GSIMReadPlatformServiceImpl implements GSIMReadPlatformService {
             final BigDecimal parentBalance = rs.getBigDecimal("parentBalance");
             final BigDecimal childBalance = rs.getBigDecimal("childBalance");
             final String savingsStatus = SavingsAccountStatusType.fromInt((int) rs.getLong("savingsStatus")).toString();
-            return GroupSavingsIndividualMonitoringAccountData.getInstance2(gsimId, groupId, clientId, accountNumber, childAccountId,
-                    childAccountNumber, parentBalance, childBalance, childAccountsCount, savingsStatus);
+
+            return GroupSavingsIndividualMonitoringAccountData.builder().gsimId(gsimId).groupId(groupId).clientId(clientId)
+                    .accountNumber(accountNumber).childAccountId(childAccountId).childAccountNumber(childAccountNumber)
+                    .childDeposit(parentBalance).parentDeposit(childBalance).childAccountsCount(childAccountsCount)
+                    .savingsStatus(savingsStatus).build();
         }
     }
 
@@ -99,8 +102,8 @@ public class GSIMReadPlatformServiceImpl implements GSIMReadPlatformService {
 
             final String loanStatus = LoanStatus.fromInt((int) rs.getLong("savingsStatus")).toString();
 
-            return GroupSavingsIndividualMonitoringAccountData.getInstance1(glimId, groupId, accountNumber, parentDeposit, loanStatus);
-
+            return GroupSavingsIndividualMonitoringAccountData.builder().gsimId(glimId).groupId(groupId).accountNumber(accountNumber)
+                    .parentDeposit(parentDeposit).savingsStatus(loanStatus).build();
         }
     }
 


### PR DESCRIPTION
## Description

- used `@Getter` & `@Builder` annotations on the above of GroupSavingsIndividualMonitoringAccountData.
- removed the getters and getInstance() methods from the implementation.
- change GSIMReadPlatformServiceImpl to make use of the new implementation.

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
