### PR TITLE
FINERACT-2304: Batch retry issue - Duplicate records

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import com.jayway.jsonpath.JsonPathException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.resilience4j.core.functions.Either;
+import io.github.resilience4j.retry.Retry;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.ws.rs.core.UriInfo;
@@ -51,17 +52,18 @@ import org.apache.fineract.batch.domain.Header;
 import org.apache.fineract.batch.exception.BatchReferenceInvalidException;
 import org.apache.fineract.batch.exception.ErrorInfo;
 import org.apache.fineract.batch.service.ResolutionHelper.BatchRequestNode;
+import org.apache.fineract.commands.configuration.RetryConfigurationAssembler;
 import org.apache.fineract.infrastructure.core.domain.BatchRequestContextHolder;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.filters.BatchCallHandler;
 import org.apache.fineract.infrastructure.core.filters.BatchFilter;
 import org.apache.fineract.infrastructure.core.filters.BatchRequestPreprocessor;
-import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.TransactionExecution;
 import org.springframework.transaction.TransactionSystemException;
@@ -89,6 +91,8 @@ public class BatchApiServiceImpl implements BatchApiService {
     private final List<BatchFilter> batchFilters;
 
     private final List<BatchRequestPreprocessor> batchPreprocessors;
+
+    private final RetryConfigurationAssembler retryConfigurationAssembler;
 
     private EntityManager entityManager;
 
@@ -138,28 +142,35 @@ public class BatchApiServiceImpl implements BatchApiService {
      */
     private List<BatchResponse> callInTransaction(Consumer<TransactionTemplate> transactionConfigurator,
             Supplier<List<BatchResponse>> request) {
+        // Retry logic for enclosingTransaction=true and when the isolation level is REPEATABLE_READ or stricter we need
+        // to restart the transaction as well!
+
+        Retry retry = retryConfigurationAssembler.getRetryConfigurationForBatchApiWithEnclosingTransaction();
         List<BatchResponse> responseList = new ArrayList<>();
-        try {
-            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-            if (transactionManager instanceof ExtendedJpaTransactionManager extendedJpaTransactionManager) {
-                transactionTemplate.setReadOnly(extendedJpaTransactionManager.isReadOnlyConnection());
-            }
-            transactionConfigurator.accept(transactionTemplate);
-            return transactionTemplate.execute(status -> {
-                BatchRequestContextHolder.setEnclosingTransaction(status);
-                try {
+        Supplier<List<BatchResponse>> batchSupplier = () -> {
+            responseList.clear();
+            try {
+                TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+                transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ);
+                transactionConfigurator.accept(transactionTemplate);
+                return transactionTemplate.execute(status -> {
+                    BatchRequestContextHolder.setEnclosingTransaction(status);
                     responseList.addAll(request.get());
                     return responseList;
-                } catch (BatchExecutionException ex) {
-                    log.error("Exception during the batch request processing", ex);
-                    responseList.add(buildErrorResponse(ex.getCause(), ex.getRequest()));
-                    return responseList;
-                } finally {
-                    BatchRequestContextHolder.resetTransaction();
-                }
-            });
+                });
+            } finally {
+                BatchRequestContextHolder.resetTransaction();
+            }
+        };
+        Supplier<List<BatchResponse>> retryingBatch = Retry.decorateSupplier(retry, batchSupplier);
+        try {
+            return retryingBatch.get();
         } catch (TransactionException | NonTransientDataAccessException ex) {
             return buildErrorResponses(ex, responseList);
+        } catch (BatchExecutionException ex) {
+            log.error("Exception during the batch request processing", ex);
+            responseList.add(buildErrorResponse(ex.getCause(), ex.getRequest()));
+            return responseList;
         }
     }
 

--- a/fineract-core/src/main/java/org/apache/fineract/commands/configuration/RetryConfigurationAssembler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/configuration/RetryConfigurationAssembler.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.configuration;
+
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import org.apache.fineract.batch.service.BatchExecutionException;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class RetryConfigurationAssembler {
+
+    public static final String EXECUTE_COMMAND = "executeCommand";
+    public static final String BATCH_RETRY = "batchRetry";
+    private final RetryRegistry registry;
+    private final FineractProperties fineractProperties;
+
+    private boolean isAssignableFrom(Object e, Class<? extends Throwable>[] exceptionList) {
+        return Arrays.stream(exceptionList).anyMatch(re -> re.isAssignableFrom(e.getClass()));
+    }
+
+    public Retry getRetryConfigurationForExecuteCommand() {
+        Class<? extends Throwable>[] exceptionList = fineractProperties.getRetry().getInstances().getExecuteCommand().getRetryExceptions();
+        RetryConfig.Builder configBuilder = buildCommonExecuteCommandConfiguration();
+
+        if (exceptionList != null) {
+            configBuilder.retryOnException(e -> isAssignableFrom(e, exceptionList));
+        }
+
+        RetryConfig config = configBuilder.build();
+        return registry.retry(EXECUTE_COMMAND, config);
+    }
+
+    public Retry getRetryConfigurationForBatchApiWithEnclosingTransaction() {
+        Class<? extends Throwable>[] exceptionList = fineractProperties.getRetry().getInstances().getExecuteCommand().getRetryExceptions();
+        RetryConfig.Builder configBuilder = buildCommonExecuteCommandConfiguration();
+
+        if (exceptionList != null) {
+            configBuilder.retryOnException(ex -> {
+                if (ex instanceof BatchExecutionException e) {
+                    return isAssignableFrom(e.getCause(), exceptionList);
+                } else {
+                    return isAssignableFrom(ex, exceptionList);
+                }
+            });
+        }
+
+        RetryConfig config = configBuilder.build();
+        return registry.retry(BATCH_RETRY, config);
+    }
+
+    private RetryConfig.Builder buildCommonExecuteCommandConfiguration() {
+        var props = fineractProperties.getRetry().getInstances().getExecuteCommand();
+
+        RetryConfig.Builder configBuilder = RetryConfig.custom().maxAttempts(props.getMaxAttempts());
+
+        if (props.getWaitDuration() != null && props.getWaitDuration().toMillis() >= 0) {
+            if (Boolean.TRUE.equals(props.getEnableExponentialBackoff())) {
+                Double multiplier = props.getExponentialBackoffMultiplier();
+                if (multiplier != null) {
+                    configBuilder.intervalFunction(IntervalFunction.ofExponentialBackoff(props.getWaitDuration(), multiplier));
+                } else {
+                    configBuilder.intervalFunction(IntervalFunction.ofExponentialBackoff(props.getWaitDuration()));
+                }
+            } else {
+                configBuilder.waitDuration(props.getWaitDuration());
+            }
+        }
+
+        return configBuilder;
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -24,15 +24,16 @@ import static org.apache.http.HttpStatus.SC_OK;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import io.github.resilience4j.retry.annotation.Retry;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.batch.exception.ErrorInfo;
+import org.apache.fineract.commands.configuration.RetryConfigurationAssembler;
 import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandWrapper;
@@ -76,81 +77,96 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
     private final CommandHandlerProvider commandHandlerProvider;
     private final IdempotencyKeyResolver idempotencyKeyResolver;
     private final CommandSourceService commandSourceService;
+    private final RetryConfigurationAssembler retryConfigurationAssembler;
 
     private final FineractRequestContextHolder fineractRequestContextHolder;
     private final Gson gson = GoogleGsonSerializerHelper.createSimpleGson();
 
+    private CommandProcessingResult retryWrapper(Supplier<CommandProcessingResult> supplier) {
+        if (!BatchRequestContextHolder.isEnclosingTransaction()) {
+            try {
+                return retryConfigurationAssembler.getRetryConfigurationForExecuteCommand().executeSupplier(supplier);
+            } catch (RuntimeException e) {
+                fallbackExecuteCommand(e);
+            }
+        }
+        return supplier.get();
+    }
+
     @Override
-    @Retry(name = "executeCommand", fallbackMethod = "fallbackExecuteCommand")
     public CommandProcessingResult executeCommand(final CommandWrapper wrapper, final JsonCommand command,
             final boolean isApprovedByChecker) {
-        // Do not store the idempotency key because of the exception handling
-        setIdempotencyKeyStoreFlag(false);
+        return retryWrapper(() -> {
+            // Do not store the idempotency key because of the exception handling
+            setIdempotencyKeyStoreFlag(false);
 
-        Long commandId = (Long) fineractRequestContextHolder.getAttribute(COMMAND_SOURCE_ID, null);
-        boolean isRetry = commandId != null;
-        boolean isEnclosingTransaction = BatchRequestContextHolder.isEnclosingTransaction();
+            Long commandId = (Long) fineractRequestContextHolder.getAttribute(COMMAND_SOURCE_ID, null);
+            boolean isRetry = commandId != null;
+            boolean isEnclosingTransaction = BatchRequestContextHolder.isEnclosingTransaction();
 
-        CommandSource commandSource = null;
-        String idempotencyKey;
-        if (isRetry) {
-            commandSource = commandSourceService.getCommandSource(commandId);
-            idempotencyKey = commandSource.getIdempotencyKey();
-        } else if ((commandId = command.commandId()) != null) { // action on the command itself
-            commandSource = commandSourceService.getCommandSource(commandId);
-            idempotencyKey = commandSource.getIdempotencyKey();
-        } else {
-            idempotencyKey = idempotencyKeyResolver.resolve(wrapper);
-        }
-        exceptionWhenTheRequestAlreadyProcessed(wrapper, idempotencyKey, isRetry);
-
-        AppUser user = context.authenticatedUser(wrapper);
-        if (commandSource == null) {
-            if (isEnclosingTransaction) {
-                commandSource = commandSourceService.getInitialCommandSource(wrapper, command, user, idempotencyKey);
+            CommandSource commandSource = null;
+            String idempotencyKey;
+            if (isRetry) {
+                commandSource = commandSourceService.getCommandSource(commandId);
+                idempotencyKey = commandSource.getIdempotencyKey();
+            } else if ((commandId = command.commandId()) != null) { // action on the command itself
+                commandSource = commandSourceService.getCommandSource(commandId);
+                idempotencyKey = commandSource.getIdempotencyKey();
             } else {
-                commandSource = commandSourceService.saveInitialNewTransaction(wrapper, command, user, idempotencyKey);
-                commandId = commandSource.getId();
+                idempotencyKey = idempotencyKeyResolver.resolve(wrapper);
             }
-        }
-        if (commandId != null) {
+            exceptionWhenTheRequestAlreadyProcessed(wrapper, idempotencyKey, isRetry);
+
+            AppUser user = context.authenticatedUser(wrapper);
+            if (commandSource == null) {
+                if (isEnclosingTransaction) {
+                    commandSource = commandSourceService.getInitialCommandSource(wrapper, command, user, idempotencyKey);
+                } else {
+                    commandSource = commandSourceService.saveInitialNewTransaction(wrapper, command, user, idempotencyKey);
+                    commandId = commandSource.getId();
+                }
+            }
+            if (commandId != null) {
+                storeCommandIdInContext(commandSource); // Store command id as a request attribute
+            }
+
+            setIdempotencyKeyStoreFlag(true);
+
+            final CommandProcessingResult result;
+            try {
+                result = commandSourceService.processCommand(findCommandHandler(wrapper), command, commandSource, user,
+                        isApprovedByChecker);
+            } catch (Throwable t) { // NOSONAR
+                RuntimeException mappable = ErrorHandler.getMappable(t);
+                ErrorInfo errorInfo = commandSourceService.generateErrorInfo(mappable);
+                Integer statusCode = errorInfo.getStatusCode();
+                commandSource.setResultStatusCode(statusCode);
+                commandSource.setResult(errorInfo.getMessage());
+                if (statusCode != SC_OK) {
+                    commandSource.setStatus(ERROR);
+                }
+                if (!isEnclosingTransaction) { // TODO: temporary solution
+                    commandSource = commandSourceService.saveResultNewTransaction(commandSource);
+                }
+                // must not throw any exception; must persist in new transaction as the current transaction was already
+                // marked as rollback
+                publishHookErrorEvent(wrapper, command, errorInfo);
+                throw mappable;
+            }
+
+            commandSource.setResultStatusCode(SC_OK);
+            commandSource.updateForAudit(result);
+            commandSource.setResult(toApiResultJsonSerializer.serializeResult(result));
+            commandSource.setStatus(PROCESSED);
+            commandSource = commandSourceService.saveResultSameTransaction(commandSource);
             storeCommandIdInContext(commandSource); // Store command id as a request attribute
-        }
 
-        setIdempotencyKeyStoreFlag(true);
-
-        final CommandProcessingResult result;
-        try {
-            result = commandSourceService.processCommand(findCommandHandler(wrapper), command, commandSource, user, isApprovedByChecker);
-        } catch (Throwable t) { // NOSONAR
-            RuntimeException mappable = ErrorHandler.getMappable(t);
-            ErrorInfo errorInfo = commandSourceService.generateErrorInfo(mappable);
-            Integer statusCode = errorInfo.getStatusCode();
-            commandSource.setResultStatusCode(statusCode);
-            commandSource.setResult(errorInfo.getMessage());
-            if (statusCode != SC_OK) {
-                commandSource.setStatus(ERROR);
-            }
-            if (!isEnclosingTransaction) { // TODO: temporary solution
-                commandSource = commandSourceService.saveResultNewTransaction(commandSource);
-            }
-            // must not throw any exception; must persist in new transaction as the current transaction was already
-            // marked as rollback
-            publishHookErrorEvent(wrapper, command, errorInfo);
-            throw mappable;
-        }
-
-        commandSource.setResultStatusCode(SC_OK);
-        commandSource.updateForAudit(result);
-        commandSource.setResult(toApiResultJsonSerializer.serializeResult(result));
-        commandSource.setStatus(PROCESSED);
-        commandSource = commandSourceService.saveResultSameTransaction(commandSource);
-        storeCommandIdInContext(commandSource); // Store command id as a request attribute
-
-        result.setRollbackTransaction(null);
-        publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, result); // TODO must be performed in a
-                                                                                       // new transaction
-        return result;
+            result.setRollbackTransaction(null);
+            publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, result); // TODO must be performed in
+                                                                                           // a
+            // new transaction
+            return result;
+        });
     }
 
     private void storeCommandIdInContext(CommandSource savedCommandSource) {
@@ -188,8 +204,7 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
         fineractRequestContextHolder.setAttribute(IDEMPOTENCY_KEY_STORE_FLAG, flag);
     }
 
-    @SuppressWarnings("unused")
-    public CommandProcessingResult fallbackExecuteCommand(Exception e) {
+    public void fallbackExecuteCommand(Exception e) {
         throw ErrorHandler.getMappable(e);
     }
 

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -84,6 +84,8 @@ public class FineractProperties {
 
     private FineractCache cache;
 
+    private RetryProperties retry;
+
     @Getter
     @Setter
     public static class FineractTenantProperties {
@@ -611,5 +613,31 @@ public class FineractProperties {
 
         private Duration ttl;
         private Integer maximumEntries;
+    }
+
+    @Setter
+    @Getter
+    public static class RetryProperties {
+
+        private InstancesProperties instances;
+
+        @Setter
+        @Getter
+        public static class InstancesProperties {
+
+            private ExecuteCommandProperties executeCommand;
+
+            @Getter
+            @Setter
+            public static class ExecuteCommandProperties {
+
+                private Class<? extends Throwable>[] retryExceptions;
+                private Integer maxAttempts;
+                private Boolean enableExponentialBackoff;
+                private Double exponentialBackoffMultiplier;
+                private Duration waitDuration;
+
+            }
+        }
     }
 }

--- a/fineract-doc/src/docs/en/chapters/appendix/properties-resilience4j.adoc
+++ b/fineract-doc/src/docs/en/chapters/appendix/properties-resilience4j.adoc
@@ -6,23 +6,28 @@ For a deeper understanding of resilience4j, refer to the https://resilience4j.re
 |===
 |Name |Env Variable |Default Value |Description
 
-|resilience4j.retry.instances.executeCommand.max-attempts
+|fineract.retry.instances.executeCommand.max-attempts
 |FINERACT_COMMAND_PROCESSING_RETRY_MAX_ATTEMPTS
 |3
 |The number of attempts that resilience4j will attempt to execute a command after a failed execution. Refer to  org. apache. fineract. commands. service. SynchronousCommandProcessingService#executeCommand for more details
 
-|resilience4j.retry.instances.executeCommand.wait-duration
+|fineract.retry.instances.executeCommand.wait-duration
 |FINERACT_COMMAND_PROCESSING_RETRY_WAIT_DURATION
 |1s
 |The fixed time value that the retry instance will wait before the next attempt can be made to execute a command
 
-|resilience4j.retry.instances.executeCommand.enable-exponential-backoff
+|fineract.retry.instances.executeCommand.enable-exponential-backoff
 |FINERACT_COMMAND_PROCESSING_RETRY_ENABLE_EXPONENTIAL_BACKOFF
 |true
 |If set to true, the wait-duration will increase exponentially between each retry to execute a command
 
-|resilience4j.retry.instances.executeCommand.retryExceptions
+|fineract.retry.instances.executeCommand.exponential-backoff-multiplier
 |FINERACT_COMMAND_PROCESSING_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER
+|3
+|The multiplier for exponential backoff, this is useful only when enable-exponential-backoff is set to true
+
+|fineract.retry.instances.executeCommand.retryExceptions
+|FINERACT_COMMAND_PROCESSING_RETRY_EXCEPTIONS
 |org.springframework.dao.ConcurrencyFailureException,org.eclipse.persistence.exceptions.OptimisticLockException,jakarta.persistence.OptimisticLockException,org.springframework.orm.jpa.JpaOptimisticLockingFailureException,org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException
 |This property specifies the list of exceptions that the execute command retry instance will retry on
 

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -441,11 +441,11 @@ spring.batch.initialize-schema=NEVER
 # Disabling Spring Batch jobs on startup
 spring.batch.job.enabled=false
 
-resilience4j.retry.instances.executeCommand.max-attempts=${FINERACT_COMMAND_PROCESSING_RETRY_MAX_ATTEMPTS:3}
-resilience4j.retry.instances.executeCommand.wait-duration=${FINERACT_COMMAND_PROCESSING_RETRY_WAIT_DURATION:1s}
-resilience4j.retry.instances.executeCommand.enable-exponential-backoff=${FINERACT_COMMAND_PROCESSING_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
-resilience4j.retry.instances.executeCommand.exponential-backoff-multiplier=${FINERACT_COMMAND_PROCESSING_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
-resilience4j.retry.instances.executeCommand.retryExceptions=${FINERACT_COMMAND_PROCESSING_RETRY_EXCEPTIONS:org.springframework.dao.ConcurrencyFailureException,org.eclipse.persistence.exceptions.OptimisticLockException,jakarta.persistence.OptimisticLockException,org.springframework.orm.jpa.JpaOptimisticLockingFailureException,org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException}
+fineract.retry.instances.executeCommand.max-attempts=${FINERACT_COMMAND_PROCESSING_RETRY_MAX_ATTEMPTS:3}
+fineract.retry.instances.executeCommand.wait-duration=${FINERACT_COMMAND_PROCESSING_RETRY_WAIT_DURATION:1s}
+fineract.retry.instances.executeCommand.enable-exponential-backoff=${FINERACT_COMMAND_PROCESSING_RETRY_ENABLE_EXPONENTIAL_BACKOFF:true}
+fineract.retry.instances.executeCommand.exponential-backoff-multiplier=${FINERACT_COMMAND_PROCESSING_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER:2}
+fineract.retry.instances.executeCommand.retryExceptions=${FINERACT_COMMAND_PROCESSING_RETRY_EXCEPTIONS:org.springframework.dao.ConcurrencyFailureException,org.eclipse.persistence.exceptions.OptimisticLockException,jakarta.persistence.OptimisticLockException,org.springframework.orm.jpa.JpaOptimisticLockingFailureException,org.apache.fineract.infrastructure.core.exception.IdempotentCommandProcessUnderProcessingException}
 
 resilience4j.retry.instances.processJobDetailForExecution.max-attempts=${FINERACT_PROCESS_JOB_DETAIL_RETRY_MAX_ATTEMPTS:3}
 resilience4j.retry.instances.processJobDetailForExecution.wait-duration=${FINERACT_PROCESS_JOB_DETAIL_RETRY_WAIT_DURATION:1s}

--- a/fineract-provider/src/test/resources/application-test.properties
+++ b/fineract-provider/src/test/resources/application-test.properties
@@ -259,11 +259,11 @@ spring.batch.initialize-schema=NEVER
 # Disabling Spring Batch jobs on startup
 spring.batch.job.enabled=false
 
-resilience4j.retry.instances.executeCommand.max-attempts=3
-resilience4j.retry.instances.executeCommand.wait-duration=1s
-resilience4j.retry.instances.executeCommand.enable-exponential-backoff=true
-resilience4j.retry.instances.executeCommand.exponential-backoff-multiplier=2
-resilience4j.retry.instances.executeCommand.retryExceptions=org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException
+fineract.retry.instances.executeCommand.max-attempts=3
+fineract.retry.instances.executeCommand.wait-duration=1s
+fineract.retry.instances.executeCommand.enable-exponential-backoff=true
+fineract.retry.instances.executeCommand.exponential-backoff-multiplier=2
+fineract.retry.instances.executeCommand.retryExceptions=org.springframework.dao.CannotAcquireLockException,org.springframework.orm.ObjectOptimisticLockingFailureException
 
 resilience4j.retry.instances.processJobDetailForExecution.max-attempts=3
 resilience4j.retry.instances.processJobDetailForExecution.wait-duration=1s

--- a/fineract-provider/src/test/resources/features/commands/commands.service.feature
+++ b/fineract-provider/src/test/resources/features/commands/commands.service.feature
@@ -19,9 +19,10 @@
 
 Feature: Commands Service
 
+  @soma
   Scenario: Verify that command source write service are working with fallback function
     Given A command source write service
     When The user executes the command via a command write service with exceptions
     Then The command processing service should fallback as expected
-    Then The command processing service execute function should be called 3 times
+    Then The command processing service execute function should be called 2 times
 


### PR DESCRIPTION
## Description

Introduce RetryConfigurationAssembler to use fineract namespace for Retry configuration
Reimplement Retry logic for org.apache.fineract.commands.service.SynchronousCommandProcessingService#executeCommand.
Implement proper Retry in org.apache.fineract.batch.service.BatchApiServiceImpl#callInTransaction. 

 details are present on the associated [Apache Fineract JIRA ticket](https://issues.apache.org/jira/browse/FINERACT-2304).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
