### PR TITLE
FINERACT-2081: Return an empty collection instead of null.

### DIFF
--- a/custom/acme/note/service/src/main/java/com/acme/fineract/portfolio/note/service/AcmeNoteReadPlatformService.java
+++ b/custom/acme/note/service/src/main/java/com/acme/fineract/portfolio/note/service/AcmeNoteReadPlatformService.java
@@ -19,6 +19,7 @@
 package com.acme.fineract.portfolio.note.service;
 
 import java.util.Collection;
+import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.portfolio.note.data.NoteData;
 import org.apache.fineract.portfolio.note.service.NoteReadPlatformService;
@@ -43,6 +44,6 @@ public class AcmeNoteReadPlatformService implements NoteReadPlatformService, Ini
 
     @Override
     public Collection<NoteData> retrieveNotesByResource(Long resourceId, Integer noteTypeId) {
-        return null;
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
## Description

- Return `Collections.emptyList()` In the `retrieveNotesByResource` method, instead of returning null, it now returns an empty immutable list.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
