### PR TITLE
FINERACT-391: Fund Management-Archive Fund

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -399,7 +399,15 @@ public class CommandWrapperBuilder {
         this.actionName = "UPDATE";
         this.entityName = "FUND";
         this.entityId = fundId;
-        this.href = "/funds/" + fundId;
+        this.href = "/funds/" + fundId + "/archive";
+        return this;
+    }
+
+    public CommandWrapperBuilder archiveFund(Long fundId) {
+        this.actionName = "UPDATE";
+        this.entityName = "FUND";
+        this.entityId = fundId;
+        this.href = "/fund/" + fundId;
         return this;
     }
 
@@ -3822,4 +3830,6 @@ public class CommandWrapperBuilder {
         this.href = "/v1/loans/external-id/" + loanExternalId + "/interest-pauses/" + variationId;
         return this;
     }
+
+
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonCommand.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonCommand.java
@@ -20,6 +20,7 @@ package org.apache.fineract.infrastructure.core.api;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/data/FundData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/data/FundData.java
@@ -34,13 +34,17 @@ public final class FundData implements Serializable {
     @SuppressWarnings("unused")
     private final String externalId;
 
-    public static FundData instance(final Long id, final String name, final String externalId) {
-        return new FundData(id, name, externalId);
+    private final Boolean isActive;
+
+    public static FundData instance(final Long id, final String name, final String externalId, final Boolean isActive) {
+        return new FundData(id, name, externalId, isActive);
     }
 
-    private FundData(final Long id, final String name, final String externalId) {
+    private FundData(final Long id, final String name, final String externalId, final Boolean isActive) {
         this.id = id;
         this.name = name;
         this.externalId = externalId;
+        this.isActive = isActive;
     }
+    public String getName(){return this.name; } //for testing
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/domain/Fund.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/fund/domain/Fund.java
@@ -24,9 +24,13 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+
+import javax.swing.text.StyledEditorKit;
 
 @Entity
 @Table(name = "m_fund", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }, name = "fund_name_org"),
@@ -39,6 +43,9 @@ public class Fund extends AbstractPersistableCustom<Long> {
     @Column(name = "external_id", length = 100)
     private String externalId;
 
+    @Column(name = "is_active")
+    private Boolean isActive;
+
     public static Fund fromJson(final JsonCommand command) {
 
         final String firstnameParamName = "name";
@@ -47,16 +54,21 @@ public class Fund extends AbstractPersistableCustom<Long> {
         final String lastnameParamName = "externalId";
         final String externalId = command.stringValueOfParameterNamed(lastnameParamName);
 
-        return new Fund(name, externalId);
+        final String archiveParamName = "isActive";
+        final Boolean isActiveValue = command.booleanObjectValueOfParameterNamed(archiveParamName);
+        final Boolean isActive = isActiveValue != null ? isActiveValue : true ;
+
+        return new Fund(name, externalId, isActive);
     }
 
     protected Fund() {
         //
     }
 
-    private Fund(final String fundName, final String externalId) {
+    private Fund(final String fundName, final String externalId, final Boolean isActive) {
         this.name = StringUtils.defaultIfEmpty(fundName, null);
         this.externalId = StringUtils.defaultIfEmpty(externalId, null);
+        this.isActive = BooleanUtils.toBooleanDefaultIfNull(isActive, true);
     }
 
     public Map<String, Object> update(final JsonCommand command) {
@@ -78,5 +90,13 @@ public class Fund extends AbstractPersistableCustom<Long> {
         }
 
         return actualChanges;
+    }
+
+    public void setArchived(){
+        this.isActive = false;
+    }
+
+    public Boolean isActive() {
+        return this.isActive;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/api/FundsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/api/FundsApiResource.java
@@ -117,4 +117,20 @@ public class FundsApiResource {
         final CommandProcessingResult result = commandsSourceWritePlatformService.logCommandSource(commandRequest);
         return toApiJsonSerializer.serialize(result);
     }
+
+    @PUT
+    @Path("{fundId}/archive")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Archive a Fund", description = "Set the isActive instance of fund to false.")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = FundRequest.class)))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = FundsApiResourceSwagger.PutFundsFundIdResponse.class))) })
+    public String archiveFund(@PathParam("fundId") @Parameter(description = "fundId") final Long fundId,
+                             @Parameter(hidden = true) final FundRequest fundRequest) {
+        final CommandWrapper commandRequest = new CommandWrapperBuilder().archiveFund(fundId)
+                .withJson(toApiJsonSerializer.serialize(fundRequest)).build();
+        final CommandProcessingResult result = commandsSourceWritePlatformService.logCommandSource(commandRequest);
+        return toApiJsonSerializer.serialize(result);
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/data/FundRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/data/FundRequest.java
@@ -32,4 +32,5 @@ public class FundRequest implements Serializable {
 
     private String name;
     private String externalId;
+    private Boolean isActive;
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/exception/FundNotFoundException.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/exception/FundNotFoundException.java
@@ -33,4 +33,5 @@ public class FundNotFoundException extends AbstractPlatformResourceNotFoundExcep
     public FundNotFoundException(Long id, EmptyResultDataAccessException e) {
         super("error.msg.fund.id.invalid", "Fund with identifier " + id + " does not exist", id, e);
     }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/handler/ArchiveFundCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/handler/ArchiveFundCommandHandler.java
@@ -1,0 +1,27 @@
+package org.apache.fineract.portfolio.fund.handler;
+
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.fund.service.FundWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Service
+@CommandType(entity = "FUND", action = "UPDATE")
+public class ArchiveFundCommandHandler implements NewCommandSourceHandler {
+    private final FundWritePlatformService writePlatformService;
+
+    @Autowired
+    public ArchiveFundCommandHandler(final FundWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+
+        return this.writePlatformService.archiveFund(command.entityId());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/serialization/FundCommandFromApiJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/serialization/FundCommandFromApiJsonDeserializer.java
@@ -33,6 +33,7 @@ import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.kafka.common.protocol.types.Field;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +42,11 @@ public final class FundCommandFromApiJsonDeserializer {
 
     public static final String NAME = "name";
     public static final String EXTERNAL_ID = "externalId";
+    public static final String IS_ACTIVE = "isActive";
     /**
      * The parameters supported for this command.
      */
-    private static final Set<String> SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(NAME, EXTERNAL_ID));
+    private static final Set<String> SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(NAME, EXTERNAL_ID, IS_ACTIVE));
     public static final String FUND = "fund";
 
     private final FromJsonHelper fromApiJsonHelper;
@@ -73,6 +75,10 @@ public final class FundCommandFromApiJsonDeserializer {
         final String externalId = this.fromApiJsonHelper.extractStringNamed(EXTERNAL_ID, element);
         baseDataValidator.reset().parameter(EXTERNAL_ID).value(externalId).notExceedingLengthOf(100);
 
+        final Boolean isActive = this.fromApiJsonHelper.extractBooleanNamed(IS_ACTIVE, element);
+        baseDataValidator.reset().parameter(IS_ACTIVE).value(isActive).value(isActive).notNull();
+
+
         throwExceptionIfValidationWarningsExist(dataValidationErrors);
     }
 
@@ -96,6 +102,11 @@ public final class FundCommandFromApiJsonDeserializer {
         if (this.fromApiJsonHelper.parameterExists(EXTERNAL_ID, element)) {
             final String externalId = this.fromApiJsonHelper.extractStringNamed(EXTERNAL_ID, element);
             baseDataValidator.reset().parameter(EXTERNAL_ID).value(externalId).notExceedingLengthOf(100);
+        }
+
+        if (this.fromApiJsonHelper.parameterExists(IS_ACTIVE, element)) {
+            final Boolean isActive = this.fromApiJsonHelper.extractBooleanNamed(IS_ACTIVE, element);
+            baseDataValidator.reset().parameter(IS_ACTIVE).value(isActive).value(isActive).notNull();
         }
 
         throwExceptionIfValidationWarningsExist(dataValidationErrors);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundReadPlatformServiceImpl.java
@@ -39,7 +39,7 @@ public class FundReadPlatformServiceImpl implements FundReadPlatformService {
     private static final class FundMapper implements RowMapper<FundData> {
 
         public String schema() {
-            return " f.id as id, f.name as name, f.external_id as externalId from m_fund f ";
+            return " f.id as id, f.name as name, f.external_id as externalId, f.is_active as isActive from m_fund f ";
         }
 
         @Override
@@ -48,8 +48,9 @@ public class FundReadPlatformServiceImpl implements FundReadPlatformService {
             final Long id = rs.getLong("id");
             final String name = rs.getString("name");
             final String externalId = rs.getString("externalId");
+            final Boolean isActive = rs.getBoolean("isActive");
 
-            return FundData.instance(id, name, externalId);
+            return FundData.instance(id, name, externalId, isActive);
         }
     }
 
@@ -60,7 +61,7 @@ public class FundReadPlatformServiceImpl implements FundReadPlatformService {
         this.context.authenticatedUser();
 
         final FundMapper rm = new FundMapper();
-        final String sql = "select " + rm.schema() + " order by f.name";
+        final String sql = "select " + rm.schema() + " where f.is_active = true order by f.name";
 
         return this.jdbcTemplate.query(sql, rm); // NOSONAR
     }
@@ -72,7 +73,7 @@ public class FundReadPlatformServiceImpl implements FundReadPlatformService {
             this.context.authenticatedUser();
 
             final FundMapper rm = new FundMapper();
-            final String sql = "select " + rm.schema() + " where f.id = ?";
+            final String sql = "select " + rm.schema() + "where f.is_active = true where f.id = ?";
 
             final FundData selectedFund = this.jdbcTemplate.queryForObject(sql, rm, new Object[] { fundId }); // NOSONAR
 
@@ -80,5 +81,6 @@ public class FundReadPlatformServiceImpl implements FundReadPlatformService {
         } catch (final EmptyResultDataAccessException e) {
             throw new FundNotFoundException(fundId, e);
         }
+
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformService.java
@@ -26,4 +26,6 @@ public interface FundWritePlatformService {
     CommandProcessingResult createFund(JsonCommand command);
 
     CommandProcessingResult updateFund(Long fundId, JsonCommand command);
+
+    CommandProcessingResult archiveFund(Long fundId);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformServiceJpaRepositoryImpl.java
@@ -99,6 +99,25 @@ public class FundWritePlatformServiceJpaRepositoryImpl implements FundWritePlatf
         }
     }
 
+    @Transactional
+    @Override
+    @CacheEvict(value = "funds", key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('fn')")
+    public CommandProcessingResult archiveFund(final Long fundId) {
+
+        this.context.authenticatedUser();
+
+        final Fund fund = this.fundRepository.findById(fundId)
+                .orElseThrow(() -> new FundNotFoundException(fundId));
+
+        fund.setArchived();
+
+        this.fundRepository.saveAndFlush(fund);
+
+        return new CommandProcessingResultBuilder()
+                .withEntityId(fund.getId())
+                .build();
+    }
+
     /*
      * Guaranteed to throw an exception no matter what the data integrity issue is.
      */

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -193,4 +193,5 @@
     <include file="parts/0172_create_loan_capitalized_income_balance.xml" relativeToChangelogFile="true"/>
     <include file="parts/0173_user_change_pwd.xml" relativeToChangelogFile="true" />
     <include file="parts/0174_loan_product_add_capitalized_income_type.xml" relativeToChangelogFile="true" />
+    <include file="parts/0175_add_is_active_column_to_fund.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0175_add_is_active_column_to_fund.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0175_add_is_active_column_to_fund.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_fund">
+            <column name="is_active" type="boolean" defaultValueBoolean="true"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/fund/service/FundWritePlatformServiceImplTest.java
@@ -1,0 +1,63 @@
+package org.apache.fineract.portfolio.fund.service;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.fund.domain.Fund;
+import org.apache.fineract.portfolio.fund.domain.FundRepository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+public class FundWritePlatformServiceImplTest {
+    @Mock
+    private FundRepository fundRepository;
+
+    @InjectMocks
+    private FundWritePlatformServiceJpaRepositoryImpl fundWritePlatformService;
+
+    private JsonCommand createTestJsonCommandForFund(String name, String externalId, boolean isActive) {
+        FromJsonHelper fromJsonHelper = new FromJsonHelper();
+
+        String json = String.format("""
+                                    {
+                                        "name": "%s",
+                                        "externalId": "%s",
+                                        "isActive": %s
+                                    }
+                                    """,
+                                    name, externalId, isActive);
+
+        JsonObject parsedJson = JsonParser.parseString(json).getAsJsonObject();
+
+        return JsonCommand.from(
+                json,        // first: raw JSON string
+                parsedJson,  // second: parsed JSON
+                fromJsonHelper,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null
+        );
+    }
+
+    @Test
+    void shouldArchiveFundSuccessfully() {
+        JsonCommand command = createTestJsonCommandForFund("Test Fund", "EXT123", true);
+
+        Fund fund = Fund.fromJson(command);
+
+        fund.setArchived();
+
+        assertFalse(fund.isActive());
+
+    }
+}


### PR DESCRIPTION
## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

Related to FINERACT-391. 
Created boolean 'isActive' instance so that funds can be marked true or false. If 'isActive' is false, then it should not show up when funds are requested. Added 'is_active' column to m_funds in the database. Created a unit test to check if archiveFunds for writeplatformservice worked; it passed the unit test. 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
