### PR TITLE
FINERACT-2107: Merchant issued refund linked to related interest refund

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionRelationTypeEnum.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionRelationTypeEnum.java
@@ -23,7 +23,8 @@ public enum LoanTransactionRelationTypeEnum {
     INVALID(0, "loanTransactionType.invalid"), //
     CHARGEBACK(1, "loanTransactionRelationType.chargeback"), //
     CHARGE_ADJUSTMENT(2, "loanTransactionRelationType.chargeAdjustment"), //
-    REPLAYED(3, "loanTransactionRelationType.replayed");
+    REPLAYED(3, "loanTransactionRelationType.replayed"), //
+    RELATED(4, "loanTransactionRelationType.related");
 
     private final Integer value;
     private final String code;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
@@ -868,6 +868,10 @@ public class LoanAccountDomainServiceJpa implements LoanAccountDomainService {
 
         if (shouldCreateInterestRefundTransaction) {
             interestRefundTransaction = createInterestRefundLoanTransaction(loan, transactionDate, transactionAmount);
+            if (interestRefundTransaction != null) {
+                interestRefundTransaction.getLoanTransactionRelations().add(LoanTransactionRelation
+                        .linkToTransaction(interestRefundTransaction, refundTransaction, LoanTransactionRelationTypeEnum.RELATED));
+            }
         }
 
         final LoanRepaymentScheduleTransactionProcessor loanRepaymentScheduleTransactionProcessor = transactionProcessorFactory


### PR DESCRIPTION
- on reversal reverse interest refund aswell

## Description

On merchant issued refund reversal related interest refund also gets reversed.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
