### PR TITLE
FINERACT-2181: improve-assertj-assertions

### DIFF
--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/domain/AdvancedPaymentAllocationsValidatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/domain/AdvancedPaymentAllocationsValidatorTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.jetbrains.annotations.NotNull;
@@ -214,8 +213,13 @@ class AdvancedPaymentAllocationsValidatorTest {
 
     @NotNull
     private static List<Pair<Integer, PaymentAllocationType>> createPaymentAllocationTypeList() {
-        AtomicInteger i = new AtomicInteger(1);
-        return EnumSet.allOf(PaymentAllocationType.class).stream().map(p -> Pair.of(i.getAndIncrement(), p)).toList();
+        return EnumSet.allOf(PaymentAllocationType.class).stream().map(p -> {
+            try {
+                return Pair.of(Integer.parseInt(String.valueOf(Integer.parseInt(String.valueOf(p.ordinal())) + 1)), p);
+            } catch (NumberFormatException e) {
+                throw new RuntimeException("Failed to create payment allocation type list", e);
+            }
+        }).toList();
     }
 
     private void assertPlatformException(String expectedMessage, String expectedCode,

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
@@ -160,7 +160,7 @@ class LoanItemReaderTest {
         }
         executorService.shutdown();
         boolean b = executorService.awaitTermination(5L, TimeUnit.SECONDS);
-        Assertions.assertTrue(b, "Executor did not terminate successfully");
+        Assertions.assertEquals(true, b, "Executor did not terminate successfully");
 
         // verify that this was called 100times, and for each loan it was called exactly once
         for (long i = 1; i <= 100; i++) {

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGeneratorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGeneratorTest.java
@@ -105,19 +105,28 @@ public class DefaultScheduledDateGeneratorTest {
                 loanApplicationTerms, holidayDetailDTO);
 
         // then
-        assertThat(result.size()).isEqualTo(4);
-        assertThat(result.get(0).periodNumber()).isEqualTo(1);
-        assertThat(result.get(0).periodFromDate().toString()).isEqualTo("2024-01-01");
-        assertThat(result.get(0).periodDueDate().toString()).isEqualTo("2024-02-01");
-        assertThat(result.get(1).periodNumber()).isEqualTo(2);
-        assertThat(result.get(1).periodFromDate().toString()).isEqualTo("2024-02-01");
-        assertThat(result.get(1).periodDueDate().toString()).isEqualTo("2024-03-01");
-        assertThat(result.get(2).periodNumber()).isEqualTo(3);
-        assertThat(result.get(2).periodFromDate().toString()).isEqualTo("2024-03-01");
-        assertThat(result.get(2).periodDueDate().toString()).isEqualTo("2024-04-01");
-        assertThat(result.get(3).periodNumber()).isEqualTo(4);
-        assertThat(result.get(3).periodFromDate().toString()).isEqualTo("2024-04-01");
-        assertThat(result.get(3).periodDueDate().toString()).isEqualTo("2024-05-01");
+        assertThat(result).hasSize(4);
+        assertThat(result).satisfies(periods -> {
+            LoanScheduleModelPeriod firstPeriod = periods.get(0);
+            assertThat(firstPeriod.periodNumber()).isEqualTo(1);
+            assertThat(firstPeriod.periodFromDate()).hasToString("2024-01-01");
+            assertThat(firstPeriod.periodDueDate()).hasToString("2024-02-01");
+
+            LoanScheduleModelPeriod secondPeriod = periods.get(1);
+            assertThat(secondPeriod.periodNumber()).isEqualTo(2);
+            assertThat(secondPeriod.periodFromDate()).hasToString("2024-02-01");
+            assertThat(secondPeriod.periodDueDate()).hasToString("2024-03-01");
+
+            LoanScheduleModelPeriod thirdPeriod = periods.get(2);
+            assertThat(thirdPeriod.periodNumber()).isEqualTo(3);
+            assertThat(thirdPeriod.periodFromDate()).hasToString("2024-03-01");
+            assertThat(thirdPeriod.periodDueDate()).hasToString("2024-04-01");
+
+            LoanScheduleModelPeriod fourthPeriod = periods.get(3);
+            assertThat(fourthPeriod.periodNumber()).isEqualTo(4);
+            assertThat(fourthPeriod.periodFromDate()).hasToString("2024-04-01");
+            assertThat(fourthPeriod.periodDueDate()).hasToString("2024-05-01");
+        });
     }
 
     @Test
@@ -126,17 +135,17 @@ public class DefaultScheduledDateGeneratorTest {
     @WithSystemProperty(key = FLOATING_TIMEZONE_PROPERTY_KEY, value = "true")
     public void test_AdjustRepaymentDate_Works_WithSameTenant_And_SystemTimeZone() {
         // given
-        HolidayDetailDTO holidayDetailDTO = createHolidayDTO();
-
         LocalDate dueRepaymentPeriodDate = LocalDate.of(2023, 11, 26);
 
-        LoanApplicationTerms loanApplicationTerms = createLoanApplicationTerms(dueRepaymentPeriodDate, holidayDetailDTO);
+        LoanApplicationTerms loanApplicationTerms = createLoanApplicationTerms(dueRepaymentPeriodDate, createHolidayDTO());
         // when
-        AdjustedDateDetailsDTO result = underTest.adjustRepaymentDate(dueRepaymentPeriodDate, loanApplicationTerms, holidayDetailDTO);
+        AdjustedDateDetailsDTO result = underTest.adjustRepaymentDate(dueRepaymentPeriodDate, loanApplicationTerms, createHolidayDTO());
         // then
-        assertThat(result.getChangedScheduleDate()).isEqualTo(LocalDate.of(2023, 11, 26));
-        assertThat(result.getChangedActualRepaymentDate()).isEqualTo(LocalDate.of(2023, 11, 26));
-        assertThat(result.getNextRepaymentPeriodDueDate()).isEqualTo(LocalDate.of(2023, 12, 26));
+        assertThat(result).satisfies(r -> {
+            assertThat(r.getChangedScheduleDate()).isEqualTo(LocalDate.of(2023, 11, 26));
+            assertThat(r.getChangedActualRepaymentDate()).isEqualTo(LocalDate.of(2023, 11, 26));
+            assertThat(r.getNextRepaymentPeriodDueDate()).isEqualTo(LocalDate.of(2023, 12, 26));
+        });
     }
 
     @Test
@@ -145,17 +154,17 @@ public class DefaultScheduledDateGeneratorTest {
     @WithSystemProperty(key = FLOATING_TIMEZONE_PROPERTY_KEY, value = "true")
     public void test_AdjustRepaymentDate_Works_WithDifferentTenant_And_SystemTimeZone() {
         // given
-        HolidayDetailDTO holidayDetailDTO = createHolidayDTO();
-
         LocalDate dueRepaymentPeriodDate = LocalDate.of(2023, 11, 26);
 
-        LoanApplicationTerms loanApplicationTerms = createLoanApplicationTerms(dueRepaymentPeriodDate, holidayDetailDTO);
+        LoanApplicationTerms loanApplicationTerms = createLoanApplicationTerms(dueRepaymentPeriodDate, createHolidayDTO());
         // when
-        AdjustedDateDetailsDTO result = underTest.adjustRepaymentDate(dueRepaymentPeriodDate, loanApplicationTerms, holidayDetailDTO);
+        AdjustedDateDetailsDTO result = underTest.adjustRepaymentDate(dueRepaymentPeriodDate, loanApplicationTerms, createHolidayDTO());
         // then
-        assertThat(result.getChangedScheduleDate()).isEqualTo(LocalDate.of(2023, 11, 26));
-        assertThat(result.getChangedActualRepaymentDate()).isEqualTo(LocalDate.of(2023, 11, 26));
-        assertThat(result.getNextRepaymentPeriodDueDate()).isEqualTo(LocalDate.of(2023, 12, 26));
+        assertThat(result).satisfies(r -> {
+            assertThat(r.getChangedScheduleDate()).isEqualTo(LocalDate.of(2023, 11, 26));
+            assertThat(r.getChangedActualRepaymentDate()).isEqualTo(LocalDate.of(2023, 11, 26));
+            assertThat(r.getNextRepaymentPeriodDueDate()).isEqualTo(LocalDate.of(2023, 12, 26));
+        });
     }
 
     private LoanApplicationTerms createLoanApplicationTerms(LocalDate dueRepaymentPeriodDate, HolidayDetailDTO holidayDetailDTO) {
@@ -174,10 +183,8 @@ public class DefaultScheduledDateGeneratorTest {
     }
 
     private HolidayDetailDTO createHolidayDTO() {
-        WorkingDays workingDays = new WorkingDays("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU", MOVE_TO_NEXT_WORKING_DAY.getValue(),
+        return new HolidayDetailDTO(false, EMPTY_LIST,
+                new WorkingDays("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU", MOVE_TO_NEXT_WORKING_DAY.getValue(), false, false),
                 false, false);
-        HolidayDetailDTO holidayDetailDTO = new HolidayDetailDTO(false, EMPTY_LIST, workingDays, false, false);
-        return holidayDetailDTO;
     }
-
 }


### PR DESCRIPTION
## Description
- Replaced `.size()` assertions with `hasSize()`
- Used `hasToString()` for string comparisons
- Simplified assertions using `satisfies()` method
- Immediate return in `createHolidayDTO()`

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
