### PR TITLE
FINERACT-2181: Use `disruptor` only if it is configured

### DIFF
--- a/fineract-command/src/main/java/org/apache/fineract/command/starter/CommandConfiguration.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/starter/CommandConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.fineract.command.core.CommandProperties;
 import org.apache.fineract.command.core.CommandRouter;
 import org.apache.fineract.command.implementation.DisruptorCommandExecutor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -42,11 +43,13 @@ class CommandConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(value = "fineract.command.executor", havingValue = "disruptor")
     WaitStrategy waitStrategy() {
         return new YieldingWaitStrategy();
     }
 
     @Bean
+    @ConditionalOnProperty(value = "fineract.command.executor", havingValue = "disruptor")
     Disruptor<?> disruptor(CommandProperties properties, WaitStrategy waitStrategy, List<CommandMiddleware> middlewares,
             CommandRouter router) {
         // TODO: make this more configurable


### PR DESCRIPTION
## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
