### PR TITLE
FINERACT-2081: Apply penalty to overdue loans enhancements

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/COB.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/COB.feature
@@ -64,15 +64,15 @@ Feature: COBFeature
     Then Admin checks that delinquency range is: "RANGE_3" and has delinquentDate "2023-08-03"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 |                |
+      | RANGE_3                | 10 August 2023 |                |
       | RANGE_1                | 04 August 2023 | 09 August 2023 |
     When Admin sets the business date to "12 August 2023"
     When Admin runs COB job
     Then Admin checks that last closed business date of loan is "09 August 2023"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 |                |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 |                |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
 
 
   Scenario: Verify that COB doesn’t touch CLOSED loans
@@ -89,22 +89,22 @@ Feature: COBFeature
     Then Admin checks that delinquency range is: "RANGE_3" and has delinquentDate "2023-08-03"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 |                |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 |                |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
     And Customer makes "AUTOPAY" repayment on "10 August 2023" with 1000 EUR transaction amount
     Then Loan status will be "CLOSED_OBLIGATIONS_MET"
     Then Admin checks that delinquency range is: "NO_DELINQUENCY" and has delinquentDate ""
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 | 10 August 2023 |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 | 10 August 2023 |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
     When Admin sets the business date to "11 August 2023"
     When Admin runs COB job
     Then Admin checks that last closed business date of loan is "09 August 2023"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 | 10 August 2023 |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 | 10 August 2023 |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
 
 
   Scenario: Verify that COB doesn’t touch OVERPAID loans
@@ -121,22 +121,22 @@ Feature: COBFeature
     Then Admin checks that delinquency range is: "RANGE_3" and has delinquentDate "2023-08-03"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 |                |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 |                |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
     And Customer makes "AUTOPAY" repayment on "10 August 2023" with 1200 EUR transaction amount
     Then Loan status will be "OVERPAID"
     Then Admin checks that delinquency range is: "NO_DELINQUENCY" and has delinquentDate ""
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 | 10 August 2023 |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 | 10 August 2023 |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
     When Admin sets the business date to "11 August 2023"
     When Admin runs COB job
     Then Admin checks that last closed business date of loan is "09 August 2023"
     Then Loan delinquency history has the following details:
       | Range (Classification) | Added on date  | Lifted on date |
-      | RANGE_3                | 09 August 2023 | 10 August 2023 |
-      | RANGE_1                | 04 August 2023 | 09 August 2023 |
+      | RANGE_3                | 10 August 2023 | 10 August 2023 |
+      | RANGE_1                | 04 August 2023 | 10 August 2023 |
 
    @Skip
   Scenario: Verify that COB catch up runs properly on loan which is behind date because of locked with error

--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanDelinquency.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanDelinquency.feature
@@ -625,10 +625,7 @@ Feature: LoanDelinquency
       | PAUSE  | 15 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 250.0            | 04 October 2023 | 11             | 14          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 11             | 14          |
     Then Installment level delinquency event has correct data
 #    --- Delinquency resume ---
     When Admin sets the business date to "25 October 2023"
@@ -647,10 +644,7 @@ Feature: LoanDelinquency
       | RESUME | 25 October 2023 |                 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 500.0            | 04 October 2023 | 12             | 25          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
+      | NO_DELINQUENCY | 500.0            | 04 October 2023 | 12             | 25          |
     Then Installment level delinquency event has correct data
 
 
@@ -674,10 +668,7 @@ Feature: LoanDelinquency
       | PAUSE  | 15 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 250.0            | 04 October 2023 | 11             | 14          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 11             | 14          |
     Then Installment level delinquency event has correct data
 #    --- Delinquency resume ---
     When Admin sets the business date to "25 October 2023"
@@ -696,10 +687,7 @@ Feature: LoanDelinquency
       | RESUME | 25 October 2023 |                 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 500.0            | 04 October 2023 | 12             | 25          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
+      | NO_DELINQUENCY | 500.0            | 04 October 2023 | 12             | 25          |
     Then Installment level delinquency event has correct data
 #   --- Delinquency runs ---
     When Admin sets the business date to "13 November 2023"
@@ -755,11 +743,12 @@ Feature: LoanDelinquency
       | PAUSE  | 14 November 2023 | 30 November 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_30       | 1000.0           | 04 October 2023 | 31             | 60          |
+      | RANGE_3        | 1000.0           | 04 October 2023 | 31             | 60          |
     Then Loan has the following INSTALLMENT level delinquency data:
       | rangeId | Range    | Amount |
-      | 2       | RANGE_3  | 500.00 |
-      | 3       | RANGE_30 | 250.00 |
+      | 2       | RANGE_1  | 250.00 |
+      | 3       | RANGE_3  | 250.00 |
+      | 4       | RANGE_30 | 250.00 |
 #    --- Delinquency runs again ---
     When Admin sets the business date to "01 December 2023"
     When Admin runs inline COB job for Loan
@@ -802,11 +791,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 5           |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 5           |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     Then Installment level delinquency event has correct data
 #    --- Full repayment for late/due date installments ---
     When Admin sets the business date to "16 October 2023"
@@ -818,11 +804,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 15          |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 15          |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     And Customer makes "AUTOPAY" repayment on "16 October 2023" with 500 EUR transaction amount
     When Admin runs inline COB job for Loan
     Then Loan Delinquency pause periods has the following data:
@@ -857,11 +840,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 5           |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 5           |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     Then Installment level delinquency event has correct data
 #    --- Full repayment for late/due date installments ---
     When Admin sets the business date to "16 October 2023"
@@ -873,11 +853,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 15          |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 15          |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     And Customer makes "AUTOPAY" repayment on "16 October 2023" with 150 EUR transaction amount
     When Admin runs inline COB job for Loan
     Then Loan Delinquency pause periods has the following data:
