### PR TITLE
Replace mysqladmin with mariadb-admin in probes

### DIFF
--- a/kubernetes/fineractmysql-deployment.yml
+++ b/kubernetes/fineractmysql-deployment.yml
@@ -103,7 +103,7 @@ spec:
                   key: password
           livenessProbe:
             exec:
-              command: ["sh","-c","mysqladmin ping -h localhost -uroot -p${MARIADB_ROOT_PASSWORD}"]
+              command: ["sh","-c","mariadb-admin ping -h localhost -uroot -p${MARIADB_ROOT_PASSWORD}"]
             failureThreshold: 10
             timeoutSeconds: 10
           readinessProbe:
@@ -111,7 +111,7 @@ spec:
               command:
                 - sh
                 - -c
-                - mysqladmin ping -uroot -p${MARIADB_ROOT_PASSWORD}
+                - mariadb-admin ping -uroot -p${MARIADB_ROOT_PASSWORD}
             failureThreshold: 10
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
Docker image for MariaDB 11.0.1 removed the symlinks from mysqladmin -> mariadb-admin.

See release notes for MariaDB 11.0.1: https://mariadb.com/docs/release-notes/community-server/old-releases/release-notes-mariadb-11-0-series/mariadb-11-0-1-release-notes#docker-official-images

## Description

Docker image for MariaDB 11.0.1 removed the symlinks from mysqladmin -> mariadb-admin.

See release notes for MariaDB 11.0.1: https://mariadb.com/docs/release-notes/community-server/old-releases/release-notes-mariadb-11-0-series/mariadb-11-0-1-release-notes#docker-official-images

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

Couldn't seem to access the JIRA board to get a ticket number?
- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests - 
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
