### PR TITLE
FINERACT-2335: don't rename release tarballs

### DIFF
--- a/buildSrc/src/main/groovy/org.apache.fineract.release.gradle
+++ b/buildSrc/src/main/groovy/org.apache.fineract.release.gradle
@@ -176,8 +176,8 @@ fineract {
             description: 'Sign the distribution artifacts',
             gpg: [
                 files: [
-                    "${rootDir}/fineract-war/build/distributions/apache-fineract-${project.version}-src.tar.gz",
-                    "${rootDir}/fineract-war/build/distributions/apache-fineract-${project.version}-binary.tar.gz"
+                    "${rootDir}/fineract-war/build/distributions/apache-fineract-src-${project.version}.tar.gz",
+                    "${rootDir}/fineract-war/build/distributions/apache-fineract-bin-${project.version}.tar.gz"
                 ]
             ]
         ],

--- a/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
@@ -16,12 +16,12 @@ Make sure to do some sanity checks. The source tarball and the code in the relea
 [source,bash,subs="attributes+"]
 ----
 % cd /fineract-release-preparations
-% tar -xvf path/to/apache-fineract-{revnumber}-src.tar.gz
+% tar -xvf path/to/apache-fineract-src-{revnumber}.tar.gz
 % git clone git@github.com:apache/fineract.git
 % cd fineract/
 % git checkout tags/{revnumber}
 % cd ..
-% diff -r fineract apache-fineract-{revnumber}
+% diff -r fineract apache-fineract-src-{revnumber}
 ----
 
 Make sure the code compiles and tests pass on the uncompressed source. Do as much testing as you can and share what you did. Ideally you'd build code and docs and run every possible test and check, but https://github.com/apache/fineract/actions[running everything has complex dependencies, caches, and takes many hours]. It is rarely done in practice offline / local / on developer machines. But please, go ahead and run the test and doc tasks, and more! Grab a cup of coffee and run everything you can. See the various builds in `.github/workflows/` and try the same things on your own. We should all hammer on a release candidate as much as we can to see if it breaks and fix it if so. All that of course improves our final release.

--- a/fineract-doc/src/docs/en/chapters/release/process-step07.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step07.adoc
@@ -6,10 +6,10 @@ Release source and binary tarballs must be checksummed and signed. In order to s
 
 [source,bash,subs="attributes+,+macros"]
 ----
-% gpg --armor --output apache-fineract-{revnumber}-src.tar.gz.asc --detach-sig apache-fineract-{revnumber}-src.tar.gz
-% gpg --print-md SHA512 apache-fineract-{revnumber}-src.tar.gz > apache-fineract-{revnumber}-src.tar.gz.sha512
-% gpg --armor --output apache-fineract-{revnumber}-binary.tar.gz.asc --detach-sig apache-fineract-{revnumber}-binary.tar.gz
-% gpg --print-md SHA512 apache-fineract-{revnumber}-binary.tar.gz > apache-fineract-{revnumber}-binary.tar.gz.sha512
+% gpg --armor --output apache-fineract-src-{revnumber}.tar.gz.asc --detach-sig apache-fineract-src-{revnumber}.tar.gz
+% gpg --print-md SHA512 apache-fineract-src-{revnumber}.tar.gz > apache-fineract-src-{revnumber}.tar.gz.sha512
+% gpg --armor --output apache-fineract-bin-{revnumber}.tar.gz.asc --detach-sig apache-fineract-bin-{revnumber}.tar.gz
+% gpg --print-md SHA512 apache-fineract-bin-{revnumber}.tar.gz > apache-fineract-bin-{revnumber}.tar.gz.sha512
 ----
 
 == Gradle Task

--- a/fineract-doc/src/docs/en/chapters/release/process-step08.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step08.adoc
@@ -4,12 +4,12 @@
 
 Finally create a directory with release name ({revnumber} in this example) in https://dist.apache.org/repos/dist/dev/fineract and add the following files in this new directory:
 
-* apache-fineract-{revnumber}-binary.tar.gz
-* apache-fineract-{revnumber}-binary.tar.gz.sha512
-* apache-fineract-{revnumber}-binary.tar.gz.asc
-* apache-fineract-{revnumber}-src.tar.gz
-* apache-fineract-{revnumber}-src.tar.gz.sha512
-* apache-fineract-{revnumber}-src.tar.gz.asc
+* apache-fineract-bin-{revnumber}.tar.gz
+* apache-fineract-bin-{revnumber}.tar.gz.sha512
+* apache-fineract-bin-{revnumber}.tar.gz.asc
+* apache-fineract-src-{revnumber}.tar.gz
+* apache-fineract-src-{revnumber}.tar.gz.sha512
+* apache-fineract-src-{revnumber}.tar.gz.asc
 
 These files (or "artifacts") make up the release candidate.
 

--- a/fineract-war/build.gradle
+++ b/fineract-war/build.gradle
@@ -105,7 +105,7 @@ tasks.withType(Tar) {
 
 distributions {
     binary {
-        distributionBaseName = 'apache-fineract-binary'
+        distributionBaseName = 'apache-fineract-bin'
         contents {
             // Track inputs explicitly for binary distribution
             filesMatching('**/*.jar') {
@@ -170,21 +170,11 @@ tasks.named('binaryDistTar') {
               ':fineract-provider:build', ':fineract-doc:doc',
               ':fineract-client:javadocJar', ':fineract-client:sourcesJar',
               ':fineract-avro-schemas:javadocJar', ':fineract-avro-schemas:sourcesJar')
-              
-    doLast {
-        file("${buildDir}/distributions/apache-fineract-binary-${version}.tar.gz")
-            .renameTo("${buildDir}/distributions/apache-fineract-${version}-binary.tar.gz")
-    }
 }
 
 tasks.named('srcDistTar') {
     description = 'Assembles the source distribution as a tar archive'
     outputs.cacheIf { true }
-    
-    doLast {
-        file("${buildDir}/distributions/apache-fineract-src-${version}.tar.gz")
-            .renameTo("${buildDir}/distributions/apache-fineract-${version}-src.tar.gz")
-    }
 }
 
 // Disable zip distributions as they're not needed


### PR DESCRIPTION
## Description

See FINERACT-2335.

It's so we get this:

```text
$ ls -lh fineract-war/build/distributions/
total 433M
-rw-rw-r-- 1 marie users 422M Jul 28 07:11 apache-fineract-bin-1.12.1.tar.gz
-rw-rw-r-- 1 marie users  11M Jul 28 07:06 apache-fineract-src-1.12.1.tar.gz
```

instead of this:

```text
$ ls -lh fineract-war/build/distributions/
total 433M
-rw-rw-r-- 1 marie users 422M Jul 28 07:11 apache-fineract-1.12.1-binary.tar.gz
-rw-rw-r-- 1 marie users  11M Jul 28 07:06 apache-fineract-1.12.1-src.tar.gz
```

and so their contents match their names (so they explode into a directory of the same name as the file, minus `.tar.gz`)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
