### PR TITLE
FINERACT-1971: Fix Accrual Activity Reversal on Installment Due Date.

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/AbstractLoanRepaymentScheduleTransactionProcessor.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/AbstractLoanRepaymentScheduleTransactionProcessor.java
@@ -216,6 +216,17 @@ public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implemen
         return changedTransactionDetail;
     }
 
+    boolean areNormalInstalmentsFullyRepaid(List<LoanRepaymentScheduleInstallment> installments) {
+        return installments.stream() //
+                .filter(i -> !i.isAdditional() && !i.isDownPayment()) //
+                .noneMatch(LoanRepaymentScheduleInstallment::isNotFullyPaidOff); //
+    }
+
+    boolean isClosedOrOverpaid(Loan loan) {
+        var status = loan.getStatus();
+        return status.isClosed() || status.isOverpaid();
+    }
+
     protected void calculateAccrualActivity(LoanTransaction loanTransaction, MonetaryCurrency currency,
             List<LoanRepaymentScheduleInstallment> installments) {
 
@@ -225,8 +236,9 @@ public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implemen
                 .filter(installment -> LoanRepaymentScheduleProcessingWrapper.isInPeriod(loanTransaction.getTransactionDate(), installment,
                         installment.getInstallmentNumber().equals(firstNormalInstallmentNumber)))
                 .findFirst().orElseThrow();
-        if (loanTransaction.getDateOf().isEqual(currentInstallment.getDueDate()) || installments.stream()
-                .filter(i -> !i.isAdditional() && !i.isDownPayment()).noneMatch(LoanRepaymentScheduleInstallment::isNotFullyPaidOff)) {
+        boolean areNormalInstalmentsFullyRepaid = areNormalInstalmentsFullyRepaid(installments);
+        boolean isAAonDueDate = loanTransaction.getDateOf().isEqual(currentInstallment.getDueDate());
+        if (areNormalInstalmentsFullyRepaid || (isAAonDueDate && !isClosedOrOverpaid(loanTransaction.getLoan()))) {
             loanTransaction.resetDerivedComponents();
             final Money principalPortion = Money.zero(currency);
             Money interestPortion = currentInstallment.getInterestCharged(currency);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -62,6 +63,7 @@ import org.apache.fineract.client.models.BusinessDateRequest;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
 import org.apache.fineract.client.models.PaymentAllocationOrder;
@@ -236,6 +238,32 @@ public abstract class BaseLoanIntegrationTest {
         assertEquals(interestOutstanding, period.getInterestOutstanding());
         assertEquals(paidInAdvance, period.getTotalPaidInAdvanceForPeriod());
         assertEquals(paidLate, period.getTotalPaidLateForPeriod());
+    }
+
+    /**
+     * Verifies the loan status by applying the given extractor function to the status of the loan details. This method
+     * ensures that the loan details, loan status, and the result of the extractor are not null and asserts that the
+     * result of the extractor function is true.
+     *
+     * @param loanDetails
+     *            the loan details object containing the loan status
+     * @param extractor
+     *            a function that extracts a boolean value from the loan status for verification
+     * @throws AssertionError
+     *             if any of the following conditions are not met:
+     *             <ul>
+     *             <li>The loan details object is not null</li>
+     *             <li>The loan status in the loan details is not null</li>
+     *             <li>The value extracted by the extractor function is not null</li>
+     *             <li>The value extracted by the extractor function is true</li>
+     *             </ul>
+     */
+    protected void verifyLoanStatus(GetLoansLoanIdResponse loanDetails, Function<GetLoansLoanIdStatus, Boolean> extractor) {
+        Assertions.assertNotNull(loanDetails);
+        Assertions.assertNotNull(loanDetails.getStatus());
+        Boolean actualValue = extractor.apply(loanDetails.getStatus());
+        Assertions.assertNotNull(actualValue);
+        Assertions.assertTrue(actualValue);
     }
 
     private String getNonByPassUserAuthKey(RequestSpecification requestSpec, ResponseSpecification responseSpec) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
@@ -42,6 +42,8 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
@@ -51,6 +53,7 @@ import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.infrastructure.event.external.service.validation.ExternalEventDTO;
 import org.apache.fineract.integrationtests.common.BusinessStepHelper;
@@ -706,6 +709,73 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check that third part cannot post for that charge, because it already fully adjusted
             Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, InterestRecalculation, 25% yearly interest 6
+     * repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day</li>
+     * <li>verify there is no reverse replayed transaction during reversing the repayment</li>
+     * <li>verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
+        runAt("17 January 2025", () -> {
+            enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(600.0, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            deleteAllExternalEvents();
+            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+
+            List<ExternalEventDTO> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            // Verify that there were no reverse-replay event
+            List<ExternalEventDTO> list = allExternalEvents.stream() //
+                    .filter(x -> "LoanAdjustTransactionBusinessEvent".equals(x.getType()) //
+                            && x.getPayLoad().get("newTransactionDetail") != null //
+                            && x.getPayLoad().get("transactionToAdjust") != null) //
+                    .toList(); //
+            Assertions.assertEquals(0, list.size());
+
+            // verify that there were 2 transaction reversal event
+            list = allExternalEvents.stream() //
+                    .filter(x -> "LoanAdjustTransactionBusinessEvent".equals(x.getType()) //
+                            && x.getPayLoad().get("newTransactionDetail") == null //
+                            && x.getPayLoad().get("transactionToAdjust") != null) //
+                    .toList(); //
+            Assertions.assertEquals(2, list.size());
+
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    reversedTransaction(600.0, "Repayment", "17 January 2025")); //
         });
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
@@ -43,6 +43,7 @@ import org.apache.fineract.client.models.ChargeToGLAccountMapper;
 import org.apache.fineract.client.models.GetLoanFeeToIncomeAccountMappings;
 import org.apache.fineract.client.models.GetLoanPaymentChannelToFundSourceMappings;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.PaymentAllocationOrder;
 import org.apache.fineract.client.models.PostChargesRequest;
 import org.apache.fineract.client.models.PostChargesResponse;
@@ -106,6 +107,327 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
                 "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "ACCRUAL_ACTIVITY_POSTING");
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, NO InterestRecalculation, 25% yearly interest
+     * 6 repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day</li>
+     * <li>verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1() {
+        runAt("17 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(600.0, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    reversedTransaction(600.0, "Repayment", "17 January 2025")); //
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, InterestRecalculation, 25% yearly interest 6
+     * repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day</li>
+     * <li>verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
+        runAt("17 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(600.0, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    reversedTransaction(600.0, "Repayment", "17 January 2025")); //
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, NO InterestRecalculation, 25% yearly interest
+     * 6 repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day</li>
+     * <li>verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1b() {
+        runAt("18 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(600.0, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "18 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "18 January 2025"), //
+                    reversedTransaction(600.0, "Repayment", "17 January 2025"), //
+                    transaction(3.31, "Accrual Activity", "17 January 2025")); //
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, NO InterestRecalculation, 25% yearly interest
+     * 6 repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 483.52f on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become Closed Obligations Met</li>
+     * <li>add charge on 17 January 2025</li>
+     * <li>verify loan become active</li>
+     * <li>verify Accrual Activity transaction was removed</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2() {
+        runAt("17 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .currencyCode("USD") //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(483.52, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            addCharge(loanId, false, 15.0, "17 January 2025");
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(483.52, "Repayment", "17 January 2025")); //
+        });
+    }
+
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepaymentBackdatedRepaymentsAndMerchantIssuedRefund() {
+        runAt("17 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .currencyCode("USD") //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(true));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 497.04f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(497.04, "Repayment", "17 January 2025"), //
+                    transaction(47.04, "Accrual", "17 January 2025"), //
+                    transaction(47.04, "Accrual Activity", "17 January 2025")); //
+            loanTransactionHelper.makeLoanRepayment("MerchantIssuedRefund", "17 August 2024", 450.0f, loanId.intValue()).getResourceId();
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(450.0, "Merchant Issued Refund", "17 August 2024"), //
+                    transaction(497.04, "Repayment", "17 January 2025"), //
+                    transaction(47.04, "Accrual", "17 January 2025"), //
+                    transaction(47.04, "Accrual Adjustment", "17 January 2025")); //
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, NO InterestRecalculation, 25% yearly interest
+     * 6 repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2b() {
+        runAt("17 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .currencyCode("USD") //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(483.52, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            addCharge(loanId, false, 15.0, "15 January 2025");
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "17 January 2025"), //
+                    transaction(483.52, "Repayment", "17 January 2025")); //
+        });
+    }
+
+    /**
+     * Using Interest bearing Progressive Loan, Accrual Activity Posting, NO InterestRecalculation, 25% yearly interest
+     * 6 repayment 450 USD principal.
+     * <li>apply, approve and disburse backdated on 17 August 2024</li>
+     * <li>repay 600 on 17 January 2025</li>
+     * <li>verify Accrual and Accrual Activity transaction creation</li>
+     * <li>verify that the loan become overpaid</li>
+     * <li>reverse repayment on same day verify transaction reversals</li>
+     */
+    @Test
+    public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2c() {
+        runAt("18 January 2025", () -> {
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+                    .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
+                    .enableAccrualActivityPosting(true) //
+                    .currencyCode("USD") //
+                    .daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .isInterestRecalculationEnabled(false));//
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            Long loanId = postLoansResponse.getLoanId();
+            Assertions.assertNotNull(loanId);
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024") //
+            );
+            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Assertions.assertNotNull(repaymentId);
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
+            verifyTransactions(loanId, //
+                    transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(483.52, "Repayment", "17 January 2025"), //
+                    transaction(33.52, "Accrual", "18 January 2025"), //
+                    transaction(33.52, "Accrual Activity", "17 January 2025")); //
+            addCharge(loanId, false, 15.0, "15 January 2025");
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
+            verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
+                    transaction(33.52, "Accrual", "18 January 2025"), //
+                    transaction(483.52, "Repayment", "17 January 2025"), //
+                    transaction(18.31, "Accrual Activity", "17 January 2025")); //
+
+        });
     }
 
     // Create Loan with Interest and enabled Accrual Activity Posting
