### PR TITLE
FINERACT-2217: Replace 500 by meaningful error when request requires c…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessService.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.ApiParameterHelper;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.dataqueries.api.RunreportsApiResource;
 import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 import org.apache.fineract.infrastructure.dataqueries.service.export.DatatableReportExportService;
@@ -59,7 +60,8 @@ public class DatatableReportingProcessService extends AbstractReportingProcessSe
         final String parameterTypeValue = ApiParameterHelper.parameterType(queryParams) ? "parameter" : "report";
         final Map<String, String> reportParams = getReportParams(queryParams);
         ResponseHolder response = findReportExportService(exportMode) //
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported export target: " + exportMode)) //
+                .orElseThrow(() -> new GeneralPlatformDomainRuleException("error.msg.report.export.mode.unavailable",
+                        "Export mode %s unavailable".formatted(exportMode.name()))) //
                 .export(reportName, queryParams, reportParams, isSelfServiceUserReport, parameterTypeValue);
         Response.ResponseBuilder builder = Response.status(response.status().getStatusCode());
         if (StringUtils.isNotBlank(response.contentType())) {

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessServiceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessServiceTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.dataqueries.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.dataqueries.service.export.DatatableReportExportService;
+import org.apache.fineract.infrastructure.dataqueries.service.export.ResponseHolder;
+import org.apache.fineract.infrastructure.security.service.SqlValidator;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DatatableReportingProcessServiceTest {
+
+    @Test
+    void exportToS3ThrowsGeneralPlatformDomainRuleException() {
+
+        DatatableReportExportService jsonExportService = Mockito.mock(DatatableReportExportService.class);
+        Mockito.doReturn(true).when(jsonExportService).supports(DatatableExportTargetParameter.JSON);
+        SqlValidator sqlValidator = Mockito.mock(SqlValidator.class);
+
+        DatatableReportingProcessService datatableReportingProcessService = new DatatableReportingProcessService(List.of(jsonExportService),
+                sqlValidator);
+
+        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        queryParams.put("isSelfServiceUserReport", List.of("false"));
+        queryParams.put("R_officeId", List.of("2"));
+        queryParams.put("exportS3", List.of("true"));
+
+        GeneralPlatformDomainRuleException exception = assertThrows(GeneralPlatformDomainRuleException.class,
+                () -> datatableReportingProcessService.processRequest("clientListing", queryParams));
+
+        assertEquals("error.msg.report.export.mode.unavailable", exception.getGlobalisationMessageCode(),
+                "Wrong globalisation message code");
+        assertEquals("Export mode S3 unavailable", exception.getDefaultUserMessage(), "Wrong default user message");
+
+    }
+
+    @Test
+    void exportToS3ThrowsNoException() {
+        DatatableReportExportService jsonExportService = Mockito.mock(DatatableReportExportService.class);
+        Mockito.doReturn(true).when(jsonExportService).supports(DatatableExportTargetParameter.S3);
+
+        ResponseHolder responseHolder = new ResponseHolder(Response.Status.CREATED);
+
+        // ContentType.APPLICATION_JSON.toString(), "export.json"
+        Mockito.doReturn(responseHolder).when(jsonExportService).export(any(), any(), any(), anyBoolean(), any());
+        SqlValidator sqlValidator = Mockito.mock(SqlValidator.class);
+
+        DatatableReportingProcessService datatableReportingProcessService = new DatatableReportingProcessService(List.of(jsonExportService),
+                sqlValidator);
+
+        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        queryParams.put("isSelfServiceUserReport", List.of("false"));
+        queryParams.put("R_officeId", List.of("2"));
+        queryParams.put("exportS3", List.of("true"));
+
+        assertDoesNotThrow(() -> datatableReportingProcessService.processRequest("clientListing", queryParams));
+    }
+
+}


### PR DESCRIPTION
## Description

Fix to return a proper error message when S3 is not configured and a report request requires upload to S3.

(https://issues.apache.org/jira/browse/FINERACT-2217).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
