### PR TITLE
FINERACT-2340: remove nonexistant project "fineract-api"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
         fineractCustomProjects = []
         fineractJavaProjects = subprojects.findAll{
             [
-                'fineract-api',
                 'fineract-core',
                 'fineract-cob',
                 'fineract-validation',
@@ -56,7 +55,6 @@ buildscript {
         fineractPublishProjects = subprojects.findAll{
             [
                 'fineract-avro-schemas',
-                'fineract-api',
                 'fineract-client',
                 'fineract-core',
                 'fineract-cob',


### PR DESCRIPTION
## Description

See FINERACT-2340.

`fineract-api` appears to be errant in the top-level `build.gradle`.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)