### PR TITLE
FINERACT-2217: Replace 500 by meaningful error when request requires configured S3

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/export/S3DatatableReportExportServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/export/S3DatatableReportExportServiceImpl.java
@@ -25,8 +25,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.dataqueries.service.DatatableExportTargetParameter;
 import org.apache.fineract.infrastructure.dataqueries.service.ReadReportingService;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -51,9 +53,22 @@ public class S3DatatableReportExportServiceImpl implements DatatableReportExport
                     isSelfServiceUserReport);
             try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
                 output.write(byteArrayOutputStream);
+                byte[] fileBytes = byteArrayOutputStream.toByteArray();
+                if (fileBytes.length == 0) {
+                    throw new GeneralPlatformDomainRuleException("error.report.upload.empty.content",
+                            "Can not upload empty report content to S3");
+                }
+                String bucketName = properties.getReport().getExport().getS3().getBucketName();
+                if (StringUtils.isBlank(bucketName)) {
+                    throw new GeneralPlatformDomainRuleException("error.report.upload.missing.bucket", "S3 bucket name is not configured");
+                }
                 String folder = configurationDomainService.retrieveReportExportS3FolderName();
                 String filePath = DatatableExportUtil.generateS3DatatableExportFileName(AWS_S3_MAXIMUM_KEY_LENGTH, folder, "csv",
                         reportName, reportParams);
+                if (filePath.length() > AWS_S3_MAXIMUM_KEY_LENGTH) {
+                    throw new GeneralPlatformDomainRuleException("error.aws.s3.key.length.exceeded",
+                            "S3 object key length exceeds maximum allowed limit");
+                }
                 s3Client.putObject(
                         builder -> builder.bucket(properties.getReport().getExport().getS3().getBucketName()).key(filePath).build(),
                         RequestBody.fromBytes(byteArrayOutputStream.toByteArray()));

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportExportTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportExportTest.java
@@ -63,4 +63,90 @@ public class ReportExportTest extends IntegrationTest {
         assertThat(result.code()).isEqualTo(204);
     }
 
+    @Test
+    @CIOnly
+    void runClientListingTableReportS3WithValidData() throws IOException {
+        Response<ResponseBody> result = okR(fineractClient().reportsRun.runReportGetFile("Client Listing",
+                Map.of("R_officeId", "1", "exportS3", "true", "R_currencyId", "USD"), false));
+        assertThat(result.code()).isEqualTo(204);
+    }
+
+    @Test
+    @CIOnly
+    void runReportS3WithEmptyContent() throws IOException {
+        try {
+            Response<ResponseBody> result = okR(fineractClient().reportsRun.runReportGetFile("Client Listing",
+                    Map.of("R_officeId", "999999", "exportS3", "true"), false));
+
+            if (!result.isSuccessful()) {
+                assertThat(result.code()).isIn(400, 500);
+            }
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("empty report content");
+        }
+    }
+
+    @Test
+    @CIOnly
+    void runReportS3WithLongFileName() throws IOException {
+        String longReportName = "A".repeat(1000);
+
+        try {
+            Response<ResponseBody> result = okR(
+                    fineractClient().reportsRun.runReportGetFile(longReportName, Map.of("R_officeId", "1", "exportS3", "true"), false));
+
+            if (!result.isSuccessful()) {
+                assertThat(result.code()).isIn(400, 500);
+            }
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("key length exceeds maximum");
+        }
+    }
+
+    @Test
+    @CIOnly
+    void runReportS3WithMissingBucket() throws IOException {
+        Response<ResponseBody> result = okR(
+                fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "1", "exportS3", "true"), false));
+
+        assertThat(result.code()).isEqualTo(204);
+    }
+
+    @Test
+    void runReportWithInvalidOfficeId() throws IOException {
+        try {
+            Response<ResponseBody> result = okR(
+                    fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "-1", "exportCSV", "true"), false));
+
+            if (result.isSuccessful()) {
+                assertThat(result.body().contentType()).isEqualTo(MediaType.parse("text/csv"));
+            } else {
+                assertThat(result.code()).isIn(400, 404, 500);
+            }
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @CIOnly
+    void runMultipleS3ExportsSimultaneously() throws IOException {
+        Response<ResponseBody> result1 = okR(
+                fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "1", "exportS3", "true"), false));
+
+        Response<ResponseBody> result2 = okR(
+                fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "2", "exportS3", "true"), false));
+
+        assertThat(result1.code()).isEqualTo(204);
+        assertThat(result2.code()).isEqualTo(204);
+    }
+
+    @Test
+    @CIOnly
+    void runReportS3WithSpecialCharactersInParams() throws IOException {
+        Response<ResponseBody> result = okR(fineractClient().reportsRun.runReportGetFile("Client Listing",
+                Map.of("R_officeId", "1", "exportS3", "true", "R_clientName", "Test Client & Co."), false));
+
+        assertThat(result.code()).isEqualTo(204);
+    }
 }


### PR DESCRIPTION

- Added a proper validation check in `S3DatatableReportExportServiceImpl` before attempting an S3 upload.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
