### PR TITLE
FINERACT-2101: Loan product using global config values

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
@@ -163,4 +163,6 @@ public interface LoanProductConstants {
     String ADVANCED_PAYMENT_ALLOCATION_STRATEGY = "advanced-payment-allocation-strategy";
 
     String FIXED_LENGTH = "fixedLength";
+
+    String USE_DUE_REPAYMENT_GLOBAL_CONFIGS = "useDueRepaymentGlobalConfigs";
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
@@ -157,6 +157,8 @@ final class LoanProductsApiResourceSwagger {
         public Long delinquencyBucketId;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean useDueRepaymentGlobalConfigs;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")
@@ -1260,6 +1262,8 @@ final class LoanProductsApiResourceSwagger {
         public Boolean enableInstallmentLevelDelinquency;
         @Schema(example = "true")
         public Boolean disallowExpectedDisbursements;
+        @Schema(example = "false")
+        public Boolean useDueRepaymentGlobalConfigs;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")
@@ -1402,6 +1406,8 @@ final class LoanProductsApiResourceSwagger {
         public Long delinquencyBucketId;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean useDueRepaymentGlobalConfigs;
         @Schema(example = "3")
         public Integer dueDaysForRepaymentEvent;
         @Schema(example = "3")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
@@ -212,6 +212,7 @@ public class LoanProductData implements Serializable {
     private final Collection<DelinquencyBucketData> delinquencyBucketOptions;
     private final DelinquencyBucketData delinquencyBucket;
 
+    private final boolean useDueRepaymentGlobalConfigs;
     private final Integer dueDaysForRepaymentEvent;
     private final Integer overDueDaysForRepaymentEvent;
 
@@ -310,6 +311,7 @@ public class LoanProductData implements Serializable {
         final boolean isRatesEnabled = false;
         final Collection<DelinquencyBucketData> delinquencyBucketOptions = null;
         final DelinquencyBucketData delinquencyBucket = null;
+        final boolean useDueRepaymentGlobalConfigs = false;
         final Integer dueDaysForRepaymentEvent = null;
         final Integer overDueDaysForRepaymentEvent = null;
         final boolean enableDownPayment = false;
@@ -343,7 +345,7 @@ public class LoanProductData implements Serializable {
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
                 paymentAllocation, creditAllocation, repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType,
-                loanScheduleProcessingType, fixedLength);
+                loanScheduleProcessingType, fixedLength, useDueRepaymentGlobalConfigs);
 
     }
 
@@ -432,6 +434,7 @@ public class LoanProductData implements Serializable {
         final boolean isRatesEnabled = false;
         final Collection<DelinquencyBucketData> delinquencyBucketOptions = null;
         final DelinquencyBucketData delinquencyBucket = null;
+        final boolean useDueRepaymentGlobalConfigs = false;
         final Integer dueDaysForRepaymentEvent = null;
         final Integer overDueDaysForRepaymentEvent = null;
         final boolean enableDownPayment = false;
@@ -463,7 +466,7 @@ public class LoanProductData implements Serializable {
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
                 paymentAllocation, creditAllocation, repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType,
-                loanScheduleProcessingType, fixedLength);
+                loanScheduleProcessingType, fixedLength, useDueRepaymentGlobalConfigs);
 
     }
 
@@ -559,6 +562,7 @@ public class LoanProductData implements Serializable {
         final boolean isRatesEnabled = false;
         final Collection<DelinquencyBucketData> delinquencyBucketOptions = null;
         final DelinquencyBucketData delinquencyBucket = null;
+        final boolean useDueRepaymentGlobalConfigs = false;
         final Integer dueDaysForRepaymentEvent = null;
         final Integer overDueDaysForRepaymentEvent = null;
         final boolean enableDownPayment = false;
@@ -590,7 +594,7 @@ public class LoanProductData implements Serializable {
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
                 paymentAllocation, creditAllocation, repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType,
-                loanScheduleProcessingType, fixedLength);
+                loanScheduleProcessingType, fixedLength, useDueRepaymentGlobalConfigs);
 
     }
 
@@ -680,6 +684,7 @@ public class LoanProductData implements Serializable {
         final boolean isRatesEnabled = false;
         final Collection<DelinquencyBucketData> delinquencyBucketOptions = null;
         final DelinquencyBucketData delinquencyBucket = null;
+        final boolean useDueRepaymentGlobalConfigs = false;
         final Integer dueDaysForRepaymentEvent = null;
         final Integer overDueDaysForRepaymentEvent = null;
         final boolean enableDownPayment = false;
@@ -711,7 +716,7 @@ public class LoanProductData implements Serializable {
                 fixedPrincipalPercentagePerInstallment, delinquencyBucketOptions, delinquencyBucket, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
                 paymentAllocation, creditAllocationData, repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType,
-                loanScheduleProcessingType, fixedLength);
+                loanScheduleProcessingType, fixedLength, useDueRepaymentGlobalConfigs);
     }
 
     public static LoanProductData withAccountingDetails(final LoanProductData productData, final Map<String, Object> accountingMappings,
@@ -761,7 +766,8 @@ public class LoanProductData implements Serializable {
             final BigDecimal disbursedAmountPercentageForDownPayment, final boolean enableAutoRepaymentForDownPayment,
             final Collection<AdvancedPaymentData> paymentAllocation, final Collection<CreditAllocationData> creditAllocation,
             final EnumOptionData repaymentStartDateType, final boolean enableInstallmentLevelDelinquency,
-            final EnumOptionData loanScheduleType, final EnumOptionData loanScheduleProcessingType, final Integer fixedLength) {
+            final EnumOptionData loanScheduleType, final EnumOptionData loanScheduleProcessingType, final Integer fixedLength,
+            final boolean useDueRepaymentGlobalConfigs) {
         this.id = id;
         this.name = name;
         this.shortName = shortName;
@@ -878,6 +884,7 @@ public class LoanProductData implements Serializable {
         this.isEqualAmortization = isEqualAmortization;
         this.delinquencyBucketOptions = delinquencyBucketOptions;
         this.delinquencyBucket = delinquencyBucket;
+        this.useDueRepaymentGlobalConfigs = useDueRepaymentGlobalConfigs;
         this.dueDaysForRepaymentEvent = dueDaysForRepaymentEvent;
         this.overDueDaysForRepaymentEvent = overDueDaysForRepaymentEvent;
         this.enableDownPayment = enableDownPayment;
@@ -1053,6 +1060,7 @@ public class LoanProductData implements Serializable {
         this.isRatesEnabled = isRatesEnabled;
         this.delinquencyBucketOptions = delinquencyBucketOptions;
         this.delinquencyBucket = productData.delinquencyBucket;
+        this.useDueRepaymentGlobalConfigs = productData.useDueRepaymentGlobalConfigs;
         this.dueDaysForRepaymentEvent = productData.dueDaysForRepaymentEvent;
         this.overDueDaysForRepaymentEvent = productData.overDueDaysForRepaymentEvent;
         this.enableDownPayment = productData.enableDownPayment;

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
@@ -232,6 +232,9 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
     @Column(name = "repayment_start_date_type_enum", nullable = false)
     private RepaymentStartDateType repaymentStartDateType;
 
+    @Column(name = "use_due_repayment_global_configs", nullable = false)
+    private boolean useDueRepaymentGlobalConfigs = false;
+
     public static LoanProduct assembleFromJson(final Fund fund, final String loanTransactionProcessingStrategy,
             final List<Charge> productCharges, final JsonCommand command, final AprCalculator aprCalculator, FloatingRate floatingRate,
             final List<Rate> productRates, List<LoanProductPaymentAllocationRule> loanProductPaymentAllocationRules,
@@ -439,6 +442,9 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
 
         final Integer fixedLength = command.integerValueOfParameterNamed(LoanProductConstants.FIXED_LENGTH);
 
+        final boolean useDueRepaymentGlobalConfigs = command
+                .booleanPrimitiveValueOfParameterNamed(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS);
+
         return new LoanProduct(fund, loanTransactionProcessingStrategy, loanProductPaymentAllocationRules, loanProductCreditAllocationRules,
                 name, shortName, description, currency, principal, minPrincipal, maxPrincipal, interestRatePerPeriod,
                 minInterestRatePerPeriod, maxInterestRatePerPeriod, interestFrequencyType, annualInterestRate, interestMethod,
@@ -457,7 +463,8 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
                 isEqualAmortization, productRates, fixedPrincipalPercentagePerInstallment, disallowExpectedDisbursements,
                 allowApprovedDisbursedAmountsOverApplied, overAppliedCalculationType, overAppliedNumber, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
-                repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType, loanScheduleProcessingType, fixedLength);
+                repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType, loanScheduleProcessingType, fixedLength,
+                useDueRepaymentGlobalConfigs);
 
     }
 
@@ -674,7 +681,8 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
             final boolean enableDownPayment, final BigDecimal disbursedAmountPercentageForDownPayment,
             final boolean enableAutoRepaymentForDownPayment, final RepaymentStartDateType repaymentStartDateType,
             final boolean enableInstallmentLevelDelinquency, final LoanScheduleType loanScheduleType,
-            final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength) {
+            final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
+            final boolean useDueRepaymentGlobalConfigs) {
         this.fund = fund;
         this.transactionProcessingStrategyCode = transactionProcessingStrategyCode;
 
@@ -771,6 +779,7 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
             this.rates = rates;
         }
 
+        this.useDueRepaymentGlobalConfigs = useDueRepaymentGlobalConfigs;
         this.dueDaysForRepaymentEvent = dueDaysForRepaymentEvent;
         this.overDueDaysForRepaymentEvent = overDueDaysForRepaymentEvent;
         this.repaymentStartDateType = repaymentStartDateType;
@@ -1275,6 +1284,13 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
             actualChanges.put(LoanProductConstants.OVER_APPLIED_NUMBER, newValue);
             actualChanges.put("locale", localeAsInput);
             this.overAppliedNumber = newValue;
+        }
+
+        if (command.isChangeInBooleanParameterNamed(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS,
+                this.useDueRepaymentGlobalConfigs)) {
+            final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS);
+            actualChanges.put(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS, newValue);
+            this.useDueRepaymentGlobalConfigs = newValue;
         }
 
         if (command.isChangeInIntegerParameterNamed(LoanProductConstants.DUE_DAYS_FOR_REPAYMENT_EVENT, this.dueDaysForRepaymentEvent)) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/handler/CreateLoanProductCommandHandler.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/handler/CreateLoanProductCommandHandler.java
@@ -18,25 +18,21 @@
  */
 package org.apache.fineract.portfolio.loanproduct.handler;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.fineract.commands.annotation.CommandType;
 import org.apache.fineract.commands.handler.NewCommandSourceHandler;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductWritePlatformService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @CommandType(entity = "LOANPRODUCT", action = "CREATE")
+@RequiredArgsConstructor
 public class CreateLoanProductCommandHandler implements NewCommandSourceHandler {
 
     private final LoanProductWritePlatformService writePlatformService;
-
-    @Autowired
-    public CreateLoanProductCommandHandler(final LoanProductWritePlatformService writePlatformService) {
-        this.writePlatformService = writePlatformService;
-    }
 
     @Transactional
     @Override

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/handler/UpdateLoanProductCommandHandler.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/handler/UpdateLoanProductCommandHandler.java
@@ -18,25 +18,21 @@
  */
 package org.apache.fineract.portfolio.loanproduct.handler;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.fineract.commands.annotation.CommandType;
 import org.apache.fineract.commands.handler.NewCommandSourceHandler;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductWritePlatformService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @CommandType(entity = "LOANPRODUCT", action = "UPDATE")
+@RequiredArgsConstructor
 public class UpdateLoanProductCommandHandler implements NewCommandSourceHandler {
 
     private final LoanProductWritePlatformService writePlatformService;
-
-    @Autowired
-    public UpdateLoanProductCommandHandler(final LoanProductWritePlatformService writePlatformService) {
-        this.writePlatformService = writePlatformService;
-    }
 
     @Transactional
     @Override

--- a/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/module-changelog-master.xml
+++ b/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/module-changelog-master.xml
@@ -44,4 +44,5 @@
   <include relativeToChangelogFile="true" file="parts/1019_add_fixed_length.xml"/>
   <include relativeToChangelogFile="true" file="parts/1020_add_re_aged_flag_to_loan_installment.xml"/>
   <include relativeToChangelogFile="true" file="parts/1021_add_loan_status_change_history.xml"/>
+  <include relativeToChangelogFile="true" file="parts/1022_add_use_due_repayment_global_configs_to_product.xml"/>
 </databaseChangeLog>

--- a/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/parts/1022_add_use_due_repayment_global_configs_to_product.xml
+++ b/fineract-loan/src/main/resources/db/changelog/tenant/module/loan/parts/1022_add_use_due_repayment_global_configs_to_product.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_product_loan">
+            <column name="use_due_repayment_global_configs" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -172,7 +172,8 @@ public final class LoanProductDataValidator {
             LoanProductConstants.ENABLE_DOWN_PAYMENT, LoanProductConstants.DISBURSED_AMOUNT_PERCENTAGE_DOWN_PAYMENT,
             LoanProductConstants.ENABLE_AUTO_REPAYMENT_DOWN_PAYMENT, LoanProductConstants.REPAYMENT_START_DATE_TYPE,
             LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY, LoanProductConstants.LOAN_SCHEDULE_TYPE,
-            LoanProductConstants.LOAN_SCHEDULE_PROCESSING_TYPE, LoanProductConstants.FIXED_LENGTH));
+            LoanProductConstants.LOAN_SCHEDULE_PROCESSING_TYPE, LoanProductConstants.FIXED_LENGTH,
+            LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS));
 
     private static final String[] SUPPORTED_LOAN_CONFIGURABLE_ATTRIBUTES = { LoanProductConstants.amortizationTypeParamName,
             LoanProductConstants.interestTypeParamName, LoanProductConstants.transactionProcessingStrategyCodeParamName,
@@ -568,7 +569,6 @@ public final class LoanProductDataValidator {
         }
 
         // Fixed Length validation
-
         fixedLengthValidations(transactionProcessingStrategyCode, isInterestBearing, numberOfRepayments, repaymentEvery, element,
                 baseDataValidator);
 
@@ -755,6 +755,13 @@ public final class LoanProductDataValidator {
         if (this.fromApiJsonHelper.parameterExists(LoanProductConstants.CAN_USE_FOR_TOPUP, element)) {
             final Boolean canUseForTopup = this.fromApiJsonHelper.extractBooleanNamed(LoanProductConstants.CAN_USE_FOR_TOPUP, element);
             baseDataValidator.reset().parameter(LoanProductConstants.CAN_USE_FOR_TOPUP).value(canUseForTopup).validateForBooleanValue();
+        }
+
+        if (this.fromApiJsonHelper.parameterExists(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS, element)) {
+            final Boolean useDueRepaymentGlobalConfig = this.fromApiJsonHelper
+                    .extractBooleanNamed(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS, element);
+            baseDataValidator.reset().parameter(LoanProductConstants.USE_DUE_REPAYMENT_GLOBAL_CONFIGS).value(useDueRepaymentGlobalConfig)
+                    .validateForBooleanValue();
         }
 
         final Integer dueDaysForRepaymentEvent = this.fromApiJsonHelper

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -242,7 +242,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
                     + "lp.allow_multiple_disbursals as multiDisburseLoan, lp.max_disbursals as maxTrancheCount, lp.max_outstanding_loan_balance as outstandingLoanBalance, "
                     + "lp.disallow_expected_disbursements as disallowExpectedDisbursements, lp.allow_approved_disbursed_amounts_over_applied as allowApprovedDisbursedAmountsOverApplied, lp.over_applied_calculation_type as overAppliedCalculationType, over_applied_number as overAppliedNumber, "
                     + "lp.days_in_month_enum as daysInMonth, lp.days_in_year_enum as daysInYear, lp.interest_recalculation_enabled as isInterestRecalculationEnabled, "
-                    + "lp.can_define_fixed_emi_amount as canDefineInstallmentAmount, lp.instalment_amount_in_multiples_of as installmentAmountInMultiplesOf, "
+                    + "lp.can_define_fixed_emi_amount as canDefineInstallmentAmount, lp.instalment_amount_in_multiples_of as installmentAmountInMultiplesOf, lp.use_due_repayment_global_configs as useDueRepaymentGlobalConfigs, "
                     + "lp.due_days_for_repayment_event as dueDaysForRepaymentEvent, lp.overdue_days_for_repayment_event as overDueDaysForRepaymentEvent, lp.enable_down_payment as enableDownPayment, lp.disbursed_amount_percentage_for_down_payment as disbursedAmountPercentageForDownPayment, lp.enable_auto_repayment_for_down_payment as enableAutoRepaymentForDownPayment, lp.repayment_start_date_type_enum as repaymentStartDateType, "
                     + "lp.enable_installment_level_delinquency as enableInstallmentLevelDelinquency, "
                     + "lpr.pre_close_interest_calculation_strategy as preCloseInterestCalculationStrategy, "
@@ -525,6 +525,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
             final LoanScheduleType loanScheduleType = LoanScheduleType.valueOf(loanScheduleTypeStr);
             final String loanScheduleProcessingTypeStr = rs.getString("loanScheduleProcessingType");
             final LoanScheduleProcessingType loanScheduleProcessingType = LoanScheduleProcessingType.valueOf(loanScheduleProcessingTypeStr);
+            final boolean useDueRepaymentGlobalConfigs = rs.getBoolean("useDueRepaymentGlobalConfigs");
 
             return new LoanProductData(id, name, shortName, description, currency, principal, minPrincipal, maxPrincipal, tolerance,
                     numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, repaymentEvery, interestRatePerPeriod,
@@ -547,7 +548,7 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
                     dueDaysForRepaymentEvent, overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageForDownPayment,
                     enableAutoRepaymentForDownPayment, advancedPaymentData, creditAllocationData, repaymentStartDateType,
                     enableInstallmentLevelDelinquency, loanScheduleType.asEnumOptionData(), loanScheduleProcessingType.asEnumOptionData(),
-                    fixedLength);
+                    fixedLength, useDueRepaymentGlobalConfigs);
         }
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductWithRepaymentDueEventConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductWithRepaymentDueEventConfigurationTest.java
@@ -68,6 +68,7 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
                 delinquencyBucketId);
 
         // event days configuration
