### PR TITLE
FINERACT-1981: Function Value using simple interest for EMI calculation

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/emi/FnValueFunctions.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/emi/FnValueFunctions.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.emi;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+public class FnValueFunctions {
+
+    protected FnValueFunctions() {}
+
+    /**
+     * To calculate the function value for each period, we are going to use the next formula:
+     *
+     * fn = 1 + fnValueFrom * rateFactorEnd
+     *
+     * @param previousFnValue
+     *
+     * @param currentRateFactor
+     *
+     * @param mathContext
+     *
+     */
+    public static BigDecimal fnValue(final BigDecimal previousFnValue, final BigDecimal currentRateFactor, final MathContext mc) {
+        return BigDecimal.ONE.add(previousFnValue.multiply(currentRateFactor, mc));
+    }
+
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ratefactor/RateFactorFunctions.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ratefactor/RateFactorFunctions.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.portfolio.loanproduct.ratefactor;
+package org.apache.fineract.portfolio.loanproduct.calc.ratefactor;
 
 import java.math.BigDecimal;
 import java.math.MathContext;


### PR DESCRIPTION
## Description

In order to calculate the monthly payment, we first need to calculate something called the Fn Value. We're going to be using simple interest. The Fn Value for simple interest is calculated by the following formula:

`fn = 1 + fnValueFrom * rateFactorEnd`

[FINERACT-1981](https://issues.apache.org/jira/browse/FINERACT-1981)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
