### PR TITLE
FINERACT-2181: Capitalized Income and Buy Down Fees accounting values are still…

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingHelper.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingHelper.java
@@ -559,6 +559,15 @@ public class ProductToGLAccountMappingHelper {
         return glAccount;
     }
 
+    public void deleteProductToGLAccountMapping(final Long loanProductId, final PortfolioProductType portfolioProductType,
+            final int accountTypeId) {
+        final ProductToGLAccountMapping accountMapping = this.accountMappingRepository.findCoreProductToFinAccountMapping(loanProductId,
+                portfolioProductType.getValue(), accountTypeId);
+        if (accountMapping != null && accountMapping.getGlAccount() != null) {
+            this.accountMappingRepository.delete(accountMapping);
+        }
+    }
+
     public void deleteProductToGLAccountMapping(final Long loanProductId, final PortfolioProductType portfolioProductType) {
         final List<ProductToGLAccountMapping> productToGLAccountMappings = this.accountMappingRepository
                 .findByProductIdAndProductType(loanProductId, portfolioProductType.getValue());

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingWritePlatformService.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingWritePlatformService.java
@@ -30,7 +30,7 @@ public interface ProductToGLAccountMappingWritePlatformService {
     void createSavingProductToGLAccountMapping(Long savingProductId, JsonCommand command, DepositAccountType accountType);
 
     Map<String, Object> updateLoanProductToGLAccountMapping(Long loanProductId, JsonCommand command, boolean accountingRuleChanged,
-            AccountingRuleType accountingRuleTypeId);
+            AccountingRuleType accountingRuleTypeId, boolean enableIncomeCapitalization, boolean enableBuyDownFee);
 
     Map<String, Object> updateSavingsProductToGLAccountMapping(Long savingsProductId, JsonCommand command, boolean accountingRuleChanged,
             int accountingRuleTypeId, DepositAccountType accountType);

--- a/fineract-loan/src/main/java/org/apache/fineract/accounting/productaccountmapping/service/LoanProductToGLAccountMappingHelper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/accounting/productaccountmapping/service/LoanProductToGLAccountMappingHelper.java
@@ -255,7 +255,8 @@ public class LoanProductToGLAccountMappingHelper extends ProductToGLAccountMappi
      * @param accountingRuleType
      */
     public void handleChangesToLoanProductToGLAccountMappings(final Long loanProductId, final Map<String, Object> changes,
-            final JsonElement element, final AccountingRuleType accountingRuleType) {
+            final JsonElement element, final AccountingRuleType accountingRuleType, final boolean enableIncomeCapitalization,
+            final boolean enableBuyDownFee) {
         switch (accountingRuleType) {
             case NONE:
             break;
@@ -365,12 +366,22 @@ public class LoanProductToGLAccountMappingHelper extends ProductToGLAccountMappi
                 mergeLoanToIncomeAccountMappingChanges(element, LoanProductAccountingParams.INCOME_FROM_GOODWILL_CREDIT_PENALTY.getValue(),
                         loanProductId, AccrualAccountsForLoan.INCOME_FROM_GOODWILL_CREDIT_PENALTY.getValue(),
                         AccrualAccountsForLoan.INCOME_FROM_GOODWILL_CREDIT_PENALTY.toString(), changes);
-                mergeLoanToIncomeAccountMappingChanges(element, LoanProductAccountingParams.INCOME_FROM_CAPITALIZATION.getValue(),
-                        loanProductId, AccrualAccountsForLoan.INCOME_FROM_CAPITALIZATION.getValue(),
-                        AccrualAccountsForLoan.INCOME_FROM_CAPITALIZATION.toString(), changes);
-                mergeLoanToIncomeAccountMappingChanges(element, LoanProductAccountingParams.INCOME_FROM_BUY_DOWN.getValue(), loanProductId,
-                        AccrualAccountsForLoan.INCOME_FROM_BUY_DOWN.getValue(), AccrualAccountsForLoan.INCOME_FROM_BUY_DOWN.toString(),
-                        changes);
+                if (!enableIncomeCapitalization) {
+                    deleteProductToGLAccountMapping(loanProductId, PortfolioProductType.LOAN,
+                            AccrualAccountsForLoan.INCOME_FROM_CAPITALIZATION.getValue());
+                } else {
+                    mergeLoanToIncomeAccountMappingChanges(element, LoanProductAccountingParams.INCOME_FROM_CAPITALIZATION.getValue(),
+                            loanProductId, AccrualAccountsForLoan.INCOME_FROM_CAPITALIZATION.getValue(),
+                            AccrualAccountsForLoan.INCOME_FROM_CAPITALIZATION.toString(), changes);
+                }
+                if (!enableBuyDownFee) {
+                    deleteProductToGLAccountMapping(loanProductId, PortfolioProductType.LOAN,
+                            AccrualAccountsForLoan.INCOME_FROM_BUY_DOWN.getValue());
+                } else {
+                    mergeLoanToIncomeAccountMappingChanges(element, LoanProductAccountingParams.INCOME_FROM_BUY_DOWN.getValue(),
+                            loanProductId, AccrualAccountsForLoan.INCOME_FROM_BUY_DOWN.getValue(),
+                            AccrualAccountsForLoan.INCOME_FROM_BUY_DOWN.toString(), changes);
+                }
 
                 // expenses
                 mergeLoanToExpenseAccountMappingChanges(element, LoanProductAccountingParams.LOSSES_WRITTEN_OFF.getValue(), loanProductId,
@@ -384,15 +395,26 @@ public class LoanProductToGLAccountMappingHelper extends ProductToGLAccountMappi
                 mergeLoanToExpenseAccountMappingChanges(element, LoanProductAccountingParams.CHARGE_OFF_FRAUD_EXPENSE.getValue(),
                         loanProductId, AccrualAccountsForLoan.CHARGE_OFF_FRAUD_EXPENSE.getValue(),
                         AccrualAccountsForLoan.CHARGE_OFF_FRAUD_EXPENSE.toString(), changes);
-                mergeLoanToExpenseAccountMappingChanges(element, LoanProductAccountingParams.BUY_DOWN_EXPENSE.getValue(), loanProductId,
-                        AccrualAccountsForLoan.BUY_DOWN_EXPENSE.getValue(), AccrualAccountsForLoan.BUY_DOWN_EXPENSE.toString(), changes);
+                if (!enableBuyDownFee) {
+                    deleteProductToGLAccountMapping(loanProductId, PortfolioProductType.LOAN,
+                            AccrualAccountsForLoan.BUY_DOWN_EXPENSE.getValue());
+                } else {
+                    mergeLoanToExpenseAccountMappingChanges(element, LoanProductAccountingParams.BUY_DOWN_EXPENSE.getValue(), loanProductId,
+                            AccrualAccountsForLoan.BUY_DOWN_EXPENSE.getValue(), AccrualAccountsForLoan.BUY_DOWN_EXPENSE.toString(),
+                            changes);
+                }
 
                 // liabilities
                 mergeLoanToLiabilityAccountMappingChanges(element, LoanProductAccountingParams.OVERPAYMENT.getValue(), loanProductId,
                         CashAccountsForLoan.OVERPAYMENT.getValue(), CashAccountsForLoan.OVERPAYMENT.toString(), changes);
-                mergeLoanToLiabilityAccountMappingChanges(element, LoanProductAccountingParams.DEFERRED_INCOME_LIABILITY.getValue(),
-                        loanProductId, AccrualAccountsForLoan.DEFERRED_INCOME_LIABILITY.getValue(),
-                        AccrualAccountsForLoan.DEFERRED_INCOME_LIABILITY.toString(), changes);
+                if (!enableBuyDownFee && !enableIncomeCapitalization) {
+                    deleteProductToGLAccountMapping(loanProductId, PortfolioProductType.LOAN,
+                            AccrualAccountsForLoan.DEFERRED_INCOME_LIABILITY.getValue());
+                } else {
+                    mergeLoanToLiabilityAccountMappingChanges(element, LoanProductAccountingParams.DEFERRED_INCOME_LIABILITY.getValue(),
+                            loanProductId, AccrualAccountsForLoan.DEFERRED_INCOME_LIABILITY.getValue(),
+                            AccrualAccountsForLoan.DEFERRED_INCOME_LIABILITY.toString(), changes);
+                }
             break;
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/productaccountmapping/service/ProductToGLAccountMappingWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/productaccountmapping/service/ProductToGLAccountMappingWritePlatformServiceImpl.java
@@ -369,7 +369,8 @@ public class ProductToGLAccountMappingWritePlatformServiceImpl implements Produc
     @Override
     @Transactional
     public Map<String, Object> updateLoanProductToGLAccountMapping(final Long loanProductId, final JsonCommand command,
-            final boolean accountingRuleChanged, final AccountingRuleType accountingRuleType) {
+            final boolean accountingRuleChanged, final AccountingRuleType accountingRuleType, final boolean enableIncomeCapitalization,
+            final boolean enableBuyDownFee) {
         /***
          * Variable tracks all accounting mapping properties that have been updated
          ***/
@@ -389,7 +390,7 @@ public class ProductToGLAccountMappingWritePlatformServiceImpl implements Produc
         } /*** else examine and update individual changes ***/
         else {
             this.loanProductToGLAccountMappingHelper.handleChangesToLoanProductToGLAccountMappings(loanProductId, changes, element,
-                    accountingRuleType);
+                    accountingRuleType, enableIncomeCapitalization, enableBuyDownFee);
             this.loanProductToGLAccountMappingHelper.updatePaymentChannelToFundSourceMappings(command, element, loanProductId, changes);
             this.loanProductToGLAccountMappingHelper.updateChargesToIncomeAccountMappings(command, element, loanProductId, changes);
             this.loanProductToGLAccountMappingHelper.updateChargeOffReasonToExpenseAccountMappings(command, element, loanProductId,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
@@ -258,10 +258,20 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
                 }
             }
 
+            boolean enableIncomeCapitalization = product.getLoanProductRelatedDetail().isEnableIncomeCapitalization();
+            if (changes.containsKey(LoanProductConstants.ENABLE_INCOME_CAPITALIZATION_PARAM_NAME)) {
+                enableIncomeCapitalization = (boolean) changes.get(LoanProductConstants.ENABLE_INCOME_CAPITALIZATION_PARAM_NAME);
+            }
+            boolean enableBuyDownFee = product.getLoanProductRelatedDetail().isEnableBuyDownFee();
+            if (changes.containsKey(LoanProductConstants.ENABLE_BUY_DOWN_FEE_PARAM_NAME)) {
+                enableBuyDownFee = (boolean) changes.get(LoanProductConstants.ENABLE_BUY_DOWN_FEE_PARAM_NAME);
+            }
+
             // accounting related changes
             final boolean accountingTypeChanged = changes.containsKey("accountingRule");
             final Map<String, Object> accountingMappingChanges = this.accountMappingWritePlatformService
-                    .updateLoanProductToGLAccountMapping(product.getId(), command, accountingTypeChanged, product.getAccountingRule());
+                    .updateLoanProductToGLAccountMapping(product.getId(), command, accountingTypeChanged, product.getAccountingRule(),
+                            enableIncomeCapitalization, enableBuyDownFee);
             changes.putAll(accountingMappingChanges);
 
             if (changes.containsKey(LoanProductConstants.RATES_PARAM_NAME)) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductTest.java
@@ -156,13 +156,12 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getCapitalizedIncomeType().getCode());
 
             loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
-                    new PutLoanProductsProductIdRequest().enableIncomeCapitalization(false)
+                    new PutLoanProductsProductIdRequest()
                             .incomeFromCapitalizationAccountId(interestIncomeAccount.getAccountID().longValue())
                             .capitalizedIncomeType(PutLoanProductsProductIdRequest.CapitalizedIncomeTypeEnum.INTEREST));
-
-            final GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
+            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
                     .retrieveLoanProductById(loanProductsResponse.getResourceId());
-            Assertions.assertEquals(Boolean.FALSE, updatedLoanProductsProductIdResponse.getEnableIncomeCapitalization());
+            Assertions.assertEquals(Boolean.TRUE, updatedLoanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getCapitalizedIncomeCalculationType());
             Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
                     updatedLoanProductsProductIdResponse.getCapitalizedIncomeCalculationType().getCode());
