### PR TITLE
FINERACT-2304: Avoid retrying after the command succeed

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/configuration/RetryConfigurationAssembler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/configuration/RetryConfigurationAssembler.java
@@ -25,6 +25,7 @@ import io.github.resilience4j.retry.RetryRegistry;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import org.apache.fineract.batch.service.BatchExecutionException;
+import org.apache.fineract.commands.exception.CommandResultPersistenceException;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.domain.FineractRequestContextHolder;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,7 @@ public class RetryConfigurationAssembler {
 
     public static final String EXECUTE_COMMAND = "executeCommand";
     public static final String BATCH_RETRY = "batchRetry";
+    public static final String COMMAND_RESULT_PERSISTENCE = "commandResultPersistence";
     private static final String LAST_EXECUTION_EXCEPTION_KEY = "LAST_EXECUTION_EXCEPTION";
     private final RetryRegistry registry;
     private final FineractProperties fineractProperties;
@@ -106,5 +108,14 @@ public class RetryConfigurationAssembler {
         }
 
         return configBuilder;
+    }
+
+    public Retry getRetryConfigurationForCommandResultPersistence() {
+        RetryConfig.Builder configBuilder = buildCommonExecuteCommandConfiguration();
+
+        configBuilder.retryOnException(e -> e instanceof RuntimeException && !(e instanceof CommandResultPersistenceException));
+
+        RetryConfig config = configBuilder.build();
+        return registry.retry(COMMAND_RESULT_PERSISTENCE, config);
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/commands/exception/CommandResultPersistenceException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/exception/CommandResultPersistenceException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.exception;
+
+public class CommandResultPersistenceException extends RuntimeException {
+
+    public CommandResultPersistenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Once the org.apache.fineract.commands.service.CommandSourceService#processCommand finished successfully (Transaction #1 is committed successfully), there are some additional logic. These might can fail and initiate a retry.

## Description

Implemented retry logic for these commands

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
