### PR TITLE
FINERACT-2304 Fix auditing of failed batch request while enclosing transaction got enabled

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
@@ -53,6 +53,8 @@ import org.apache.fineract.batch.exception.BatchReferenceInvalidException;
 import org.apache.fineract.batch.exception.ErrorInfo;
 import org.apache.fineract.batch.service.ResolutionHelper.BatchRequestNode;
 import org.apache.fineract.commands.configuration.RetryConfigurationAssembler;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.service.CommandSourceService;
 import org.apache.fineract.infrastructure.core.domain.BatchRequestContextHolder;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.filters.BatchCallHandler;
@@ -93,6 +95,8 @@ public class BatchApiServiceImpl implements BatchApiService {
     private final List<BatchRequestPreprocessor> batchPreprocessors;
 
     private final RetryConfigurationAssembler retryConfigurationAssembler;
+
+    private final CommandSourceService commandSourceService;
 
     private EntityManager entityManager;
 
@@ -166,9 +170,11 @@ public class BatchApiServiceImpl implements BatchApiService {
         try {
             return retryingBatch.get();
         } catch (TransactionException | NonTransientDataAccessException ex) {
+            saveFailedCommandSourceEntries(ex);
             return buildErrorResponses(ex, responseList);
         } catch (BatchExecutionException ex) {
             log.error("Exception during the batch request processing", ex);
+            saveFailedCommandSourceEntries(ex.getCause());
             responseList.add(buildErrorResponse(ex.getCause(), ex.getRequest()));
             return responseList;
         }
@@ -394,5 +400,18 @@ public class BatchApiServiceImpl implements BatchApiService {
     @PersistenceContext
     public void setEntityManager(EntityManager entityManager) {
         this.entityManager = entityManager;
+    }
+
+    private void saveFailedCommandSourceEntries(final Throwable ex) {
+        try {
+            final List<CommandSource> commandSources = BatchRequestContextHolder.getCommandSources();
+            if (!commandSources.isEmpty()) {
+                final String errorMessage = ex != null ? ex.getMessage() : "Batch processing failed";
+                log.debug("Saving {} failed entries for batch audit with error: {}", commandSources.size(), errorMessage);
+                commandSourceService.saveFailedCommandSourcesNewTransaction(commandSources);
+            }
+        } catch (Exception e) {
+            log.error("Failed to save failed CommandSource entries for batch audit", e);
+        }
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandProcessingResultType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandProcessingResultType.java
@@ -34,7 +34,8 @@ public enum CommandProcessingResultType {
     AWAITING_APPROVAL(2, "commandProcessingResultType.awaiting.approval"), //
     REJECTED(3, "commandProcessingResultType.rejected"), //
     UNDER_PROCESSING(4, "commandProcessingResultType.underProcessing"), //
-    ERROR(5, "commandProcessingResultType.error");
+    ERROR(5, "commandProcessingResultType.error"), //
+    ROLLBACK(6, "commandProcessingResultType.rollback");
 
     private static final Map<Integer, CommandProcessingResultType> BY_ID = Arrays.stream(values())
             .collect(Collectors.toMap(CommandProcessingResultType::getValue, v -> v));

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
@@ -22,9 +22,11 @@ import static org.apache.fineract.commands.domain.CommandProcessingResultType.UN
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.batch.exception.ErrorInfo;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.commands.domain.CommandWrapper;
@@ -70,12 +72,6 @@ public class CommandSourceService {
     }
 
     @NonNull
-    @Transactional(propagation = Propagation.REQUIRED)
-    public CommandSource saveInitialSameTransaction(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
-        return saveInitial(wrapper, jsonCommand, maker, idempotencyKey);
-    }
-
-    @NonNull
     private CommandSource saveInitial(CommandWrapper wrapper, JsonCommand jsonCommand, AppUser maker, String idempotencyKey) {
         try {
             CommandSource initialCommandSource = getInitialCommandSource(wrapper, jsonCommand, maker, idempotencyKey);
@@ -90,8 +86,8 @@ public class CommandSourceService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
-    public CommandSource saveResultNewTransaction(@NonNull CommandSource commandSource) {
-        return saveResult(commandSource);
+    public void saveResultNewTransaction(@NonNull CommandSource commandSource) {
+        saveResult(commandSource);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -106,6 +102,14 @@ public class CommandSourceService {
 
     public ErrorInfo generateErrorInfo(Throwable t) {
         return errorHandler.handle(ErrorHandler.getMappable(t));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailedCommandSourcesNewTransaction(final List<CommandSource> commandSources) {
+        commandSources.forEach(commandSource -> {
+            commandSource.setStatus(CommandProcessingResultType.ROLLBACK);
+            commandSourceRepository.saveAndFlush(commandSource);
+        });
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -132,6 +132,10 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
                 storeCommandIdInContext(commandSource); // Store command id as a request attribute
             }
 
+            if (isEnclosingTransaction) {
+                BatchRequestContextHolder.addCommandSource(commandSource);
+            }
+
             setIdempotencyKeyStoreFlag(true);
 
             return executeCommand(wrapper, command, isApprovedByChecker, commandSource, user, isEnclosingTransaction);

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/domain/BatchRequestContextHolder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/domain/BatchRequestContextHolder.java
@@ -18,8 +18,11 @@
  */
 package org.apache.fineract.infrastructure.core.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.fineract.commands.domain.CommandSource;
 import org.springframework.transaction.TransactionStatus;
 
 public final class BatchRequestContextHolder {
@@ -31,6 +34,8 @@ public final class BatchRequestContextHolder {
     private static final ThreadLocal<Optional<TransactionStatus>> batchTransaction = ThreadLocal.withInitial(Optional::empty);
 
     private static final ThreadLocal<Boolean> isEnclosingTransaction = new ThreadLocal<>();
+
+    private static final ThreadLocal<List<CommandSource>> commandSources = ThreadLocal.withInitial(ArrayList::new);
 
     /**
      * True if the batch attributes are set
@@ -87,6 +92,7 @@ public final class BatchRequestContextHolder {
 
     public static void resetIsEnclosingTransaction() {
         isEnclosingTransaction.remove();
+        commandSources.get().clear();
     }
 
     /**
@@ -130,4 +136,15 @@ public final class BatchRequestContextHolder {
     public static void resetTransaction() {
         batchTransaction.set(Optional.empty());
     }
+
+    public static void addCommandSource(final CommandSource commandSource) {
+        if (isEnclosingTransaction() && commandSource != null) {
+            commandSources.get().add(commandSource);
+        }
+    }
+
+    public static List<CommandSource> getCommandSources() {
+        return new ArrayList<>(commandSources.get());
+    }
+
 }

--- a/fineract-core/src/test/java/org/apache/fineract/batch/service/BatchApiServiceImplTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/batch/service/BatchApiServiceImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.batch.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -41,7 +42,10 @@ import org.apache.fineract.batch.domain.BatchRequest;
 import org.apache.fineract.batch.domain.BatchResponse;
 import org.apache.fineract.batch.exception.ErrorInfo;
 import org.apache.fineract.commands.configuration.RetryConfigurationAssembler;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.service.CommandSourceService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.domain.BatchRequestContextHolder;
 import org.apache.fineract.infrastructure.core.domain.FineractRequestContextHolder;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.filters.BatchRequestPreprocessor;
@@ -75,6 +79,9 @@ class BatchApiServiceImplTest {
     private ErrorHandler errorHandler;
 
     @Mock
+    private CommandSourceService commandSourceService;
+
+    @Mock
     private RetryRegistry registry;
 
     @Mock
@@ -97,7 +104,7 @@ class BatchApiServiceImplTest {
     @BeforeEach
     void setUp() {
         batchApiService = new BatchApiServiceImpl(strategyProvider, resolutionHelper, transactionManager, errorHandler, List.of(),
-                batchPreprocessors, retryConfigurationAssembler);
+                batchPreprocessors, retryConfigurationAssembler, commandSourceService);
         batchApiService.setEntityManager(entityManager);
         request = new BatchRequest();
         request.setRequestId(1L);
@@ -225,6 +232,32 @@ class BatchApiServiceImplTest {
         assertEquals(200, result.get(0).getStatusCode());
         assertTrue(result.get(0).getBody().contains("Success"));
         Mockito.verifyNoInteractions(entityManager);
+    }
+
+    @Test
+    void testFailedCommandSourceEntriesAreSavedOnBatchFailure() {
+        final List<BatchRequest> requestList = List.of(request);
+        when(strategyProvider.getCommandStrategy(any())).thenReturn(commandStrategy);
+        when(commandStrategy.execute(any(), any())).thenThrow(new RuntimeException("Test failure"));
+
+        final ErrorInfo errorInfo = mock(ErrorInfo.class);
+        when(errorInfo.getMessage()).thenReturn("Test failure");
+        when(errorInfo.getStatusCode()).thenReturn(500);
+        when(errorHandler.handle(any())).thenReturn(errorInfo);
+
+        when(transactionManager.getTransaction(any()))
+                .thenReturn(new DefaultTransactionStatus("txn_name", null, true, true, false, false, false, null));
+
+        final CommandSource mockCommandSource = mock(CommandSource.class);
+        BatchRequestContextHolder.setIsEnclosingTransaction(true);
+        BatchRequestContextHolder.addCommandSource(mockCommandSource);
+
+        final BatchResponse result = batchApiService.handleBatchRequestsWithEnclosingTransaction(requestList, uriInfo).getFirst();
+        assertNotNull(result);
+        assertEquals(500, result.getStatusCode());
+        assertTrue(result.getBody().contains("Test failure"));
+
+        verify(commandSourceService, times(1)).saveFailedCommandSourcesNewTransaction(any());
     }
 
     private static final class RetryException extends RuntimeException {}


### PR DESCRIPTION
## Description

In case it is a BatchAPI request and enclosingTransaction=true, we should collect the sub requests CommandSource entries and in case it fails at the end, we should create Audit entries for them with FAILED status. This way we can make sure there are audit entries for such requests as well.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
