### PR TITLE
FINERACT-1982: Introduce a new type of ACTUAL during calculation of days in year

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/common/domain/DaysInYearCustomStrategyType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/common/domain/DaysInYearCustomStrategyType.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.common.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+/**
+ * Defines the method of leap year calculation for determining the number of days in a year.
+ * <p>
+ * This enum has two modes:
+ * </p>
+ * <ul>
+ *   <li>{@link #FULL_LEAP_YEAR} - Always considers 366 days in a leap year.</li>
+ *   <li>{@link #FEB_29_PERIOD_ONLY} - Considers 366 days only if the period includes February 29th; otherwise, uses 365 days.</li>
+ * </ul>
+ * <p>
+ * When using {@link DaysInYearType#ACTUAL}, the {@code FEB_29_PERIOD_ONLY} rule applies:
+ * </p>
+ * <ul>
+ *   <li>If the period includes February 29th, the calculation considers 366 days.</li>
+ *   <li>Otherwise, even if the year is a leap year, the calculation uses 365 days.</li>
+ * </ul>
+ * <p>
+ * <b>Examples:</b>
+ * </p>
+ * <ul>
+ *   <li><b>366 Days:</b> A period from February 10th to March 10th in a leap year
+ *       will consider 366 days, since February 29th is within the period.</li>
+ *   <li><b>365 Days:</b> A period from March 10th to April 10th in a leap year
+ *       will consider 365 days, as February 29th is not within the period.</li>
+ * </ul>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DaysInYearCustomStrategyType {
+
+    /** Always considers 366 days in a leap year. */
+    FULL_LEAP_YEAR(1, "DaysInYearCustomStrategyType.fullLeapYear"),
+
+    /** Considers 366 days only if the period includes February 29th; otherwise, uses 365 days. */
+    FEB_29_PERIOD_ONLY(2, "DaysInYearCustomStrategyType.feb29PeriodOnly");
+
+    private final Integer value;
+    private final String code;
+
+    public static Object[] integerValues() {
+        return Arrays.stream(values()).map(value -> value.value).toList().toArray();
+    }
+
+    public static DaysInYearCustomStrategyType fromInt(final Integer type) {
+        if (type == null || type.equals( FULL_LEAP_YEAR.getValue())) {
+            return FULL_LEAP_YEAR;
+        } else if (type.equals( FEB_29_PERIOD_ONLY.getValue())) {
+            return FEB_29_PERIOD_ONLY;
+        }
+        // default
+        return null;
+    }
+}

--- a/fineract-investor/src/main/resources/jpa/investor/persistence.xml
+++ b/fineract-investor/src/main/resources/jpa/investor/persistence.xml
@@ -119,6 +119,7 @@
         <class>org.apache.fineract.portfolio.loanproduct.domain.CreditAllocationTransactionType</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationTypeListConverter</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.SupportedInterestRefundTypesListConverter</class>
+        <class>org.apache.fineract.portfolio.loanproduct.domain.DaysInYearCustomStrategyTypeAttributeConverter</class>
         <class>org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter</class>
         <class>org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest</class>
         <class>org.apache.fineract.portfolio.repaymentwithpostdatedchecks.domain.PostDatedChecks</class>

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
@@ -38,6 +38,7 @@ import org.apache.fineract.portfolio.calendar.domain.CalendarInstance;
 import org.apache.fineract.portfolio.calendar.service.CalendarUtils;
 import org.apache.fineract.portfolio.common.domain.DayOfWeekType;
 import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.NthDayType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
