### PR TITLE
FINERACT-2108: Fix gradle build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,17 @@ buildscript {
         classpath 'io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.22'
         classpath 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     }
+
+
+    configurations.classpath {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'com.burgstaller' && details.requested.name == 'okhttp-digest' && details.requested.version == '1.10') {
+                details.useTarget "io.github.rburgst:${details.requested.name}:1.21"
+                    details.because 'Dependency has moved'
+            }
+        }
+    }
+
 }
 
 plugins {


### PR DESCRIPTION
## Description

As mentioned in [the Jira ticket](https://issues.apache.org/jira/browse/FINERACT-2108), `com.burgstaller:okhttp-digest:1.10` is no longer available on Maven Central nor any other repositories.

### The full error:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'fineract'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.burgstaller:okhttp-digest:1.10.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/com/burgstaller/okhttp-digest/1.10/okhttp-digest-1.10.pom
     Required by:
         project : > org.asciidoctor.jvm.gems:org.asciidoctor.jvm.gems.gradle.plugin:3.3.2 > org.asciidoctor:asciidoctor-gradle-jvm-gems:3.3.2 > com.github.jruby-gradle:jruby-gradle-core-plugin:2.0.2 > io.github.http-builder-ng:http-builder-ng-okhttp:1.0.3

* Try:
> If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.
```

### Credit:
- [psathuluri](https://github.com/rburgst/okhttp-digest/issues/86#issuecomment-2240821581) (Github issue)
- [Samart Singh Thakur](https://issues.apache.org/jira/browse/FINERACT-2108?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=17875588) (Jira Ticket)

## Checklist

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)