### PR TITLE
FINERACT-2081: downgrade Develocity for ge.apache.org compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     "docs/**",
     "fineract-client/**"
   ],
+  "ignoreDeps": [
+    "com.gradle.develocity"
+  ],
   "labels": ["renovate"],
   "packageRules": [{
     "description": "Limit the aws sdk to monthly updates because otherwise it PRs every day",

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id 'com.gradle.develocity' version '3.18.1'
+    id 'com.gradle.develocity' version '3.17.6'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 


### PR DESCRIPTION
the latest develocity plugin (3.18.0+) is incompatible with our current ge.apache.org server. This commit downgrades the develocity plugin to the latest supported version, and also updates the renovate config to make the changes stuck.
 
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
