### PR TITLE
FINERACT-2102: Loan Product enableDownPayment overrided in the Loan a…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -1245,6 +1245,8 @@ final class LoansApiResourceSwagger {
         public String loanScheduleProcessingType;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean enableDownPayment;
     }
 
     @Schema(description = "PostLoansResponse")
@@ -1394,6 +1396,8 @@ final class LoansApiResourceSwagger {
         public String loanScheduleProcessingType;
         @Schema(example = "false")
         public Boolean enableInstallmentLevelDelinquency;
+        @Schema(example = "false")
+        public Boolean enableDownPayment;
 
         static final class PutLoansLoanIdChanges {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
@@ -169,7 +169,7 @@ public final class LoanApplicationValidator {
             LoanApiConstants.daysInYearTypeParameterName, LoanApiConstants.fixedPrincipalPercentagePerInstallmentParamName,
             LoanApiConstants.DISALLOW_EXPECTED_DISBURSEMENTS, LoanApiConstants.FRAUD_ATTRIBUTE_NAME,
             LoanProductConstants.LOAN_SCHEDULE_PROCESSING_TYPE, LoanProductConstants.FIXED_LENGTH,
-            LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY));
+            LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY, LoanProductConstants.ENABLE_DOWN_PAYMENT));
     public static final String LOANAPPLICATION_UNDO = "loanapplication.undo";
 
     private final FromJsonHelper fromApiJsonHelper;
@@ -740,6 +740,8 @@ public final class LoanApplicationValidator {
                             "Loan with externalId is already registered.");
                 }
             }
+
+            loanScheduleValidator.validateDownPaymentAttribute(loanProduct.getLoanProductRelatedDetail().isEnableDownPayment(), element);
 
             checkForProductMixRestrictions(element);
             validateSubmittedOnDate(element, submittedOnDate, loanProduct);
@@ -1395,6 +1397,8 @@ public final class LoanApplicationValidator {
                     }
                 }
             }
+
+            loanScheduleValidator.validateDownPaymentAttribute(loanProduct.getLoanProductRelatedDetail().isEnableDownPayment(), element);
 
             validateDisbursementDetails(loanProduct, element);
             validateSubmittedOnDate(element, loan.getSubmittedOnDate(), loanProduct);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanScheduleValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanScheduleValidator.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
@@ -71,7 +72,8 @@ public final class LoanScheduleValidator {
             LoanApiConstants.repaymentFrequencyDayOfWeekTypeParameterName, LoanApiConstants.isTopup, LoanApiConstants.loanIdToClose,
             LoanApiConstants.datatables, LoanApiConstants.isEqualAmortizationParam, LoanProductConstants.RATES_PARAM_NAME,
             LoanApiConstants.daysInYearTypeParameterName, LoanApiConstants.fixedPrincipalPercentagePerInstallmentParamName,
-            LoanProductConstants.FIXED_LENGTH, LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY));
+            LoanProductConstants.FIXED_LENGTH, LoanProductConstants.ENABLE_INSTALLMENT_LEVEL_DELINQUENCY,
+            LoanProductConstants.ENABLE_DOWN_PAYMENT));
 
     private final FromJsonHelper fromApiJsonHelper;
 
@@ -176,4 +178,15 @@ public final class LoanScheduleValidator {
             dataValidationErrors.add(error);
         }
     }
+
+    public void validateDownPaymentAttribute(final boolean isDownPaymentEnabledInLoanProduct, final JsonElement element) {
+        final Boolean inputIsDownPaymentEnabled = this.fromApiJsonHelper.extractBooleanNamed(LoanProductConstants.ENABLE_DOWN_PAYMENT,
+                element);
+        if (!isDownPaymentEnabledInLoanProduct && Boolean.TRUE.equals(inputIsDownPaymentEnabled)) {
+            throw new GeneralPlatformDomainRuleException("error.msg.downpayment.is.not.enabled.in.loan.product",
+                    "The Loan can not override the downpayment flag because in the Loan Product the downpayment is disabled",
+                    inputIsDownPaymentEnabled);
+        }
+    }
+
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanApplicationTestBuilder.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanApplicationTestBuilder.java
@@ -85,6 +85,7 @@ public class LoanApplicationTestBuilder {
     private String linkAccountId;
     private String inArrearsTolerance;
     private boolean createStandingInstructionAtDisbursement = false;
+    private boolean enableDownPayment = false;
 
     public String build(final String clientID, final String groupID, final String loanProductId, final String savingsID) {
         final HashMap<String, Object> map = new HashMap<>();
@@ -207,6 +208,9 @@ public class LoanApplicationTestBuilder {
 
         if (createStandingInstructionAtDisbursement == true) {
             map.put("createStandingInstructionAtDisbursement", true);
+        }
+        if (enableDownPayment == true) {
+            map.put("enableDownPayment", enableDownPayment);
         }
         LOG.info("Loan Application request : {} ", map);
         return new Gson().toJson(map);
@@ -440,4 +444,10 @@ public class LoanApplicationTestBuilder {
         this.createStandingInstructionAtDisbursement = true;
         return this;
     }
+
+    public LoanApplicationTestBuilder withEnableDownPayment() {
+        this.enableDownPayment = true;
+        return this;
+    }
+
 }


### PR DESCRIPTION
…pplication

## Description

There is need to decide dynamically the loan is downpayment loan or not under the same product constraints. The change here to allow override previously configured `enableDownPayment` field

[FINERACT-2102](https://issues.apache.org/jira/browse/FINERACT-2102)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
