### PR TITLE
FINERACT-2096: Fix duplicate key value exception

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
@@ -31,8 +31,10 @@ import org.apache.fineract.commands.handler.NewCommandSourceHandler;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException;
 import org.apache.fineract.useradministration.domain.AppUser;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
@@ -64,8 +66,16 @@ public class CommandSourceService {
 
     @NotNull
     private CommandSource saveInitial(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
-        CommandSource initialCommandSource = getInitialCommandSource(wrapper, jsonCommand, maker, idempotencyKey);
-        return commandSourceRepository.saveAndFlush(initialCommandSource);
+        try {
+            CommandSource initialCommandSource = getInitialCommandSource(wrapper, jsonCommand, maker, idempotencyKey);
+            return commandSourceRepository.saveAndFlush(initialCommandSource);
+        } catch (JpaSystemException jse) {
+            final String message = (jse.getRootCause() != null) ? jse.getRootCause().getMessage() : null;
+            if (message != null && message.toUpperCase().contains("UNIQUE_PORTFOLIO_COMMAND_SOURCE")) {
+                throw new IdempotentCommandProcessUnderProcessingException(wrapper, idempotencyKey, jse);
+            }
+            throw jse;
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/IdempotentCommandProcessUnderProcessingException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/IdempotentCommandProcessUnderProcessingException.java
@@ -28,4 +28,9 @@ public class IdempotentCommandProcessUnderProcessingException extends AbstractId
     public IdempotentCommandProcessUnderProcessingException(CommandWrapper wrapper, String idempotencyKey) {
         super(wrapper.actionName(), wrapper.entityName(), idempotencyKey, wrapper.getJson());
     }
+
+    public IdempotentCommandProcessUnderProcessingException(CommandWrapper wrapper, String idempotencyKey, Exception e) {
+        super(wrapper.actionName(), wrapper.entityName(), idempotencyKey, wrapper.getJson());
+    }
+
 }


### PR DESCRIPTION
## Description

Fix duplicate key value exception to be managed as `IdempotentCommandProcessUnderProcessingException` with HTTP code 425

[FINERACT-2096](https://issues.apache.org/jira/browse/FINERACT-2096)

<img width="1369" alt="Screenshot 2024-06-13 at 7 13 51 a m" src="https://github.com/apache/fineract/assets/154766431/1bf2fd70-6113-4339-82ba-2b5ef5539ebd">

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