+        boolean useDueRepaymentGlobalConfigs = true;
         Integer dueDaysForRepaymentEvent = 1;
         Integer overDueDaysForRepaymentEvent = 2;
 
@@ -75,13 +76,15 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
 
         final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
         Integer loanProductId = createLoanProductWithDueDaysForRepaymentEvent(loanTransactionHelper, delinquencyBucketId,
-                dueDaysForRepaymentEvent, overDueDaysForRepaymentEvent);
+                dueDaysForRepaymentEvent, overDueDaysForRepaymentEvent, useDueRepaymentGlobalConfigs);
         final GetLoanProductsProductIdResponse getLoanProductsProductResponse = loanTransactionHelper.getLoanProduct(loanProductId);
         assertNotNull(getLoanProductsProductResponse);
         assertNotNull(getLoanProductsProductResponse.getDueDaysForRepaymentEvent());
         assertNotNull(getLoanProductsProductResponse.getOverDueDaysForRepaymentEvent());
         assertEquals(getLoanProductsProductResponse.getDueDaysForRepaymentEvent(), dueDaysForRepaymentEvent);
         assertEquals(getLoanProductsProductResponse.getOverDueDaysForRepaymentEvent(), overDueDaysForRepaymentEvent);
+        assertNotNull(getLoanProductsProductResponse.getUseDueRepaymentGlobalConfigs());
+        assertEquals(useDueRepaymentGlobalConfigs, getLoanProductsProductResponse.getUseDueRepaymentGlobalConfigs());
     }
 
     @Test
