### PR TITLE
FINERACT-2237: Fix GSIM account creation to generate single parent for multiple clients

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
@@ -168,7 +168,9 @@ public class SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
 
                     Group group = this.groupRepositoryWrapper.findOneWithNotFoundDetection(groupId);
 
-                    if (command.booleanObjectValueOfParameterNamed("isParentAccount") != null) {
+                    if (command.booleanObjectValueOfParameterNamed("isParentAccount") != null
+                            && ("1".equals(command.stringValueOfParameterNamed("isParentAccount"))
+                                    || command.booleanObjectValueOfParameterNamed("isParentAccount"))) {
                         // empty table check
                         if (gsimRepository.count() != 0) {
                             // Parent-Not an empty table
@@ -193,7 +195,12 @@ public class SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
                     } else {
                         if (gsimRepository.count() != 0) {
                             // Child-Not an empty table check
-                            gsimAccount = gsimRepository.findOneByIsAcceptingChildAndApplicationId(true, applicationId);
+                            if (applicationId.compareTo(BigDecimal.ZERO) == 0) {
+                                gsimAccount = gsimRepository.findOneByIsAcceptingChildAndApplicationIdAndGroupId(true, applicationId,
+                                        groupId);
+                            } else {
+                                gsimAccount = gsimRepository.findOneByIsAcceptingChildAndApplicationId(true, applicationId);
+                            }
                             accountNumber = gsimAccount.getAccountNumber() + (gsimAccount.getChildAccountsCount() + 1);
                             account.updateAccountNo(accountNumber);
                             this.gsimWritePlatformService.incrementChildAccountCount(gsimAccount);

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/GSIMRepositoy.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/GSIMRepositoy.java
@@ -31,4 +31,7 @@ public interface GSIMRepositoy
     GroupSavingsIndividualMonitoring findOneByIsAcceptingChildAndApplicationId(boolean acceptingChild, BigDecimal applicationId);
 
     GroupSavingsIndividualMonitoring findOneByAccountNumber(String accountNumber);
+
+    GroupSavingsIndividualMonitoring findOneByIsAcceptingChildAndApplicationIdAndGroupId(boolean acceptingChild, BigDecimal applicationId,
+            Long groupId);
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GroupHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GroupHelper.java
@@ -407,6 +407,17 @@ public class GroupHelper {
         return list;
     }
 
+    public static Integer getChildAccountCount(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
+            final Integer groupID) {
+        List<Object> list;
+        LOG.info("------------------------------GET CHILD ACCOUNT COUNT------------------------------------\n");
+        final String GROUP_URL = "/fineract-provider/api/v1/groups/" + groupID + "/gsimaccounts?" + Utils.TENANT_IDENTIFIER;
+        list = Utils.performServerGet(requestSpec, responseSpec, GROUP_URL, "childGSIMAccounts");
+
+        return ((ArrayList) list.get(0)).size();
+
+    }
+
     public static String randomNameGenerator(final String prefix, final int lenOfRandomSuffix) {
         return Utils.uniqueRandomStringGenerator(prefix, lenOfRandomSuffix);
     }


### PR DESCRIPTION
## Description

This fix corrects the logic for GSIM account creation to ensure that only a single GSIM parent account is created and the remaining accounts are listed as child accounts under the GSIM account when multiple clients are provided in the request payload (with only one client having `"isParentAccount": 1` set). The previous logic caused multiple GSIM parent accounts to be erroneously created, each associated with only a single client as the condition for checking if a parent account is to be created was wrong.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
