### PR TITLE
FINERACT-1971: Fix EMI Calculator: Last Unpaid Repayment Period Handling

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -307,7 +307,13 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         Money diff = totalDisbursedAmount.plus(totalDueInterest, mc).minus(totalEMI, mc);
         Optional<RepaymentPeriod> findLastUnpaidRepaymentPeriod = scheduleModel.repaymentPeriods().stream().filter(rp -> !rp.isFullyPaid())
                 .reduce((first, second) -> second);
-        findLastUnpaidRepaymentPeriod.ifPresent(repaymentPeriod -> repaymentPeriod.setEmi(repaymentPeriod.getEmi().add(diff, mc)));
+        findLastUnpaidRepaymentPeriod.ifPresent(repaymentPeriod -> {
+            repaymentPeriod.setEmi(repaymentPeriod.getEmi().add(diff, mc));
+            if (repaymentPeriod.getEmi().isLessThanZero()) {
+                repaymentPeriod.setEmi(repaymentPeriod.getEmi().zero());
+                calculateLastUnpaidRepaymentPeriodEMI(scheduleModel);
+            }
+        });
     }
 
     private void calculateOutstandingBalance(ProgressiveLoanInterestScheduleModel scheduleModel) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -1075,6 +1075,10 @@ public abstract class BaseLoanIntegrationTest {
         return new Installment(principalAmount, interestAmount, null, null, totalOutstandingAmount, completed, dueDate, null, null);
     }
 
+    protected Installment fullyRepaidInstallment(double principalAmount, double interestAmount, String dueDate) {
+        return new Installment(principalAmount, interestAmount, null, null, 0.0, true, dueDate, null, null);
+    }
+
     protected Installment installment(double principalAmount, double interestAmount, double feeAmount, double totalOutstandingAmount,
             Boolean completed, String dueDate) {
         return new Installment(principalAmount, interestAmount, feeAmount, null, totalOutstandingAmount, completed, dueDate, null, null);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRefundTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRefundTest.java
@@ -219,6 +219,127 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     }
 
     @Test
+    public void verifyInterestRefundCreatedForMerchantIssuedRefundDay22HighInterest12month() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+        runAt("1 January 2021", () -> {
+            PostLoanProductsResponse loanProduct = loanProductHelper
+                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                            .daysInYearType(DaysInYearType.ACTUAL) //
+                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            );
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
+                    12, null);
+            Assertions.assertNotNull(loanId);
+            loanIdRef.set(loanId);
+            disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
+        });
+        runAt("22 January 2021", () -> {
+            Long loanId = loanIdRef.get();
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper
+                    .makeLoanRepayment("MerchantIssuedRefund", "22 January 2021", 1000F, loanId.intValue());
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
+
+            verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
+                    transaction(14.96, "Accrual", "22 January 2021"), //
+                    transaction(14.96, "Interest Refund", "22 January 2021"), //
+                    transaction(1000.0, "Merchant Issued Refund", "22 January 2021") //
+            );
+            verifyRepaymentSchedule(loanId, installment(1000.0, null, "01 January 2021"), //
+                    fullyRepaidInstallment(80.52, 14.96, "01 February 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 March 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 April 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 May 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 June 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 July 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 August 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 September 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 October 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 November 2021"), //
+                    fullyRepaidInstallment(60.16, 0.0, "01 December 2021"), //
+                    fullyRepaidInstallment(0.0, 0.0, "01 January 2022") //
+            );
+        });
+    }
+
+    @Test
+    public void verifyFullMerchantIssuedRefundOnDay0HighInterest12month() {
+        runAt("1 January 2021", () -> {
+            PostLoanProductsResponse loanProduct = loanProductHelper
+                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                            .daysInYearType(DaysInYearType.ACTUAL) //
+                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            );
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
+                    12, null);
+            Assertions.assertNotNull(loanId);
+            disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper
+                    .makeLoanRepayment("MerchantIssuedRefund", "1 January 2021", 1000F, loanId.intValue());
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
+
+            verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
+                    transaction(1000.0, "Merchant Issued Refund", "01 January 2021") //
+            );
+            verifyRepaymentSchedule(loanId, installment(1000.0, null, "01 January 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 February 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 March 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 April 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 May 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 June 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 July 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 August 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 September 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 October 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 November 2021"), //
+                    fullyRepaidInstallment(45.2, 0.0, "01 December 2021"), //
+                    fullyRepaidInstallment(0.0, 0.0, "01 January 2022") //
+            );
+        });
+    }
+
+    @Test
+    public void verifyRepaymentDay0HighInterest12month() {
+        runAt("1 January 2021", () -> {
+            PostLoanProductsResponse loanProduct = loanProductHelper
+                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                            .daysInYearType(DaysInYearType.ACTUAL) //
+                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            );
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
+                    12, null);
+            Assertions.assertNotNull(loanId);
+            disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment("Repayment",
+                    "1 January 2021", 1000F, loanId.intValue());
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
+            Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
+
+            verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
+                    transaction(1000.0, "Repayment", "01 January 2021") //
+            );
+            verifyRepaymentSchedule(loanId, installment(1000.0, null, "01 January 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 February 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 March 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 April 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 May 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 June 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 July 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 August 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 September 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 October 2021"), //
+                    fullyRepaidInstallment(95.48, 0.0, "01 November 2021"), //
+                    fullyRepaidInstallment(45.2, 0.0, "01 December 2021"), //
+                    fullyRepaidInstallment(0.0, 0.0, "01 January 2022") //
+            );
+        });
+    }
+
+    @Test
     public void verifyUC01() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {


### PR DESCRIPTION
## Description

Call calculateLastUnpaidRepaymentPeriodEMI recursively when emi is less than zero to adjust remaining emi correction for previous period.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-1971).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