@@ -230,6 +231,7 @@ public final class LoanApplicationTerms {
     private List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes;
     private LoanChargeOffBehaviour chargeOffBehaviour;
     private boolean interestRecognitionOnDisbursementDate;
+    private DaysInYearCustomStrategyType daysInYearCustomStrategy;
 
     private LoanApplicationTerms(Builder builder) {
         this.currency = builder.currency;
@@ -294,6 +296,7 @@ public final class LoanApplicationTerms {
         private LocalDate seedDate;
         private MathContext mc;
         private Boolean interestRecognitionOnDisbursementDate;
+        private DaysInYearCustomStrategyType daysInYearCustomStrategy;
 
         public Builder currency(CurrencyData currency) {
             this.currency = currency;
@@ -413,6 +416,11 @@ public final class LoanApplicationTerms {
         public LoanApplicationTerms build() {
             return new LoanApplicationTerms(this);
         }
+
+        public Builder daysInYearCustomStrategy(DaysInYearCustomStrategyType daysInYearCustomStrategy) {
+            this.daysInYearCustomStrategy = daysInYearCustomStrategy;
+            return this;
+        }
     }
 
     public static LoanApplicationTerms assembleFrom(LoanRepaymentScheduleModelData modelData, MathContext mc) {
@@ -439,7 +447,9 @@ public final class LoanApplicationTerms {
                 .inArrearsTolerance(Money.zero(modelData.currency(), mc)).disbursementDatas(new ArrayList<>())
                 .isDownPaymentEnabled(modelData.downPaymentEnabled()).downPaymentPercentage(downPaymentPercentage)
                 .submittedOnDate(modelData.scheduleGenerationStartDate()).seedDate(seedDate)
-                .interestRecognitionOnDisbursementDate(modelData.interestRecognitionOnDisbursementDate()).mc(mc).build();
+                .interestRecognitionOnDisbursementDate(modelData.interestRecognitionOnDisbursementDate())
+                .daysInYearCustomStrategy(modelData.daysInYearCustomStrategy())
+                .mc(mc).build();
     }
 
     public static LoanApplicationTerms assembleFrom(final CurrencyData currency, final Integer loanTermFrequency,
@@ -470,7 +480,7 @@ public final class LoanApplicationTerms {
             final LocalDate submittedOnDate, final LoanScheduleType loanScheduleType,
             final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
             final boolean enableAccrualActivityPosting, final List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes,
-            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate) {
+            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate, final DaysInYearCustomStrategyType daysInYearCustomStrategy) {
 
         final LoanRescheduleStrategyMethod rescheduleStrategyMethod = null;
         final CalendarHistoryDataWrapper calendarHistoryDataWrapper = null;
@@ -490,7 +500,7 @@ public final class LoanApplicationTerms {
                 isPrincipalCompoundingDisabledForOverdueLoans, enableDownPayment, disbursedAmountPercentageForDownPayment,
                 isAutoRepaymentForDownPaymentEnabled, repaymentStartDateType, submittedOnDate, loanScheduleType, loanScheduleProcessingType,
                 fixedLength, enableAccrualActivityPosting, supportedInterestRefundTypes, chargeOffBehaviour,
-                interestRecognitionOnDisbursementDate);
+                interestRecognitionOnDisbursementDate, daysInYearCustomStrategy);
 
     }
 
@@ -564,7 +574,7 @@ public final class LoanApplicationTerms {
                 disbursedAmountPercentageForDownPayment, isAutoRepaymentForDownPaymentEnabled, repaymentStartDateType, submittedOnDate,
                 loanScheduleType, loanScheduleProcessingType, fixedLength, loanProductRelatedDetail.isEnableAccrualActivityPosting(),
                 loanProductRelatedDetail.getSupportedInterestRefundTypes(), loanProductRelatedDetail.getChargeOffBehaviour(),
-                loanProductRelatedDetail.isInterestRecognitionOnDisbursementDate());
+                loanProductRelatedDetail.isInterestRecognitionOnDisbursementDate(),loanProductRelatedDetail.getDaysInYearCustomStrategy());
     }
 
     private LoanApplicationTerms(final CurrencyData currency, final Integer loanTermFrequency,
@@ -595,7 +605,7 @@ public final class LoanApplicationTerms {
             final RepaymentStartDateType repaymentStartDateType, final LocalDate submittedOnDate, final LoanScheduleType loanScheduleType,
             final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength, boolean enableAccrualActivityPosting,
             final List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes, final LoanChargeOffBehaviour chargeOffBehaviour,
-            final boolean interestRecognitionOnDisbursementDate) {
+            final boolean interestRecognitionOnDisbursementDate, final DaysInYearCustomStrategyType daysInYearCustomStrategy) {
 
         this.currency = currency;
         this.loanTermFrequency = loanTermFrequency;
@@ -696,6 +706,7 @@ public final class LoanApplicationTerms {
         this.supportedInterestRefundTypes = supportedInterestRefundTypes;
         this.chargeOffBehaviour = chargeOffBehaviour;
         this.interestRecognitionOnDisbursementDate = interestRecognitionOnDisbursementDate;
+        this.daysInYearCustomStrategy = daysInYearCustomStrategy;
     }
 
     public Money adjustPrincipalIfLastRepaymentPeriod(final Money principalForPeriod, final Money totalCumulativePrincipalToDate,
@@ -1557,7 +1568,7 @@ public final class LoanApplicationTerms {
                 this.interestRecalculationEnabled, this.isEqualAmortization, this.isDownPaymentEnabled,
                 this.disbursedAmountPercentageForDownPayment, this.isAutoRepaymentForDownPaymentEnabled, this.loanScheduleType,
                 this.loanScheduleProcessingType, this.fixedLength, this.enableAccrualActivityPosting, this.supportedInterestRefundTypes,
-                this.chargeOffBehaviour, this.interestRecognitionOnDisbursementDate);
+                this.chargeOffBehaviour, this.interestRecognitionOnDisbursementDate, this.daysInYearCustomStrategy);
     }
 
     public LoanProductMinimumRepaymentScheduleRelatedDetail toLoanProductRelatedDetailMinimumData() {
@@ -1567,7 +1578,7 @@ public final class LoanApplicationTerms {
                 interestPaymentGrace, principalGrace, recurringMoratoriumOnPrincipalPeriods, interestMethod,
                 interestCalculationPeriodMethod, daysInYearType, daysInMonthType, amortizationMethod, repaymentPeriodFrequencyType,
                 repaymentEvery, numberOfRepayments,
-                isInterestChargedFromDateSameAsDisbursalDateEnabled != null && isInterestChargedFromDateSameAsDisbursalDateEnabled);
+                isInterestChargedFromDateSameAsDisbursalDateEnabled != null && isInterestChargedFromDateSameAsDisbursalDateEnabled, daysInYearCustomStrategy);
     }
 
     public Integer getLoanTermFrequency() {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanRepaymentScheduleModelData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanRepaymentScheduleModelData.java
@@ -18,20 +18,22 @@
  */
 package org.apache.fineract.portfolio.loanaccount.loanschedule.domain;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
 import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 
 public record LoanRepaymentScheduleModelData(@NotNull LocalDate scheduleGenerationStartDate, @NotNull CurrencyData currency,
-        @NotNull BigDecimal disbursementAmount, @NotNull LocalDate disbursementDate, @NotNull int numberOfRepayments,
-        @NotNull int repaymentFrequency, @NotBlank String repaymentFrequencyType, @NotNull BigDecimal annualNominalInterestRate,
-        @NotNull boolean downPaymentEnabled, @NotNull DaysInMonthType daysInMonth, @NotNull DaysInYearType daysInYear,
-        BigDecimal downPaymentPercentage, Integer installmentAmountInMultiplesOf, Integer fixedLength,
-        @NotNull Boolean interestRecognitionOnDisbursementDate) {
+                                             @NotNull BigDecimal disbursementAmount, @NotNull LocalDate disbursementDate, @NotNull int numberOfRepayments,
+                                             @NotNull int repaymentFrequency, @NotBlank String repaymentFrequencyType, @NotNull BigDecimal annualNominalInterestRate,
+                                             @NotNull boolean downPaymentEnabled, @NotNull DaysInMonthType daysInMonth, @NotNull DaysInYearType daysInYear,
+                                             BigDecimal downPaymentPercentage, Integer installmentAmountInMultiplesOf, Integer fixedLength,
+                                             @NotNull Boolean interestRecognitionOnDisbursementDate, @Nullable DaysInYearCustomStrategyType daysInYearCustomStrategy) {
 
     LoanRepaymentScheduleModelData(@NotNull LocalDate scheduleGenerationStartDate, @NotNull CurrencyData currency,
             @NotNull BigDecimal disbursementAmount, @NotNull LocalDate disbursementDate, @NotNull int numberOfRepayments,
@@ -40,6 +42,6 @@ public record LoanRepaymentScheduleModelData(@NotNull LocalDate scheduleGenerati
             BigDecimal downPaymentPercentage, Integer installmentAmountInMultiplesOf, Integer fixedLength) {
         this(scheduleGenerationStartDate, currency, disbursementAmount, disbursementDate, numberOfRepayments, repaymentFrequency,
                 repaymentFrequencyType, annualNominalInterestRate, downPaymentEnabled, daysInMonth, daysInYear, downPaymentPercentage,
-                installmentAmountInMultiplesOf, fixedLength, false);
+                installmentAmountInMultiplesOf, fixedLength, false, null);
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
@@ -81,6 +81,7 @@ public interface LoanProductConstants {
     // Interest recalculation related
     String IS_INTEREST_RECALCULATION_ENABLED_PARAMETER_NAME = "isInterestRecalculationEnabled";
     String DAYS_IN_YEAR_TYPE_PARAMETER_NAME = "daysInYearType";
+    String DAYS_IN_YEAR_CUSTOM_STRATEGY_TYPE_PARAMETER_NAME = "daysInYearCustomStrategy";
     String DAYS_IN_MONTH_TYPE_PARAMETER_NAME = "daysInMonthType";
     String interestRecalculationCompoundingMethodParameterName = "interestRecalculationCompoundingMethod";
     String rescheduleStrategyMethodParameterName = "rescheduleStrategyMethod";

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductRelatedDetailMinimumData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductRelatedDetailMinimumData.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.loanproduct.data;
 import java.math.BigDecimal;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
 import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanproduct.domain.AmortizationMethod;
@@ -46,13 +47,14 @@ public class LoanProductRelatedDetailMinimumData implements LoanProductMinimumRe
     private final Integer repaymentEvery;
     private final Integer numberOfRepayments;
     private final boolean interestRecognitionOnDisbursementDate;
+    private final DaysInYearCustomStrategyType daysInYearCustomStrategy;
 
     public LoanProductRelatedDetailMinimumData(CurrencyData currency, BigDecimal interestRatePerPeriod,
-            BigDecimal annualNominalInterestRate, Integer interestChargingGrace, Integer interestPaymentGrace, Integer principalGrace,
-            Integer recurringMoratoriumOnPrincipalPeriods, InterestMethod interestMethod,
-            InterestCalculationPeriodMethod interestCalculationPeriodMethod, DaysInYearType daysInYearType, DaysInMonthType daysInMonthType,
-            AmortizationMethod amortizationMethod, PeriodFrequencyType repaymentPeriodFrequencyType, Integer repaymentEvery,
-            Integer numberOfRepayments, boolean interestRecognitionOnDisbursementDate) {
+                                               BigDecimal annualNominalInterestRate, Integer interestChargingGrace, Integer interestPaymentGrace, Integer principalGrace,
+                                               Integer recurringMoratoriumOnPrincipalPeriods, InterestMethod interestMethod,
+                                               InterestCalculationPeriodMethod interestCalculationPeriodMethod, DaysInYearType daysInYearType, DaysInMonthType daysInMonthType,
+                                               AmortizationMethod amortizationMethod, PeriodFrequencyType repaymentPeriodFrequencyType, Integer repaymentEvery,
+                                               Integer numberOfRepayments, boolean interestRecognitionOnDisbursementDate, DaysInYearCustomStrategyType daysInYearCustomStrategy) {
         this.currency = currency;
         this.interestRatePerPeriod = interestRatePerPeriod;
         this.annualNominalInterestRate = annualNominalInterestRate;
@@ -69,6 +71,7 @@ public class LoanProductRelatedDetailMinimumData implements LoanProductMinimumRe
         this.repaymentEvery = repaymentEvery;
         this.numberOfRepayments = numberOfRepayments;
         this.interestRecognitionOnDisbursementDate = interestRecognitionOnDisbursementDate;
+        this.daysInYearCustomStrategy = daysInYearCustomStrategy;
     }
 
     private Integer defaultToNullIfZero(final Integer value) {
@@ -167,5 +170,10 @@ public class LoanProductRelatedDetailMinimumData implements LoanProductMinimumRe
     @Override
     public boolean isInterestRecognitionOnDisbursementDate() {
         return interestRecognitionOnDisbursementDate;
+    }
+
+    @Override
+    public DaysInYearCustomStrategyType daysInYearCustomStrategy() {
+        return daysInYearCustomStrategy;
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/DaysInYearCustomStrategyTypeAttributeConverter.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/DaysInYearCustomStrategyTypeAttributeConverter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
+
+@Converter(autoApply = true)
+public class DaysInYearCustomStrategyTypeAttributeConverter implements AttributeConverter<DaysInYearCustomStrategyType, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(DaysInYearCustomStrategyType daysInYearCustomStrategyType) {
+        return daysInYearCustomStrategyType.getValue();
+    }
+
+    @Override
+    public DaysInYearCustomStrategyType convertToEntityAttribute(Integer integer) {
+        return DaysInYearCustomStrategyType.fromInt(integer);
+    }
+}

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
@@ -56,6 +56,7 @@ import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.portfolio.charge.domain.Charge;
 import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucket;
@@ -366,6 +367,9 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
         final DaysInYearType daysInYearType = DaysInYearType
                 .fromInt(command.integerValueOfParameterNamed(LoanProductConstants.DAYS_IN_YEAR_TYPE_PARAMETER_NAME));
 
+        final DaysInYearCustomStrategyType daysInYearCustomStrategy = DaysInYearCustomStrategyType
+                .fromInt(command.integerValueOfParameterNamed(LoanProductConstants.DAYS_IN_YEAR_CUSTOM_STRATEGY_TYPE_PARAMETER_NAME));
+
         LoanProductInterestRecalculationDetails interestRecalculationSettings = null;
 
         if (isInterestRecalculationEnabled) {
@@ -486,7 +490,7 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
                 allowApprovedDisbursedAmountsOverApplied, overAppliedCalculationType, overAppliedNumber, dueDaysForRepaymentEvent,
                 overDueDaysForRepaymentEvent, enableDownPayment, disbursedAmountPercentageDownPayment, enableAutoRepaymentForDownPayment,
                 repaymentStartDateType, enableInstallmentLevelDelinquency, loanScheduleType, loanScheduleProcessingType, fixedLength,
-                enableAccrualActivityPosting, supportedInterestRefundTypes, chargeOffBehaviour, interestRecognitionOnDisbursementDate);
+                enableAccrualActivityPosting, supportedInterestRefundTypes, chargeOffBehaviour, interestRecognitionOnDisbursementDate, daysInYearCustomStrategy);
 
     }
 
@@ -669,43 +673,43 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
     }
 
     public LoanProduct(final Fund fund, final String transactionProcessingStrategyCode,
-            final List<LoanProductPaymentAllocationRule> paymentAllocationRules,
-            final List<LoanProductCreditAllocationRule> creditAllocationRules, final String name, final String shortName,
-            final String description, final MonetaryCurrency currency, final BigDecimal defaultPrincipal,
-            final BigDecimal defaultMinPrincipal, final BigDecimal defaultMaxPrincipal,
-            final BigDecimal defaultNominalInterestRatePerPeriod, final BigDecimal defaultMinNominalInterestRatePerPeriod,
-            final BigDecimal defaultMaxNominalInterestRatePerPeriod, final PeriodFrequencyType interestPeriodFrequencyType,
-            final BigDecimal defaultAnnualNominalInterestRate, final InterestMethod interestMethod,
-            final InterestCalculationPeriodMethod interestCalculationPeriodMethod, final boolean considerPartialPeriodInterest,
-            final Integer repayEvery, final PeriodFrequencyType repaymentFrequencyType, final Integer defaultNumberOfInstallments,
-            final Integer defaultMinNumberOfInstallments, final Integer defaultMaxNumberOfInstallments,
-            final Integer graceOnPrincipalPayment, final Integer recurringMoratoriumOnPrincipalPeriods,
-            final Integer graceOnInterestPayment, final Integer graceOnInterestCharged, final AmortizationMethod amortizationMethod,
-            final BigDecimal inArrearsTolerance, final List<Charge> charges, final AccountingRuleType accountingRuleType,
-            final boolean includeInBorrowerCycle, final LocalDate startDate, final LocalDate closeDate, final ExternalId externalId,
-            final boolean useBorrowerCycle, final Set<LoanProductBorrowerCycleVariations> loanProductBorrowerCycleVariations,
-            final boolean multiDisburseLoan, final Integer maxTrancheCount, final BigDecimal outstandingLoanBalance,
-            final Integer graceOnArrearsAgeing, final Integer overdueDaysForNPA, final DaysInMonthType daysInMonthType,
-            final DaysInYearType daysInYearType, final boolean isInterestRecalculationEnabled,
-            final LoanProductInterestRecalculationDetails productInterestRecalculationDetails,
-            final Integer minimumDaysBetweenDisbursalAndFirstRepayment, final boolean holdGuarantorFunds,
-            final LoanProductGuaranteeDetails loanProductGuaranteeDetails, final BigDecimal principalThresholdForLastInstallment,
-            final boolean accountMovesOutOfNPAOnlyOnArrearsCompletion, final boolean canDefineEmiAmount,
-            final Integer installmentAmountInMultiplesOf, final LoanProductConfigurableAttributes loanProductConfigurableAttributes,
-            Boolean isLinkedToFloatingInterestRates, FloatingRate floatingRate, BigDecimal interestRateDifferential,
-            BigDecimal minDifferentialLendingRate, BigDecimal maxDifferentialLendingRate, BigDecimal defaultDifferentialLendingRate,
-            Boolean isFloatingInterestRateCalculationAllowed, final Boolean isVariableInstallmentsAllowed,
-            final Integer minimumGapBetweenInstallments, final Integer maximumGapBetweenInstallments,
-            final boolean syncExpectedWithDisbursementDate, final boolean canUseForTopup, final boolean isEqualAmortization,
-            final List<Rate> rates, final BigDecimal fixedPrincipalPercentagePerInstallment, final boolean disallowExpectedDisbursements,
-            final boolean allowApprovedDisbursedAmountsOverApplied, final String overAppliedCalculationType,
-            final Integer overAppliedNumber, final Integer dueDaysForRepaymentEvent, final Integer overDueDaysForRepaymentEvent,
-            final boolean enableDownPayment, final BigDecimal disbursedAmountPercentageForDownPayment,
-            final boolean enableAutoRepaymentForDownPayment, final RepaymentStartDateType repaymentStartDateType,
-            final boolean enableInstallmentLevelDelinquency, final LoanScheduleType loanScheduleType,
-            final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
-            final boolean enableAccrualActivityPosting, final List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes,
-            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean isInterestRecognitionOnDisbursementDate) {
+                       final List<LoanProductPaymentAllocationRule> paymentAllocationRules,
+                       final List<LoanProductCreditAllocationRule> creditAllocationRules, final String name, final String shortName,
+                       final String description, final MonetaryCurrency currency, final BigDecimal defaultPrincipal,
+                       final BigDecimal defaultMinPrincipal, final BigDecimal defaultMaxPrincipal,
+                       final BigDecimal defaultNominalInterestRatePerPeriod, final BigDecimal defaultMinNominalInterestRatePerPeriod,
+                       final BigDecimal defaultMaxNominalInterestRatePerPeriod, final PeriodFrequencyType interestPeriodFrequencyType,
+                       final BigDecimal defaultAnnualNominalInterestRate, final InterestMethod interestMethod,
+                       final InterestCalculationPeriodMethod interestCalculationPeriodMethod, final boolean considerPartialPeriodInterest,
+                       final Integer repayEvery, final PeriodFrequencyType repaymentFrequencyType, final Integer defaultNumberOfInstallments,
+                       final Integer defaultMinNumberOfInstallments, final Integer defaultMaxNumberOfInstallments,
+                       final Integer graceOnPrincipalPayment, final Integer recurringMoratoriumOnPrincipalPeriods,
+                       final Integer graceOnInterestPayment, final Integer graceOnInterestCharged, final AmortizationMethod amortizationMethod,
+                       final BigDecimal inArrearsTolerance, final List<Charge> charges, final AccountingRuleType accountingRuleType,
+                       final boolean includeInBorrowerCycle, final LocalDate startDate, final LocalDate closeDate, final ExternalId externalId,
+                       final boolean useBorrowerCycle, final Set<LoanProductBorrowerCycleVariations> loanProductBorrowerCycleVariations,
+                       final boolean multiDisburseLoan, final Integer maxTrancheCount, final BigDecimal outstandingLoanBalance,
+                       final Integer graceOnArrearsAgeing, final Integer overdueDaysForNPA, final DaysInMonthType daysInMonthType,
+                       final DaysInYearType daysInYearType, final boolean isInterestRecalculationEnabled,
+                       final LoanProductInterestRecalculationDetails productInterestRecalculationDetails,
+                       final Integer minimumDaysBetweenDisbursalAndFirstRepayment, final boolean holdGuarantorFunds,
+                       final LoanProductGuaranteeDetails loanProductGuaranteeDetails, final BigDecimal principalThresholdForLastInstallment,
+                       final boolean accountMovesOutOfNPAOnlyOnArrearsCompletion, final boolean canDefineEmiAmount,
+                       final Integer installmentAmountInMultiplesOf, final LoanProductConfigurableAttributes loanProductConfigurableAttributes,
+                       Boolean isLinkedToFloatingInterestRates, FloatingRate floatingRate, BigDecimal interestRateDifferential,
+                       BigDecimal minDifferentialLendingRate, BigDecimal maxDifferentialLendingRate, BigDecimal defaultDifferentialLendingRate,
+                       Boolean isFloatingInterestRateCalculationAllowed, final Boolean isVariableInstallmentsAllowed,
+                       final Integer minimumGapBetweenInstallments, final Integer maximumGapBetweenInstallments,
+                       final boolean syncExpectedWithDisbursementDate, final boolean canUseForTopup, final boolean isEqualAmortization,
+                       final List<Rate> rates, final BigDecimal fixedPrincipalPercentagePerInstallment, final boolean disallowExpectedDisbursements,
+                       final boolean allowApprovedDisbursedAmountsOverApplied, final String overAppliedCalculationType,
+                       final Integer overAppliedNumber, final Integer dueDaysForRepaymentEvent, final Integer overDueDaysForRepaymentEvent,
+                       final boolean enableDownPayment, final BigDecimal disbursedAmountPercentageForDownPayment,
+                       final boolean enableAutoRepaymentForDownPayment, final RepaymentStartDateType repaymentStartDateType,
+                       final boolean enableInstallmentLevelDelinquency, final LoanScheduleType loanScheduleType,
+                       final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
+                       final boolean enableAccrualActivityPosting, final List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes,
+                       final LoanChargeOffBehaviour chargeOffBehaviour, final boolean isInterestRecognitionOnDisbursementDate, final DaysInYearCustomStrategyType daysInYearCustomStrategy) {
         this.fund = fund;
         this.transactionProcessingStrategyCode = transactionProcessingStrategyCode;
 
@@ -755,7 +759,7 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
                 inArrearsTolerance, graceOnArrearsAgeing, daysInMonthType.getValue(), daysInYearType.getValue(),
                 isInterestRecalculationEnabled, isEqualAmortization, enableDownPayment, disbursedAmountPercentageForDownPayment,
                 enableAutoRepaymentForDownPayment, loanScheduleType, loanScheduleProcessingType, fixedLength, enableAccrualActivityPosting,
-                supportedInterestRefundTypes, chargeOffBehaviour, isInterestRecognitionOnDisbursementDate);
+                supportedInterestRefundTypes, chargeOffBehaviour, isInterestRecognitionOnDisbursementDate, daysInYearCustomStrategy);
 
         this.loanProductMinMaxConstraints = new LoanProductMinMaxConstraints(defaultMinPrincipal, defaultMaxPrincipal,
                 defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod, defaultMinNumberOfInstallments,

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductMinimumRepaymentScheduleRelatedDetail.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductMinimumRepaymentScheduleRelatedDetail.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.loanproduct.domain;
 
 import java.math.BigDecimal;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 
 /**
@@ -62,4 +63,6 @@ public interface LoanProductMinimumRepaymentScheduleRelatedDetail {
     Integer getDaysInYearType();
 
     boolean isInterestRecognitionOnDisbursementDate();
+
+    DaysInYearCustomStrategyType daysInYearCustomStrategy();
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
@@ -35,6 +35,7 @@ import org.apache.fineract.organisation.monetary.data.CurrencyData;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
+import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
@@ -168,6 +169,10 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     @Column(name = "interest_recognition_on_disbursement_date", nullable = false)
     private boolean interestRecognitionOnDisbursementDate = false;
 
+    @Convert(converter = DaysInYearCustomStrategyTypeAttributeConverter.class)
+    @Column(name = "days_in_year_custom_strategy")
+    private DaysInYearCustomStrategyType daysInYearCustomStrategy;
+
     public static LoanProductRelatedDetail createFrom(final CurrencyData currencyData, final BigDecimal principal,
             final BigDecimal nominalInterestRatePerPeriod, final PeriodFrequencyType interestRatePeriodFrequencyType,
             final BigDecimal nominalAnnualInterestRate, final InterestMethod interestMethod,
@@ -181,7 +186,7 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
             final boolean enableAutoRepaymentForDownPayment, final LoanScheduleType loanScheduleType,
             final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
             final boolean enableAccrualActivityPosting, final List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes,
-            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate) {
+            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate, final DaysInYearCustomStrategyType daysInYearCustomStrategy) {
 
         final MonetaryCurrency currency = MonetaryCurrency.fromCurrencyData(currencyData);
         return new LoanProductRelatedDetail(currency, principal, nominalInterestRatePerPeriod, interestRatePeriodFrequencyType,
@@ -191,7 +196,7 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
                 inArrearsTolerance, graceOnArrearsAgeing, daysInMonthType, daysInYearType, isInterestRecalculationEnabled,
                 isEqualAmortization, enableDownPayment, disbursedAmountPercentageForDownPayment, enableAutoRepaymentForDownPayment,
                 loanScheduleType, loanScheduleProcessingType, fixedLength, enableAccrualActivityPosting, supportedInterestRefundTypes,
-                chargeOffBehaviour, interestRecognitionOnDisbursementDate);
+                chargeOffBehaviour, interestRecognitionOnDisbursementDate, daysInYearCustomStrategy);
     }
 
     protected LoanProductRelatedDetail() {
@@ -211,7 +216,7 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
             final boolean enableAutoRepaymentForDownPayment, final LoanScheduleType loanScheduleType,
             final LoanScheduleProcessingType loanScheduleProcessingType, final Integer fixedLength,
             final boolean enableAccrualActivityPosting, List<LoanSupportedInterestRefundTypes> supportedInterestRefundTypes,
-            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate) {
+            final LoanChargeOffBehaviour chargeOffBehaviour, final boolean interestRecognitionOnDisbursementDate, final DaysInYearCustomStrategyType daysInYearCustomStrategy) {
         this.currency = currency;
         this.principal = defaultPrincipal;
         this.nominalInterestRatePerPeriod = defaultNominalInterestRatePerPeriod;
@@ -248,6 +253,7 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
         this.supportedInterestRefundTypes = supportedInterestRefundTypes;
         this.chargeOffBehaviour = chargeOffBehaviour;
         this.interestRecognitionOnDisbursementDate = interestRecognitionOnDisbursementDate;
+        this.daysInYearCustomStrategy = daysInYearCustomStrategy;
     }
 
     private Integer defaultToNullIfZero(final Integer value) {
@@ -293,6 +299,11 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     public BigDecimal getAnnualNominalInterestRate() {
         return this.annualNominalInterestRate == null ? null
                 : BigDecimal.valueOf(Double.parseDouble(this.annualNominalInterestRate.stripTrailingZeros().toString()));
+    }
+
+    @Override
+    public DaysInYearCustomStrategyType daysInYearCustomStrategy() {
+        return null;
     }
 
     // TODO: Move into assembler

--- a/fineract-progressive-loan/src/main/resources/jpa/progressiveloan/persistence.xml
+++ b/fineract-progressive-loan/src/main/resources/jpa/progressiveloan/persistence.xml
@@ -115,6 +115,7 @@
         <class>org.apache.fineract.portfolio.loanproduct.domain.CreditAllocationTransactionType</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationTypeListConverter</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.SupportedInterestRefundTypesListConverter</class>
+        <class>org.apache.fineract.portfolio.loanproduct.domain.DaysInYearCustomStrategyTypeAttributeConverter</class>
         <class>org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter</class>
         <class>org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest</class>
         <class>org.apache.fineract.portfolio.repaymentwithpostdatedchecks.domain.PostDatedChecks</class>

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -2855,6 +2855,193 @@ class ProgressiveEMICalculatorTest {
         checkPeriod(interestSchedule, 5, 0, 17.19, 0.005833333333, 0.0996916666611, 0.10, 17.09, 0.0);
     }
 
+    @Nested
+    class LeapYear366OnlyForPeriodWith29thOfFebruaryTest {
+
+    /**
+     * February is split and leap year
+     */
+    @Test
+    public void test_leap_year_only_actual_for_loan_S1() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                repayment(1, LocalDate.of(2023, 12, 12), LocalDate.of(2024, 1, 12)),
+                repayment(1, LocalDate.of(2024, 1, 12), LocalDate.of(2024, 2, 12)),
+                repayment(1, LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 12)),
+                repayment(1, LocalDate.of(2024, 3, 12), LocalDate.of(2024, 4, 12)),
+                repayment(1, LocalDate.of(2024, 4, 12), LocalDate.of(2024, 5, 12)),
+                repayment(1, LocalDate.of(2024, 5, 12), LocalDate.of(2024, 6, 12)));
+
+        final BigDecimal interestRate = BigDecimal.valueOf(9.482);
+        final Integer installmentAmountInMultiplesOf = null;
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                expectedRepaymentPeriods, loanProductRelatedDetail, List.of(), installmentAmountInMultiplesOf, mc);
+
+        final Money disbursedAmount = toMoney(10000.0);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2023, 12, 12), disbursedAmount);
+
+        checkPeriod(interestSchedule, 0, 1713.21, 80.53, 1632.68, 8367.32, false);
+        checkPeriod(interestSchedule, 1, 1713.21, 67.38, 1645.83, 6721.49, false);
+        checkPeriod(interestSchedule, 2, 1713.21, 50.50, 1662.71, 5058.78, false);
+        checkPeriod(interestSchedule, 3, 1713.21, 40.74, 1672.47, 3386.31, false);
+        checkPeriod(interestSchedule, 4, 1713.21, 26.39, 1686.82, 1699.49, false);
+        checkPeriod(interestSchedule, 5, 1713.18, 13.69, 1699.49, 0.00, false);
+
+    }
+
+    /**
+     * No february but leap year
+     */
+    @Test
+    public void test_leap_year_only_actual_for_loan_S2() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                repayment(1, LocalDate.of(2024, 7, 23), LocalDate.of(2024, 8, 23)),
+                repayment(1, LocalDate.of(2024, 8, 23), LocalDate.of(2024, 9, 23)),
+                repayment(1, LocalDate.of(2024, 9, 23), LocalDate.of(2024, 10, 23)),
+                repayment(1, LocalDate.of(2024, 10, 23), LocalDate.of(2024, 11, 23)));
+
+        final BigDecimal interestRate = BigDecimal.valueOf(12.0);
+        final Integer installmentAmountInMultiplesOf = null;
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                expectedRepaymentPeriods, loanProductRelatedDetail, List.of(), installmentAmountInMultiplesOf, mc);
+
+        final Money disbursedAmount = toMoney(15000.0);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 7, 23), disbursedAmount);
+        
+        checkPeriod(interestSchedule, 0, 3845.41, 152.88, 3692.53, 11307.47, false);
+        checkPeriod(interestSchedule, 1, 3845.41, 115.24, 3730.17, 7577.30, false);
+        checkPeriod(interestSchedule, 2, 3845.41, 74.74, 3770.67, 3806.63, false);
+        checkPeriod(interestSchedule, 3, 3845.43, 38.80, 3806.63, 0.00, false);
+    }
+
+    /**
+     * February in one period
+     */
+    @Test
+    public void test_leap_year_only_actual_for_loan_S3() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                repayment(1, LocalDate.of(2022, 10, 31), LocalDate.of(2022, 11, 30)),
+                repayment(1, LocalDate.of(2022, 11, 30), LocalDate.of(2022, 12, 31)),
+                repayment(1, LocalDate.of(2022, 12, 31), LocalDate.of(2023, 1, 31)),
+                repayment(1, LocalDate.of(2023, 1, 31), LocalDate.of(2023, 2, 28)),
+                repayment(1, LocalDate.of(2023, 2, 28), LocalDate.of(2023, 3, 31)),
+                repayment(1, LocalDate.of(2023, 3, 31), LocalDate.of(2023, 4, 30)));
+
+        final BigDecimal interestRate = BigDecimal.valueOf(45.00);
+        final Integer installmentAmountInMultiplesOf = null;
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                expectedRepaymentPeriods, loanProductRelatedDetail, List.of(), installmentAmountInMultiplesOf, mc);
+
+        final Money disbursedAmount = toMoney(245000.0);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2022, 10, 31), disbursedAmount);
+
+        checkPeriod(interestSchedule, 0, 46348.39, 9061.64, 37286.75, 207713.25, false);
+        checkPeriod(interestSchedule, 1, 46348.39, 7938.63, 38409.76, 169303.49, false);
+        checkPeriod(interestSchedule, 2, 46348.39, 6470.64, 39877.75, 129425.74, false);
+        checkPeriod(interestSchedule, 3, 46348.39, 4614.77, 41733.62, 87692.12, false);
+        checkPeriod(interestSchedule, 4, 46348.39, 3351.52, 42996.87, 44695.25, false);
+        checkPeriod(interestSchedule, 5, 46348.36, 1653.11, 44695.25, 0.00, false);
+
+    }
+
+    /**
+     * No Feb month - leap and non leap year split
+     */
+    @Test
+    public void test_leap_year_only_actual_for_loan_S4() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                repayment(1, LocalDate.of(2024, 10, 31), LocalDate.of(2024, 11, 30)),
+                repayment(1, LocalDate.of(2024, 11, 30), LocalDate.of(2024, 12, 31)),
+                repayment(1, LocalDate.of(2024, 12, 31), LocalDate.of(2025, 1, 31)),
+                repayment(1, LocalDate.of(2025, 1, 31), LocalDate.of(2025, 2, 28)),
+                repayment(1, LocalDate.of(2025, 2, 28), LocalDate.of(2025, 3, 31)),
+                repayment(1, LocalDate.of(2025, 3, 31), LocalDate.of(2025, 4, 30)));
+
+        final BigDecimal interestRate = BigDecimal.valueOf(9.99);
+        final Integer installmentAmountInMultiplesOf = null;
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                expectedRepaymentPeriods, loanProductRelatedDetail, List.of(), installmentAmountInMultiplesOf, mc);
+
+        final Money disbursedAmount = toMoney(2450);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 10, 31), disbursedAmount);
+
+        checkPeriod(interestSchedule, 0, 420.24, 20.12, 400.12, 2049.88, false);
+        checkPeriod(interestSchedule, 1, 420.24, 17.39, 402.85, 1647.03, false);
+        checkPeriod(interestSchedule, 2, 420.24, 13.97, 406.27, 1240.76, false);
+        checkPeriod(interestSchedule, 3, 420.24, 9.51, 410.73, 830.03, false);
+        checkPeriod(interestSchedule, 4, 420.24, 7.04, 413.20, 416.83, false);
+        checkPeriod(interestSchedule, 5, 420.25, 3.42, 416.83, 0.00, false);
+    }
+
+    /**
+     * no leap year
+     */
+    @Test
+    public void test_leap_year_only_actual_for_loan_S5() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                repayment(1, LocalDate.of(2022, 10, 29), LocalDate.of(2022, 12, 29)),
+                repayment(1, LocalDate.of(2022, 12, 29), LocalDate.of(2023, 2, 28)),
+                repayment(1, LocalDate.of(2023, 2, 28), LocalDate.of(2023, 4, 29)),
+                repayment(1, LocalDate.of(2023, 4, 29), LocalDate.of(2023, 6, 29)),
+                repayment(1, LocalDate.of(2023, 6, 29), LocalDate.of(2023, 8, 29)),
+                repayment(1, LocalDate.of(2023, 8, 29), LocalDate.of(2023, 10, 29)));
+
+        final BigDecimal interestRate = BigDecimal.valueOf(7.00);
+        final Integer installmentAmountInMultiplesOf = null;
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(2);
+        Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                expectedRepaymentPeriods, loanProductRelatedDetail, List.of(), installmentAmountInMultiplesOf, mc);
+
+        final Money disbursedAmount = toMoney(5000.0);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2022, 10, 29), disbursedAmount);
+
+        checkPeriod(interestSchedule, 0, 867.68, 58.49, 809.19, 4190.81, false);
+        checkPeriod(interestSchedule, 1, 867.68, 49.03, 818.65, 3372.16, false);
+        checkPeriod(interestSchedule, 2, 867.68, 38.80, 828.88, 2543.28, false);
+        checkPeriod(interestSchedule, 3, 867.68, 29.75, 837.93, 1705.35, false);
+        checkPeriod(interestSchedule, 4, 867.68, 19.95, 847.73, 857.62, false);
+        checkPeriod(interestSchedule, 5, 867.65, 10.03, 857.62, 0.00, false);
+    }
+
+    }
     @Test
     public void test_s5_chargeback_in_period_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
