### PR TITLE
Fix/triggered sms campaign

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
@@ -90,36 +90,48 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
             if (!smsDataMap.isEmpty()) {
                 List<SmsMessage> toSaveMessages = new ArrayList<>();
                 List<SmsMessage> toSendNotificationMessages = new ArrayList<>();
+                
+                // First collect all messages
                 for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
-                    Iterator<SmsMessage> smsMessageIterator = entry.getValue().iterator();
-                    Collection<SmsMessageApiQueueResourceData> apiQueueResourceDatas = new ArrayList<>();
-                    while (smsMessageIterator.hasNext()) {
-                        SmsMessage smsMessage = smsMessageIterator.next();
+                    for (SmsMessage smsMessage : entry.getValue()) {
                         if (smsMessage.isNotification()) {
                             smsMessage.setStatusType(SmsMessageStatusType.WAITING_FOR_DELIVERY_REPORT.getValue());
                             toSendNotificationMessages.add(smsMessage);
                         } else {
-                            SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData.instance(
-                                    smsMessage.getId(), null, null, null, smsMessage.getMobileNo(), smsMessage.getMessage(),
-                                    entry.getKey().getProviderId());
-                            apiQueueResourceDatas.add(apiQueueResourceData);
                             smsMessage.setStatusType(SmsMessageStatusType.WAITING_FOR_DELIVERY_REPORT.getValue());
                             toSaveMessages.add(smsMessage);
                         }
                     }
-                    if (toSaveMessages.size() > 0) {
-                        this.smsMessageRepository.saveAll(toSaveMessages);
-                        this.smsMessageRepository.flush();
-                        this.taskExecutor.execute(new SmsTask(apiQueueResourceDatas, ThreadLocalContextUtil.getContext()));
-                    }
-                    if (!toSendNotificationMessages.isEmpty()) {
-                        this.notificationSenderService.sendNotification(toSendNotificationMessages);
-                    }
+                }
 
+                // Save messages first to get IDs
+                if (!toSaveMessages.isEmpty()) {
+                    this.smsMessageRepository.saveAll(toSaveMessages);
+                    this.smsMessageRepository.flush();
+                    
+                    // Now create queue data with saved message IDs
+                    for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
+                        Collection<SmsMessageApiQueueResourceData> apiQueueResourceDatas = new ArrayList<>();
+                        for (SmsMessage smsMessage : entry.getValue()) {
+                            if (!smsMessage.isNotification()) {
+                                SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData.instance(
+                                    smsMessage.getId(), null, null, null, smsMessage.getMobileNo(), 
+                                    smsMessage.getMessage(), entry.getKey().getProviderId());
+                                apiQueueResourceDatas.add(apiQueueResourceData);
+                            }
+                        }
+                        if (!apiQueueResourceDatas.isEmpty()) {
+                            this.taskExecutor.execute(new SmsTask(apiQueueResourceDatas, ThreadLocalContextUtil.getContext()));
+                        }
+                    }
+                }
+                
+                if (!toSendNotificationMessages.isEmpty()) {
+                    this.notificationSenderService.sendNotification(toSendNotificationMessages);
                 }
             }
         } catch (Exception e) {
-            log.error("Error occured.", e);
+            log.error("Error occurred.", e);
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
@@ -76,7 +76,7 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
 
         });
         if (responseOne != null) {
-            // String smsResponse = responseOne.getBody();
+            
             if (!responseOne.getStatusCode().equals(HttpStatus.ACCEPTED)) {
                 log.debug("{}", responseOne.getStatusCode().value());
                 throw new ConnectionFailureException(SmsCampaignConstants.SMS);
@@ -91,7 +91,7 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
                 List<SmsMessage> toSaveMessages = new ArrayList<>();
                 List<SmsMessage> toSendNotificationMessages = new ArrayList<>();
                 
-                // First collect all messages
+                
                 for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
                     for (SmsMessage smsMessage : entry.getValue()) {
                         if (smsMessage.isNotification()) {
@@ -104,12 +104,12 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
                     }
                 }
 
-                // Save messages first to get IDs
+                
                 if (!toSaveMessages.isEmpty()) {
                     this.smsMessageRepository.saveAll(toSaveMessages);
                     this.smsMessageRepository.flush();
                     
-                    // Now create queue data with saved message IDs
+                    
                     for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
                         Collection<SmsMessageApiQueueResourceData> apiQueueResourceDatas = new ArrayList<>();
                         for (SmsMessage smsMessage : entry.getValue()) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/scheduler/SmsMessageScheduledJobServiceImpl.java
@@ -52,7 +52,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * Scheduled job services that send SMS messages and get delivery reports for the sent SMS messages
+ * Scheduled job services that send SMS messages and get delivery reports for
+ * the sent SMS messages
  **/
 @Service
 @Slf4j
@@ -72,11 +73,12 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
                 SmsMessageApiQueueResourceData.toJsonString(apiQueueResourceDatas));
         URI uri = (URI) hostConfig.get("uri");
         HttpEntity<?> entity = (HttpEntity<?>) hostConfig.get("entity");
-        ResponseEntity<String> responseOne = restTemplate.exchange(uri, HttpMethod.POST, entity, new ParameterizedTypeReference<String>() {
+        ResponseEntity<String> responseOne = restTemplate.exchange(uri, HttpMethod.POST, entity,
+                new ParameterizedTypeReference<String>() {
 
-        });
+                });
         if (responseOne != null) {
-            
+
             if (!responseOne.getStatusCode().equals(HttpStatus.ACCEPTED)) {
                 log.debug("{}", responseOne.getStatusCode().value());
                 throw new ConnectionFailureException(SmsCampaignConstants.SMS);
@@ -90,8 +92,7 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
             if (!smsDataMap.isEmpty()) {
                 List<SmsMessage> toSaveMessages = new ArrayList<>();
                 List<SmsMessage> toSendNotificationMessages = new ArrayList<>();
-                
-                
+
                 for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
                     for (SmsMessage smsMessage : entry.getValue()) {
                         if (smsMessage.isNotification()) {
@@ -104,28 +105,28 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
                     }
                 }
 
-                
                 if (!toSaveMessages.isEmpty()) {
                     this.smsMessageRepository.saveAll(toSaveMessages);
                     this.smsMessageRepository.flush();
-                    
-                    
+
                     for (Map.Entry<SmsCampaign, Collection<SmsMessage>> entry : smsDataMap.entrySet()) {
                         Collection<SmsMessageApiQueueResourceData> apiQueueResourceDatas = new ArrayList<>();
                         for (SmsMessage smsMessage : entry.getValue()) {
                             if (!smsMessage.isNotification()) {
-                                SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData.instance(
-                                    smsMessage.getId(), null, null, null, smsMessage.getMobileNo(), 
-                                    smsMessage.getMessage(), entry.getKey().getProviderId());
+                                SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData
+                                        .instance(
+                                                smsMessage.getId(), null, null, null, smsMessage.getMobileNo(),
+                                                smsMessage.getMessage(), entry.getKey().getProviderId());
                                 apiQueueResourceDatas.add(apiQueueResourceData);
                             }
                         }
                         if (!apiQueueResourceDatas.isEmpty()) {
-                            this.taskExecutor.execute(new SmsTask(apiQueueResourceDatas, ThreadLocalContextUtil.getContext()));
+                            this.taskExecutor
+                                    .execute(new SmsTask(apiQueueResourceDatas, ThreadLocalContextUtil.getContext()));
                         }
                     }
                 }
-                
+
                 if (!toSendNotificationMessages.isEmpty()) {
                     this.notificationSenderService.sendNotification(toSendNotificationMessages);
                 }
@@ -141,7 +142,8 @@ public class SmsMessageScheduledJobServiceImpl implements SmsMessageScheduledJob
             Collection<SmsMessageApiQueueResourceData> apiQueueResourceDatas = new ArrayList<>();
             StringBuilder request = new StringBuilder();
             for (SmsMessage smsMessage : smsMessages) {
-                SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData.instance(smsMessage.getId(), null,
+                SmsMessageApiQueueResourceData apiQueueResourceData = SmsMessageApiQueueResourceData.instance(
+                        smsMessage.getId(), null,
                         null, null, smsMessage.getMobileNo(), smsMessage.getMessage(), providerId);
                 apiQueueResourceDatas.add(apiQueueResourceData);
                 smsMessage.setStatusType(SmsMessageStatusType.WAITING_FOR_DELIVERY_REPORT.getValue());

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Fix SMS message ID issue in triggered message flow

## Problem
When processing triggered messages, `SmsMessageApiQueueResourceData` objects are being created before `SmsMessage` objects are saved to the database. This results in:

- `smsMessage.getId()` returning null
- Invalid or missing IDs in the queue data
- Inconsistency between direct and triggered message flows

## Solution
Modified the triggered message flow in `SmsMessageScheduledJobServiceImpl.java` to:

1. Save SMS messages to the database first
2. Create queue data objects using the database-generated IDs
3. Send messages to the gateway with proper internal IDs

## Implementation Details
- Reordered operations to ensure database persistence occurs before queue data creation
- Maintained all existing functionality while fixing the ID reference issue
- Aligned the triggered message flow with the direct message flow pattern
