### PR TITLE
FINERACT-2081: Handle unauthenticated requests in LoanCOBApiFilter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBApiFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBApiFilter.java
@@ -32,6 +32,7 @@ import org.apache.fineract.infrastructure.jobs.exception.LoanIdsHardLockedExcept
 import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
 import org.apache.http.HttpStatus;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -84,7 +85,7 @@ public class LoanCOBApiFilter extends OncePerRequestFilter {
                     }
                 }
             } catch (UnAuthenticatedUserException e) {
-                Reject.reject(null, HttpStatus.SC_UNAUTHORIZED).toServletResponse(response);
+                throw new AuthenticationCredentialsNotFoundException("Not Authenticated", e);
             }
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContext.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContext.java
@@ -63,7 +63,10 @@ public class SpringSecurityPlatformSecurityContext implements PlatformSecurityCo
         if (context != null) {
             final Authentication auth = context.getAuthentication();
             if (auth != null) {
-                currentUser = (AppUser) auth.getPrincipal();
+                Object principal = auth.getPrincipal();
+                if (principal instanceof AppUser appUser) {
+                    currentUser = appUser;
+                }
             }
         }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContextTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/service/SpringSecurityPlatformSecurityContextTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.security.exception.ResetPasswordException;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class SpringSecurityPlatformSecurityContextTest {
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private AppUser appUser;
+
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+
+    @InjectMocks
+    private SpringSecurityPlatformSecurityContext securityContextProvider;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldReturnAppUserWhenPrincipalIsAppUser() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(appUser);
+        when(configurationDomainService.isPasswordForcedResetEnable()).thenReturn(false);
+
+        AppUser result = securityContextProvider.authenticatedUser();
+
+        assertEquals(appUser, result, "authenticatedUser() should return AppUser");
+    }
+
+    @Test
+    void shouldThrowUnAuthenticatedUserExceptionWhenPrincipalIsNotAppUser() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn("anonymousUser");
+
+        assertThrows(UnAuthenticatedUserException.class,
+                     () -> securityContextProvider.authenticatedUser(),
+                     "authenticatedUser() should throw UnAuthenticatedUserException when "
+                             + "Principal is not AppUser");
+    }
+
+    @Test
+    void shouldThrowUnAuthenticatedUserExceptionWhenAuthenticationIsNull() {
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        assertThrows(UnAuthenticatedUserException.class,
+                     () -> securityContextProvider.authenticatedUser(),
+                     "authenticatedUser() should throw UnAuthenticatedUserException when "
+                             + "Authentication is null");
+    }
+
+    @Test
+    void shouldThrowResetPasswordExceptionWhenPasswordMustBeReset() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(appUser);
+        SpringSecurityPlatformSecurityContext spyContextProvider = spy(securityContextProvider);
+        doReturn(true).when(spyContextProvider).doesPasswordHasToBeRenewed(appUser);
+
+        assertThrows(ResetPasswordException.class,
+                     spyContextProvider::authenticatedUser,
+                     "authenticatedUser() should throw ResetPasswordException when password needs"
+                             + " to be reset");
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuthenticationIntegrationTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.Collections;
+import java.util.HashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
+import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Slf4j
+@ExtendWith(LoanTestLifecycleExtension.class)
+public class AuthenticationIntegrationTest {
+
+    private static final String LOAN_DATE = "11 July 2022";
+    private static final String APPROVE_COMMAND = "approve";
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private LoanTransactionHelper loanTransactionHelper;
+    private Integer loanID;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        setupAuthenticatedRequestSpec();
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+
+        AccountHelper accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
+        Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+        String username = Utils.uniqueRandomStringGenerator("user", 8);
+        UserHelper.createUser(this.requestSpec, this.responseSpec, 1, staffId, username, "P4ssw0rd", "resourceId");
+        Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
+
+        Integer loanProductID = setupLoanProduct(accountHelper);
+        this.loanID = loanTransactionHelper.applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID,
+                Collections.emptyList(), null, "10000", LoanApplicationTestBuilder.DEFAULT_STRATEGY, "10 July 2022", LOAN_DATE);
+    }
+
+    @Test
+    public void shouldAllowAccessForAuthenticatedUser() {
+        setupAuthenticatedRequestSpec();
+        String loanApprovalCommand = createLoanApprovalCommand();
+        String loanApprovalRequest = createLoanApprovalRequest();
+
+        HashMap response = Utils.performServerPost(this.requestSpec, this.responseSpec, loanApprovalCommand, loanApprovalRequest,
+                "changes");
+        HashMap status = (HashMap) response.get("status");
+
+        assertEquals(200, (Integer) status.get("id"));
+    }
+
+    @Test
+    public void shouldReturnUnauthorizedForUnauthenticatedAccess() throws JsonProcessingException {
+        setupUnauthenticatedRequestSpec();
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(401).build();
+
+        String loanApprovalCommand = createLoanApprovalCommand();
+        String loanApprovalRequest = createLoanApprovalRequest();
+
+        String rawResponse = Utils.performServerPost(this.requestSpec, this.responseSpec, loanApprovalCommand, loanApprovalRequest, null);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        HashMap response = objectMapper.readValue(rawResponse, HashMap.class);
+
+        assertEquals(401, (Integer) response.get("status"));
+        assertEquals("Unauthorized", response.get("error"));
+    }
+
+    private Integer setupLoanProduct(AccountHelper accountHelper) {
+        return this.loanTransactionHelper.createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, "2",
+                accountHelper.createAssetAccount(), accountHelper.createIncomeAccount(), accountHelper.createExpenseAccount(),
+                accountHelper.createLiabilityAccount());
+    }
+
+    private void setupAuthenticatedRequestSpec() {
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+    }
+
+    private void setupUnauthenticatedRequestSpec() {
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+    }
+
+    private String createLoanApprovalRequest() {
+        return this.loanTransactionHelper.getApproveLoanAsJSON(LOAN_DATE);
+    }
+
+    private String createLoanApprovalCommand() {
+        return this.loanTransactionHelper.createLoanOperationURL(APPROVE_COMMAND, loanID);
+    }
+}


### PR DESCRIPTION
## Description

Fixes user authentication issue in LoanCOBApiFilter by throwing AuthenticationCredentialsNotFoundException for unauthenticated requests with "No Auth" type, ensuring correct 401 error handling.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
