### PR TITLE
FINERACT-2339: squelch static weaving log messages

### DIFF
--- a/static-weaving.gradle
+++ b/static-weaving.gradle
@@ -22,7 +22,7 @@
 project.afterEvaluate {
     // Only configure if this is a Java project
     if (!project.plugins.hasPlugin('java')) {
-        logger.lifecycle("ℹ Skipping static weaving configuration for non-Java project: ${project.name}")
+        logger.info("ℹ Skipping static weaving configuration for non-Java project: ${project.name}")
         return
     }
 
@@ -31,7 +31,7 @@ project.afterEvaluate {
     def hasJpaEntities = persistenceXmlFile.exists()
 
     if (hasJpaEntities) {
-        logger.lifecycle("Configuring EclipseLink static weaving for ${project.name}")
+        logger.info("Configuring EclipseLink static weaving for ${project.name}")
 
         compileJava.doLast {
             def source = sourceSets.main.java.classesDirectory.get()
@@ -59,8 +59,8 @@ project.afterEvaluate {
             }
         }
 
-        logger.lifecycle("✓ EclipseLink static weaving configured for ${project.name}")
+        logger.info("✓ EclipseLink static weaving configured for ${project.name}")
     } else {
-        logger.lifecycle("ℹ No JPA entities found in ${project.name}, skipping static weaving configuration")
+        logger.info("ℹ No JPA entities found in ${project.name}, skipping static weaving configuration")
     }
 }


### PR DESCRIPTION
## Description

See FINERACT-2339.

This quality of life patch reduces static weaving log message priority, reducing the default gradle build output by about 60 lines.

example gradle run with these messages:

```text
> Configure project :custom
ℹ Skipping static weaving configuration for non-Java project: custom

> Configure project :fineract-accounting
Configuring EclipseLink static weaving for fineract-accounting

> Configure project :fineract-branch
Configuring EclipseLink static weaving for fineract-branch
...
```

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)