### PR TITLE
FINERACT-2197: Introduce a new type of ACTUAL during calculation of d…

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
@@ -350,6 +350,30 @@ final class LoanProductsApiResourceSwagger {
         public Long resourceId;
     }
 
+    public static final class GetLoanProductsDaysInMonthType {
+
+        private GetLoanProductsDaysInMonthType() {}
+
+        @Schema(example = "1")
+        public Long id;
+        @Schema(example = "DaysInMonthType.actual")
+        public String code;
+        @Schema(example = "Actual")
+        public String description;
+    }
+
+    public static final class GetLoanProductsDaysInYearType {
+
+        private GetLoanProductsDaysInYearType() {}
+
+        @Schema(example = "1")
+        public Long id;
+        @Schema(example = "DaysInYearType.actual")
+        public String code;
+        @Schema(example = "Actual")
+        public String description;
+    }
+
     @Schema(description = "GetLoanProductsResponse")
     public static final class GetLoanProductsResponse {
 
@@ -432,30 +456,6 @@ final class LoanProductsApiResourceSwagger {
             @Schema(example = "interestCalculationPeriodType.same.as.repayment.period")
             public String code;
             @Schema(example = "Same as repayment period")
-            public String description;
-        }
-
-        static final class GetLoansProductsDaysInMonthType {
-
-            private GetLoansProductsDaysInMonthType() {}
-
-            @Schema(example = "30")
-            public Long id;
-            @Schema(example = "DaysInMonthType.days360")
-            public String code;
-            @Schema(example = "30 Days")
-            public String description;
-        }
-
-        static final class GetLoansProductsDaysInYearType {
-
-            private GetLoansProductsDaysInYearType() {}
-
-            @Schema(example = "360")
-            public Long id;
-            @Schema(example = "DaysInYearType.days360")
-            public String code;
-            @Schema(example = "360 Days")
             public String description;
         }
 
@@ -626,8 +626,8 @@ final class LoanProductsApiResourceSwagger {
         public List<Integer> interestRateVariationsForBorrowerCycle;
         @Schema(example = "[]")
         public List<Integer> numberOfRepaymentVariationsForBorrowerCycle;
-        public GetLoansProductsDaysInMonthType daysInMonthType;
-        public GetLoansProductsDaysInYearType daysInYearType;
+        public GetLoanProductsDaysInMonthType daysInMonthType;
+        public GetLoanProductsDaysInYearType daysInYearType;
         public GetLoanProductsDaysInYearCustomStrategy daysInYearCustomStrategy;
         @Schema(example = "true")
         public Boolean isInterestRecalculationEnabled;
@@ -710,42 +710,6 @@ final class LoanProductsApiResourceSwagger {
             @Schema(example = "accountingRuleType.none")
             public String code;
             @Schema(example = "NONE")
-            public String description;
-        }
-
-        static final class GetLoansProductsDaysInMonthTemplateType {
-
-            private GetLoansProductsDaysInMonthTemplateType() {}
-
-            @Schema(example = "1")
-            public Long id;
-            @Schema(example = "DaysInMonthType.actual")
-            public String code;
-            @Schema(example = "Actual")
-            public String description;
-        }
-
-        static final class GetLoanProductsDaysInYearTemplateType {
-
-            private GetLoanProductsDaysInYearTemplateType() {}
-
-            @Schema(example = "1")
-            public Long id;
-            @Schema(example = "DaysInYearType.actual")
-            public String code;
-            @Schema(example = "Actual")
-            public String description;
-        }
-
-        static final class GetLoanProductsDaysInYearCustomStrategyTemplateType {
-
-            private GetLoanProductsDaysInYearCustomStrategyTemplateType() {}
-
-            @Schema(example = "FULL_LEAP_YEAR")
-            public String id;
-            @Schema(example = "DaysInYearCustomStrategyType.fullLeapYear")
-            public String code;
-            @Schema(example = "Full Leap Year")
             public String description;
         }
 
@@ -1098,9 +1062,9 @@ final class LoanProductsApiResourceSwagger {
         @Schema(example = "[]")
         public List<Integer> numberOfRepaymentVariationsForBorrowerCycle;
         public GetLoanProductsTemplateResponse.GetLoanProductsAccountingRule accountingRule;
-        public GetLoansProductsDaysInMonthTemplateType daysInMonthType;
-        public GetLoanProductsDaysInYearTemplateType daysInYearType;
-        public GetLoanProductsDaysInYearCustomStrategyTemplateType daysInYearCustomStrategy;
+        public GetLoanProductsDaysInMonthType daysInMonthType;
+        public GetLoanProductsDaysInYearType daysInYearType;
+        public StringEnumOptionData daysInYearCustomStrategy;
         @Schema(example = "false")
         public Boolean isInterestRecalculationEnabled;
         public GetLoanProductsInterestRecalculationTemplateData interestRecalculationData;
@@ -1117,9 +1081,9 @@ final class LoanProductsApiResourceSwagger {
         public Set<GetLoanProductsResponse.GetLoanProductsAccountingRule> accountingRuleOptions;
         public GetLoanProductsAccountingMappingOptions accountingMappingOptions;
         public Set<GetLoanProductsValueConditionTypeOptions> valueConditionTypeOptions;
-        public Set<GetLoansProductsDaysInMonthTemplateType> daysInMonthTypeOptions;
+        public Set<StringEnumOptionData> daysInMonthTypeOptions;
         public Set<GetLoanProductsInterestTemplateType> daysInYearTypeOptions;
-        public Set<GetLoanProductsDaysInYearCustomStrategyTemplateType> daysInYearTypeCustomStrategyOptions;
+        public Set<StringEnumOptionData> daysInYearTypeCustomStrategyOptions;
         public Set<GetLoanProductsResponse.GetLoanProductsInterestRecalculationData.GetLoanProductsInterestRecalculationCompoundingType> interestRecalculationCompoundingTypeOptions;
         public Set<GetLoanProductsResponse.GetLoanProductsInterestRecalculationData.GetLoanProductsRescheduleStrategyType> rescheduleStrategyTypeOptions;
         public Set<GetLoanProductsResponse.GetLoanProductsInterestRecalculationData.GetLoanProductsInterestRecalculationCompoundingFrequencyType> interestRecalculationFrequencyTypeOptions;
@@ -1402,6 +1366,9 @@ final class LoanProductsApiResourceSwagger {
         @Schema(example = "[]")
         public List<Integer> numberOfRepaymentVariationsForBorrowerCycle;
         public GetLoanProductsResponse.GetLoanProductsAccountingRule accountingRule;
+        public GetLoanProductsDaysInMonthType daysInMonthType;
+        public GetLoanProductsDaysInYearType daysInYearType;
+        public StringEnumOptionData daysInYearCustomStrategy;
         @Schema(example = "false")
         public Boolean canUseForTopup;
         public GetLoanAccountingMappings accountingMappings;
@@ -1555,6 +1522,8 @@ final class LoanProductsApiResourceSwagger {
         public Long daysInMonthType;
         @Schema(example = "1")
         public Long daysInYearType;
+        @Schema(example = "FULL_LEAP_YEAR")
+        public String daysInYearCustomStrategy;
         @Schema(example = "true")
         public Boolean allowPartialPeriodInterestCalcualtion;
         @Schema(example = "179")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
@@ -523,6 +523,13 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
             this.daysInYearType = newValue;
         }
 
+        if (command.parameterExists(LoanProductConstants.DAYS_IN_YEAR_CUSTOM_STRATEGY_TYPE_PARAMETER_NAME)) {
+            final DaysInYearCustomStrategyType newValue = DaysInYearCustomStrategyType
+                    .valueOf(command.stringValueOfParameterNamed(LoanProductConstants.DAYS_IN_YEAR_CUSTOM_STRATEGY_TYPE_PARAMETER_NAME));
+            actualChanges.put(LoanProductConstants.DAYS_IN_YEAR_CUSTOM_STRATEGY_TYPE_PARAMETER_NAME, newValue.name());
+            this.daysInYearCustomStrategy = newValue;
+        }
+
         if (command.isChangeInBooleanParameterNamed(LoanProductConstants.IS_INTEREST_RECALCULATION_ENABLED_PARAMETER_NAME,
                 this.isInterestRecalculationEnabled)) {
             final boolean newValue = command

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DaysInYearCustomStrategyTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DaysInYearCustomStrategyTest.java
@@ -20,7 +20,9 @@ package org.apache.fineract.integrationtests;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.junit.jupiter.api.Assertions;
@@ -44,6 +46,22 @@ public class DaysInYearCustomStrategyTest extends BaseLoanIntegrationTest {
         } catch (IOException e) {
             Assertions.fail("Unexpected exception", e);
         }
+    }
+
+    @Test
+    public void test_Update_DaysInYearsCustomStrategy_Value() {
+        PostLoanProductsResponse postLoanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD")
+                .daysInYearType(DaysInYearType.ACTUAL).daysInYearCustomStrategy(DaysInYearCustomStrategy.FEB_29_PERIOD_ONLY));
+        Assertions.assertNotNull(postLoanProduct.getResourceId());
+        final Long loanProductId = postLoanProduct.getResourceId();
+
+        GetLoanProductsProductIdResponse loanProduct = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        Assertions.assertEquals("FEB_29_PERIOD_ONLY", loanProduct.getDaysInYearCustomStrategy().getId());
+
+        loanProductHelper.updateLoanProductById(loanProductId,
+                new PutLoanProductsProductIdRequest().daysInYearCustomStrategy(DaysInYearCustomStrategy.FULL_LEAP_YEAR));
+        loanProduct = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        Assertions.assertEquals("FULL_LEAP_YEAR", loanProduct.getDaysInYearCustomStrategy().getId());
     }
 
     @Test


### PR DESCRIPTION
…ays in year, update

## Description

Allow the update for the new flag `days_in_year_custom_strategy` and calculations for values in case of Days In Years set to ACTUAL.

`FULL_LEAP_YEAR`: 366 days for full leap year. → This is the by default value!
`FEB_29_PERIOD_ONLY`: 366 days for period of February 29

 [FINERACT-2197](https://issues.apache.org/jira/browse/FINERACT-2197)

<img width="1502" alt="Screenshot 2025-03-20 at 10 58 57 a m" src="https://github.com/user-attachments/assets/1304df3e-bc5d-4c18-97b3-ce15c7a956ed" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
