### PR TITLE
FINERACT-2181: Add customData field to LoanRepaymentBusinessEvent

### DIFF
--- a/fineract-avro-schemas/src/main/avro/loan/v1/LoanRepaymentDueDataV1.avsc
+++ b/fineract-avro-schemas/src/main/avro/loan/v1/LoanRepaymentDueDataV1.avsc
@@ -38,6 +38,17 @@
                 "null",
                 "org.apache.fineract.avro.loan.v1.RepaymentPastDueDataV1"
             ]
+        },
+        {
+            "default": null,
+            "name": "customData",
+            "type": [
+                "null",
+                {
+                    "values": "bytes",
+                    "type": "map"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Description

`customData` field was added to LoanTransactionDataV1 and LoanAccountDataV1, but there are other loan related events as well where it is still missing, in this case we are adding to `LoanRepaymentBusinessEvent`

[FINERACT-2181](https://github.com/apache/fineract/pull/FINERACT-2181)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
