### PR TITLE
FINERACT-1981: Fix interest refund transaction with zero amount

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/InterestRefundService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/InterestRefundService.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
+import java.math.MathContext;
 import java.time.LocalDate;
 import java.util.List;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
@@ -36,5 +37,5 @@ public interface InterestRefundService {
     Money totalInterestByTransactions(LoanRepaymentScheduleTransactionProcessor processor, Long loanId,
             LocalDate relatedRefundTransactionDate, List<LoanTransaction> newTransactions, List<Long> oldTransactionIds);
 
-    Money getTotalInterestRefunded(List<LoanTransaction> loanTransactions, MonetaryCurrency currency);
+    Money getTotalInterestRefunded(List<LoanTransaction> loanTransactions, MonetaryCurrency currency, MathContext mc);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ProgressiveLoanInterestRefundServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ProgressiveLoanInterestRefundServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.loanaccount.service;
 import static org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType.REPAYMENT;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -135,9 +136,13 @@ public class ProgressiveLoanInterestRefundServiceImpl implements InterestRefundS
     }
 
     @Override
-    public Money getTotalInterestRefunded(List<LoanTransaction> loanTransactions, MonetaryCurrency currency) {
-        return Money.of(currency, loanTransactions.stream().filter(LoanTransaction::isNotReversed).filter(LoanTransaction::isInterestRefund)
-                .map(LoanTransaction::getAmount).reduce(BigDecimal.ZERO, BigDecimal::add));
+    public Money getTotalInterestRefunded(List<LoanTransaction> loanTransactions, MonetaryCurrency currency, MathContext mc) {
+        final BigDecimal totalInterestRefunded = loanTransactions.stream() //
+                .filter(LoanTransaction::isNotReversed) //
+                .filter(LoanTransaction::isInterestRefund) //
+                .map(LoanTransaction::getAmount) //
+                .reduce(BigDecimal.ZERO, BigDecimal::add); //
+        return Money.of(currency, totalInterestRefunded, mc);
     }
 
 }


### PR DESCRIPTION
This P.R. fixes a bug related to a merchant-issued refund. 
There was a zero amount Interest refund transaction and now we won't create if the transaction amount is zero.

Also includes a minor refactor.