### PR TITLE
FINERACT-2096: Fix Failed exception handling with Idempotency key length

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.batch.exception.ErrorInfo;
 import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -51,6 +51,7 @@ import org.springframework.core.NestedRuntimeException;
 import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.lang.Nullable;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.stereotype.Component;
 
 /**
@@ -171,6 +172,14 @@ public final class ErrorHandler {
         Throwable cause;
         if ((cause = PessimisticLockingFailureCode.match(t)) != null) {
             return new PessimisticLockingFailureException(msg, cause); // deadlock
+        }
+        if (t instanceof JpaSystemException) {
+            msgCode = msgCode == null ? codePfx + ".database.error" : msgCode;
+            msg = t.getMessage();
+            if (t instanceof NestedRuntimeException nre) {
+                msg = nre.getMostSpecificCause().getMessage();
+            }
+            return new GeneralPlatformDomainRuleException(msgCode, msg, param, args);
         }
         if (t instanceof NestedRuntimeException nre) {
             cause = nre.getMostSpecificCause();


### PR DESCRIPTION
## Description

Seems when too long idempotency id was added, HTTP 403 was raised, but the name and message is weird. Check and fix it

[FINERACT-2096](https://issues.apache.org/jira/browse/FINERACT-2096)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
