### PR TITLE
FINERACT-2326: Swagger - Add capitalizedIncomeAdjustment as part Loan summary

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -524,6 +524,8 @@ final class LoansApiResourceSwagger {
             @Schema(example = "1000000.000000")
             public BigDecimal totalCapitalizedIncome;
             @Schema(example = "0.000000")
+            public BigDecimal totalCapitalizedIncomeAdjustment;
+            @Schema(example = "0.000000")
             public BigDecimal principalPaid;
             @Schema(example = "0.00")
             public BigDecimal principalAdjustments;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
@@ -372,6 +372,10 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             addRepaymentForLoan(loanId, 67.45, "2 January 2024");
 
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            assertNotNull(loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment());
+            assertEquals(BigDecimal.valueOf(100.0).stripTrailingZeros(),
+                    loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment().stripTrailingZeros());
+
             Optional<GetLoansLoanIdTransactions> replayedCapitalizedIncomeAdjustmentOpt = loanDetails.getTransactions().stream()
                     .filter(t -> t.getType().getCapitalizedIncomeAdjustment()).findFirst();
             Assertions.assertTrue(replayedCapitalizedIncomeAdjustmentOpt.isPresent(), "Capitalized income adjustment not found");
@@ -964,6 +968,9 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.75, 0.0, 150.00, 15.0);
+            assertNotNull(loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment());
+            assertEquals(BigDecimal.valueOf(15.0).stripTrailingZeros(),
+                    loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment().stripTrailingZeros());
             // Validate Loan goes to Overpaid
             assertTrue(loanDetails.getStatus().getOverpaid());
         });


### PR DESCRIPTION
## Description

We are adding the `capitalizedIncomeAdjustment` field on `GetLoansLoanIdSummary` response because It was missed

[FINERACT-2326](https://issues.apache.org/jira/browse/FINERACT-2326)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