@@ -99,21 +102,25 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
         final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
         final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
                 delinquencyBucketId);
+        final Long loanProductId = getLoanProductsProductResponse.getId();
         assertNotNull(getLoanProductsProductResponse);
 
         // Modify Loan Product
-        PutLoanProductsProductIdResponse loanProductModifyResponse = updateLoanProduct(loanTransactionHelper,
-                getLoanProductsProductResponse.getId());
+        PutLoanProductsProductIdResponse loanProductModifyResponse = updateLoanProduct(loanTransactionHelper, loanProductId);
         assertNotNull(loanProductModifyResponse);
 
+        final GetLoanProductsProductIdResponse getloanProductsResponse = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        assertEquals(true, getloanProductsResponse.getUseDueRepaymentGlobalConfigs());
     }
 
     private PutLoanProductsProductIdResponse updateLoanProduct(LoanTransactionHelper loanTransactionHelper, Long id) {
         // event days configuration
+        boolean useGlobalConfigs = true;
         Integer dueDaysForRepaymentEvent = 1;
         Integer overDueDaysForRepaymentEvent = 2;
         final PutLoanProductsProductIdRequest requestModifyLoan = new PutLoanProductsProductIdRequest()
-                .dueDaysForRepaymentEvent(dueDaysForRepaymentEvent).overDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).locale("en");
+                .dueDaysForRepaymentEvent(dueDaysForRepaymentEvent).overDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent)
+                .useDueRepaymentGlobalConfigs(useGlobalConfigs).locale("en");
         return loanTransactionHelper.updateLoanProduct(id, requestModifyLoan);
     }
 
