### PR TITLE
FINERACT-2181: Resolves SonarQube warning about unclosed AutoCloseable resource

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/s3/AmazonS3ConfigCondition.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/s3/AmazonS3ConfigCondition.java
@@ -34,10 +34,8 @@ public class AmazonS3ConfigCondition extends PropertiesCondition {
     }
 
     private boolean isAwsCredentialValid() {
-        try {
-            // The credentials provider is intentionally not closed here since Spring will close it at the
-            // context closure event
-            DefaultCredentialsProvider.create().resolveCredentials();
+        try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
+            credentialsProvider.resolveCredentials();
             DefaultAwsRegionProviderChain.builder().build().getRegion();
             return true;
         } catch (Exception e) {


### PR DESCRIPTION


## Description
- Fix use try-with-resources for `DefaultCredentialsProvider` to prevent resource leak by properly closing the credentials provider after AWS credential validation.

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
