### PR TITLE
FINERACT-2181: Add customData field to LoanProductBusinessEvent

### DIFF
--- a/fineract-avro-schemas/src/main/avro/loan/v1/LoanProductDataV1.avsc
+++ b/fineract-avro-schemas/src/main/avro/loan/v1/LoanProductDataV1.avsc
@@ -657,6 +657,17 @@
                 "null",
                 "boolean"
             ]
+        },
+        {
+            "default": null,
+            "name": "customData",
+            "type": [
+                "null",
+                {
+                    "values": "bytes",
+                    "type": "map"
+                }
+            ]
         }
     ]
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/mapper/loan/LoanAccountDataMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/mapper/loan/LoanAccountDataMapper.java
@@ -38,6 +38,7 @@ public interface LoanAccountDataMapper {
     @Mapping(target = "purchasePriceRatio", ignore = true)
     @Mapping(target = "delinquent.installmentDelinquencyBuckets", ignore = true)
     @Mapping(target = "customData", ignore = true)
+    @Mapping(target = "product.customData", ignore = true)
     LoanAccountDataV1 map(LoanAccountData source);
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/mapper/loan/LoanProductDataMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/mapper/loan/LoanProductDataMapper.java
@@ -22,9 +22,11 @@ import org.apache.fineract.avro.loan.v1.LoanProductDataV1;
 import org.apache.fineract.infrastructure.event.external.service.serialization.mapper.support.AvroMapperConfig;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(config = AvroMapperConfig.class)
 public interface LoanProductDataMapper {
 
+    @Mapping(target = "customData", ignore = true)
     LoanProductDataV1 map(LoanProductData source);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/AbstractBusinessEventWithCustomDataSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/AbstractBusinessEventWithCustomDataSerializer.java
@@ -16,17 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.event.external.service.serialization.serializer.loan;
+package org.apache.fineract.infrastructure.event.external.service.serialization.serializer;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
-import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.BusinessEventSerializer;
-import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.ExternalEventCustomDataSerializer;
 
-public abstract class AbstractLoanBusinessEventSerializer<T extends BusinessEvent<?>> implements BusinessEventSerializer {
+public abstract class AbstractBusinessEventWithCustomDataSerializer<T extends BusinessEvent<?>> implements BusinessEventSerializer {
 
     protected Map<String, ByteBuffer> collectCustomData(final T event) {
         return getExternalEventCustomDataSerializers().stream().collect(HashMap::new, (map, serializer) -> {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanBusinessEventSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanBusinessEventSerializer.java
@@ -29,6 +29,7 @@ import org.apache.fineract.avro.loan.v1.LoanInstallmentDelinquencyBucketDataV1;
 import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanBusinessEvent;
 import org.apache.fineract.infrastructure.event.external.service.serialization.mapper.loan.LoanAccountDataMapper;
+import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.AbstractBusinessEventWithCustomDataSerializer;
 import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.BusinessEventSerializer;
 import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.ExternalEventCustomDataSerializer;
 import org.apache.fineract.portfolio.delinquency.service.DelinquencyReadPlatformService;
@@ -47,7 +48,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LoanBusinessEventSerializer extends AbstractLoanBusinessEventSerializer<LoanBusinessEvent> implements BusinessEventSerializer {
+public class LoanBusinessEventSerializer extends AbstractBusinessEventWithCustomDataSerializer<LoanBusinessEvent>
+        implements BusinessEventSerializer {
 
     private final LoanReadPlatformService service;
     private final LoanAccountDataMapper mapper;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanChargeBusinessEventSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanChargeBusinessEventSerializer.java
@@ -26,6 +26,7 @@ import org.apache.fineract.avro.loan.v1.LoanChargeDataV1;
 import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.charge.LoanChargeBusinessEvent;
 import org.apache.fineract.infrastructure.event.external.service.serialization.mapper.loan.LoanChargeDataMapper;
+import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.AbstractBusinessEventWithCustomDataSerializer;
 import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.ExternalEventCustomDataSerializer;
 import org.apache.fineract.portfolio.loanaccount.data.LoanChargeData;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeReadPlatformService;
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LoanChargeBusinessEventSerializer extends AbstractLoanBusinessEventSerializer<LoanChargeBusinessEvent> {
+public class LoanChargeBusinessEventSerializer extends AbstractBusinessEventWithCustomDataSerializer<LoanChargeBusinessEvent> {
 
     private final LoanChargeReadPlatformService service;
     private final LoanChargeDataMapper mapper;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanTransactionBusinessEventSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanTransactionBusinessEventSerializer.java
@@ -26,6 +26,7 @@ import org.apache.fineract.avro.loan.v1.LoanTransactionDataV1;
 import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.transaction.LoanTransactionBusinessEvent;
 import org.apache.fineract.infrastructure.event.external.service.serialization.mapper.loan.LoanTransactionDataMapper;
+import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.AbstractBusinessEventWithCustomDataSerializer;
 import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.BusinessEventSerializer;
 import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.ExternalEventCustomDataSerializer;
 import org.apache.fineract.portfolio.loanaccount.data.LoanTransactionData;
@@ -35,7 +36,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LoanTransactionBusinessEventSerializer extends AbstractLoanBusinessEventSerializer<LoanTransactionBusinessEvent>
+public class LoanTransactionBusinessEventSerializer extends AbstractBusinessEventWithCustomDataSerializer<LoanTransactionBusinessEvent>
         implements BusinessEventSerializer {
 
     private final LoanReadPlatformService service;

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanProductBusinessEventSerializerTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/service/serialization/serializer/loan/LoanProductBusinessEventSerializerTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.event.external.service.serialization.serializer.loan;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.avro.loan.v1.LoanProductDataV1;
+import org.apache.fineract.infrastructure.event.business.domain.loan.product.LoanProductBusinessEvent;
+import org.apache.fineract.infrastructure.event.external.service.serialization.mapper.loan.LoanProductDataMapper;
+import org.apache.fineract.infrastructure.event.external.service.serialization.serializer.ExternalEventCustomDataSerializer;
+import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class LoanProductBusinessEventSerializerTest {
+
+    @Mock
+    private LoanProductReadPlatformService loanProductReadPlatformService;
+    @Mock
+    private LoanProductDataMapper loanProductDataMapper;
+
+    private LoanProductBusinessEventSerializer serializer;
+
+    @BeforeEach
+    void setUp() {
+        final List<ExternalEventCustomDataSerializer<LoanProductBusinessEvent>> externalEventCustomDataSerializers = List
+                .of(new ExternalEventCustomDataSerializer<>() {
+
+                    @Override
+                    public ByteBuffer serialize(final LoanProductBusinessEvent event) {
+                        return ByteBuffer.wrap("test_data_for_loan_product".getBytes(UTF_8));
+                    }
+
+                    @Override
+                    public String key() {
+                        return "test_key_1";
+                    }
+                }, new ExternalEventCustomDataSerializer<>() {
+
+                    @Override
+                    public ByteBuffer serialize(final LoanProductBusinessEvent event) {
+                        return ByteBuffer.wrap("test_data_for_loan_product_1".getBytes(UTF_8));
+                    }
+
+                    @Override
+                    public String key() {
+                        return "test_key_1";
+                    }
+                }, new ExternalEventCustomDataSerializer<>() {
+
+                    @Override
+                    public ByteBuffer serialize(final LoanProductBusinessEvent event) {
+                        return ByteBuffer.wrap("test_data_for_loan_product_2".getBytes(UTF_8));
+                    }
+
+                    @Override
+                    public String key() {
+                        return "test_key_2";
+                    }
+                });
+        serializer = new LoanProductBusinessEventSerializer(loanProductReadPlatformService, loanProductDataMapper,
+                externalEventCustomDataSerializers);
+    }
+
+    @Test
+    void testLoanProductCustomDataSerialization() {
+        final long productId = 1;
+
+        final LoanProduct loanProduct = mock(LoanProduct.class);
+        final LoanProductData loanProductData = mock(LoanProductData.class);
+        final LoanProductBusinessEvent event = mock(LoanProductBusinessEvent.class);
+
+        when(loanProductReadPlatformService.retrieveLoanProduct(productId)).thenReturn(loanProductData);
+        when(loanProduct.getId()).thenReturn(productId);
+        when(event.get()).thenReturn(loanProduct);
+
+        final LoanProductDataV1 expectedAvroData = LoanProductDataV1.newBuilder().setId(productId).setCustomData(new HashMap<>()).build();
+        when(loanProductDataMapper.map(any(LoanProductData.class))).thenReturn(expectedAvroData);
+
+        final LoanProductDataV1 result = (LoanProductDataV1) serializer.toAvroDTO(event);
+
+        assertNotNull(result);
+        assertNotNull(result.getCustomData());
+        final Map<String, ByteBuffer> customData = result.getCustomData();
+        assertEquals("test_data_for_loan_product_1", new String(customData.get("test_key_1").array(), UTF_8));
+        assertEquals("test_data_for_loan_product_2", new String(customData.get("test_key_2").array(), UTF_8));
+    }
+
+}


### PR DESCRIPTION
## Description

customData field was added to LoanTransactionDataV1 and LoanAccountDataV1, but there are other loan related events as well where it is still missing, in this case we are adding to `LoanProductBusinessEvent`

[FINERACT-2181](https://github.com/apache/fineract/pull/FINERACT-2181)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
