### PR TITLE
FINERACT-2114: Interest Rate Modification - adjust reschedule validation

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonCommand.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonCommand.java
@@ -262,6 +262,10 @@ public final class JsonCommand {
         return parameterExists(parameterName);
     }
 
+    public boolean hasParameterValue(final String parameterName) {
+        return this.fromApiJsonHelper.parameterHasValue(parameterName, this.parsedCommand);
+    }
+
     public String dateFormat() {
         return stringValueOfParameterNamed("dateFormat");
     }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/serialization/FromJsonHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/serialization/FromJsonHelper.java
@@ -157,6 +157,13 @@ public class FromJsonHelper {
         return this.helperDelegator.parameterExists(parameterName, element);
     }
 
+    /**
+     * Check Parameter has a non-blank value
+     */
+    public boolean parameterHasValue(final String parameterName, final JsonElement element) {
+        return this.helperDelegator.parameterHasValue(parameterName, element);
+    }
+
     public String extractStringNamed(final String parameterName, final JsonElement element) {
         return this.helperDelegator.extractStringNamed(parameterName, element, new HashSet<String>());
     }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelper.java
@@ -61,6 +61,27 @@ public class JsonParserHelper {
         return element.getAsJsonObject().has(parameterName);
     }
 
+    /**
+     * Check Parameter has a non-blank value
+     */
+    public boolean parameterHasValue(final String parameterName, final JsonElement element) {
+        if (element == null || !element.isJsonObject()) {
+            return false;
+        }
+
+        var valueObject = element.getAsJsonObject().get(parameterName);
+        if (valueObject == null || valueObject.isJsonNull()) {
+            return false;
+        }
+        if (valueObject instanceof JsonArray) {
+            return !valueObject.getAsJsonArray().isEmpty();
+        }
+        if (valueObject instanceof JsonObject) {
+            return !valueObject.getAsJsonObject().isEmpty();
+        }
+        return valueObject.isJsonPrimitive() && !valueObject.getAsJsonPrimitive().getAsString().isBlank();
+    }
+
     public Boolean extractBooleanNamed(final String parameterName, final JsonElement element, final Set<String> requestParamatersDetected) {
         Boolean value = null;
         if (element.isJsonObject()) {

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelperTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/serialization/JsonParserHelperTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.serialization;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JsonParserHelperTest {
+
+    static final JsonParserHelper onTestUnit = new JsonParserHelper();
+
+    static final String testDataHasValues = "{\n" + "  \"integerNumber\": 10,\n" + "  \"doubleNumber\": 3.14,\n"
+            + "  \"string\": \"example\",\n" + "  \"arrayList\": [1, \"two\", 3.0],\n" + "  \"localDate\": \"2024-08-10\",\n"
+            + "  \"keyValue\": {\n" + "    \"key\": \"sampleKey\",\n" + "    \"value\": \"sampleValue\"\n" + "  }\n" + "}";
+
+    static final String testDataValuesEmpty = "{\n" + "  \"integerNumber\": null,\n" + "  \"doubleNumber\": 0.0,\n"
+            + "  \"string\": \"\",\n" + "  \"arrayList\": [],\n" + "  \"localDate\": null,\n" + "  \"keyValue\": {\n"
+            + "    \"key\": \"\",\n" + "    \"value\": null\n" + "  }\n" + "}";
+
+    static final String testDataValuesMissing = "{}";
+
+    @Test
+    void parameterExists() {
+        JsonElement jsonHasValues = JsonParser.parseString(testDataHasValues);
+        JsonElement jsonValuesEmpty = JsonParser.parseString(testDataValuesEmpty);
+        JsonElement jsonValuesMissing = JsonParser.parseString(testDataValuesMissing);
+
+        Assertions.assertTrue(onTestUnit.parameterExists("integerNumber", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterExists("doubleNumber", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterExists("string", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterExists("arrayList", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterExists("localDate", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterExists("keyValue", jsonHasValues));
+
+        Assertions.assertTrue(onTestUnit.parameterExists("integerNumber", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterExists("doubleNumber", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterExists("string", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterExists("arrayList", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterExists("localDate", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterExists("keyValue", jsonValuesEmpty));
+
+        Assertions.assertFalse(onTestUnit.parameterExists("integerNumber", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterExists("doubleNumber", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterExists("string", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterExists("arrayList", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterExists("localDate", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterExists("keyValue", jsonValuesMissing));
+    }
+
+    @Test
+    void parameterHasValue() {
+        JsonElement jsonHasValues = JsonParser.parseString(testDataHasValues);
+        JsonElement jsonValuesEmpty = JsonParser.parseString(testDataValuesEmpty);
+        JsonElement jsonValuesMissing = JsonParser.parseString(testDataValuesMissing);
+
+        Assertions.assertTrue(onTestUnit.parameterHasValue("integerNumber", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("doubleNumber", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("string", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("arrayList", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("localDate", jsonHasValues));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("keyValue", jsonHasValues));
+
+        Assertions.assertFalse(onTestUnit.parameterHasValue("integerNumber", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("doubleNumber", jsonValuesEmpty));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("string", jsonValuesEmpty));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("arrayList", jsonValuesEmpty));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("localDate", jsonValuesEmpty));
+        Assertions.assertTrue(onTestUnit.parameterHasValue("keyValue", jsonValuesEmpty));
+
+        Assertions.assertFalse(onTestUnit.parameterHasValue("integerNumber", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("doubleNumber", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("string", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("arrayList", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("localDate", jsonValuesMissing));
+        Assertions.assertFalse(onTestUnit.parameterHasValue("keyValue", jsonValuesMissing));
+    }
+}

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -4567,6 +4567,21 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
     }
 
     /**
+     * @param date
+     * @return a schedule installment is related to the provided date
+     **/
+    public LoanRepaymentScheduleInstallment getRelatedRepaymentScheduleInstallment(LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+        return getRepaymentScheduleInstallments()//
+                .stream()//
+                .filter(installment -> date.isAfter(installment.getFromDate()) && !date.isAfter(installment.getDueDate()))//
+                .findAny()//
+                .orElse(null);//
+    }
+
+    /**
      * @return loan disbursement data
      **/
     public List<DisbursementData> getDisbursmentData() {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/RescheduleLoansApiConstants.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/RescheduleLoansApiConstants.java
@@ -50,8 +50,9 @@ public final class RescheduleLoansApiConstants {
     public static final String rescheduleReasonCommentParamName = "rescheduleReasonComment";
     public static final String submittedOnDateParamName = "submittedOnDate";
     public static final String adjustedDueDateParamName = "adjustedDueDate";
-    public static final String resheduleForMultiDisbursementNotSupportedErrorCode = "loan.reschedule.tranche.multidisbursement.error.code";
-    public static final String resheduleWithInterestRecalculationNotSupportedErrorCode = "loan.reschedule.interestrecalculation.error.code";
+    public static final String rescheduleForMultiDisbursementNotSupportedErrorCode = "loan.reschedule.tranche.multidisbursement.error.code";
+    public static final String rescheduleMultipleOperationsNotSupportedErrorCode = "loan.reschedule.multioperations.error.code";
+    public static final String rescheduleSelectedOperationNotSupportedErrorCode = "loan.reschedule.selectedoperationnotsupported.error.code";
     public static final String allCommandParamName = "all";
     public static final String approveCommandParamName = "approve";
     public static final String pendingCommandParamName = "pending";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -195,29 +195,18 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
                 submittedOnDate = jsonCommand.localDateValueOfParameterNamed(RescheduleLoansApiConstants.submittedOnDateParamName);
             }
 
-            // initially set the value to null
-            LocalDate rescheduleFromDate = null;
-
             // start point of the rescheduling exercise
             Integer rescheduleFromInstallment = null;
 
             // initially set the value to null
             LocalDate adjustedDueDate = null;
 
+            LocalDate rescheduleFromDate = jsonCommand
+                    .localDateValueOfParameterNamed(RescheduleLoansApiConstants.rescheduleFromDateParamName);
             // check if the parameter is in the JsonCommand object
-            if (jsonCommand.hasParameter(RescheduleLoansApiConstants.rescheduleFromDateParamName)) {
-                // create a LocalDate object from the "rescheduleFromDate" Date
-                // string
-                LocalDate localDate = jsonCommand.localDateValueOfParameterNamed(RescheduleLoansApiConstants.rescheduleFromDateParamName);
-
-                if (localDate != null) {
-                    // get installment by due date
-                    LoanRepaymentScheduleInstallment installment = loan.getRepaymentScheduleInstallment(localDate);
-                    rescheduleFromInstallment = installment.getInstallmentNumber();
-
-                    // update the value of the "rescheduleFromDate" variable
-                    rescheduleFromDate = localDate;
-                }
+            if (rescheduleFromDate != null) {
+                // get installment by due date
+                rescheduleFromInstallment = loan.getRelatedRepaymentScheduleInstallment(rescheduleFromDate).getInstallmentNumber();
             }
 
             if (jsonCommand.hasParameter(RescheduleLoansApiConstants.adjustedDueDateParamName)) {


### PR DESCRIPTION
## Description

Adjust progressive loan reschedule validation logic to accept interest rate change for any day in the schedule.

Progressive loan Reschedule validations:
- accepts only one change at the same time (due date change and interest change should be two reschedule operation on the loan)
- due date change accept only period due date
- interest change accept any day in the schedule
- validation take care and reject any change that is not supported yet on reschedule

https://issues.apache.org/jira/browse/FINERACT-2114