### PR TITLE
FINERACT-2081: Validation error in mandatory loan account parameters

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilder.java
@@ -1056,4 +1056,12 @@ public class DataValidatorBuilder {
             throw new PlatformApiDataValidationException(dataValidationErrors);
         }
     }
+
+    public static ApiParameterError buildValidationParameterApiError(final String resource, final String parameterName,
+            final String errorCode, final String errorMessage, final Object... defaultUserMessageArgs) {
+        final String validationErrorCode = "validation.msg." + resource + "." + parameterName + errorCode;
+        String defaultEnglishMessage = "The parameter `" + parameterName + "` " + errorMessage;
+        return ApiParameterError.parameterError(validationErrorCode, defaultEnglishMessage, parameterName, defaultUserMessageArgs);
+    }
+
 }

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
@@ -513,8 +513,8 @@ public class LoanStepDef extends AbstractStepDef {
 
     @When("Admin creates a fully customized loan with Advanced payment allocation and with product no Advanced payment allocation set results an error:")
     public void createFullyCustomizedLoanNoAdvancedPaymentError(DataTable table) throws IOException {
-        int errorCodeExpected = 400;
-        String errorMessageExpected = "Failed data validation due to: strategy.cannot.be.advanced.payment.allocation.if.not.configured.";
+        int errorCodeExpected = 403;
+        String errorMessageExpected = "Loan transaction processing strategy cannot be Advanced Payment Allocation Strategy if it's not configured on loan product";
 
         List<List<String>> data = table.asLists();
         List<String> loanData = data.get(1);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -574,7 +574,6 @@ public final class LoanProductDataValidator {
         }
 
         // Fixed Length validation
-
         fixedLengthValidations(transactionProcessingStrategyCode, isInterestBearing, numberOfRepayments, repaymentEvery, element,
                 baseDataValidator);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanApplicationApprovalTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanApplicationApprovalTest.java
@@ -160,7 +160,7 @@ public class LoanApplicationApprovalTest {
         log.info("----------------------------------LOAN PRODUCT CREATED WITH ID------------------------------------------- {}",
                 loanProductId);
 
-        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpecForStatusCode400);
+        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpecForStatusCode403);
         final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
                 .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
                 .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
@@ -169,8 +169,7 @@ public class LoanApplicationApprovalTest {
                 .withRepaymentStrategy(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                 .build(clientId.toString(), loanProductId.toString(), null);
         List<HashMap> error = (List<HashMap>) loanTransactionHelper.createLoanAccount(loanApplicationJSON, CommonConstants.RESPONSE_ERROR);
-        assertEquals(
-                "validation.msg.loan.transactionProcessingStrategyCode.strategy.cannot.be.advanced.payment.allocation.if.not.configured",
+        assertEquals("strategy.cannot.be.advanced.payment.allocation.if.not.configured",
                 error.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
 
     }


### PR DESCRIPTION
## Description

In CreateLoan request, missing mandatory fields which were being returned as 400 in the past are currently being returned as 403 ? Is this an expected change? Please confirm. The following fields are being returned with 403 code when missing

- clientId
- productId
- principal
- transactionProcessingStrategyCode
- expectedDisbursementDate
- submittedOnDate

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

<img width="1324" alt="Screenshot 2024-08-30 at 2 17 35 p m" src="https://github.com/user-attachments/assets/dc507620-9496-4fc8-a6cc-885443018726">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
