### PR TITLE
FINERACT-2220: Use stored ProgressiveLoanInterestScheduleModel for periodic accrual creation

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanDownPaymentHandlerServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanDownPaymentHandlerServiceImpl.java
@@ -131,6 +131,11 @@ public class LoanDownPaymentHandlerServiceImpl implements LoanDownPaymentHandler
                 || !DateUtils.isEqualBusinessDate(loanTransaction.getTransactionDate()) || currentInstallment == null
                 || !currentInstallment.getTotalOutstanding(loan.getCurrency()).isEqualTo(loanTransaction.getAmount(loan.getCurrency()));
 
+        // TODO FINERACT-2220 fix processLatestTransaction to save model.
+        if (loan.isProgressiveSchedule() && loan.isInterestBearing()) {
+            reprocess = true;
+        }
+
         if (isTransactionChronologicallyLatest && adjustedTransaction == null
                 && (!reprocess || !loan.isInterestBearingAndInterestRecalculationEnabled()) && !loan.isForeclosure()) {
             loanTransactionProcessingService.processLatestTransaction(loan.getTransactionProcessingStrategyCode(), loanTransaction,

--- a/fineract-progressive-loan-embeddable-schedule-generator/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/EmbeddableProgressiveLoanScheduleGenerator.java
+++ b/fineract-progressive-loan-embeddable-schedule-generator/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/EmbeddableProgressiveLoanScheduleGenerator.java
@@ -19,9 +19,16 @@
 package org.apache.fineract.portfolio.loanaccount.loanschedule.domain;
 
 import java.math.MathContext;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.ProgressiveLoanModel;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePlan;
+import org.apache.fineract.portfolio.loanaccount.service.InterestScheduleModelRepositoryWrapper;
 import org.apache.fineract.portfolio.loanproduct.calc.EMICalculator;
 import org.apache.fineract.portfolio.loanproduct.calc.ProgressiveEMICalculator;
+import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductMinimumRepaymentScheduleRelatedDetail;
 
 @SuppressWarnings("unused")
 public class EmbeddableProgressiveLoanScheduleGenerator {
@@ -33,10 +40,40 @@ public class EmbeddableProgressiveLoanScheduleGenerator {
     public EmbeddableProgressiveLoanScheduleGenerator() {
         this.emiCalculator = new ProgressiveEMICalculator();
         this.scheduledDateGenerator = new DefaultScheduledDateGenerator();
-        this.scheduleGenerator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator);
+        this.scheduleGenerator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator,
+                new NoopInterestScheduleModelRepositoryWrapper());
     }
 
     public LoanSchedulePlan generate(final MathContext mc, final LoanRepaymentScheduleModelData modelData) {
         return scheduleGenerator.generate(mc, modelData);
+    }
+
+    private static final class NoopInterestScheduleModelRepositoryWrapper implements InterestScheduleModelRepositoryWrapper {
+
+        @Override
+        public Optional<ProgressiveLoanModel> findOneByLoanId(Long loanId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<ProgressiveLoanInterestScheduleModel> extractModel(Optional<ProgressiveLoanModel> progressiveLoanModel) {
+            return Optional.empty();
+        }
+
+        @Override
+        public String writeInterestScheduleModel(Loan loan, ProgressiveLoanInterestScheduleModel model) {
+            return "";
+        }
+
+        @Override
+        public Optional<ProgressiveLoanInterestScheduleModel> readProgressiveLoanInterestScheduleModel(Long loanId,
+                LoanProductMinimumRepaymentScheduleRelatedDetail detail, Integer installmentAmountInMultipliesOf) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<ProgressiveLoanInterestScheduleModel> getSavedModel(Loan loan, LocalDate businessDate) {
+            return Optional.empty();
+        }
     }
 }

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleGeneratorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleGeneratorTest.java
@@ -33,6 +33,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleP
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePlanDisbursementPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePlanDownPaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePlanRepaymentPeriod;
+import org.apache.fineract.portfolio.loanaccount.service.InterestScheduleModelRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.service.LoanTransactionProcessingService;
 import org.apache.fineract.portfolio.loanproduct.calc.ProgressiveEMICalculator;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,8 @@ class LoanScheduleGeneratorTest {
     private static final MathContext mc = new MathContext(12, RoundingMode.HALF_EVEN);
     private static final BigDecimal DOWN_PAYMENT_PORTION = BigDecimal.valueOf(25);
     private static final LoanTransactionProcessingService loanTransactionProcessingService = mock(LoanTransactionProcessingService.class);
+    private static final InterestScheduleModelRepositoryWrapper interestScheduleModelRepositoryWrapperMock = mock(
+            InterestScheduleModelRepositoryWrapper.class);
 
     @Test
     void testGenerateLoanSchedule() {
@@ -63,7 +66,8 @@ class LoanScheduleGeneratorTest {
                 NOMINAL_INTEREST_RATE, false, DaysInMonthType.DAYS_30, DaysInYearType.DAYS_360, null, null, null, false, null);
 
         ScheduledDateGenerator scheduledDateGenerator = new DefaultScheduledDateGenerator();
-        ProgressiveLoanScheduleGenerator generator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator);
+        ProgressiveLoanScheduleGenerator generator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator,
+                interestScheduleModelRepositoryWrapperMock);
         generator.setLoanTransactionProcessingService(loanTransactionProcessingService);
 
         LoanSchedulePlan loanSchedule = generator.generate(mc, modelData);
@@ -100,7 +104,8 @@ class LoanScheduleGeneratorTest {
                 null);
 
         ScheduledDateGenerator scheduledDateGenerator = new DefaultScheduledDateGenerator();
-        ProgressiveLoanScheduleGenerator generator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator);
+        ProgressiveLoanScheduleGenerator generator = new ProgressiveLoanScheduleGenerator(scheduledDateGenerator, emiCalculator,
+                interestScheduleModelRepositoryWrapperMock);
         generator.setLoanTransactionProcessingService(loanTransactionProcessingService);
 
         LoanSchedulePlan loanSchedule = generator.generate(mc, modelData);


### PR DESCRIPTION
## Description

Use ProgressiveLoanInterestScheduleModel (model) 
* in COB Periodic Accrual Step
* in Prepay Amounts API

Describe the changes made and why they were made.

These details are present on the associated [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-2220).
