### PR TITLE
FINERACT-2225: Save journal entries for accrual transaction created by charge adjustment

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingService.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.fineract.infrastructure.core.exception.MultiException;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.springframework.lang.NonNull;
 
 public interface LoanAccrualsProcessingService {
 
@@ -41,7 +42,7 @@ public interface LoanAccrualsProcessingService {
 
     void processIncomePostingAndAccruals(@NotNull Loan loan);
 
-    void processAccrualsOnLoanClosure(@NotNull Loan loan);
+    void processAccrualsOnLoanClosure(@NonNull Loan loan, boolean addJournal);
 
     void processAccrualsOnLoanForeClosure(@NotNull Loan loan, @NotNull LocalDate foreClosureDate,
             @NotNull List<LoanTransaction> newAccrualTransactions);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualEventService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualEventService.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.loanaccount.service;
 
 import jakarta.annotation.PostConstruct;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.event.business.BusinessEventListener;
@@ -27,6 +28,7 @@ import org.apache.fineract.infrastructure.event.business.domain.loan.LoanCloseBu
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRelationTypeEnum;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -50,7 +52,7 @@ public class LoanAccrualEventService {
             LoanStatus status = loan.getStatus();
             if (status.isClosedObligationsMet() || status.isOverpaid()) {
                 log.debug("Loan closure on accrual for loan {}", loan.getId());
-                loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan);
+                loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan, false);
                 loanAccrualActivityProcessingService.processAccrualActivityForLoanClosure(loan);
             }
         }
@@ -64,9 +66,19 @@ public class LoanAccrualEventService {
             LoanStatus status = loan.getStatus();
             if (status.isClosedObligationsMet() || status.isOverpaid()) {
                 log.debug("Loan balance change on accrual for loan {}", loan.getId());
-                loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan);
+                final boolean hasChargeAdjustment = hasChargeAdjustment(loan);
+                loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan, hasChargeAdjustment);
                 loanAccrualActivityProcessingService.processAccrualActivityForLoanClosure(loan);
             }
+        }
+
+        private boolean hasChargeAdjustment(final Loan loan) {
+            return loan.getLoanTransactions().stream()
+                    .filter(transaction -> transaction.isChargeAdjustment() && transaction.isNotReversed())
+                    .anyMatch(chargeAdjustment -> chargeAdjustment.getLoanTransactionRelations().stream()
+                            .anyMatch(relation -> relation.getRelationType() == LoanTransactionRelationTypeEnum.CHARGE_ADJUSTMENT
+                                    && relation.getFromTransaction() != null
+                                    && Objects.equals(relation.getFromTransaction().getId(), chargeAdjustment.getId())));
         }
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImpl.java
@@ -83,6 +83,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanSchedul
 import org.apache.fineract.portfolio.loanproduct.domain.InterestRecalculationCompoundingMethod;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -284,9 +285,9 @@ public class LoanAccrualsProcessingServiceImpl implements LoanAccrualsProcessing
      * method calculates accruals for loan on loan closure
      */
     @Override
-    public void processAccrualsOnLoanClosure(@NotNull Loan loan) {
+    public void processAccrualsOnLoanClosure(@NonNull final Loan loan, final boolean addJournal) {
         // check and process accruals for loan WITHOUT interest recalculation details and compounding posted as income
-        addAccruals(loan, loan.getLastLoanRepaymentScheduleInstallment().getDueDate(), false, true, false);
+        addAccruals(loan, loan.getLastLoanRepaymentScheduleInstallment().getDueDate(), false, true, addJournal);
         if (isProgressiveAccrual(loan)) {
             return;
         }


### PR DESCRIPTION
## Description

This PR fixes an issue where accrual transactions created as a result of charge adjustment on a loan with zero principal balance were not generating journal entries.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
