### PR TITLE
FINERACT-2311: Buy Down fees - Reversal of existing transaction

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/ErrorMessageHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/ErrorMessageHelper.java
@@ -179,6 +179,11 @@ public final class ErrorMessageHelper {
         return "Capitalized income transaction cannot be reversed when non-reversed adjustment exists for it.";
     }
 
+    public static String buyDownFeeUndoFailureAdjustmentExists(Long loanId) {
+        String loanIdStr = String.valueOf(loanId);
+        return String.format("Undo Loan Transaction: %s is not allowed. Loan transaction has not reversed transaction related", loanIdStr);
+    }
+
     public static String wrongAmountInRepaymentSchedule(int line, BigDecimal actual, BigDecimal expected) {
         String lineToStr = String.valueOf(line);
         String actualToStr = actual.toString();

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRepaymentStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRepaymentStepDef.java
@@ -538,7 +538,13 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
 
         Response<PostLoansLoanIdTransactionsResponse> transactionUndoResponse = loanTransactionsApi
                 .adjustLoanTransaction(loanId, targetTransaction.getId(), transactionUndoRequest, "").execute();
-        checkMakeTransactionForbidden(transactionUndoResponse, 403, ErrorMessageHelper.addCapitalizedIncomeUndoFailureAdjustmentExists());
+        if (transactionType.equals("Buy Down Fee")) {
+            checkMakeTransactionForbidden(transactionUndoResponse, 403,
+                    ErrorMessageHelper.buyDownFeeUndoFailureAdjustmentExists(targetTransaction.getId()));
+        } else if (transactionType.equals("Capitalized Income")) {
+            checkMakeTransactionForbidden(transactionUndoResponse, 403,
+                    ErrorMessageHelper.addCapitalizedIncomeUndoFailureAdjustmentExists());
+        }
     }
 
     @When("Customer undo {string}th {string} transaction made on {string} with linked {string} transaction")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
@@ -707,6 +707,10 @@ public class LoanTransaction extends AbstractAuditableWithUTCDateTimeCustom<Long
         return LoanTransactionType.CAPITALIZED_INCOME.equals(getTypeOf()) && isNotReversed();
     }
 
+    public boolean isDeferredIncome() {
+        return isCapitalizedIncome() || isBuyDownFee();
+    }
+
     public boolean isCapitalizedIncomeAmortization() {
         return LoanTransactionType.CAPITALIZED_INCOME_AMORTIZATION.equals(getTypeOf()) && isNotReversed();
     }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionRelationRepository.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionRelationRepository.java
@@ -20,8 +20,17 @@ package org.apache.fineract.portfolio.loanaccount.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LoanTransactionRelationRepository
         extends JpaRepository<LoanTransactionRelation, Long>, JpaSpecificationExecutor<LoanTransactionRelation> {
+
+    @Query("""
+            SELECT CASE WHEN COUNT(ltr) > 0 THEN true ELSE false END
+            FROM LoanTransactionRelation ltr
+            WHERE ltr.toTransaction = :toTransaction AND ltr.relationType = :relationType
+              AND ltr.fromTransaction.reversed = false
+            """)
+    boolean hasLoanTransactionRelationsWithType(LoanTransaction toTransaction, LoanTransactionRelationTypeEnum relationType);
 
 }

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/BuyDownFeePlatformService.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/BuyDownFeePlatformService.java
@@ -18,8 +18,10 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
+import java.util.Optional;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface BuyDownFeePlatformService {
@@ -29,4 +31,7 @@ public interface BuyDownFeePlatformService {
 
     @Transactional
     CommandProcessingResult buyDownFeeAdjustment(Long loanId, Long buyDownFeeTransactionId, JsonCommand command);
+
+    @Transactional
+    Optional<LoanTransaction> reverseBuyDownFee(LoanTransaction buyDownFeeTransaction);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
@@ -393,11 +393,12 @@ public class LoanAccountConfiguration {
             NoteWritePlatformService noteWritePlatformService, ExternalIdFactory externalIdFactory,
             LoanBuyDownFeeBalanceRepository loanBuyDownFeeBalanceRepository,
             ReprocessLoanTransactionsService reprocessLoanTransactionsService, LoanBalanceService loanBalanceService,
-            LoanLifecycleStateMachine loanLifecycleStateMachine, BusinessEventNotifierService businessEventNotifierService) {
+            LoanLifecycleStateMachine loanLifecycleStateMachine, BusinessEventNotifierService businessEventNotifierService,
+            LoanTransactionRelationRepository loanTransactionRelationRepository) {
         return new BuyDownFeeWritePlatformServiceImpl(loanTransactionValidator, loanAssembler, loanTransactionRepository,
                 paymentDetailWritePlatformService, loanJournalEntryPoster, noteWritePlatformService, externalIdFactory,
                 loanBuyDownFeeBalanceRepository, reprocessLoanTransactionsService, loanBalanceService, loanLifecycleStateMachine,
-                businessEventNotifierService);
+                businessEventNotifierService, loanTransactionRelationRepository);
     }
 
     @Bean


### PR DESCRIPTION
## Description

Support reversal of “Buy Down fees” transactions.

- Not yet reversed “Buy Down fees” transaction is allowed to be reversed if
Mirror JE entries will be based for reversal entry of that transaction
There is no any not yet reversed “Buy Down fees Adjustment” that belongs to this transactions (transaction relationship)

- When “Buy Down fees” transaction is reversed, all already amortized amounts should be corrected in a “Buy Down fees amortization adjustment“ transaction.
Mirror JE entries of “Buy Down fees amortization“.
COB will handle the adjustment transaction
Delete related buy down fee balance

[FINERACT-2311](https://issues.apache.org/jira/browse/FINERACT-2311)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
