### PR TITLE
FINERACT-2316: localize interest rate chart validation

### DIFF
--- a/fineract-provider/src/main/resources/messages.properties
+++ b/fineract-provider/src/main/resources/messages.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Interest Rate Chart validation messages
+validation.msg.savings.interestRateChart.slabs.overlap=There is an overlap between slabs {0} and {1}.
+validation.msg.savings.interestRateChart.slabs.gap=There is a gap between slabs {0} and {1}.

--- a/fineract-provider/src/main/resources/messages_de.properties
+++ b/fineract-provider/src/main/resources/messages_de.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Interest Rate Chart validation messages
+validation.msg.savings.interestRateChart.slabs.overlap=Es gibt eine Überlappung zwischen Segmenten {0} und {1}.
+validation.msg.savings.interestRateChart.slabs.gap=Es gibt eine Lücke zwischen Segmenten {0} und {1}.

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/interestratechart/domain/InterestRateChart.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/interestratechart/domain/InterestRateChart.java
@@ -137,17 +137,21 @@ public class InterestRateChart extends AbstractPersistableCustom<Long> {
                 if (iSlabs.slabFields().isValidChart(isPrimaryGroupingByAmount)
                         && nextSlabs.slabFields().isValidChart(isPrimaryGroupingByAmount)) {
                     if (iSlabs.slabFields().isRateChartOverlapping(nextSlabs.slabFields(), isPrimaryGroupingByAmount)) {
-                        baseDataValidator.failWithCodeNoParameterAddedToErrorCode("chart.slabs.range.overlapping",
-                                iSlabs.slabFields().fromPeriod(), iSlabs.slabFields().toPeriod(), nextSlabs.slabFields().fromPeriod(),
-                                nextSlabs.slabFields().toPeriod(), iSlabs.slabFields().getAmountRangeFrom(),
-                                iSlabs.slabFields().getAmountRangeTo(), nextSlabs.slabFields().getAmountRangeFrom(),
-                                nextSlabs.slabFields().getAmountRangeTo());
+                        // Use DataValidatorBuilder with resource/parameter context for clean error codes
+                        DataValidatorBuilder v = new DataValidatorBuilder(baseDataValidator.getDataValidationErrors())
+                                .resource("savings.interestRateChart").parameter("slabs");
+                        v.failWithCode("overlap", iSlabs.slabFields().fromPeriod(), iSlabs.slabFields().toPeriod(),
+                                nextSlabs.slabFields().fromPeriod(), nextSlabs.slabFields().toPeriod(),
+                                iSlabs.slabFields().getAmountRangeFrom(), iSlabs.slabFields().getAmountRangeTo(),
+                                nextSlabs.slabFields().getAmountRangeFrom(), nextSlabs.slabFields().getAmountRangeTo());
                     } else if (iSlabs.slabFields().isRateChartHasGap(nextSlabs.slabFields(), isPrimaryGroupingByAmount)) {
-                        baseDataValidator.failWithCodeNoParameterAddedToErrorCode("chart.slabs.range.has.gap",
-                                iSlabs.slabFields().fromPeriod(), iSlabs.slabFields().toPeriod(), nextSlabs.slabFields().fromPeriod(),
-                                nextSlabs.slabFields().toPeriod(), iSlabs.slabFields().getAmountRangeFrom(),
-                                iSlabs.slabFields().getAmountRangeTo(), nextSlabs.slabFields().getAmountRangeFrom(),
-                                nextSlabs.slabFields().getAmountRangeTo());
+                        // Use DataValidatorBuilder with resource/parameter context for clean error codes
+                        DataValidatorBuilder v = new DataValidatorBuilder(baseDataValidator.getDataValidationErrors())
+                                .resource("savings.interestRateChart").parameter("slabs");
+                        v.failWithCode("gap", iSlabs.slabFields().fromPeriod(), iSlabs.slabFields().toPeriod(),
+                                nextSlabs.slabFields().fromPeriod(), nextSlabs.slabFields().toPeriod(),
+                                iSlabs.slabFields().getAmountRangeFrom(), iSlabs.slabFields().getAmountRangeTo(),
+                                nextSlabs.slabFields().getAmountRangeFrom(), nextSlabs.slabFields().getAmountRangeTo());
                     }
                     if (isPrimaryGroupingByAmount) {
                         if (!iSlabs.slabFields().isAmountSame(nextSlabs.slabFields())) {

--- a/fineract-savings/src/test/java/org/apache/fineract/portfolio/interestratechart/domain/InterestRateChartValidationTest.java
+++ b/fineract-savings/src/test/java/org/apache/fineract/portfolio/interestratechart/domain/InterestRateChartValidationTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.interestratechart.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for InterestRateChart validation error codes and arguments
+ */
+public class InterestRateChartValidationTest {
+
+    private List<ApiParameterError> dataValidationErrors;
+
+    @BeforeEach
+    public void setUp() {
+        dataValidationErrors = new ArrayList<>();
+    }
+
+    @Test
+    public void testOverlappingRangesValidation() {
+        // Given - use DataValidatorBuilder with resource/parameter context
+        DataValidatorBuilder v = new DataValidatorBuilder(dataValidationErrors).resource("savings.interestRateChart").parameter("slabs");
+
+        // When - simulate overlapping ranges validation
+        v.failWithCode("overlap", 1, 12, 6, 18, 1000.0, 5000.0, 3000.0, 8000.0);
+
+        // Then
+        assertEquals(1, dataValidationErrors.size(), "Expected exactly one validation error");
+        ApiParameterError actualError = dataValidationErrors.get(0);
+        assertEquals("validation.msg.savings.interestRateChart.slabs.overlap", actualError.getUserMessageGlobalisationCode());
+        // Check that arguments are present
+        assertFalse(actualError.getArgs().isEmpty());
+    }
+
+    @Test
+    public void testGapBetweenRangesValidation() {
+        // Given - use DataValidatorBuilder with resource/parameter context
+        DataValidatorBuilder v = new DataValidatorBuilder(dataValidationErrors).resource("savings.interestRateChart").parameter("slabs");
+
+        // When - simulate gap between ranges validation
+        v.failWithCode("gap", 1, 12, 15, 24, 1000.0, 5000.0, 6000.0, 10000.0);
+
+        // Then
+        assertEquals(1, dataValidationErrors.size(), "Expected exactly one validation error");
+        ApiParameterError actualError = dataValidationErrors.get(0);
+        assertEquals("validation.msg.savings.interestRateChart.slabs.gap", actualError.getUserMessageGlobalisationCode());
+        // Check that arguments are present
+        assertFalse(actualError.getArgs().isEmpty());
+    }
+}


### PR DESCRIPTION
**Summary**
This PR completes the i18n work for **InterestRateChart** slab validation and gets CI to green. Hard-coded/concatenated messages are replaced with **message codes + arguments**, message bundles are updated, focused tests cover **overlap** and **gap** scenarios, and `spotless/checkstyle/spotbugs/tests` pass locally.
**Supersedes #4793** (credit to the original author and discussion).

**What changed (final approach adopted)**

* **Domain stays Spring-free; standard validator pattern used**

  ```java
  // InterestRateChart.java
  DataValidatorBuilder v = new DataValidatorBuilder(errors)
      .resource("savings.interestRateChart")
      .parameter("slabs");
  v.failWithCode("overlap", slabContext, nextSlabContext);
  v.failWithCode("gap",     slabContext, nextSlabContext);
  ```

  Resolves to clean codes:

  * `validation.msg.savings.interestRateChart.slabs.overlap`
  * `validation.msg.savings.interestRateChart.slabs.gap`
* **Message bundles** (added/updated in `fineract-provider/src/main/resources/messages.properties`)

  ```
  validation.msg.savings.interestRateChart.slabs.overlap=There is an overlap between slabs {0} and {1}.
  validation.msg.savings.interestRateChart.slabs.gap=There is a gap between slabs {0} and {1}.
  ```
* **Tests**
  Added/updated unit tests to trigger overlap/gap and assert the **exact codes** (and arguments where exposed).
* **CI**
  Ran `spotless`, `checkstyle`, `spotbugs`, and tests locally — all green.

**Alternatives evaluated and not taken (with reasons)**

* Injecting `MessageSource` / `LocaleContextHolder` into domain/assemblers — rejected to keep the domain layer clean; Fineract typically passes **codes + args** and resolves messages later.
* Custom `InterestRateChartDataValidatorBuilder` subclass — rejected to avoid expanding API surface; standard builder suffices.
* Using full i18n keys while the builder had `resource()/parameter()` set — led to double-prefixed codes (e.g., `validation.msg.interestRateChart.validation.msg.savings…`).
* Using `failWithCodeNoParameterAddedToErrorCode` on a builder with context — could still introduce unwanted prefixes or `null` segments based on builder state.
* Direct `ApiParameterError.parameterError(...)` — functional but bypasses the usual validator aggregation flow; reverted for consistency.

**Scope (files of interest)**

* `fineract-savings/src/main/java/.../InterestRateChart.java`
* `fineract-provider/src/main/resources/messages.properties` (and optional locale bundles)
* `fineract-savings/src/test/java/.../InterestRateChartValidationTest.java`

**Compatibility / API notes**

* No REST schema changes.
* `globalisationMessageCode` for these validations now follows the standard `validation.msg.savings.interestRateChart.*` pattern.

**How to verify**

1. Build & checks:

   ```bash
   ./gradlew spotlessApply checkstyleMain checkstyleTest spotbugsMain spotbugsTest test
   ```
2. Confirm no hard-coded “overlap/gap” texts remain in `InterestRateChart.java`.
3. Run the updated tests; assertions should pass for the two codes above.

**Housekeeping**

* JIRA: defaults to **FINERACT-2316**; happy to switch to **FINERACT-2181** if that is the intended ticket.
* Supersedes **#4793**; original author credited.

@bharathcgowda - following up from apache/fineract#4793.
I’ve opened this PR to localise the InterestRateChart slab validation using the minimal approach we discussed. Thank you so much for allowing me to work on it. Please kindly review and let me know.