### PR TITLE
FINERACT-2181: fix Charges using percentage calculation with min and max gap values

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiResource.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiResource.java
@@ -84,6 +84,8 @@ public class ChargesApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Retrieve a Charge", description = "Returns the details of a defined Charge.\n" + "\n" + "Example Requests:\n"
             + "\n" + "charges/1")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ChargesApiResourceSwagger.GetChargesResponse.class))) })
     public ChargeData retrieveCharge(@PathParam("chargeId") @Parameter(description = "chargeId") final Long chargeId,
             @Context final UriInfo uriInfo) {
         context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiResourceSwagger.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiResourceSwagger.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.charge.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.util.Set;
 
 /**
@@ -110,6 +111,8 @@ final class ChargesApiResourceSwagger {
         public GetChargesAppliesToResponse chargeAppliesTo;
         public GetChargesCalculationTypeResponse chargeCalculationType;
         public GetChargesPaymentModeResponse chargePaymentMode;
+        public BigDecimal minCap;
+        public BigDecimal maxCap;
     }
 
     @Schema(description = "PostChargesRequest")
@@ -139,6 +142,10 @@ final class ChargesApiResourceSwagger {
         public String monthDayFormat;
         @Schema(example = "false")
         public boolean penalty;
+        @Schema(example = "23.43")
+        public BigDecimal minCap;
+        @Schema(example = "45.56")
+        public BigDecimal maxCap;
     }
 
     @Schema(description = "PostChargesResponse")
@@ -196,9 +203,9 @@ final class ChargesApiResourceSwagger {
         @Schema(example = "1")
         public Long paymentTypeId;
         @Schema(example = "10.0")
-        public Double minCap;
+        public BigDecimal minCap;
         @Schema(example = "120.0")
-        public Double maxCap;
+        public BigDecimal maxCap;
     }
 
     @Schema(description = "PutChargesChargeIdResponse")

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
@@ -262,7 +262,7 @@ public class Charge extends AbstractPersistableCustom<Long> {
             }
         }
 
-        if (isPercentageOfApprovedAmount()) {
+        if (isPercentageOfDisbursementAmount() || isPercentageOfApprovedAmount()) {
             this.minCap = minCap;
             this.maxCap = maxCap;
         }

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/request/ChargeRequest.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/request/ChargeRequest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.charge.request;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -48,5 +49,7 @@ public class ChargeRequest implements Serializable {
     private String feeFrequency;
     private Long paymentTypeId;
     private Boolean enablePaymentType;
+    private BigDecimal minCap;
+    private BigDecimal maxCap;
 
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
@@ -24,6 +24,7 @@ import io.restassured.specification.ResponseSpecification;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.GetChargesResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.client.util.JSON;
@@ -809,5 +810,9 @@ public final class ChargesHelper {
 
     public PostChargesResponse createCharges(ChargeRequest request) {
         return Calls.ok(FineractClientHelper.getFineractClient().charges.createCharge(request));
+    }
+
+    public GetChargesResponse retrieveCharge(final Long chargeId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().charges.retrieveCharge(chargeId));
     }
 }


### PR DESCRIPTION
## Description

Due missed attributes in the `ChargeRequest` and Swagger API docs the `Charge` `min` and `max` gap values were removed from the json passed

[FINERACT-2181](https://github.com/apache/fineract/pull/FINERACT-2181)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