@@ -172,6 +171,14 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
             Assertions.assertEquals(interestIncomeAccount.getAccountID().longValue(),
                     updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromCapitalizationAccount().getId());
+
+            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
+                    new PutLoanProductsProductIdRequest().enableIncomeCapitalization(false));
+
+            updatedLoanProductsProductIdResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
+            Assertions.assertEquals(Boolean.FALSE, updatedLoanProductsProductIdResponse.getEnableIncomeCapitalization());
+            Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
+            Assertions.assertNull(updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromCapitalizationAccount());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getCapitalizedIncomeType());
             Assertions.assertEquals(LoanCapitalizedIncomeType.INTEREST.getCode(),
                     updatedLoanProductsProductIdResponse.getCapitalizedIncomeType().getCode());
@@ -355,12 +362,28 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount().getId());
 
             loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
-                    new PutLoanProductsProductIdRequest().enableBuyDownFee(false)
+                    new PutLoanProductsProductIdRequest()
                             .buyDownFeeIncomeType(PutLoanProductsProductIdRequest.BuyDownFeeIncomeTypeEnum.INTEREST)
                             .incomeFromBuyDownAccountId(interestIncomeAccount.getAccountID().longValue()));
 
-            final GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
+            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
                     .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            Assertions.assertEquals(Boolean.TRUE, updatedLoanProductsProductIdResponse.getEnableBuyDownFee());
