### PR TITLE
FINERACT-2215: Exclude reversed transactions from hasMonetaryActivityAfter

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -3527,7 +3527,8 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
 
     public boolean hasMonetaryActivityAfter(final LocalDate transactionDate) {
         for (LoanTransaction transaction : this.getLoanTransactions()) {
-            if (transaction.getTransactionDate().isAfter(transactionDate) && !transaction.isNonMonetaryTransaction()) {
+            if (transaction.getTransactionDate().isAfter(transactionDate) && transaction.isNotReversed()
+                    && !transaction.isNonMonetaryTransaction()) {
                 return true;
             }
         }


### PR DESCRIPTION


## Description

**JIRA**: [FINERACT-2215](https://issues.apache.org/jira/browse/FINERACT-2215)

This PR excludes reversed transactions from the `hasMonetaryActivityAfter` check.  
Previously, reversed transactions could block a new charge-off if their dates were  
after the intended charge-off date. With this fix, only non-reversed monetary  
transactions will prevent a new charge-off.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