@@ -541,7 +541,7 @@ public class LoanScheduleAssembler {
                 loanScheduleType, loanScheduleProcessingType, fixedLength,
                 loanProduct.getLoanProductRelatedDetail().isEnableAccrualActivityPosting(),
                 loanProduct.getLoanProductRelatedDetail().getSupportedInterestRefundTypes(),
-                loanProduct.getLoanProductRelatedDetail().getChargeOffBehaviour(), interestRecognitionOnDisbursementDate);
+                loanProduct.getLoanProductRelatedDetail().getChargeOffBehaviour(), interestRecognitionOnDisbursementDate, loanProduct.getLoanProductRelatedDetail().getDaysInYearCustomStrategy());
     }
 
     private CalendarInstance createCalendarForSameAsRepayment(final Integer repaymentEvery,

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -186,4 +186,5 @@
     <include file="parts/0165_add_credited_interest_to_instalment.xml" relativeToChangelogFile="true" />
     <include file="parts/0166_transaction_summary_with_asset_owner_report_charge_adjustment_fix.xml" relativeToChangelogFile="true" />
     <include file="parts/0167_create_m_calendar_instance_index.xml" relativeToChangelogFile="true" />
+    <include file="parts/0168_days_in_year_custom_strategy.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0168_days_in_year_custom_strategy.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0168_days_in_year_custom_strategy.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_loan">
+            <column name="days_in_year_custom_strategy" type="INT" defaultValueNumeric="NULL">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="m_product_loan">
+            <column name="days_in_year_custom_strategy" type="INT" defaultValueNumeric="NULL">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/jpa/persistence.xml
+++ b/fineract-provider/src/main/resources/jpa/persistence.xml
@@ -124,6 +124,7 @@
         <class>org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationType</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationTypeListConverter</class>
         <class>org.apache.fineract.portfolio.loanproduct.domain.SupportedInterestRefundTypesListConverter</class>
+        <class>org.apache.fineract.portfolio.loanproduct.domain.DaysInYearCustomStrategyTypeAttributeConverter</class>
         <class>org.apache.fineract.portfolio.repaymentwithpostdatedchecks.domain.PostDatedChecks</class>
         <!-- Fineract Savings module -->
         <class>org.apache.fineract.interoperation.domain.InteropIdentifier</class>

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGeneratorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGeneratorTest.java
@@ -98,7 +98,7 @@ public class DefaultScheduledDateGeneratorTest {
                 Money.of(fromApplicationCurrency(dollarCurrency), ZERO), false, null, EMPTY_LIST, BigDecimal.valueOf(36_000L), null,
                 DaysInMonthType.ACTUAL, DaysInYearType.ACTUAL, false, null, null, null, null, null, ZERO, null, NONE, null, ZERO,
                 EMPTY_LIST, true, 0, false, holidayDetailDTO, false, false, false, null, false, false, null, false, DISBURSEMENT_DATE,
-                submittedOnDate, CUMULATIVE, LoanScheduleProcessingType.HORIZONTAL, null, false, null, null, false);
+                submittedOnDate, CUMULATIVE, LoanScheduleProcessingType.HORIZONTAL, null, false, null, null, false, null);
 
         // when
         List<? extends LoanScheduleModelPeriod> result = underTest.generateRepaymentPeriods(mathContext, expectedDisbursementDate,
@@ -170,7 +170,7 @@ public class DefaultScheduledDateGeneratorTest {
                 EMPTY_LIST, BigDecimal.valueOf(36_000L), null, DaysInMonthType.ACTUAL, DaysInYearType.ACTUAL, false, null, null, null, null,
                 null, ZERO, null, NONE, null, ZERO, EMPTY_LIST, true, 0, false, holidayDetailDTO, false, false, false, null, false, false,
                 null, false, DISBURSEMENT_DATE, submittedOnDate, CUMULATIVE, LoanScheduleProcessingType.HORIZONTAL, null, false, null, null,
-                false);
+                false, null);
     }
 
     private HolidayDetailDTO createHolidayDTO() {


### PR DESCRIPTION
## Description
Introduce new flag `days_in_year_custom_strategy` and calculations for values in case of Days In Years set to `ACTUAL`.
* `FULL_LEAP_YEAR`: 366 days for full leap year. → This is the by default value!
* `FEB_29_PERIOD_ONLY`: 366 days for period of February 29
* Introduce new field for loan and loan product
* Implement calculations in `EMICalculator`
* With covering unittest for EMI Calculator

Check associated [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-1982).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
