### PR TITLE
FINERACT-2081: Loan account data additional fields for summary, fix negative amount

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanSummaryData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanSummaryData.java
@@ -152,6 +152,9 @@ public class LoanSummaryData {
             if (MathUtil.isGreaterThanZero(totalUnpaidAccruedDueInterest)) {
                 totalUnpaidAccruedDueInterest = totalUnpaidAccruedDueInterest
                         .subtract(computeTotalInterestPaidDueAmount(repaymentSchedule.getPeriods()));
+                if (MathUtil.isLessThanZero(totalUnpaidAccruedDueInterest)) {
+                    totalUnpaidAccruedDueInterest = BigDecimal.ZERO;
+                }
             }
 
             // Accrued Due Interest on Actual Installment
@@ -159,6 +162,9 @@ public class LoanSummaryData {
             if (MathUtil.isGreaterThanZero(totalUnpaidAccruedNotDueInterest)) {
                 totalUnpaidAccruedNotDueInterest = totalUnpaidAccruedNotDueInterest
                         .subtract(computeTotalInterestPaidNotDueAmountOnActualPeriod(repaymentSchedule.getPeriods()));
+                if (MathUtil.isLessThanZero(totalUnpaidAccruedNotDueInterest)) {
+                    totalUnpaidAccruedNotDueInterest = BigDecimal.ZERO;
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Fix for the case when the Interest paid is higher than Accrued interest and avoid to have negative amount.

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

<img width="2056" alt="Screenshot 2024-07-23 at 10 41 36 p m" src="https://github.com/user-attachments/assets/148822d2-47c2-4b7c-9ea3-ec30cceb4604">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
