### PR TITLE
FINERACT-2306: release doc fixes

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/fineract/gradle/FineractPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/fineract/gradle/FineractPlugin.groovy
@@ -194,7 +194,7 @@ class FineractPlugin implements Plugin<Project> {
 
                 String version = project.properties?['fineract.release.version']
                 String issue = project.properties?['fineract.release.issue']
-                String date = project.properties?['fineract.release.date']
+                String date = project.properties?['fineract.releaseBranch.date']
 
                 if(!version || !issue || !date) {
                     TextIO textIO = TextIoFactory.getTextIO()
@@ -225,7 +225,7 @@ class FineractPlugin implements Plugin<Project> {
 
                 this.context?.project?['fineract.release.version'] = version
                 this.context?.project?['fineract.release.issue'] = issue
-                this.context?.project?['fineract.release.date'] = date
+                this.context?.project?['fineract.releaseBranch.date'] = date
 
                 if(step.email) {
                     emailService.send( processEmailParams(step.email, this.context) )

--- a/buildSrc/src/main/resources/email/release.step01.headsup.message.ftl
+++ b/buildSrc/src/main/resources/email/release.step01.headsup.message.ftl
@@ -20,11 +20,11 @@
 -->
 Hello everyone,
 
-... based on our "How to Release Apache Fineract" process documented at https://cwiki.apache.org/confluence/x/DRwIB:
+... based on our "How to Release Apache Fineract" process (https://cwiki.apache.org/confluence/x/DRwIB) as well as the "Releases" chapter in the docs (https://fineract.apache.org/docs/current/#_releases),
 
-I will create a ${project['fineract.release.version']} branch off develop in our git repository at https://github.com/apache/fineract on ${project['fineract.release.date']}.
+I will create a ${project['fineract.release.version']} branch off develop in our git repository at https://github.com/apache/fineract on ${project['fineract.releaseBranch.date']}.
 
-The release tracking umbrella issue for tracking all activity in JIRA is FINERACT-${project['fineract.release.issue']!'0000'} (https://issues.apache.org/jira/browse/FINERACT-${project['fineract.release.issue']!'0000'}) for this Fineract ${project['fineract.release.version']}.
+The release tracking umbrella issue for tracking all activity in JIRA is FINERACT-${project['fineract.release.issue']!'0000'} (https://issues.apache.org/jira/browse/FINERACT-${project['fineract.release.issue']!'0000'}).
 
 If you have any work in progress that you would like to see included in this release, please add "blocking" links to the release JIRA issue.
 

--- a/fineract-doc/src/docs/en/chapters/release/process-step01.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step01.adoc
@@ -2,7 +2,7 @@
 
 == Description
 
-The RM should, if one doesn't already exist, first create a new release umbrella issue in JIRA. This issue is dedicated to tracking (a summary of) any discussion related to the planned new release. An example of such an issue is FINERACT-873 - Release Apache Fineract v1.4.0 RESOLVED.
+The RM should, if one doesn't already exist, first create a new release umbrella issue in JIRA. This issue is dedicated to tracking (a summary of) any discussion related to the planned new release. An example of such an issue is https://issues.apache.org/jira/browse/FINERACT-873[FINERACT-873].
 
 The RM then creates a list of resolved issues & features through an initial check in JIRA for already resolved issues for the release, and then setup a timeline for release branch point. The time for the day the issue list is created to the release branch point must be at least two weeks in order to give the community a chance to prioritize and commit any last minute features and issues they would like to see in the upcoming release.
 
@@ -22,5 +22,5 @@ include::{rootdir}/buildSrc/src/main/resources/email/release.step01.headsup.mess
 .Command
 [source,bash,subs="attributes+,+macros"]
 ----
-% ./gradlew fineractReleaseStep1 -Pfineract.release.issue=1234 -Pfineract.release.date="Monday, April 25, 2022" -Pfineract.release.version={revnumber}
+% ./gradlew fineractReleaseStep1 -Pfineract.release.issue=1234 -Pfineract.releaseBranch.date="Monday, April 25, 2022" -Pfineract.release.version={revnumber}
 ----


### PR DESCRIPTION
## Description

* asciidoc: link directly to FINERACT-873 and shorten it for brevity / clarity
* fineract plugin:
  * print email, don't send (WIP, but I might keep this... I prefer manually sending emails for now.)
  * support different release date and release branch date

see also: FINERACT-2306

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
