### PR TITLE
FINERACT-2081: update the `authenticatedUser()` method to utilize actionName & entityName instead of the whole wrapper

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -53,9 +53,10 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
     @Override
     public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
         boolean isApprovedByChecker = false;
+        AppUser user = this.context.getAuthenticatedUser(wrapper.getActionName(), wrapper.getEntityName());
 
         // check if is update of own account details
-        if (wrapper.isUpdateOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+        if (wrapper.isUpdateOfOwnUserDetails(user.getId())) {
             // then allow this operation to proceed.
             // maker checker doesnt mean anything here.
             isApprovedByChecker = true; // set to true in case permissions have
@@ -64,7 +65,7 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
         } else {
             // if not user changing their own details - check user has
             // permission to perform specific task.
-            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+            user.validateHasPermissionTo(wrapper.getTaskPermissionName());
         }
         validateIsUpdateAllowed();
 

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -104,7 +104,7 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
         }
         exceptionWhenTheRequestAlreadyProcessed(wrapper, idempotencyKey, isRetry);
 
-        AppUser user = context.authenticatedUser(wrapper);
+        AppUser user = context.getAuthenticatedUser(wrapper.getActionName(), wrapper.getEntityName());
         if (commandSource == null) {
             if (isEnclosingTransaction) {
                 commandSource = commandSourceService.getInitialCommandSource(wrapper, command, user, idempotencyKey);
@@ -265,7 +265,7 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
 
     protected void publishHookEvent(final String entityName, final String actionName, JsonCommand command, final Object result) {
 
-        final AppUser appUser = context.authenticatedUser(CommandWrapper.wrap(actionName, entityName, null, null));
+        final AppUser appUser = context.getAuthenticatedUser(actionName, entityName);
 
         final HookEventSource hookEventSource = new HookEventSource(entityName, actionName);
 

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/service/PlatformSecurityContext.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/service/PlatformSecurityContext.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.infrastructure.security.service;
 
-import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.useradministration.domain.AppUser;
 
 public interface PlatformSecurityContext extends PlatformUserRightsContext {
@@ -41,5 +40,5 @@ public interface PlatformSecurityContext extends PlatformUserRightsContext {
 
     boolean doesPasswordHasToBeRenewed(AppUser currentUser);
 
-    AppUser authenticatedUser(CommandWrapper commandWrapper);
+    AppUser getAuthenticatedUser(String actionName, String entityName);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContext.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContext.java
@@ -107,7 +107,7 @@ public class SpringSecurityPlatformSecurityContext implements PlatformSecurityCo
     }
 
     @Override
-    public AppUser authenticatedUser(CommandWrapper commandWrapper) {
+    public AppUser getAuthenticatedUser(String actionName, String entityName) {
 
         AppUser currentUser = null;
         final SecurityContext context = SecurityContextHolder.getContext();
@@ -122,7 +122,7 @@ public class SpringSecurityPlatformSecurityContext implements PlatformSecurityCo
             throw new UnAuthenticatedUserException();
         }
 
-        if (this.shouldCheckForPasswordForceReset(commandWrapper) && this.doesPasswordHasToBeRenewed(currentUser)) {
+        if (this.shouldCheckForPasswordForceReset(actionName, entityName) && this.doesPasswordHasToBeRenewed(currentUser)) {
             throw new ResetPasswordException(currentUser.getId());
         }
 
@@ -165,14 +165,8 @@ public class SpringSecurityPlatformSecurityContext implements PlatformSecurityCo
 
     }
 
-    private boolean shouldCheckForPasswordForceReset(CommandWrapper commandWrapper) {
-        for (CommandWrapper commandItem : EXEMPT_FROM_PASSWORD_RESET_CHECK) {
-            if (commandItem.actionName().equals(commandWrapper.actionName())
-                    && commandItem.getEntityName().equals(commandWrapper.getEntityName())) {
-                return false;
-            }
-        }
-        return true;
+    private boolean shouldCheckForPasswordForceReset(String actionName, String entityName) {
+        return EXEMPT_FROM_PASSWORD_RESET_CHECK.stream()
+                .noneMatch(commandItem -> commandItem.actionName().equals(actionName) && commandItem.getEntityName().equals(entityName));
     }
-
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
@@ -159,7 +160,8 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
     @Caching(evict = { @CacheEvict(value = "users", allEntries = true), @CacheEvict(value = "usersByUsername", allEntries = true) })
     public CommandProcessingResult updateUser(final Long userId, final JsonCommand command) {
         try {
-            this.context.authenticatedUser(new CommandWrapperBuilder().updateUser(null).build());
+            CommandWrapper wrapper = new CommandWrapperBuilder().updateUser(userId).build();
+            this.context.getAuthenticatedUser(wrapper.getActionName(), wrapper.getEntityName());
 
             this.fromApiJsonDeserializer.validateForUpdate(command.json(), this.context.authenticatedUser());
 

--- a/fineract-provider/src/test/java/org/apache/fineract/commands/service/SynchronousCommandProcessingServiceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/commands/service/SynchronousCommandProcessingServiceTest.java
@@ -112,10 +112,12 @@ public class SynchronousCommandProcessingServiceTest {
         when(commandSourceService.getCommandSource(commandId)).thenReturn(commandSource);
 
         AppUser appUser = Mockito.mock(AppUser.class);
+        CommandWrapper wrapper = Mockito.mock(CommandWrapper.class);
+
         when(commandSourceService.saveInitialNewTransaction(commandWrapper, jsonCommand, appUser, idk)).thenReturn(commandSource);
         when(commandSourceService.saveResultSameTransaction(commandSource)).thenReturn(commandSource);
         when(commandSource.getStatus()).thenReturn(CommandProcessingResultType.PROCESSED.getValue());
-        when(context.authenticatedUser(Mockito.any(CommandWrapper.class))).thenReturn(appUser);
+        when(context.getAuthenticatedUser(wrapper.getActionName(), wrapper.getEntityName())).thenReturn(appUser);
 
         when(commandSourceService.processCommand(commandHandler, jsonCommand, commandSource, appUser, false, false))
                 .thenReturn(commandProcessingResult);
@@ -155,8 +157,10 @@ public class SynchronousCommandProcessingServiceTest {
         when(commandSourceService.getCommandSource(commandId)).thenReturn(commandSource);
 
         AppUser appUser = Mockito.mock(AppUser.class);
+        CommandWrapper wrapper = Mockito.mock(CommandWrapper.class);
+
         when(appUser.getId()).thenReturn(1L);
-        when(context.authenticatedUser(Mockito.any(CommandWrapper.class))).thenReturn(appUser);
+        when(context.getAuthenticatedUser(wrapper.getActionName(), wrapper.getEntityName())).thenReturn(appUser);
         when(commandSourceService.saveInitialNewTransaction(commandWrapper, jsonCommand, appUser, idk)).thenReturn(commandSource);
 
         CommandSource initialCommandSource = Mockito.mock(CommandSource.class);


### PR DESCRIPTION
- Update the method signature to express that we are fetching the user that's authenticated to process this command `getAuthenticatedUserTo`
- Would simplify the implementation with the new mirror API for FINERACT-2021 ticket.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
