### PR TITLE
FINERACT-1971: Fix boolean values used in Loan product charge-off rea…

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingReadPlatformServiceImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingReadPlatformServiceImpl.java
@@ -88,8 +88,8 @@ public class ProductToGLAccountMappingReadPlatformServiceImpl implements Product
             final String codeValue = rs.getString("codeValueName");
             final String codeDescription = rs.getString("codeDescription");
             final Integer orderPosition = rs.getInt("orderPosition");
-            final Integer isActive = rs.getInt("isActive");
-            final Integer isMandatory = rs.getInt("isMandatory");
+            final Boolean isActive = rs.getBoolean("isActive");
+            final Boolean isMandatory = rs.getBoolean("isMandatory");
 
             final Map<String, Object> loanProductToGLAccountMap = new LinkedHashMap<>(5);
             loanProductToGLAccountMap.put("id", id);
@@ -377,10 +377,8 @@ public class ProductToGLAccountMappingReadPlatformServiceImpl implements Product
             final String codeValue = (String) chargeOffReasonMap.get("codeValue");
             final String codeDescription = (String) chargeOffReasonMap.get("codeDescription");
             final Integer orderPosition = (Integer) chargeOffReasonMap.get("orderPosition");
-            final Integer isActive = (Integer) chargeOffReasonMap.get("isActive");
-            final Integer isMandatory = (Integer) chargeOffReasonMap.get("isMandatory");
-            final boolean active = isActive != null && isActive == 1;
-            final boolean mandatory = isMandatory != null && isMandatory == 1;
+            final Boolean active = (Boolean) chargeOffReasonMap.get("isActive");
+            final Boolean mandatory = (Boolean) chargeOffReasonMap.get("isMandatory");
             final CodeValueData chargeOffReasonsCodeValue = CodeValueData.builder().id(Long.valueOf(chargeOffReasonId)).name(codeValue)
                     .description(codeDescription).position(orderPosition).active(active).mandatory(mandatory).build();
 


### PR DESCRIPTION
…sons accounting mappings

## Description

Fix boolean values used in Loan product charge-off reasons accounting mappings It was using integers and for Postgres it was not working 

[FINERACT-1971](https://issues.apache.org/jira/browse/FINERACT-1971)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
