### PR TITLE
FINERACT-2232: Capitalized Income - Fetch amortization details

### DIFF
--- a/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
+++ b/fineract-client/src/main/java/org/apache/fineract/client/util/FineractClient.java
@@ -88,6 +88,7 @@ import org.apache.fineract.client.services.LoanAccountLockApi;
 import org.apache.fineract.client.services.LoanChargesApi;
 import org.apache.fineract.client.services.LoanCobCatchUpApi;
 import org.apache.fineract.client.services.LoanCollateralApi;
+import org.apache.fineract.client.services.LoanDeferredIncomeDataApi;
 import org.apache.fineract.client.services.LoanDisbursementDetailsApi;
 import org.apache.fineract.client.services.LoanInterestPauseApi;
 import org.apache.fineract.client.services.LoanProductsApi;
@@ -230,6 +231,7 @@ public final class FineractClient {
     public final LoanChargesApi loanCharges;
     public final LoanCobCatchUpApi loanCobCatchUpApi;
     public final LoanCollateralApi loanCollaterals;
+    public final LoanDeferredIncomeDataApi loanDeferredIncome;
     public final LoanProductsApi loanProducts;
     public final LoanReschedulingApi loanSchedules;
     public final LoansPointInTimeApi loansPointInTimeApi;
@@ -359,6 +361,7 @@ public final class FineractClient {
         loanCharges = retrofit.create(LoanChargesApi.class);
         loanCobCatchUpApi = retrofit.create(LoanCobCatchUpApi.class);
         loanCollaterals = retrofit.create(LoanCollateralApi.class);
+        loanDeferredIncome = retrofit.create(LoanDeferredIncomeDataApi.class);
         loanProducts = retrofit.create(LoanProductsApi.class);
         loanSchedules = retrofit.create(LoanReschedulingApi.class);
         loansPointInTimeApi = retrofit.create(LoansPointInTimeApi.class);

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
@@ -268,4 +268,7 @@ public interface LoanRepository extends JpaRepository<Loan, Long>, JpaSpecificat
 
     @Query(FIND_LOAN_BY_EXTERNAL_ID)
     Optional<Loan> findByExternalId(@Param("externalId") ExternalId externalId);
+
+    @Query("select loan.loanRepaymentScheduleDetail.enableIncomeCapitalization from Loan loan where loan.id = :loanId")
+    Boolean isEnabledCapitalizedIncome(Long loanId);
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
@@ -309,4 +309,8 @@ public class LoanRepositoryWrapper {
     public boolean existsByLoanId(Long loanId) {
         return repository.existsById(loanId);
     }
+
+    public boolean isEnabledCapitalizedIncome(Long loanId) {
+        return repository.isEnabledCapitalizedIncome(loanId);
+    }
 }

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanDeferredIncomeApiResource.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanDeferredIncomeApiResource.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.loanaccount.data.LoanDeferredIncomeData;
+import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomeBalanceReadService;
+import org.springframework.stereotype.Component;
+
+@Path("/v1/loans/{loanId}/deferredincome")
+@Component
+@Tag(name = "Loan Deferred Income data", description = "Loan deferred income like Capitalized Income to fetch the Deferred Income related informations")
+@RequiredArgsConstructor
+public class LoanDeferredIncomeApiResource {
+
+    private static final String RESOURCE_NAME_FOR_PERMISSIONS = "LOAN";
+    private final PlatformSecurityContext context;
+    private final CapitalizedIncomeBalanceReadService capitalizedIncomeBalanceReadService;
+
+    @GET
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Fetch the Capitalized Income related informations")
+    public LoanDeferredIncomeData fetchDeferredIncomeDetails(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
+            @Context final UriInfo uriInfo) {
+        this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+
+        return capitalizedIncomeBalanceReadService.fetchLoanDeferredIncomeData(loanId);
+    }
+
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/CapitalizedIncomeDetails.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/CapitalizedIncomeDetails.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.data;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@ToString
+@Getter
+@Setter
+public class CapitalizedIncomeDetails {
+
+    private BigDecimal amount;
+    private BigDecimal amortizedAmount;
+    private BigDecimal unrecognizedAmount;
+    private BigDecimal amountAdjustment;
+    private BigDecimal chargedOffAmount;
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanDeferredIncomeData.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanDeferredIncomeData.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.data;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Getter
+@Setter
+public class LoanDeferredIncomeData {
+
+    private List<CapitalizedIncomeDetails> capitalizedIncomeData;
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeBalanceReadService.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeBalanceReadService.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.service;
+
+import org.apache.fineract.portfolio.loanaccount.data.LoanDeferredIncomeData;
+
+public interface CapitalizedIncomeBalanceReadService {
+
+    LoanDeferredIncomeData fetchLoanDeferredIncomeData(Long loanId);
+
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeBalanceReadServiceImpl.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/CapitalizedIncomeBalanceReadServiceImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.service.MathUtil;
+import org.apache.fineract.portfolio.loanaccount.data.CapitalizedIncomeDetails;
+import org.apache.fineract.portfolio.loanaccount.data.LoanDeferredIncomeData;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanCapitalizedIncomeBalance;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.repository.LoanCapitalizedIncomeBalanceRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class CapitalizedIncomeBalanceReadServiceImpl implements CapitalizedIncomeBalanceReadService {
+
+    private final LoanRepositoryWrapper loanRepository;
+    private final LoanCapitalizedIncomeBalanceRepository capitalizedIncomeBalanceRepository;
+
+    @Override
+    @Transactional
+    public LoanDeferredIncomeData fetchLoanDeferredIncomeData(final Long loanId) {
+        if (loanRepository.isEnabledCapitalizedIncome(loanId)) {
+
+            List<CapitalizedIncomeDetails> capitalizedIncomeData = new ArrayList<>();
+            List<LoanCapitalizedIncomeBalance> capitalizedIncomeBalances = capitalizedIncomeBalanceRepository.findAllByLoanId(loanId);
+            for (final LoanCapitalizedIncomeBalance capitalizedIncomeBalance : capitalizedIncomeBalances) {
+                final BigDecimal amortizedAmount = capitalizedIncomeBalance.getAmount() //
+                        .subtract(MathUtil.nullToZero(capitalizedIncomeBalance.getUnrecognizedAmount())) //
+                        .subtract(MathUtil.nullToZero(capitalizedIncomeBalance.getAmountAdjustment())) //
+                        .subtract(MathUtil.nullToZero(capitalizedIncomeBalance.getChargedOffAmount()));
+
+                capitalizedIncomeData.add(new CapitalizedIncomeDetails(capitalizedIncomeBalance.getAmount(), amortizedAmount,
+                        capitalizedIncomeBalance.getUnrecognizedAmount(), //
+                        capitalizedIncomeBalance.getAmountAdjustment(), //
+                        capitalizedIncomeBalance.getChargedOffAmount()));
+            }
+
+            return new LoanDeferredIncomeData(capitalizedIncomeData);
+        }
+        throw new GeneralPlatformDomainRuleException("error.msg.loan.is.not.enabled.capitalized.income",
+                "Loan: " + loanId + " is not enabled Capitalized Income feature", loanId);
+    }
+
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/ProgressiveLoanAccountConfiguration.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/ProgressiveLoanAccountConfiguration.java
@@ -27,6 +27,8 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepositor
 import org.apache.fineract.portfolio.loanaccount.repository.LoanBuyDownFeeBalanceRepository;
 import org.apache.fineract.portfolio.loanaccount.repository.LoanCapitalizedIncomeBalanceRepository;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanTransactionValidator;
+import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomeBalanceReadService;
+import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomeBalanceReadServiceImpl;
 import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomeBalanceService;
 import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomeBalanceServiceImpl;
 import org.apache.fineract.portfolio.loanaccount.service.CapitalizedIncomePlatformService;
@@ -76,5 +78,12 @@ public class ProgressiveLoanAccountConfiguration {
     public CapitalizedIncomeBalanceService capitalizedIncomeBalanceService(
             LoanCapitalizedIncomeBalanceRepository loanCapitalizedIncomeBalanceRepository) {
         return new CapitalizedIncomeBalanceServiceImpl(loanCapitalizedIncomeBalanceRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CapitalizedIncomeBalanceReadService.class)
+    public CapitalizedIncomeBalanceReadService capitalizedIncomeBalanceReadService(LoanRepositoryWrapper loanRepository,
+            LoanCapitalizedIncomeBalanceRepository loanCapitalizedIncomeBalanceRepository) {
+        return new CapitalizedIncomeBalanceReadServiceImpl(loanRepository, loanCapitalizedIncomeBalanceRepository);
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -68,6 +68,7 @@ import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateRespo
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.GetLoansResponse;
 import org.apache.fineract.client.models.InterestPauseRequestDto;
+import org.apache.fineract.client.models.LoanDeferredIncomeData;
 import org.apache.fineract.client.models.PaymentTypeData;
 import org.apache.fineract.client.models.PostAddAndDeleteDisbursementDetailRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
@@ -3044,6 +3045,10 @@ public class LoanTransactionHelper {
     public PostLoansLoanIdTransactionsResponse undoChargeOffLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         return Calls
                 .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "undo-charge-off"));
+    }
+
+    public LoanDeferredIncomeData fetchDeferredIncomeDetails(Long loanId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().loanDeferredIncome.fetchDeferredIncomeDetails(loanId));
     }
 
     // TODO: Rewrite to use fineract-client instead!


### PR DESCRIPTION
## Description

We should have an API via we can fetch the Capitalized Income related informations:

- Capitalized income amount
- Amortized amount
- Not yet amortized amount
- Adjusted amount

[FINERACT-2232](https://issues.apache.org/jira/browse/FINERACT-2232)

<img width="682" height="510" alt="Screenshot 2025-07-16 at 7 58 03 a m" src="https://github.com/user-attachments/assets/e83583e0-62e7-49af-ad08-98367e6e8706" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
