### PR TITLE
WEALTHFRONT-1234: Add month and day filter to GET savingsaccounts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,15 @@
  */
 // TODO: this is work in progress, please follow FINERACT-1171
 buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'com.burgstaller' && details.requested.name == 'okhttp-digest' && details.requested.version == '1.10') {
+                details.useTarget "io.github.rburgst:${details.requested.name}:1.21"
+                details.because 'Dependency has moved'
+            }
+        }
+    }
+
     ext {
         jacocoVersion = '0.8.10'
         retrofitVersion = '2.9.0'

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
@@ -50,6 +50,10 @@ public final class SearchParameters {
     private final Long categoryId;
     private final boolean isSelfUser;
 
+    // Birthday search params
+    private final Integer birthMonth;
+    private final Integer birthDay;
+
     public static SearchParameters from(final String sqlSearch, final Long officeId, final String externalId, final String name,
             final String hierarchy) {
         final Long staffId = null;
@@ -181,9 +185,9 @@ public final class SearchParameters {
         return new SearchParameters(provisioningEntryId, officeId, productId, categoryId, offset, limit);
     }
 
+    // Updated method with birthday parameters
     public static SearchParameters forSavings(final String sqlSearch, final String externalId, final Integer offset, final Integer limit,
-            final String orderBy, final String sortOrder) {
-
+            final String orderBy, final String sortOrder, final Integer birthMonth, final Integer birthDay) {
         final Integer maxLimitAllowed = getCheckedLimit(limit);
         final Long staffId = null;
         final String accountNo = null;
@@ -192,8 +196,14 @@ public final class SearchParameters {
         final Boolean orphansOnly = false;
         final boolean isSelfUser = false;
 
-        return new SearchParameters(sqlSearch, null, externalId, null, null, null, null, offset, maxLimitAllowed, orderBy, sortOrder,
-                staffId, accountNo, loanId, savingsId, orphansOnly, isSelfUser);
+        return new SearchParameters(sqlSearch, null, externalId, null, null, null, null, null, offset, maxLimitAllowed, orderBy, sortOrder,
+                staffId, accountNo, null, loanId, savingsId, orphansOnly, null, null, null, isSelfUser, birthMonth, birthDay);
+    }
+
+    // Create an overloaded method to maintain backward compatibility
+    public static SearchParameters forSavings(final String sqlSearch, final String externalId, final Integer offset, final Integer limit,
+            final String orderBy, final String sortOrder) {
+        return forSavings(sqlSearch, externalId, offset, limit, orderBy, sortOrder, null, null);
     }
 
     public static SearchParameters forAccountTransfer(final String sqlSearch, final String externalId, final Integer offset,
@@ -269,7 +279,8 @@ public final class SearchParameters {
         this.categoryId = null;
         this.isSelfUser = isSelfUser;
         this.status = null;
-
+        this.birthDay = null;
+        this.birthMonth = null;
     }
 
     private SearchParameters(final String sqlSearch, final Long officeId, final String externalId, final String name,
@@ -298,7 +309,8 @@ public final class SearchParameters {
         this.categoryId = null;
         this.isSelfUser = isSelfUser;
         this.status = status;
-
+        this.birthDay = null;
+        this.birthMonth = null;
     }
 
     private SearchParameters(final Long officeId, final String externalId, final String name, final String hierarchy,
@@ -327,6 +339,8 @@ public final class SearchParameters {
         this.categoryId = null;
         this.isSelfUser = isSelfUser;
         this.status = null;
+        this.birthDay = null;
+        this.birthMonth = null;
     }
 
     private SearchParameters(final Long provisioningEntryId, final Long officeId, final Long productId, final Long categoryId,
@@ -353,7 +367,8 @@ public final class SearchParameters {
         this.categoryId = categoryId;
         this.isSelfUser = false;
         this.status = null;
-
+        this.birthDay = null;
+        this.birthMonth = null;
     }
 
     public SearchParameters(final String sqlSearch, final Long officeId, final String externalId, final String name, final String hierarchy,
@@ -382,7 +397,54 @@ public final class SearchParameters {
         this.categoryId = null;
         this.isSelfUser = false;
         this.status = null;
+        this.birthDay = null;
+        this.birthMonth = null;
+    }
 
+    // Updated constructor to include birthMonth and birthDay
+    private SearchParameters(final String sqlSearch, final Long officeId, final String externalId, final String name,
+            final String hierarchy, final String firstname, final String lastname, final String status, final Integer offset,
+            final Integer limit, final String orderBy, final String sortOrder, final Long staffId, final String accountNo,
+            final String currencyCode, final Long loanId, final Long savingsId, final Boolean orphansOnly, final Long provisioningEntryId,
+            final Long productId, final Long categoryId, final boolean isSelfUser, final Integer birthMonth, final Integer birthDay) {
+        this.sqlSearch = sqlSearch;
+        this.officeId = officeId;
+        this.externalId = externalId;
+        this.name = name;
+        this.hierarchy = hierarchy;
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.status = status;
+        this.offset = offset;
+        this.limit = limit;
+        this.orderBy = orderBy;
+        this.sortOrder = sortOrder;
+        this.staffId = staffId;
+        this.accountNo = accountNo;
+        this.currencyCode = currencyCode;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.orphansOnly = orphansOnly;
+        this.provisioningEntryId = provisioningEntryId;
+        this.productId = productId;
+        this.categoryId = categoryId;
+        this.isSelfUser = isSelfUser;
+        this.birthMonth = birthMonth;
+        this.birthDay = birthDay;
+    }
+
+    // Add getters for the birthday fields
+    public Integer getBirthMonth() {
+        return this.birthMonth;
+    }
+
+    public Integer getBirthDay() {
+        return this.birthDay;
+    }
+
+    // Include hasBirthdayFilter convenience method
+    public boolean hasBirthdayFilter() {
+        return this.birthMonth != null || this.birthDay != null;
     }
 
     public boolean isOrderByRequested() {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
@@ -128,13 +128,16 @@ public class SavingsAccountsApiResource {
             @QueryParam("offset") @Parameter(description = "offset") final Integer offset,
             @QueryParam("limit") @Parameter(description = "limit") final Integer limit,
             @QueryParam("orderBy") @Parameter(description = "orderBy") final String orderBy,
-            @QueryParam("sortOrder") @Parameter(description = "sortOrder") final String sortOrder) {
+            @QueryParam("sortOrder") @Parameter(description = "sortOrder") final String sortOrder,
+            @QueryParam("month") @Parameter(description = "month") final Integer month,
+            @QueryParam("day") @Parameter(description = "day") final Integer day) {
 
         context.authenticatedUser().validateHasReadPermission(SavingsApiConstants.SAVINGS_ACCOUNT_RESOURCE_NAME);
 
-        final SearchParameters searchParameters = SearchParameters.forSavings(sqlSearch, externalId, offset, limit, orderBy, sortOrder);
+        final SearchParameters searchParameters = SearchParameters.forSavings(sqlSearch, externalId, offset, limit, orderBy, sortOrder,
+                month, day);
 
-        final Page<SavingsAccountData> products = savingsAccountReadPlatformService.retrieveAll(searchParameters);
+        final Page<SavingsAccountData> products = savingsAccountReadPlatformService.retrieveAllByBirthday(searchParameters);
 
         final ApiRequestJsonSerializationSettings settings = apiRequestParameterHelper.process(uriInfo.getQueryParameters());
         return toApiJsonSerializer.serialize(settings, products, SavingsApiSetConstants.SAVINGS_ACCOUNT_RESPONSE_DATA_PARAMETERS);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformService.java
@@ -31,6 +31,8 @@ public interface SavingsAccountReadPlatformService {
 
     Page<SavingsAccountData> retrieveAll(SearchParameters searchParameters);
 
+    Page<SavingsAccountData> retrieveAllByBirthday(SearchParameters searchParameters);
+
     Collection<SavingsAccountData> retrieveAllForLookup(Long clientId);
 
     Collection<SavingsAccountData> retrieveActiveForLookup(Long clientId, DepositAccountType depositAccountType);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -237,6 +237,78 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
     }
 
     @Override
+    public Page<SavingsAccountData> retrieveAllByBirthday(SearchParameters searchParameters) {
+        final AppUser currentUser = this.context.authenticatedUser();
+        final String hierarchy = currentUser.getOffice().getHierarchy();
+        final String hierarchySearchString = hierarchy + "%";
+
+        final StringBuilder sqlBuilder = new StringBuilder(200);
+        sqlBuilder.append("select " + sqlGenerator.calcFoundRows() + " ");
+        sqlBuilder.append(this.savingAccountMapper.schema());
+
+        sqlBuilder.append(" join m_office o on o.id = c.office_id");
+        sqlBuilder.append(" where o.hierarchy like ?");
+
+        // Add two params
+        final Object[] objectArray = new Object[4];
+        objectArray[0] = hierarchySearchString;
+        int arrayPos = 1;
+
+        if (searchParameters != null) {
+            String sqlQueryCriteria = searchParameters.getSqlSearch();
+            if (StringUtils.isNotBlank(sqlQueryCriteria)) {
+                sqlQueryCriteria = sqlQueryCriteria.replaceAll("accountNo", "sa.account_no");
+                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), sqlQueryCriteria);
+                sqlBuilder.append(" and (").append(sqlQueryCriteria).append(")");
+            }
+
+            if (StringUtils.isNotBlank(searchParameters.getExternalId())) {
+                sqlBuilder.append(" and sa.external_id = ?");
+                objectArray[arrayPos] = searchParameters.getExternalId();
+                arrayPos = arrayPos + 1;
+            }
+            if (searchParameters.getOfficeId() != null) {
+                sqlBuilder.append(" and c.office_id = ?");
+                objectArray[arrayPos] = searchParameters.getOfficeId();
+                arrayPos = arrayPos + 1;
+            }
+
+            // Add birthday filters BEFORE ORDER BY and LIMIT
+            if (searchParameters.getBirthMonth() != null) {
+                sqlBuilder.append(" and MONTH(c.date_of_birth) = ?");
+                objectArray[arrayPos++] = searchParameters.getBirthMonth();
+            }
+            if (searchParameters.getBirthDay() != null) {
+                sqlBuilder.append(" and DAY(c.date_of_birth) = ?");
+                objectArray[arrayPos++] = searchParameters.getBirthDay();
+            }
+
+            // Add ORDER BY and LIMIT after all WHERE conditions
+            if (searchParameters.isOrderByRequested()) {
+                sqlBuilder.append(" order by ").append(searchParameters.getOrderBy());
+                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getOrderBy());
+
+                if (searchParameters.isSortOrderProvided()) {
+                    sqlBuilder.append(' ').append(searchParameters.getSortOrder());
+                    this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getSortOrder());
+                }
+            }
+
+            if (searchParameters.isLimited()) {
+                sqlBuilder.append(" ");
+                if (searchParameters.isOffset()) {
+                    sqlBuilder.append(sqlGenerator.limit(searchParameters.getLimit(), searchParameters.getOffset()));
+                } else {
+                    sqlBuilder.append(sqlGenerator.limit(searchParameters.getLimit()));
+                }
+            }
+        }
+
+        final Object[] finalObjectArray = Arrays.copyOf(objectArray, arrayPos);
+        return this.paginationHelper.fetchPage(this.jdbcTemplate, sqlBuilder.toString(), finalObjectArray, this.savingAccountMapper);
+    }
+
+    @Override
     public SavingsAccountData retrieveOne(final Long accountId) {
 
         try {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.fineract.client.models.GetSavingsAccountsResponse;
 import org.apache.fineract.client.models.PostSavingsAccountsAccountIdRequest;
 import org.apache.fineract.client.models.PostSavingsAccountsAccountIdResponse;
 import org.apache.fineract.client.models.PostSavingsAccountsRequest;
@@ -37,7 +38,7 @@ import retrofit2.Response;
  * @author Danish Jamal
  *
  */
-public class SavingsAccountsTest extends IntegrationTest {
+class SavingsAccountsTest extends IntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavingsAccountsTest.class);
     private final String dateFormat = "dd MMMM yyyy";
@@ -94,4 +95,41 @@ public class SavingsAccountsTest extends IntegrationTest {
         assertThat(response.body()).isNotNull();
     }
 
+    @Test
+    @Order(4)
+    void retrieveSavingsAccountsByBirthday_Success() {
+        LOG.info("------------------------------ RETRIEVE SAVINGS ACCOUNTS BY BIRTHDAY -----------------------------");
+
+        // This test assumes test data already exists
+        int month = 4;
+        int day = 3;
+
+        Response<GetSavingsAccountsResponse> response = okR(
+                fineract().savingsAccounts.retrieveAll33(null, null, 0, 10, null, null, month, day));
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNotNull();
+        assertThat(response.body().getPageItems()).isNotEmpty();
+
+        response.body().getPageItems().forEach(account -> {
+            LOG.info("Savings Account ID: {}, Client: {}", account.getId(), account.getClientName());
+        });
+    }
+
+    @Test
+    @Order(4)
+    void retrieveSavingsAccountsByBirthday_EmptySet() {
+        LOG.info("------------------------------ RETRIEVE SAVINGS ACCOUNTS BY BIRTHDAY -----------------------------");
+
+        // Data does not exist for these dates
+        int month = 13;
+        int day = 32;
+
+        Response<GetSavingsAccountsResponse> response = okR(
+                fineract().savingsAccounts.retrieveAll33(null, null, 0, 10, null, null, month, day));
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNotNull();
+        assertThat(response.body().getPageItems()).isEmpty();
+    }
 }


### PR DESCRIPTION
## 🚀 Feature: Add Birthday Filter to Savings Accounts Endpoint

**JIRA Ticket**: WEALTHFRONT-1234  
**Summary**:  
This PR introduces support for filtering savings accounts by client birthdays using `month` and `day` query parameters on the `GET /savingsaccounts` endpoint. This feature lays the groundwork for future automation efforts like birthday email campaigns.

---

### ✨ Changes Overview

#### 🔧 API Enhancements
- Extended `GET /savingsaccounts` to accept optional `month` and `day` query parameters.
- Introduced a new `retrieveAllByBirthday` method in `SavingsAccountReadPlatformService`.

#### 📦 Core
- Enhanced `SearchParameters`:
  - Added `birthMonth` and `birthDay` fields.
  - Included overloads and helper methods for backward compatibility.

#### 📊 Service Implementation
- In `SavingsAccountReadPlatformServiceImpl`, added logic to:
  - Append `MONTH(c.date_of_birth)` and `DAY(c.date_of_birth)` to SQL queries conditionally.
  - Maintain existing filtering behavior while optionally scoping results to birthday filters.

#### ✅ Tests
- Added integration test: `retrieveSavingsAccountsByBirthday_Success`
  - Validates correct results for existing birthday records.
- Added negative test: `retrieveSavingsAccountsByBirthday_EmptySet`
  - Ensures no accounts are returned when no clients match the given birthday.

#### 🧹 Misc
- Updated `build.gradle` with dependency resolution override for `okhttp-digest`.
---

### 🔍 Validation
- ✅ Manual test with test data containing birthdays returned expected accounts.
- ✅ Verified results were correctly filtered at the SQL level.
- ✅ Regression tested `/savingsaccounts` without birthday filters for compatibility.
---

### 📌 Notes
- This implementation supports **partial** birthday filtering — month-only or day-only queries are also valid.
- Next steps may include exposing this data on the UI dashboard and setting up background email notifications.
