### PR TITLE
FINERACT-2081: Fix WholeTerm loan frequency saved on account level

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -3765,6 +3765,10 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
         this.loanRepaymentScheduleDetail.setInterestPeriodFrequencyType(this.loanProduct.getInterestPeriodFrequencyType());
     }
 
+    public void updateInterestRateFrequencyType(PeriodFrequencyType periodFrequencyType) {
+        this.loanRepaymentScheduleDetail.setInterestPeriodFrequencyType(periodFrequencyType);
+    }
+
     public void addLoanTransaction(final LoanTransaction loanTransaction) {
         this.loanTransactions.add(loanTransaction);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -1253,6 +1253,8 @@ final class LoansApiResourceSwagger {
         public Integer fixedLength;
         @Schema(example = "2")
         public BigDecimal interestRatePerPeriod;
+        @Schema(example = "3")
+        public Integer interestRateFrequencyType;
         @Schema(example = "1")
         public Integer amortizationType;
         @Schema(example = "5.5")
@@ -1414,6 +1416,8 @@ final class LoansApiResourceSwagger {
         public Integer fixedLength;
         @Schema(example = "2")
         public BigDecimal interestRatePerPeriod;
+        @Schema(example = "3")
+        public Integer interestRateFrequencyType;
         @Schema(example = "0")
         public Integer interestType;
         @Schema(example = "0")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
@@ -225,7 +225,12 @@ public class LoanScheduleAssembler {
         }
 
         final BigDecimal interestRatePerPeriod = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed("interestRatePerPeriod", element);
-        final PeriodFrequencyType interestRatePeriodFrequencyType = loanProduct.getInterestPeriodFrequencyType();
+        PeriodFrequencyType interestRatePeriodFrequencyType = loanProduct.getInterestPeriodFrequencyType();
+        if (this.fromApiJsonHelper.parameterExists(LoanApiConstants.interestRateFrequencyTypeParameterName, element)) {
+            final Integer interestRateFrequencyType = this.fromApiJsonHelper
+                    .extractIntegerWithLocaleNamed(LoanApiConstants.interestRateFrequencyTypeParameterName, element);
+            interestRatePeriodFrequencyType = PeriodFrequencyType.fromInt(interestRateFrequencyType);
+        }
 
         BigDecimal annualNominalInterestRate = BigDecimal.ZERO;
         if (interestRatePerPeriod != null) {
@@ -647,7 +652,13 @@ public class LoanScheduleAssembler {
 
     public LoanProductRelatedDetail assembleLoanProductRelatedDetail(final JsonElement element, final LoanProduct loanProduct) {
         final LoanApplicationTerms loanApplicationTerms = assembleLoanApplicationTermsFrom(element, loanProduct);
-        return loanApplicationTerms.toLoanProductRelatedDetail();
+        LoanProductRelatedDetail loanProductRelatedDetail = loanApplicationTerms.toLoanProductRelatedDetail();
+        final String interestRateFrequencyTypeParamName = "interestRateFrequencyType";
+        if (this.fromApiJsonHelper.parameterExists(interestRateFrequencyTypeParamName, element)) {
+            final Integer newValue = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(interestRateFrequencyTypeParamName, element);
+            loanProductRelatedDetail.setInterestPeriodFrequencyType(PeriodFrequencyType.fromInt(newValue));
+        }
+        return loanProductRelatedDetail;
     }
 
     public LoanScheduleModel assembleLoanScheduleFrom(final JsonElement element) {


### PR DESCRIPTION
## Description

WholeTerm loan frequency saved on account level is displayed as PerYear because It is being inherit from Loan Product.

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

<img width="953" alt="Screenshot 2024-11-04 at 4 25 35 a m" src="https://github.com/user-attachments/assets/3ba04bd8-7478-4c8a-9f5b-3d87a2575d65">

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