@@ -915,11 +892,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 5           |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 5           |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     Then Installment level delinquency event has correct data
 #    --- Full repayment for late/due date installments ---
     When Admin sets the business date to "16 October 2023"
@@ -931,11 +905,8 @@ Feature: LoanDelinquency
       | PAUSE  | 06 October 2023 | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_1        | 250.0            | 04 October 2023 | 2              | 15          |
+      | NO_DELINQUENCY | 250.0            | 04 October 2023 | 2              | 15          |
 #    --- Grace period applied only on Loan level, not on installment level ---
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 250.00 |
     And Customer makes "AUTOPAY" repayment on "16 October 2023" with 250 EUR transaction amount
     When Admin runs inline COB job for Loan
     Then Loan Delinquency pause periods has the following data:
@@ -1034,10 +1005,7 @@ Feature: LoanDelinquency
       | true   | 30 October 2023  | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 500.0            | 04 October 2023 | 21             | 29          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 500.00 |
+      | NO_DELINQUENCY | 500.0            | 04 October 2023 | 21             | 29          |
     When Admin sets the business date to "31 October 2023"
     Then Loan Delinquency pause periods has the following data:
       | active | pausePeriodStart | pausePeriodEnd  |
@@ -1045,10 +1013,7 @@ Feature: LoanDelinquency
       | false  | 30 October 2023  | 30 October 2023 |
     Then Loan has the following LOAN level delinquency data:
       | classification | delinquentAmount | delinquentDate  | delinquentDays | pastDueDays |
-      | RANGE_3        | 500.0            | 04 October 2023 | 22             | 30          |
-    Then Loan has the following INSTALLMENT level delinquency data:
-      | rangeId | Range   | Amount |
-      | 2       | RANGE_3 | 500.00 |
+      | NO_DELINQUENCY | 500.0            | 04 October 2023 | 22             | 30          |
 
 
   Scenario: Verify that creating a loan with Advanced payment allocation with product no Advanced payment allocation set results an error

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyChargeToOverdueLoansBusinessStep.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyChargeToOverdueLoansBusinessStep.java
@@ -37,7 +37,9 @@ public class ApplyChargeToOverdueLoansBusinessStep implements LoanCOBBusinessSte
     public Loan execute(Loan loan) {
         final Collection<OverdueLoanScheduleData> overdueLoanScheduleDataList = loanReadPlatformService
                 .retrieveAllOverdueInstallmentsForLoan(loan);
-        loanChargeWritePlatformService.applyOverdueChargesForLoan(loan.getId(), overdueLoanScheduleDataList);
+        if (!overdueLoanScheduleDataList.isEmpty()) {
+            loanChargeWritePlatformService.applyOverdueChargesForLoan(loan.getId(), overdueLoanScheduleDataList);
+        }
         return loan;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/applychargetooverdueloaninstallment/ApplyChargeToOverdueLoanInstallmentTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/applychargetooverdueloaninstallment/ApplyChargeToOverdueLoanInstallmentTasklet.java
@@ -68,8 +68,9 @@ public class ApplyChargeToOverdueLoanInstallmentTasklet implements Tasklet {
             List<Throwable> exceptions = new ArrayList<>();
             for (Map.Entry<Long, Collection<OverdueLoanScheduleData>> entry : overdueScheduleData.entrySet()) {
                 try {
-                    loanChargeWritePlatformService.applyOverdueChargesForLoan(entry.getKey(), entry.getValue());
-
+                    if (!entry.getValue().isEmpty()) {
+                        loanChargeWritePlatformService.applyOverdueChargesForLoan(entry.getKey(), entry.getValue());
+                    }
                 } catch (final PlatformApiDataValidationException e) {
                     final List<ApiParameterError> errors = e.getErrors();
                     for (final ApiParameterError error : errors) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -757,9 +758,17 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
     @Transactional
     @Override
     public void applyOverdueChargesForLoan(final Long loanId, Collection<OverdueLoanScheduleData> overdueLoanScheduleDataList) {
+        if (overdueLoanScheduleDataList.isEmpty()) {
+            return;
+        }
         Loan loan = this.loanAssembler.assembleFrom(loanId);
         if (loan.isChargedOff()) {
             log.warn("Adding charge to Loan: {} is not allowed. Loan Account is Charged-off", loanId);
+            return;
+        }
+        Optional<Charge> optPenaltyCharge = loan.getLoanProduct().getCharges().stream()
+                .filter((e) -> ChargeTimeType.OVERDUE_INSTALLMENT.getValue().equals(e.getChargeTimeType()) && e.isLoanCharge()).findFirst();
+        if (optPenaltyCharge.isEmpty()) {
             return;
         }
         final List<Long> existingTransactionIds = loan.findExistingTransactionIds();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
@@ -424,7 +424,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(20.0, "Accrual", "01 February 2023", 0, 0, 0, 0, 20, 0.0, 0.0),
-                    transaction(50.0, "Repayment", "10 January 2023", 950, 50, 0, 0, 0, 0.0, 0.0),
+                    transaction(50.0, "Repayment", "10 January 2023", 970, 30, 0, 0, 20, 0.0, 0.0),
                     transaction(20.0, "Accrual Activity", "01 February 2023", 0, 0, 0.0, 0.0, 20.0, 0.0, 0.0));
 
         });


### PR DESCRIPTION
## Description

Describe the changes made and why they were made.

- When there is no overdue penalty available and no overdue installment, do not reprocess the loan  

- Enhance `retrieveAllOverdueInstallmentsForLoan`  logic, if there is no penalty charge configured on the loan, do not iterate through on the installments

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
