### PR TITLE
FINERACT-2181: Loan disbursement amount exceed loan principal amount when we ha…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
@@ -35,9 +35,10 @@ public final class LoanDisbursementValidator {
 
     public void compareDisbursedToApprovedOrProposedPrincipal(final Loan loan, final BigDecimal disbursedAmount,
             final BigDecimal totalDisbursed) {
+        final BigDecimal capitalizedIncome = loan.getSummary().getTotalCapitalizedIncome();
         if (loan.loanProduct().isDisallowExpectedDisbursements() && loan.loanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
             final BigDecimal maxDisbursedAmount = loanApplicationValidator.getOverAppliedMax(loan);
-            if (totalDisbursed.compareTo(maxDisbursedAmount) > 0) {
+            if (totalDisbursed.add(capitalizedIncome).compareTo(maxDisbursedAmount) > 0) {
                 final String errorMessage = String.format(
                         "Loan disbursal amount can't be greater than maximum applied loan amount calculation. "
                                 + "Total disbursed amount: %s  Maximum disbursal amount: %s",
@@ -47,7 +48,8 @@ public final class LoanDisbursementValidator {
                         maxDisbursedAmount);
             }
         } else {
-            if (totalDisbursed.compareTo(loan.getApprovedPrincipal()) > 0) {
+            if ((totalDisbursed.compareTo(loan.getApprovedPrincipal()) > 0)
+                    || (totalDisbursed.add(capitalizedIncome).compareTo(loan.getApprovedPrincipal()) > 0)) {
                 final String errorMsg = "Loan can't be disbursed,disburse amount is exceeding approved principal ";
                 throw new LoanDisbursalException(errorMsg, "disburse.amount.must.be.less.than.approved.principal", totalDisbursed,
                         loan.getApprovedPrincipal());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
@@ -106,6 +106,7 @@ public final class LoanTransactionValidatorImpl implements LoanTransactionValida
     private final EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService;
     private final CalendarInstanceRepository calendarInstanceRepository;
     private final LoanDownPaymentTransactionValidator loanDownPaymentTransactionValidator;
+    private final LoanDisbursementValidator loanDisbursementValidator;
 
     private void throwExceptionIfValidationWarningsExist(final List<ApiParameterError> dataValidationErrors) {
         if (!dataValidationErrors.isEmpty()) {
@@ -157,6 +158,9 @@ public final class LoanTransactionValidatorImpl implements LoanTransactionValida
             validateLoanClientIsActive(loan);
             validateLoanGroupIsActive(loan);
 
+            final BigDecimal disbursedAmount = loan.getDisbursedAmount();
+            loanDisbursementValidator.compareDisbursedToApprovedOrProposedPrincipal(loan, principal, disbursedAmount);
+
             if (loan.isChargedOff()) {
                 throw new GeneralPlatformDomainRuleException("error.msg.loan.disbursal.not.allowed.on.charged.off",
                         "Loan: " + loan.getId() + " disbursement is not allowed on charged-off loan.");
@@ -173,7 +177,6 @@ public final class LoanTransactionValidatorImpl implements LoanTransactionValida
                 baseDataValidator.getDataValidationErrors().add(error);
             }
 
-            final BigDecimal disbursedAmount = loan.getDisbursedAmount();
             final Set<LoanCollateralManagement> loanCollateralManagements = loan.getLoanCollateralManagements();
 
             if ((loanCollateralManagements != null && !loanCollateralManagements.isEmpty()) && loan.getLoanType().isIndividualAccount()) {


### PR DESCRIPTION
…ve Capitalized Income

## Description

Considering a multidisbursal loan with capitalized income we must to expect an error indicates exceed approved amount should be displayed, use should be forbidden to add disbursement while

`disbursements + capitalizedIncome >= approved amount`

[FINERACT-2181](https://github.com/apache/fineract/pull/FINERACT-2181)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
