### PR TITLE
FINERACT-2147: fix extra swagger UI endpoint paths

### DIFF
--- a/fineract-provider/config/swagger/fineract-input.yaml.template
+++ b/fineract-provider/config/swagger/fineract-input.yaml.template
@@ -14,8 +14,8 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: /fineract-provider/api/v1
-  - url: https://demo.fineract.dev/fineract-provider/api/v1
+  - url: /fineract-provider/api
+  - url: https://demo.fineract.dev/fineract-provider/api
 components:
   securitySchemes:
     basicAuth:


### PR DESCRIPTION
## Description

I noticed an extra `v1/` while visiting https://localhost:8443/fineract-provider/swagger-ui/index.html

All fineract-provider (unit) tests passed.

I also manually tested out hitting a few /api/v1/ endpoints via the Swagger UI web page at the URL above and those worked as well.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made. *I think the actual endpoints are already covered, and there's no existing coverage for the request URLs generated for, displayed in, and used by the Swagger UI web page. I'm happy to look into adding coverage for this if/as desired... perhaps just a match assertion integration test looking for fineract-provider/api/v1/ and ensuring against fineract-provider/api/v1/v1/*
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)