### PR TITLE
FINERACT-2195: Fixes the Cast conversion from numeric that is causing in MariaDB issues while executing the SQL

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
@@ -161,7 +161,7 @@ public class DatabaseSpecificSQLGenerator {
 
     public String castChar(String sql) {
         if (databaseTypeResolver.isMySQL()) {
-            return format("CAST(%s AS CHAR)", sql);
+            return format("CAST(%s AS CHAR) COLLATE utf8mb4_unicode_ci", sql);
         } else if (databaseTypeResolver.isPostgreSQL()) {
             return format("%s::CHAR", sql);
         } else {


### PR DESCRIPTION
## Description

FINERACT-2195 fixes the Cast conversion from numeric that is causing in MariaDB issues while executing the SQL

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [X ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [] Create/update unit or integration tests for verifying the changes made.

- [X ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [X] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