+            Assertions.assertEquals(LoanBuyDownFeeStrategy.EQUAL_AMORTIZATION.getCode(),
+                    updatedLoanProductsProductIdResponse.getBuyDownFeeStrategy().getCode());
+            Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getBuyDownFeeIncomeType());
+            Assertions.assertEquals(LoanBuyDownFeeIncomeType.INTEREST.getCode(),
+                    updatedLoanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
+            Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
+            Assertions.assertEquals(buyDownExpenseAccount.getAccountID().longValue(),
+                    updatedLoanProductsProductIdResponse.getAccountingMappings().getBuyDownExpenseAccount().getId());
+            Assertions.assertEquals(interestIncomeAccount.getAccountID().longValue(),
+                    updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount().getId());
+
+            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
+                    new PutLoanProductsProductIdRequest().enableBuyDownFee(false));
+
+            updatedLoanProductsProductIdResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
             Assertions.assertEquals(Boolean.FALSE, updatedLoanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getBuyDownFeeCalculationType());
             Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(),
@@ -369,14 +392,9 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(LoanBuyDownFeeStrategy.EQUAL_AMORTIZATION.getCode(),
                     updatedLoanProductsProductIdResponse.getBuyDownFeeStrategy().getCode());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getBuyDownFeeIncomeType());
-            Assertions.assertEquals(LoanBuyDownFeeIncomeType.INTEREST.getCode(),
-                    updatedLoanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
-
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
-            Assertions.assertEquals(buyDownExpenseAccount.getAccountID().longValue(),
-                    updatedLoanProductsProductIdResponse.getAccountingMappings().getBuyDownExpenseAccount().getId());
-            Assertions.assertEquals(interestIncomeAccount.getAccountID().longValue(),
-                    updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount().getId());
+            Assertions.assertNull(updatedLoanProductsProductIdResponse.getAccountingMappings().getBuyDownExpenseAccount());
+            Assertions.assertNull(updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount());
         }
 
         @Test


### PR DESCRIPTION
… displayed on loan product after feature disabled

## Description

Capitalized Income and Buy Down Fees accounting values are still displayed on loan product after feature disabled. This was because when those features are disabled and exist a previous glaccount mapping(s) those were not being deleted

[FINERACT-2181](https://issues.apache.org/jira/browse/FINERACT-2181)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
