### PR TITLE
FINERACT-2081: fix sonar issues in EntityTables enum

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTables.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTables.java
@@ -49,11 +49,11 @@ public enum EntityTables {
     SHARE_PRODUCT("m_share_product", "share_product_id", "id"), //
     ;
 
-    public static final EntityTables[] VALUES = values();
+    static final EntityTables[] ENTITY_VALUES = values();
 
-    private static final List<String> ENTITY_NAMES = Arrays.stream(VALUES).map(EntityTables::getName).toList();
+    private static final List<String> ENTITY_NAMES = Arrays.stream(ENTITY_VALUES).map(EntityTables::getName).toList();
 
-    private static final Map<String, EntityTables> BY_ENTITY_NAME = Arrays.stream(VALUES)
+    private static final Map<String, EntityTables> BY_ENTITY_NAME = Arrays.stream(ENTITY_VALUES)
             .collect(Collectors.toMap(EntityTables::getName, e -> e));
 
     @NotNull
@@ -106,7 +106,7 @@ public enum EntityTables {
     }
 
     public boolean hasCheck() {
-        return checkStatuses != null && !checkStatuses.isEmpty();
+        return !checkStatuses.isEmpty();
     }
 
     public static List<String> getEntityNames() {
@@ -135,6 +135,6 @@ public enum EntityTables {
 
     @NotNull
     public static List<EntityTables> getFiltered(Predicate<EntityTables> filter) {
-        return Arrays.stream(VALUES).filter(filter).toList();
+        return Arrays.stream(ENTITY_VALUES).filter(filter).toList();
     }
 }


### PR DESCRIPTION
## Description

Fix Sonar-reported code quality issues in EntityTables enum:
- Renamed VALUES field to ENTITY_VALUES to prevent clash with values() method
- Changed static field access modifier to package-private
- Replaced Guava ImmutableList with Java List.of()

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
