### PR TITLE
FINERACT-2081: payment_types cache fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/cache/CacheConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/cache/CacheConfig.java
@@ -109,6 +109,10 @@ public class CacheConfig {
             cacheManager.createCache("userTFAccessToken", accessTokenTemplate);
         }
 
+        if (cacheManager.getCache("payment_types") == null) {
+            cacheManager.createCache("payment_types", defaultTemplate);
+        }
+
         return cacheManager;
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/projects/FINERACT/issues/FINERACT-2181

## Description

Payment_types cache was missing which caused exception during the interest recalculation process with cache on.
I have added this to the CacheConfig.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
