### PR TITLE
FINERACT-2081: Refactored LoanStatus.fromInt using switch expression enhancements

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/api/FinancialActivityAccountsJsonInputParams.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/api/FinancialActivityAccountsJsonInputParams.java
@@ -48,7 +48,7 @@ public enum FinancialActivityAccountsJsonInputParams {
 
     @Override
     public String toString() {
-        return name().toString().replaceAll("_", " ");
+        return name().replace("_", " ");
     }
 
     public String getValue() {

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanStatus.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanStatus.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,44 +40,24 @@ public enum LoanStatus {
     private final String code;
 
     public static LoanStatus fromInt(final Integer statusValue) {
-
-        LoanStatus enumeration = LoanStatus.INVALID;
-        switch (statusValue) {
-            case 100:
-                enumeration = LoanStatus.SUBMITTED_AND_PENDING_APPROVAL;
-            break;
-            case 200:
-                enumeration = LoanStatus.APPROVED;
-            break;
-            case 300:
-                enumeration = LoanStatus.ACTIVE;
-            break;
-            case 303:
-                enumeration = LoanStatus.TRANSFER_IN_PROGRESS;
-            break;
-            case 304:
-                enumeration = LoanStatus.TRANSFER_ON_HOLD;
-            break;
-            case 400:
-                enumeration = LoanStatus.WITHDRAWN_BY_CLIENT;
-            break;
-            case 500:
-                enumeration = LoanStatus.REJECTED;
-            break;
-            case 600:
-                enumeration = LoanStatus.CLOSED_OBLIGATIONS_MET;
-            break;
-            case 601:
-                enumeration = LoanStatus.CLOSED_WRITTEN_OFF;
-            break;
-            case 602:
-                enumeration = LoanStatus.CLOSED_RESCHEDULE_OUTSTANDING_AMOUNT;
-            break;
-            case 700:
-                enumeration = LoanStatus.OVERPAID;
-            break;
+        if (statusValue == null) {
+            return LoanStatus.INVALID;
         }
-        return enumeration;
+
+        return switch (statusValue) {
+            case 100 -> LoanStatus.SUBMITTED_AND_PENDING_APPROVAL;
+            case 200 -> LoanStatus.APPROVED;
+            case 300 -> LoanStatus.ACTIVE;
+            case 303 -> LoanStatus.TRANSFER_IN_PROGRESS;
+            case 304 -> LoanStatus.TRANSFER_ON_HOLD;
+            case 400 -> LoanStatus.WITHDRAWN_BY_CLIENT;
+            case 500 -> LoanStatus.REJECTED;
+            case 600 -> LoanStatus.CLOSED_OBLIGATIONS_MET;
+            case 601 -> LoanStatus.CLOSED_WRITTEN_OFF;
+            case 602 -> LoanStatus.CLOSED_RESCHEDULE_OUTSTANDING_AMOUNT;
+            case 700 -> LoanStatus.OVERPAID;
+            default -> LoanStatus.INVALID;
+        };
     }
 
     LoanStatus(final Integer value, final String code) {


### PR DESCRIPTION
## Description

This PR refactors the `LoanStatus.fromInt` method to modernize the code by:

- **Adding null safety:** The method now immediately returns `LoanStatus.INVALID` when the input is `null`.
- **Using the new arrow syntax (`->`):** This simplifies the switch code and prevents fall-through.
- **Adding a default case:** Ensures that any unexpected or unmapped `statusValue` results in `LoanStatus.INVALID`.
- **Java 14+ compatibility:** The refactored switch expression is fully compatible with Java 14 and above.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
