### PR TITLE
FINERACT-2181: No subResourceExternalId in fee waiver response after charge-off

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeAdjustmentStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeAdjustmentStepDef.java
@@ -145,6 +145,13 @@ public class LoanChargeAdjustmentStepDef extends AbstractStepDef {
         ErrorHelper.checkSuccessfulApiCall(chargeAdjustmentUndoResponse);
     }
 
+    @Then("Charge adjustment response has the subResourceExternalId")
+    public void checkChargeAdjustmentResponse() {
+        final Response<PostLoansLoanIdChargesChargeIdResponse> response = testContext().get(TestContextKey.LOAN_CHARGE_ADJUSTMENT_RESPONSE);
+        final PostLoansLoanIdChargesChargeIdResponse body = response.body();
+        assertThat(body.getSubResourceExternalId()).isNotNull();
+    }
+
     private Long getTransactionIdForTransactionMetConditions(String transactionDate, double transactionAmount,
             Response<GetLoansLoanIdResponse> loanDetailsResponse) {
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.body().getTransactions();


### PR DESCRIPTION
## Description

Covering this case with an E2E test that includes the following steps:

Creating and disbursing a loan (with interest greater than 0%)
Creating a fee on the loan
Charging off the loan
Creating a Fee Waiver on the loan (Charge adjustment)

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
