### PR TITLE
FINERACT-1971 Repayment schedule period - Incorrect values after charge with large amount

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/MathUtil.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/MathUtil.java
@@ -269,9 +269,13 @@ public final class MathUtil {
 
     /** @return sum the values considering null values */
     public static BigDecimal add(BigDecimal... amounts) {
+        return add(MoneyHelper.getMathContext(), amounts);
+    }
+
+    public static BigDecimal add(MathContext mc, BigDecimal... amounts) {
         BigDecimal result = null;
         for (BigDecimal amount : amounts) {
-            result = add(result, amount, MoneyHelper.getMathContext());
+            result = add(result, amount, mc);
         }
         return result;
     }

--- a/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/domain/MoneyHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/domain/MoneyHelper.java
@@ -33,7 +33,7 @@ public class MoneyHelper {
 
     private static RoundingMode roundingMode = null;
     private static MathContext mathContext;
-    private static final int PRECISION = 12;
+    public static final int PRECISION = 19;
 
     private static ConfigurationDomainService staticConfigurationDomainService;
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/LoanSchedulePeriodData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/LoanSchedulePeriodData.java
@@ -19,11 +19,13 @@
 package org.apache.fineract.portfolio.loanaccount.loanschedule.data;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.MathUtil;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 
 /**
  * Immutable data object that represents a period of a loan schedule.
@@ -156,11 +158,13 @@ public final class LoanSchedulePeriodData {
             final BigDecimal totalPaidLateForPeriod, final BigDecimal totalWaived, final BigDecimal totalWrittenOff,
             final BigDecimal totalCredits, final boolean isDownPayment, final BigDecimal totalAccruedInterest) {
 
-        BigDecimal totalDue = MathUtil.add(principalOriginalDue, interestDue, feeChargesDue, penaltyChargesDue);
-        BigDecimal totalOutstanding = MathUtil.add(principalOutstanding, interestOutstanding, feeChargesOutstanding,
+        final MathContext mc = MoneyHelper.getMathContext();
+
+        BigDecimal totalDue = MathUtil.add(mc, principalOriginalDue, interestDue, feeChargesDue, penaltyChargesDue);
+        BigDecimal totalOutstanding = MathUtil.add(mc, principalOutstanding, interestOutstanding, feeChargesOutstanding,
                 penaltyChargesOutstanding);
-        BigDecimal totalActualCostOfLoanForPeriod = MathUtil.add(interestDue, feeChargesDue, penaltyChargesDue);
-        BigDecimal totalInstallmentAmount = MathUtil.add(principalOriginalDue, interestDue);
+        BigDecimal totalActualCostOfLoanForPeriod = MathUtil.add(mc, interestDue, feeChargesDue, penaltyChargesDue);
+        BigDecimal totalInstallmentAmount = MathUtil.add(mc, principalOriginalDue, interestDue);
 
         return builder().period(periodNumber) //
                 .fromDate(fromDate) //

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1226,7 +1226,6 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
             Set<Long> disbursementPeriodIds = new HashSet<>();
             while (rs.next()) {
 
-                final Long loanId = rs.getLong("loanId");
                 final Integer period = JdbcSupport.getInteger(rs, "period");
                 LocalDate fromDate = JdbcSupport.getLocalDate(rs, "fromDate");
                 final LocalDate dueDate = JdbcSupport.getLocalDate(rs, "dueDate");
@@ -1306,8 +1305,6 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
 
                 final BigDecimal totalOutstandingForPeriod = principalOutstanding.add(interestOutstanding).add(feeChargesOutstanding)
                         .add(penaltyChargesOutstanding);
-
-                final BigDecimal totalActualCostOfLoanForPeriod = interestActualDue.add(feeChargesActualDue).add(penaltyChargesActualDue);
 
                 totalRepaymentExpected = totalRepaymentExpected.plus(totalDueForPeriod);
                 totalRepayment = totalRepayment.plus(totalPaidForPeriod);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/MultiActivityAccrualsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/MultiActivityAccrualsTest.java
@@ -96,12 +96,12 @@ public class MultiActivityAccrualsTest extends BaseLoanIntegrationTest {
 
             verifyTransactions(loanId, //
                     transaction(600.0, "Disbursement", "09 August 2024", 600.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-                    transaction(20.00, "Accrual", "09 December 2024", 0, 0, 20.00, 0, 0, 0.0, 0.0),
-                    transaction(5.0, "Accrual Activity", "09 September 2024", 0, 0, 5.0, 0, 0, 0.0, 0.0),
+                    transaction(19.98, "Accrual", "09 December 2024", 0, 0, 19.98, 0, 0, 0.0, 0.0),
+                    transaction(4.99, "Accrual Activity", "09 September 2024", 0, 0, 4.99, 0, 0, 0.0, 0.0),
                     transaction(5.0, "Accrual Activity", "09 October 2024", 0, 0, 5.0, 0, 0, 0.0, 0.0),
-                    transaction(5.0, "Accrual Activity", "09 November 2024", 0, 0, 5.0, 0, 0, 0.0, 0.0),
+                    transaction(4.99, "Accrual Activity", "09 November 2024", 0, 0, 4.99, 0, 0, 0.0, 0.0),
                     transaction(5.0, "Accrual Activity", "09 December 2024", 0, 0, 5.0, 0, 0, 0.0, 0.0),
-                    transaction(700.00, "Repayment", "09 December 2024", 0, 600.00, 20.0, 0, 0, 0.0, 80.0));
+                    transaction(700.00, "Repayment", "09 December 2024", 0, 600.00, 19.98, 0, 0, 0.0, 80.02));
         });
     }
 }


### PR DESCRIPTION
## Description
Repayment schedule period data is incorrect when a large amount of charge (123456789012.12) is created

[FINERACT-1971](https://github.com/apache/fineract/pull/FINERACT-1971)

<img width="1335" alt="Screenshot 2025-02-07 at 7 49 21 a m" src="https://github.com/user-attachments/assets/01326635-feab-4574-903e-c67d7d777061" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