@@ -956,10 +1278,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             Long repaymentId = loanTransactionHelper.makeLoanRepayment("02 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
-            Assertions.assertNotNull(loanDetails);
-            Assertions.assertNotNull(loanDetails.getStatus());
-            Assertions.assertNotNull(loanDetails.getStatus().getOverpaid());
-            Assertions.assertTrue(loanDetails.getStatus().getOverpaid());
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "02 January 2024"),
@@ -992,10 +1311,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
-            Assertions.assertNotNull(loanDetails);
-            Assertions.assertNotNull(loanDetails.getStatus());
-            Assertions.assertNotNull(loanDetails.getStatus().getOverpaid());
-            Assertions.assertTrue(loanDetails.getStatus().getOverpaid());
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
@@ -1003,10 +1319,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
             loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
             loanDetails = loanTransactionHelper.getLoanDetails(loanId);
-            Assertions.assertNotNull(loanDetails);
-            Assertions.assertNotNull(loanDetails.getStatus());
-            Assertions.assertNotNull(loanDetails.getStatus().getActive());
-            Assertions.assertTrue(loanDetails.getStatus().getActive());
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
                     reversedTransaction(370.0, "Repayment", "01 January 2024"));
@@ -1039,20 +1352,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
-            Assertions.assertNotNull(loanDetails);
-            Assertions.assertNotNull(loanDetails.getStatus());
-            Assertions.assertNotNull(loanDetails.getStatus().getOverpaid());
-            Assertions.assertTrue(loanDetails.getStatus().getOverpaid());
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
                     transaction(38.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "01 January 2024"));
             loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
             loanDetails = loanTransactionHelper.getLoanDetails(loanId);
-            Assertions.assertNotNull(loanDetails);
-            Assertions.assertNotNull(loanDetails.getStatus());
-            Assertions.assertNotNull(loanDetails.getStatus().getActive());
-            Assertions.assertTrue(loanDetails.getStatus().getActive());
+            verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
                     reversedTransaction(370.0, "Repayment", "01 January 2024"));


### PR DESCRIPTION


## Description

* Accrual Activity is not recalculated during reopen transaction recalculation
* integration tests cover reverse replay verification and extra use cases
* 
Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-1971).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
