### PR TITLE
FINERACT-2081: External service credential values masked

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/StringUtil.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/StringUtil.java
@@ -16,24 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.configuration.data;
+package org.apache.fineract.infrastructure.core.service;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.Serializable;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Accessors;
-import org.apache.fineract.infrastructure.core.jersey.serializer.MaskedValueSerializer;
+public final class StringUtil {
 
-@Data
-@NoArgsConstructor
-@Accessors(chain = true)
-public class ExternalServicesPropertiesData implements Serializable {
+    private StringUtil() {}
 
-    private static final long serialVersionUID = 1L;
+    public static String maskValue(String value) {
+        return maskValue(value, 4);
+    }
 
-    private String name;
-    @JsonSerialize(using = MaskedValueSerializer.class)
-    private String value;
+    public static String maskValue(String value, Integer unmaskedLength) {
+        if (value.length() <= unmaskedLength) {
+            return "****";
+        }
+        return value.substring(0, 1) + "*".repeat(value.length() - 1 - unmaskedLength) + value.substring(value.length() - unmaskedLength);
+    }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
+++ b/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
@@ -233,7 +233,6 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
             if (command.isChangeInPasswordParameterNamed(passwordParamName, this.password, platformPasswordEncoder, getId())) {
                 final String passwordEncodedValue = command.passwordValueOfParameterNamed(passwordParamName, platformPasswordEncoder,
                         getId());
-                actualChanges.put(passwordEncodedParamName, passwordEncodedValue);
                 updatePassword(passwordEncodedValue);
             }
         }
@@ -241,7 +240,6 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
         if (command.hasParameter(passwordEncodedParamName)) {
             if (command.isChangeInStringParameterNamed(passwordEncodedParamName, this.password)) {
                 final String newValue = command.stringValueOfParameterNamed(passwordEncodedParamName);
-                actualChanges.put(passwordEncodedParamName, newValue);
                 updatePassword(newValue);
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesPropertiesReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesPropertiesReadPlatformServiceImpl.java
@@ -20,13 +20,16 @@ package org.apache.fineract.infrastructure.configuration.service;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.campaigns.sms.data.MessageGatewayConfigurationData;
 import org.apache.fineract.infrastructure.configuration.data.ExternalServicesPropertiesData;
 import org.apache.fineract.infrastructure.configuration.data.S3CredentialsData;
 import org.apache.fineract.infrastructure.configuration.data.SMTPCredentialsData;
 import org.apache.fineract.infrastructure.configuration.exception.ExternalServiceConfigurationNotFoundException;
+import org.apache.fineract.infrastructure.core.service.StringUtil;
 import org.apache.fineract.infrastructure.gcm.domain.NotificationConfigurationData;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -99,14 +102,21 @@ public class ExternalServicesPropertiesReadPlatformServiceImpl implements Extern
 
     private static final class ExternalServiceMapper implements RowMapper<ExternalServicesPropertiesData> {
 
+        List<String> secretAttributes;
+
+        ExternalServiceMapper() {
+            secretAttributes = new ArrayList<>();
+            secretAttributes.add("password");
+            secretAttributes.add("server_key");
+        }
+
         @Override
         public ExternalServicesPropertiesData mapRow(ResultSet rs, @SuppressWarnings("unused") int rowNum) throws SQLException {
-            // TODO Auto-generated method stub
             final String name = rs.getString("name");
             String value = rs.getString("value");
             // Masking the password as we should not send the password back
-            if (name != null && "password".equalsIgnoreCase(name)) {
-                value = "XXXX";
+            if (name != null && secretAttributes.contains(name)) {
+                value = StringUtil.maskValue(value);
             }
             return new ExternalServicesPropertiesData().setName(name).setValue(value);
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/jersey/serializer/MaskedValueSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/jersey/serializer/MaskedValueSerializer.java
@@ -16,24 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.configuration.data;
+package org.apache.fineract.infrastructure.core.jersey.serializer;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.Serializable;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Accessors;
-import org.apache.fineract.infrastructure.core.jersey.serializer.MaskedValueSerializer;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.apache.fineract.infrastructure.core.service.StringUtil;
 
-@Data
-@NoArgsConstructor
-@Accessors(chain = true)
-public class ExternalServicesPropertiesData implements Serializable {
+public class MaskedValueSerializer extends JsonSerializer<String> {
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value == null || value.isBlank()) {
+            gen.writeString(value);
+            return;
+        }
 
-    private String name;
-    @JsonSerialize(using = MaskedValueSerializer.class)
-    private String value;
+        String masked = StringUtil.maskValue(value);
+        gen.writeString(masked);
+    }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResourceSwagger.java
@@ -197,8 +197,6 @@ final class UsersApiResourceSwagger {
 
             @Schema(example = "Test")
             public String firstname;
-            @Schema(example = "abc3326b1bb376351c7baeb4175f5e0504e33aadf6a158474a6d71de1befae51")
-            public String passwordEncoded;
         }
 
         @Schema(example = "1")

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalServicesConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalServicesConfigurationTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
@@ -83,7 +85,6 @@ public class ExternalServicesConfigurationTest {
         }
 
         // Checking for SMTP:
-
         configName = "username";
         externalServicesConfig = ExternalServicesConfigurationHelper.getExternalServicesConfigurationByServiceName(requestSpec,
                 responseSpec, "SMTP");
@@ -111,6 +112,28 @@ public class ExternalServicesConfigurationTest {
 
         }
 
+        // Checking for Notifications:
+        configName = "server_key";
+        externalServicesConfig = ExternalServicesConfigurationHelper.getExternalServicesConfigurationByServiceName(requestSpec,
+                responseSpec, "NOTIFICATION");
+        Assertions.assertNotNull(externalServicesConfig);
+
+        for (Integer configIndex = 0; configIndex < externalServicesConfig.size(); configIndex++) {
+            String name = (String) externalServicesConfig.get(configIndex).get("name");
+            String value = null;
+            if (name.equals(configName)) {
+                value = (String) externalServicesConfig.get(configIndex).get("value");
+                if (value == null) {
+                    value = "testnull";
+                }
+                LOG.info("{} : {}", name, value);
+                assertTrue(hasMoreThanThreeStars(value));
+            }
+
+        }
     }
 
+    private boolean hasMoreThanThreeStars(String input) {
+        return input != null && input.matches("(.*\\*.*){4,}");
+    }
 }


### PR DESCRIPTION
## Description

We are doing to:

- Introduce new annotation where if a field is marked we need to mask its value

`@JsonSerialize(using = MaskedValueSerializer.class) `

- `AppUser`: Do not send back the encoded value of the password as part of “changes”!

- ExternalServicesPropertiesData: Use MaskedValueSerializer.class on value field
Drop “custom” serializer in `ExternalServicesConfigurationApiResource`, return the exact data type and let jackson do the serialization!

- `UsersApiResourceSwagger`: Remove passwordEncoded field

[FINERACT-2081](https://github.com/apache/fineract/pull/FINERACT-2081)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