@@ -125,9 +132,11 @@ public class LoanProductWithRepaymentDueEventConfigurationTest {
     }
 
     private Integer createLoanProductWithDueDaysForRepaymentEvent(final LoanTransactionHelper loanTransactionHelper,
-            final Integer delinquencyBucketId, Integer dueDaysForRepaymentEvent, Integer overDueDaysForRepaymentEvent) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withDueDaysForRepaymentEvent(dueDaysForRepaymentEvent)
-                .withOverDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent).build(null, delinquencyBucketId);
+            final Integer delinquencyBucketId, Integer dueDaysForRepaymentEvent, Integer overDueDaysForRepaymentEvent,
+            boolean useGlobalConfigs) {
+        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withUseDueRepaymentGlobalConfigs(useGlobalConfigs)
+                .withDueDaysForRepaymentEvent(dueDaysForRepaymentEvent).withOverDueDaysForRepaymentEvent(overDueDaysForRepaymentEvent)
+                .build(null, delinquencyBucketId);
         final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
         return loanProductId;
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanProductTestBuilder.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanProductTestBuilder.java
@@ -151,6 +151,7 @@ public class LoanProductTestBuilder {
     private String installmentAmountInMultiplesOf;
     private boolean canDefineInstallmentAmount;
     private Integer delinquencyBucketId;
+    private boolean useDueRepaymentGlobalConfigs = false;
     private Integer dueDaysForRepaymentEvent = null;
     private Integer overDueDaysForRepaymentEvent = null;
     private boolean enableDownPayment = false;
@@ -302,6 +303,7 @@ public class LoanProductTestBuilder {
             map.put("penaltyToIncomeAccountMappings", this.penaltyToIncomeAccountMappings);
         }
 
+        map.put("useDueRepaymentGlobalConfigs", this.useDueRepaymentGlobalConfigs);
         if (this.dueDaysForRepaymentEvent != null) {
             map.put("dueDaysForRepaymentEvent", this.dueDaysForRepaymentEvent);
         }
@@ -724,6 +726,11 @@ public class LoanProductTestBuilder {
 
     public LoanProductTestBuilder withFeeAndPenaltyAssetAccount(final Account account) {
         this.feeAndPenaltyAssetAccount = account;
+        return this;
+    }
+
+    public LoanProductTestBuilder withUseDueRepaymentGlobalConfigs(final boolean useGlobalConfigs) {
+        this.useDueRepaymentGlobalConfigs = useGlobalConfigs;
         return this;
     }
 


### PR DESCRIPTION
## Description

There is an issue when loan product with "enabled" state for using global config values for `dueDaysForRepaymentEvent` and `overDueDaysForRepaymentEvent`  is edited, when opening edit screen, use global values checkbox is not checked, but global values are in the fields (so basically the values are ok, but this point by submitting the loan product the “use globals” will be disabled

[FINERACT-2101](https://issues.apache.org/jira/browse/FINERACT-2101)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
