### PR TITLE
FINERACT-2067: NPE business date partition step COB

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/JobExecutionContextCopyListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/JobExecutionContextCopyListener.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.cob.listener;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ExecutionContext;
+
+/**
+ * {@link StepExecutionListener} to copy values from Job execution context into Step execution context.
+ */
+@Slf4j
+public class JobExecutionContextCopyListener implements StepExecutionListener {
+
+    private final List<String> stepExecutionKeys;
+
+    public JobExecutionContextCopyListener(List<String> stepExecutionKeys) {
+        this.stepExecutionKeys = stepExecutionKeys;
+    }
+
+    /**
+     * Method to copy values from Job execution context into Step execution context before step execution.
+     *
+     * @param stepExecution
+     *            the step to be executed.
+     */
+    @Override
+    public void beforeStep(final StepExecution stepExecution) {
+        log.debug("Before step: copying job execution context to step [{}]", stepExecution.getStepName());
+
+        final ExecutionContext stepExecutionContext = stepExecution.getExecutionContext();
+        final ExecutionContext jobExecutionContext = stepExecution.getJobExecution().getExecutionContext();
+
+        jobExecutionContext.entrySet().forEach(jobExecutionContextEntry -> {
+            if (stepExecutionKeys.contains(jobExecutionContextEntry.getKey())
+                    && BooleanUtils.isFalse(stepExecutionContext.containsKey(jobExecutionContextEntry.getKey()))) {
+                stepExecutionContext.put(jobExecutionContextEntry.getKey(), jobExecutionContextEntry.getValue());
+            }
+        });
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBPartitioner.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBPartitioner.java
@@ -58,10 +58,10 @@ public class LoanCOBPartitioner implements Partitioner {
 
     private final Long numberOfDays;
 
-    @Value("#{jobExecutionContext['BusinessDate']}")
+    @Value("#{stepExecutionContext['BusinessDate']}")
     @Setter
     private LocalDate businessDate;
-    @Value("#{jobExecutionContext['IS_CATCH_UP']}")
+    @Value("#{stepExecutionContext['IS_CATCH_UP']}")
     @Setter
     private Boolean isCatchUp;
 

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/listener/JobExecutionContextCopyListenerTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/listener/JobExecutionContextCopyListenerTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.cob.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+
+@ExtendWith(MockitoExtension.class)
+public class JobExecutionContextCopyListenerTest {
+
+    private static final List<String> STEP_EXECUTION_KEYS = List.of("BusinessDate", "IS_CATCH_UP");
+
+    private final JobExecutionContextCopyListener jobExecutionContextCopyListener = new JobExecutionContextCopyListener(
+            List.of("BusinessDate", "IS_CATCH_UP"));
+
+    @Test
+    public void verifyJobExecutionContextMapIsCopiedToEmptyStepExecutionContextMap() {
+        Map<String, Object> jobExecutionContextMap = createRandomHashmap();
+        jobExecutionContextMap.put("BusinessDate", "value");
+        jobExecutionContextMap.put("IS_CATCH_UP", "value");
+        final JobExecution jobExecution = new JobExecution(1L);
+        jobExecution.setExecutionContext(new ExecutionContext(jobExecutionContextMap));
+        final StepExecution stepExecution = new StepExecution("someStep", jobExecution);
+
+        jobExecutionContextCopyListener.beforeStep(stepExecution);
+
+        assertEquals(stepExecution.getExecutionContext().size(), 2);
+        stepExecution.getExecutionContext().toMap().forEach((key, value) -> {
+            assertTrue(STEP_EXECUTION_KEYS.contains(key));
+            assertEquals(value, jobExecutionContextMap.get(key));
+        });
+    }
+
+    @Test
+    public void verifyStepExecutionContextMapNotOverwritten() {
+        Map<String, Object> jobExecutionContextMap = new HashMap<>();
+        jobExecutionContextMap.put("BusinessDate", "BusinessDate value");
+        jobExecutionContextMap.put("IS_CATCH_UP", "IS_CATCH_UP value");
+        Map<String, Object> expectedStepExecutionContextMap = new HashMap<>();
+        expectedStepExecutionContextMap.put("BusinessDate", "BusinessDate anotherValue");
+        expectedStepExecutionContextMap.put("IS_CATCH_UP", "IS_CATCH_UP anotherValue");
+
+        final JobExecution jobExecution = new JobExecution(1L);
+        jobExecution.setExecutionContext(new ExecutionContext(jobExecutionContextMap));
+        final StepExecution actualStepExecution = new StepExecution("someStep", jobExecution);
+        actualStepExecution.setExecutionContext(new ExecutionContext(expectedStepExecutionContextMap));
+
+        jobExecutionContextCopyListener.beforeStep(actualStepExecution);
+
+        assertEquals(actualStepExecution.getExecutionContext().size(), STEP_EXECUTION_KEYS.size());
+        actualStepExecution.getExecutionContext().toMap().forEach((key, value) -> {
+            assertTrue(STEP_EXECUTION_KEYS.contains(key));
+            assertEquals(value, expectedStepExecutionContextMap.get(key));
+        });
+    }
+
+    /**
+     * Helper method to create a random Hash Map.
+     *
+     * @return the random Hash Map.
+     */
+    private Map<String, Object> createRandomHashmap() {
+        final Random random = new Random();
+        final Map<String, Object> map = new HashMap<>();
+        for (int i = 0; i < random.nextInt(50); i++) {
+            map.put(RandomStringUtils.randomAlphanumeric(5), RandomStringUtils.randomAlphanumeric(5));
+        }
+
+        return map;
+    }
+}


### PR DESCRIPTION
## Description

This is to fix an NPE issue we are seeing in some of our test environments during COB in multi-tenant mode. 

Possible cause:

- When running in multi-tenant mode, ES and IT COBs execute at the same time.
- Both of these could somehow both be trying to access the business date value, causing NPE intermittently.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
