### PR TITLE
FINERACT-2081: Enable inline COB execution for locked loans

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/domain/LoanAccountLockRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/domain/LoanAccountLockRepository.java
@@ -36,6 +36,8 @@ public interface LoanAccountLockRepository
 
     boolean existsByLoanIdAndLockOwner(Long loanId, LockOwner lockOwner);
 
+    boolean existsByLoanIdAndLockOwnerAndErrorIsNotNull(Long loanId, LockOwner lockOwner);
+
     @Query("""
             delete from LoanAccountLock lck where lck.lockPlacedOnCobBusinessDate is not null and lck.error is not null and
             lck.lockOwner in (org.apache.fineract.cob.domain.LockOwner.LOAN_COB_CHUNK_PROCESSING,org.apache.fineract.cob.domain.LockOwner.LOAN_INLINE_COB_PROCESSING)

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanAccountLockService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanAccountLockService.java
@@ -27,5 +27,7 @@ public interface LoanAccountLockService {
 
     boolean isLoanHardLocked(Long loanId);
 
+    boolean isLockOverrulable(Long loanId);
+
     void updateCobAndRemoveLocks();
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanAccountLockServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanAccountLockServiceImpl.java
@@ -50,6 +50,12 @@ public class LoanAccountLockServiceImpl implements LoanAccountLockService {
     }
 
     @Override
+    public boolean isLockOverrulable(Long loanId) {
+        return loanAccountLockRepository.existsByLoanIdAndLockOwnerAndErrorIsNotNull(loanId, LockOwner.LOAN_COB_CHUNK_PROCESSING) //
+                || loanAccountLockRepository.existsByLoanIdAndLockOwnerAndErrorIsNotNull(loanId, LockOwner.LOAN_INLINE_COB_PROCESSING);
+    }
+
+    @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateCobAndRemoveLocks() {
         loanAccountLockRepository.updateLoanFromAccountLocks();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -600,6 +600,10 @@ public abstract class BaseLoanIntegrationTest {
         loanAccountLockHelper.placeSoftLockOnLoanAccount(loanId.intValue(), "LOAN_COB_CHUNK_PROCESSING");
     }
 
+    protected void placeHardLockOnLoan(Long loanId, String error) {
+        loanAccountLockHelper.placeSoftLockOnLoanAccount(loanId.intValue(), "LOAN_COB_CHUNK_PROCESSING", error);
+    }
+
     protected void executeInlineCOB(Long loanId) {
         inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -602,6 +602,11 @@ public class LoanTransactionHelper extends IntegrationTest {
         return ok(fineract().loanTransactions.executeLoanTransaction(loanId, request, "repayment"));
     }
 
+    public PostLoansLoanIdTransactionsResponse makeLoanRepayment(final Long loanId, final PostLoansLoanIdTransactionsRequest request,
+            final String user, final String pass) {
+        return ok(newFineract(user, pass).loanTransactions.executeLoanTransaction(loanId, request, "repayment"));
+    }
+
     public PostLoansLoanIdTransactionsResponse makeInterestPaymentWaiver(final Long loanId,
             final PostLoansLoanIdTransactionsRequest request) {
         return ok(fineract().loanTransactions.executeLoanTransaction(loanId, request, "interestPaymentWaiver"));


### PR DESCRIPTION
## Description

If the loan is locked, but there is any error attached to the lock, it means the prior execution of COB / Inline COB failed. 

For user experience it would be better if we let the inline COB to be triggered again in these situations hence noone is processing the loan at the moment, it just indicates there was some problem during the last processing.

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
