### PR TITLE
FINERACT-2081: Fix delinquent data swagger type

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -640,9 +640,9 @@ final class LoansApiResourceSwagger {
             @Schema(example = "0.000000")
             public Double totalRepaymentTransactionReversed;
             @Schema(example = "0.000000")
-            public Double totalUnpaidAccruedDueInterest;
+            public BigDecimal totalUnpaidAccruedDueInterest;
             @Schema(example = "0.000000")
-            public Double totalUnpaidAccruedNotDueInterest;
+            public BigDecimal totalUnpaidAccruedNotDueInterest;
             public Set<GetLoansLoanIdOverdueCharges> overdueCharges;
             @Schema(example = "1")
             public Long chargeOffReasonId;
@@ -1011,13 +1011,13 @@ final class LoansApiResourceSwagger {
             @Schema(example = "100.000000")
             public Double delinquentAmount;
             @Schema(example = "80.000000")
-            public Double delinquentPrincipal;
+            public BigDecimal delinquentPrincipal;
             @Schema(example = "10.000000")
-            public Double delinquentInterest;
+            public BigDecimal delinquentInterest;
             @Schema(example = "6.000000")
-            public Double delinquentFee;
+            public BigDecimal delinquentFee;
             @Schema(example = "4.000000")
-            public Double delinquentPenalty;
+            public BigDecimal delinquentPenalty;
             @Schema(example = "[2022, 07, 01]")
             public LocalDate lastPaymentDate;
             @Schema(example = "100.000000")

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
@@ -4720,8 +4720,8 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             // After Disbursement we are expecting no Accrual transactions
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            assertEquals(0.0, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest());
-            assertEquals(0.0, loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest());
+            assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest().stripTrailingZeros());
+            assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest().stripTrailingZeros());
         });
 
         // Not Due yet
@@ -4732,14 +4732,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             periodicAccrualAccountingHelper.runPeriodicAccrualAccounting("30 January 2024");
 
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
-            assertEquals(0.0, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest());
-            assertEquals(0.97, loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest());
+            assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest().stripTrailingZeros());
+            assertEquals(new BigDecimal("0.97"), loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest().stripTrailingZeros());
 
             // Partial interest repayment
             addRepaymentForLoan(createdLoanId.get(), 20.50, "30 January 2024");
             loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
-            assertEquals(0.0, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest());
-            assertEquals(0.05, loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest());
+            assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest().stripTrailingZeros());
+            assertEquals(new BigDecimal("0.05"), loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest().stripTrailingZeros());
         });
 
         // Not Due and Due Interest
@@ -4749,8 +4749,8 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             periodicAccrualAccountingHelper.runPeriodicAccrualAccounting("20 February 2024");
 
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
-            assertEquals(0.12, loanDetails.getSummary().getTotalUnpaidAccruedDueInterest());
-            assertEquals(0.52, loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest());
+            assertEquals(new BigDecimal("0.12"), loanDetails.getSummary().getTotalUnpaidAccruedDueInterest().stripTrailingZeros());
+            assertEquals(new BigDecimal("0.52"), loanDetails.getSummary().getTotalUnpaidAccruedNotDueInterest().stripTrailingZeros());
         });
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
@@ -1508,9 +1508,9 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         log.info("Loan Delinquency Data {} {}", loanDetails.getDelinquent().getDelinquentPrincipal(),
                 loanDetails.getDelinquent().getDelinquentInterest());
         assertNotNull(loanDetails.getDelinquent().getDelinquentPrincipal());
-        assertEquals(305.91, loanDetails.getDelinquent().getDelinquentPrincipal());
+        assertEquals(new BigDecimal("305.91"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertNotNull(loanDetails.getDelinquent().getDelinquentInterest());
-        assertEquals(250.72, loanDetails.getDelinquent().getDelinquentInterest());
+        assertEquals(new BigDecimal("250.72"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a partial repayment to move only the interest
         PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 120f,
@@ -1521,8 +1521,8 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
-        assertEquals(305.91, loanDetails.getDelinquent().getDelinquentPrincipal());
-        assertEquals(130.72, loanDetails.getDelinquent().getDelinquentInterest());
+        assertEquals(new BigDecimal("305.91"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
+        assertEquals(new BigDecimal("130.72"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover interest and part of the principal
         loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 330.72f, loanId.intValue());
@@ -1532,8 +1532,8 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
-        assertEquals(105.91, loanDetails.getDelinquent().getDelinquentPrincipal());
-        assertEquals(0.0, loanDetails.getDelinquent().getDelinquentInterest());
+        assertEquals(new BigDecimal("105.91"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
+        assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover the remain principal
         loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 105.91f, loanId.intValue());
@@ -1543,8 +1543,8 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNull(loanDetails.getDelinquencyRange());
-        assertEquals(0.0, loanDetails.getDelinquent().getDelinquentPrincipal());
-        assertEquals(0.0, loanDetails.getDelinquent().getDelinquentInterest());
+        assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
+        assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Undo the last repayment transaction we must to have pending the principal
         PostLoansLoanIdTransactionsResponse reverseRepayment = loanTransactionHelper.reverseLoanTransaction(loanId,
@@ -1554,8 +1554,8 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
-        assertEquals(105.91, loanDetails.getDelinquent().getDelinquentPrincipal());
-        assertEquals(0.0, loanDetails.getDelinquent().getDelinquentInterest());
+        assertEquals(new BigDecimal("105.91"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
+        assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
     }
 
     private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,


### PR DESCRIPTION
## Description

For including new fields in the Loan account data API, we need to modify the GET Loan by ID / external-id API to return those additional fields. API : `/fineract-provider/api/v1/loans/{loanId} In this case the attributes must be used with `BigDecimal` 
`
[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
