### PR TITLE
FINERACT-1724: Stucked COB job after restart Batch manager

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/domain/JobExecutionRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/domain/JobExecutionRepository.java
@@ -121,7 +121,7 @@ public class JobExecutionRepository {
                 List.of(COMPLETED.name(), FAILED.name(), UNKNOWN.name()), "threshold", threshold), Long.class);
     }
 
-    public Long getNotCompletedPartitionsCount(Long jobExecutionId, String partitionerStepName) {
+    public Long getNotCompletedPartitionsCount(Long jobExecutionId, String partitionerStepName, String exitCode) {
         return namedParameterJdbcTemplate.queryForObject("""
                     SELECT COUNT(bse.STEP_EXECUTION_ID)
                     FROM BATCH_STEP_EXECUTION BSE
@@ -131,7 +131,11 @@ public class JobExecutionRepository {
                         BSE.STEP_NAME <> :stepName
                         AND
                         BSE.status <> :status
-                """, Map.of("jobExecutionId", jobExecutionId, "stepName", partitionerStepName, "status", COMPLETED.name()), Long.class);
+                        AND
+                        BSE.exit_code <> :exitCode
+                """,
+                Map.of("jobExecutionId", jobExecutionId, "stepName", partitionerStepName, "status", COMPLETED.name(), "exitCode", exitCode),
+                Long.class);
     }
 
     public void updateJobStatusToFailed(Long stuckJobId, String partitionerStepName) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/StuckJobExecutorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/StuckJobExecutorServiceImpl.java
@@ -20,12 +20,20 @@ package org.apache.fineract.infrastructure.jobs.service;
 
 import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.jobs.data.partitionedjobs.PartitionedJob;
 import org.apache.fineract.infrastructure.jobs.domain.JobExecutionRepository;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
@@ -39,14 +47,30 @@ public class StuckJobExecutorServiceImpl implements StuckJobExecutorService {
     private final JobExecutionRepository jobExecutionRepository;
     private final TransactionTemplate transactionTemplate;
     private final JobOperator jobOperator;
+    private final JobExplorer jobExplorer;
+    private final JobRepository jobRepository;
+
+    private static final String EXIT_CODE_VALUE = "FAILED_AFTER_MANAGER_RESTARTED";
 
     @Override
     public void resumeStuckJob(String jobName) {
-        List<Long> stuckJobIds = getStuckJobIds(jobName);
-        if (isPartitionedJob(jobName) && areThereStuckJobs(jobName)) {
-            restartPartitionedJobs(jobName, stuckJobIds);
-        } else {
-            restartTaskletJobs(stuckJobIds);
+        if (areThereStuckJobs(jobName)) {
+            // Exit Status (Tag) to know If the Job and Steps were marked as Failed
+            final ExitStatus cleanupTaskExitStatus = new ExitStatus(EXIT_CODE_VALUE);
+            final List<Long> stuckJobIds = getStuckJobIds(jobName);
+
+            // Mark as Failed the Steps Executions (If exists) after Restart
+            stuckJobIds.forEach(stuckJobId -> verifyBatchStepsExecutions(stuckJobId, cleanupTaskExitStatus));
+
+            // Wait the other Job Partitions (If exists) to be completed
+            if (isPartitionedJob(jobName)) {
+                restartPartitionedJobs(jobName, stuckJobIds);
+            } else {
+                restartTaskletJobs(stuckJobIds);
+            }
+
+            // Mark as Failed the Job Executions (If exists) after Restart
+            stuckJobIds.forEach(stuckJobId -> verifyBatchJob(stuckJobId, cleanupTaskExitStatus));
         }
     }
 
@@ -108,7 +132,67 @@ public class StuckJobExecutorServiceImpl implements StuckJobExecutorService {
     }
 
     private boolean areAllPartitionsCompleted(Long stuckJobId, String partitionerStepName) {
-        Long notCompletedPartitions = jobExecutionRepository.getNotCompletedPartitionsCount(stuckJobId, partitionerStepName);
+        Long notCompletedPartitions = jobExecutionRepository.getNotCompletedPartitionsCount(stuckJobId, partitionerStepName,
+                EXIT_CODE_VALUE);
         return notCompletedPartitions == 0L;
     }
+
+    private void verifyBatchJob(long executionId, ExitStatus exitStatus) {
+        JobExecution jobExecution = jobExplorer.getJobExecution(executionId);
+        if (isRunning(jobExecution)) {
+            log.info("Job Execution {} will be mark as Failed", executionId);
+            final LocalDateTime now = DateUtils.getLocalDateTimeOfSystem();
+
+            // Mark the Job Execution as Failed
+            jobExecution.setStatus(BatchStatus.FAILED);
+            jobExecution.setExitStatus(exitStatus);
+            jobExecution.setEndTime(now);
+            jobRepository.update(jobExecution);
+        }
+    }
+
+    private void verifyBatchStepsExecutions(long executionId, ExitStatus exitStatus) {
+        final JobExecution jobExecution = jobExplorer.getJobExecution(executionId);
+        if (isRunning(jobExecution)) {
+            log.info("Step Execution {} will be mark as Failed", executionId);
+            final LocalDateTime now = DateUtils.getLocalDateTimeOfSystem();
+
+            // Mark the Step Executions as Failed
+            for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+                if (isRunning(stepExecution)) {
+                    stepExecution.setStatus(BatchStatus.FAILED);
+                    stepExecution.setExitStatus(exitStatus);
+                    stepExecution.setEndTime(now);
+                    jobRepository.update(stepExecution);
+                }
+            }
+        }
+    }
+
+    private boolean isRunning(JobExecution jobExecution) {
+        switch (jobExecution.getStatus()) {
+            case STARTED:
+            case STARTING:
+            case STOPPING:
+            case UNKNOWN:
+                return true;
+
+            default:
+                return jobExecution.getEndTime() == null;
+        }
+    }
+
+    private boolean isRunning(StepExecution stepExecution) {
+        switch (stepExecution.getStatus()) {
+            case STARTED:
+            case STARTING:
+            case STOPPING:
+            case UNKNOWN:
+                return true;
+
+            default:
+                return stepExecution.getEndTime() == null;
+        }
+    }
+
 }


### PR DESCRIPTION
## Description

The problem occurs only when one of the batch step of the manager got stucked / or remains in “STARTED” state and the batch manager got restarted.

Our stuck logic should recognize whether we are waiting on a worker batch step or waiting on a manager batch step. For the first one we should wait, but for the second we might need to restart or mark it as failed and restart the job

[FINERACT-1724](https://issues.apache.org/jira/browse/FINERACT-1724)

<img width="1510" alt="Screenshot 2024-06-20 at 5 05 29 p m" src="https://github.com/apache/fineract/assets/154766431/ecd7cd8a-073b-485b-a02a-8934bb8a95e7">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
