### PR TITLE
FINERACT-2095: Support for string type primary keys - part 2 - Use String based identifiers for enums

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/BaseEnumOptionData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/BaseEnumOptionData.java
@@ -19,6 +19,8 @@
 package org.apache.fineract.infrastructure.core.data;
 
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -27,9 +29,11 @@ import lombok.Getter;
  * </p>
  */
 @Getter
-public class EnumOptionData extends BaseEnumOptionData<Long> implements Serializable {
+@EqualsAndHashCode
+@AllArgsConstructor
+public abstract class BaseEnumOptionData<T> implements Serializable {
 
-    public EnumOptionData(Long id, String code, String description) {
-        super(id, code, description);
-    }
+    protected T id;
+    protected final String code;
+    protected final String value;
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/StringEnumOptionData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/StringEnumOptionData.java
@@ -27,9 +27,9 @@ import lombok.Getter;
  * </p>
  */
 @Getter
-public class EnumOptionData extends BaseEnumOptionData<Long> implements Serializable {
+public class StringEnumOptionData extends BaseEnumOptionData<String> implements Serializable {
 
-    public EnumOptionData(Long id, String code, String description) {
+    public StringEnumOptionData(String id, String code, String description) {
         super(id, code, description);
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/interoperation/domain/InteropIdentifierType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/interoperation/domain/InteropIdentifierType.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
 
 @Getter
 public enum InteropIdentifierType {
@@ -64,5 +65,9 @@ public enum InteropIdentifierType {
         }
         InteropIdentifierType idType = BY_ALIAS.get(name);
         return idType == null ? BY_NAME.get(name) : idType;
+    }
+
+    public StringEnumOptionData toStringEnumOptionData() {
+        return new StringEnumOptionData(name(), getCode(), getDescription());
     }
 }


### PR DESCRIPTION
## Description

Details are present on the ticket. 
Additionally the PR contains a small cleanup regarding the usage of `id` (or `value`), `code`, `description` (or `name`).

EnumOptionData has these values:

- id: T (String, Long or Integer or...) - identifier that is saved into the database and sent in the API requests
- code: String - systemwide unique identifier, usually built of the name of the enum and the name of the enum option (eg. `statusEnum.create`), technical, not shown
- description: String - user friendly display name, shown on the ui

Please see an example in org.apache.fineract.infrastructure.dataqueries.data.StatusEnum


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
