### PR TITLE
FINERACT-2081: clear closed_on date on repayment reversal

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
@@ -1352,6 +1352,21 @@ public class LoanStepDef extends AbstractStepDef {
                 .isEqualTo(loanStatusExpectedValue);
     }
 
+    @Then("Loan closedon_date is {}")
+    public void loanClosedonDate(String date) throws IOException {
+        Response<PostLoansResponse> loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
+        long loanId = loanCreateResponse.body().getLoanId();
+
+        Response<GetLoansLoanIdResponse> loanDetailsResponse = loansApi.retrieveLoan(loanId, false, "", "", "").execute();
+        ErrorHelper.checkSuccessfulApiCall(loanDetailsResponse);
+        testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
+        if (date == null || "null".equals(date)) {
+            assertThat(loanDetailsResponse.body().getTimeline().getClosedOnDate()).isNull();
+        } else {
+            assertThat(loanDetailsResponse.body().getTimeline().getClosedOnDate()).isEqualTo(date);
+        }
+    }
+
     @Then("Admin can successfully set Fraud flag to the loan")
     public void setFraud() throws IOException {
         Response<PostLoansResponse> loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);

--- a/fineract-e2e-tests-runner/src/test/resources/features/Loan.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/Loan.feature
@@ -1244,6 +1244,20 @@ Feature: Loan
       | actualMaturityDate | expectedMaturityDate |
       | 01 July 2023       | 01 July 2023         |
 
+  Scenario: Verify that closed date is updated on repayment reversal
+    When Admin sets the business date to "01 June 2023"
+    When Admin creates a client with random data
+    When Admin creates a new default Loan with date: "01 June 2023"
+    And Admin successfully approves the loan on "01 June 2023" with "1000" amount and expected disbursement date on "01 June 2023"
+    When Admin successfully disburse the loan on "01 June 2023" with "1000" EUR transaction amount
+    Then Loan status will be "ACTIVE"
+    When Admin sets the business date to "20 June 2023"
+    And Customer makes "AUTOPAY" repayment on "20 June 2023" with 1000 EUR transaction amount
+    Then Loan status will be "CLOSED_OBLIGATIONS_MET"
+    When Admin sets the business date to "20 June 2023"
+    When Customer undo "1"th "Repayment" transaction made on "20 June 2023"
+    Then Loan status will be "ACTIVE"
+    Then Loan closedon_date is null
 
   Scenario: As an admin I would like to delete a loan using external id
     When Admin sets the business date to the actual date

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/DefaultLoanLifecycleStateMachine.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/DefaultLoanLifecycleStateMachine.java
@@ -49,6 +49,20 @@ public class DefaultLoanLifecycleStateMachine implements LoanLifecycleStateMachi
                 // in case of Loan creation, a LoanCreatedBusinessEvent is also raised, no need to send a status change
                 businessEventNotifierService.notifyPostBusinessEvent(new LoanStatusChangedBusinessEvent(loan));
             }
+
+            // set mandatory field states based on new status after the transition
+            switch (newStatus) {
+                case ACTIVE -> {
+                    if (loan.getClosedOnDate() != null) {
+                        loan.setClosedOnDate(null);
+                    }
+                    if (loan.getOverpaidOnDate() != null) {
+                        loan.setOverpaidOnDate(null);
+                    }
+                }
+                default -> {
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

reversing the last repayment turned the Loan back to ACTIVE state, but left the `closedon_date` field filled. These changes fix this issue and add the related test to cover it.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
