### PR TITLE
FINERACT-2081: fix loan status on CBR reverse

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -1300,7 +1300,9 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
 
     public void updateLoanSummaryDerivedFields() {
         if (isNotDisbursed()) {
-            this.summary.zeroFields();
+            if (this.summary != null) {
+                this.summary.zeroFields();
+            }
             this.totalOverpaid = null;
         } else {
             final Money overpaidBy = calculateTotalOverpayment();
@@ -3017,7 +3019,7 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
     }
 
     public LoanStatus getStatus() {
-        return LoanStatus.fromInt(this.loanStatus);
+        return this.loanStatus == null ? null : LoanStatus.fromInt(this.loanStatus);
     }
 
     public Integer getPlainStatus() {


### PR DESCRIPTION
## Description

These changes fix the reported issue, when Loan status and loan should be reverted back to overpaid state when the CBR transaction is reversed. Instead of aiming for CBR reversals, loan derived fields now get refreshed before state transitions, which cover the reported case as well.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
