### PR TITLE
FINERACT-2232: Add missing fields on the Capitalized Income and Adjus…

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeWritePlatformServiceImpl.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeWritePlatformServiceImpl.java
@@ -104,6 +104,9 @@ public class CapitalizedIncomeWritePlatformServiceImpl implements CapitalizedInc
         return new CommandProcessingResultBuilder() //
                 .withEntityId(capitalizedIncomeTransaction.getId()) //
                 .withEntityExternalId(capitalizedIncomeTransaction.getExternalId()) //
+                .withOfficeId(loan.getOfficeId()) //
+                .withClientId(loan.getClientId()) //
+                .withLoanId(loan.getId()) //
                 .build();
     }
 
@@ -151,9 +154,13 @@ public class CapitalizedIncomeWritePlatformServiceImpl implements CapitalizedInc
                 MathUtil.negativeToZero(capitalizedIncomeBalance.getUnrecognizedAmount().subtract(transactionAmount)));
         capitalizedIncomeBalanceRepository.save(capitalizedIncomeBalance);
 
-        return new CommandProcessingResultBuilder().withLoanId(loan.getId()).withLoanExternalId(loan.getExternalId())
-                .withEntityId(savedCapitalizedIncomeAdjustment.getId())
-                .withEntityExternalId(savedCapitalizedIncomeAdjustment.getExternalId()).build();
+        return new CommandProcessingResultBuilder() //
+                .withEntityId(savedCapitalizedIncomeAdjustment.getId()) //
+                .withEntityExternalId(savedCapitalizedIncomeAdjustment.getExternalId()) //
+                .withOfficeId(loan.getOfficeId()) //
+                .withClientId(loan.getClientId()) //
+                .withLoanId(loan.getId()) //
+                .build();
     }
 
     private void recalculateLoanTransactions(Loan loan, LocalDate transactionDate, LoanTransaction transaction) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -165,7 +166,11 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     "1 January 2024", 50.0);
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
 
-            loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustmentResponse = loanTransactionHelper
+                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
+            assertNotNull(capitalizedIncomeAdjustmentResponse.getLoanId());
+            assertNotNull(capitalizedIncomeAdjustmentResponse.getClientId());
+            assertNotNull(capitalizedIncomeAdjustmentResponse.getOfficeId());
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2024"), //
@@ -401,6 +406,9 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
             PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
                     "1 January 2024", 100.0);
+            assertNotNull(capitalizedIncomeResponse.getLoanId());
+            assertNotNull(capitalizedIncomeResponse.getClientId());
+            assertNotNull(capitalizedIncomeResponse.getOfficeId());
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
 
             // random midday COB run


### PR DESCRIPTION
…tment transactions

## Description

We were only returning the `resourceId` and `resourceExternalId` at the transaction response, but previously when a transaction was created the `client id`, `office id` and `loan id` was returned. We should behave similarly and return all the fields that are returned with other transactions.

[FINERACT-2232](https://github.com/apache/fineract/pull/FINERACT-2232)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
