### PR TITLE
FINERACT-2081: Retrieving Loan Product details with invalid external-…

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/exception/LoanProductNotFoundException.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/exception/LoanProductNotFoundException.java
@@ -32,7 +32,8 @@ public class LoanProductNotFoundException extends AbstractPlatformResourceNotFou
     }
 
     public LoanProductNotFoundException(final ExternalId externalId) {
-        super("error.msg.loanproduct.id.invalid", "Loan product with identifier " + externalId + " does not exist", externalId);
+        super("error.msg.loanproduct.id.invalid", "Loan product with identifier " + externalId.getValue() + " does not exist",
+                externalId.getValue());
     }
 
     public LoanProductNotFoundException(Long id, EmptyResultDataAccessException e) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -104,7 +104,11 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
 
     @Override
     public LoanProduct retrieveLoanProductByExternalId(final ExternalId externalId) {
-        return loanProductRepository.findByExternalId(externalId);
+        final LoanProduct loanProduct = loanProductRepository.findByExternalId(externalId);
+        if (loanProduct == null) {
+            throw new LoanProductNotFoundException(externalId);
+        }
+        return loanProduct;
     }
 
     @Override


### PR DESCRIPTION
…id results in 500 error

## Description

Retrieving Loan Product details with invalid external-id result in 500 error (Internal Server Error), because It was not throwing the Not Found Exception properly

[FINERACT-2081](https://issues.apache.org/jira/browse/FINERACT-2081)

- Case with valid External Id
<img width="1098" alt="Screenshot 2024-11-28 at 1 27 42 p m" src="https://github.com/user-attachments/assets/fd7345f9-738c-4d30-b3e3-18ca4d2557d1">

- Case with Invalid External Id
<img width="1109" alt="Screenshot 2024-11-28 at 1 27 26 p m" src="https://github.com/user-attachments/assets/3a610430-d5fe-41be-859e-f26348100de4">


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
