### PR TITLE
FINERACT-2125: implement server side rate limit on Login Panel

### DIFF
--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -50,6 +50,7 @@ dependencies {
             )
     implementation(
             'org.springframework.boot:spring-boot-starter-web',
+            'org.springframework.boot:spring-boot-starter-aop',
             'org.springframework.boot:spring-boot-starter-security',
             'org.springframework.boot:spring-boot-starter-cache',
             'org.springframework.boot:spring-boot-starter-oauth2-resource-server',
@@ -85,6 +86,7 @@ dependencies {
             'com.squareup.okhttp3:okhttp',
             'com.squareup.okhttp3:okhttp-urlconnection',
 
+            'com.github.ben-manes.caffeine:caffeine:3.1.8',
             'org.apache.commons:commons-lang3',
             'commons-io:commons-io',
             'org.apache.poi:poi',

--- a/fineract-provider/src/main/java/org/apache/fineract/ServerApplication.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/ServerApplication.java
@@ -21,9 +21,11 @@ package org.apache.fineract;
 import java.io.IOException;
 import org.apache.fineract.infrastructure.core.boot.FineractLiquibaseOnlyApplicationConfiguration;
 import org.apache.fineract.infrastructure.core.boot.FineractWebApplicationConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -38,7 +40,8 @@ import org.springframework.context.annotation.Import;
  * It's the old/classic Mifos (non-X) Workspace 2.0 reborn for Fineract! ;-)
  *
  */
-
+@SpringBootApplication
+@EnableAspectJAutoProxy
 public class ServerApplication extends SpringBootServletInitializer {
 
     @Import({ FineractWebApplicationConfiguration.class, FineractLiquibaseOnlyApplicationConfiguration.class })

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/EnforceRateLimit.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/EnforceRateLimit.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnforceRateLimit {}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/InMemoryRateLimitService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/InMemoryRateLimitService.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.annotation.PostConstruct;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryRateLimitService implements RateLimitService {
+
+    @Value("${fineract.security.ratelimit.max-attempts-per-host-per-minute:60}")
+    private int maxAttemptsPerHostPerMinute;
+
+    private Cache<String, Integer> cache;
+
+    @PostConstruct
+    public void setup() {
+        cache = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.MINUTES).maximumSize(100_000).build();
+    }
+
+    @Override
+    public boolean isRateLimited(String remoteAddress) {
+        Integer existingAttempts = cache.getIfPresent(remoteAddress);
+        int currentAttempt = 1 + Optional.ofNullable(existingAttempts).orElse(0);
+        cache.put(remoteAddress, currentAttempt);
+
+        return currentAttempt > maxAttemptsPerHostPerMinute;
+    }
+
+    @Override
+    public void resetRateLimit(String remoteAddress) {
+        cache.invalidate(remoteAddress);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/RateLimitAspect.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/RateLimitAspect.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+    private final RateLimitService rateLimitService;
+
+    @Pointcut("@annotation(EnforceRateLimit) || @within(EnforceRateLimit)")
+    public void pointcut() {}
+
+    @Around("pointcut()")
+    public Object aroundRestCall(ProceedingJoinPoint joinPoint) throws Exception {
+        String remoteAddress = getRequest().getRemoteAddr();
+
+        if (rateLimitService.isRateLimited(remoteAddress)) {
+            return Response.status(429).entity("Too many requests - try again later.").build();
+
+        } else {
+            try {
+                return joinPoint.proceed();
+            } catch (Throwable t) { // CheckStyle disallows throwing Throwable
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    HttpServletRequest getRequest() {
+        return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/RateLimitService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/ratelimit/RateLimitService.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+public interface RateLimitService {
+
+    boolean isRateLimited(String remoteAddress);
+
+    void resetRateLimit(String remoteAddress);
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/security/api/SelfAuthenticationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/self/security/api/SelfAuthenticationApiResource.java
@@ -25,11 +25,14 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.security.api.AuthenticationApiResource;
 import org.apache.fineract.infrastructure.security.api.AuthenticationApiResourceSwagger;
@@ -53,7 +56,7 @@ public class SelfAuthenticationApiResource {
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = AuthenticationApiResourceSwagger.PostAuthenticationRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SelfAuthenticationApiResourceSwagger.PostSelfAuthenticationResponse.class))) })
-    public String authenticate(final String apiRequestBodyAsJson) {
-        return this.authenticationApiResource.authenticate(apiRequestBodyAsJson, true);
+    public Response authenticate(final String apiRequestBodyAsJson, @Context HttpServletRequest httpRequest) {
+        return this.authenticationApiResource.authenticate(apiRequestBodyAsJson, true, httpRequest);
     }
 }

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -24,6 +24,7 @@ fineract.node-id=${FINERACT_NODE_ID:1}
 fineract.security.basicauth.enabled=${FINERACT_SECURITY_BASICAUTH_ENABLED:true}
 fineract.security.oauth.enabled=${FINERACT_SECURITY_OAUTH_ENABLED:false}
 fineract.security.2fa.enabled=${FINERACT_SECURITY_2FA_ENABLED:false}
+fineract.security.ratelimit.max-attempts-per-host-per-minute=${FINERACT_SECURITY_RATELIMIT_MAX_ATTEMPTS_PER_HOST_PER_MINUTE:10}
 
 fineract.tenant.host=${FINERACT_DEFAULT_TENANTDB_HOSTNAME:localhost}
 fineract.tenant.port=${FINERACT_DEFAULT_TENANTDB_PORT:3306}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/ratelimit/TestInMemoryRateLimitService.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/ratelimit/TestInMemoryRateLimitService.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TestInMemoryRateLimitService {
+
+    @Test
+    public void testDefaultRateLimiter() {
+        InMemoryRateLimitService ratelimiter = new InMemoryRateLimitService();
+        ratelimiter.setup();
+        ReflectionTestUtils.setField(ratelimiter, "maxAttemptsPerHostPerMinute", 3);
+
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertTrue(ratelimiter.isRateLimited("127.0.0.1"));
+    }
+
+    @Test
+    public void testTimeEviction() throws InterruptedException {
+        InMemoryRateLimitService ratelimiter = new InMemoryRateLimitService();
+        ratelimiter.setup();
+        ReflectionTestUtils.setField(ratelimiter, "maxAttemptsPerHostPerMinute", 2);
+        ReflectionTestUtils.setField(ratelimiter, "cache",
+                Caffeine.newBuilder().expireAfterWrite(500, TimeUnit.MILLISECONDS).maximumSize(100_000).build());
+
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertTrue(ratelimiter.isRateLimited("127.0.0.1"));
+        Thread.sleep(1_000L);
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+    }
+
+    @Test
+    public void testReset() {
+        InMemoryRateLimitService ratelimiter = new InMemoryRateLimitService();
+        ratelimiter.setup();
+        ReflectionTestUtils.setField(ratelimiter, "maxAttemptsPerHostPerMinute", 2);
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+        assertTrue(ratelimiter.isRateLimited("127.0.0.1"));
+
+        ratelimiter.resetRateLimit("127.0.0.1");
+        assertFalse(ratelimiter.isRateLimited("127.0.0.1"));
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/ratelimit/TestRateLimitAspect.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/ratelimit/TestRateLimitAspect.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TestRateLimitAspect {
+
+    @Test
+    public void test() throws Exception {
+        InMemoryRateLimitService ratelimiter = new InMemoryRateLimitService();
+        ratelimiter.setup();
+        ReflectionTestUtils.setField(ratelimiter, "maxAttemptsPerHostPerMinute", 2);
+
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        RateLimitAspect aspect = spy(new RateLimitAspect(ratelimiter));
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        doReturn(mockRequest).when(aspect).getRequest();
+        when(mockRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+
+        assertNull(aspect.aroundRestCall(joinPoint));
+        assertNull(aspect.aroundRestCall(joinPoint));
+        assertEquals(429, ((Response) aspect.aroundRestCall(joinPoint)).getStatus());
+    }
+
+}


### PR DESCRIPTION
Fineract has a reported security vulnerability, because it does not limit login attempts, effectively allowing brute force attacks on the login screen. These changes enforce a configurable limitation of allowed requests on certain API requests (currently applied for the login request only).

Note that the enforcement happens in each JVM separately, so for clustered deployment each node enforces limits separately. That should be considered when determining the configuration value on critical deployments.


## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
