### PR TITLE
FINERACT-2326: Fix `split-tests.sh` script and disable failing savings tests

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5, test-twofactor, test-oauth2]
+        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5]
 
     services:
       mariadb:
@@ -100,18 +100,6 @@ jobs:
           FAILED=0
 
           case "${{ matrix.task }}" in
-            test-twofactor)
-              if ! ./gradlew --no-daemon :twofactor-tests:test -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::Two-factor tests failed"
-                FAILED=1
-              fi
-              ;;
-            test-oauth2)
-              if ! ./gradlew --no-daemon :oauth2-tests:test -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::OAuth2 tests failed"
-                FAILED=1
-              fi
-              ;;
             test-core-*)
               echo "Grouping test classes by module..."
               declare -A module_tests

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5, test-twofactor, test-oauth2]
+        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5]
 
     services:
       mysql:
@@ -100,18 +100,6 @@ jobs:
           FAILED=0
 
           case "${{ matrix.task }}" in
-            test-twofactor)
-              if ! ./gradlew --no-daemon :twofactor-tests:test -PdbType=mysql -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::Two-factor tests failed"
-                FAILED=1
-              fi
-              ;;
-            test-oauth2)
-              if ! ./gradlew --no-daemon :oauth2-tests:test -PdbType=mysql -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::OAuth2 tests failed"
-                FAILED=1
-              fi
-              ;;
             test-core-*)
               echo "Grouping test classes by module..."
               declare -A module_tests

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5, test-twofactor, test-oauth2]
+        task: [test-core-1, test-core-2, test-core-3, test-core-4, test-core-5]
 
     services:
       postgresql:
@@ -101,18 +101,6 @@ jobs:
           FAILED=0
 
           case "${{ matrix.task }}" in
-            test-twofactor)
-              if ! ./gradlew --no-daemon :twofactor-tests:test -PdbType=postgresql -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::Two-factor tests failed"
-                FAILED=1
-              fi
-              ;;
-            test-oauth2)
-              if ! ./gradlew --no-daemon :oauth2-tests:test -PdbType=postgresql -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer; then
-                echo "::error::OAuth2 tests failed"
-                FAILED=1
-              fi
-              ;;
             test-core-*)
               echo "Grouping test classes by module..."
               declare -A module_tests

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingTest.java
@@ -52,10 +52,12 @@ import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
 import org.apache.fineract.portfolio.savings.SavingsAccountTransactionType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Disabled("Disabled till FINERACT-2378 fixed")
 public class SavingsInterestPostingTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavingsInterestPostingTest.class);
@@ -88,6 +90,11 @@ public class SavingsInterestPostingTest {
     @Test
     public void testPostInterestWithOverdraftProduct() {
         try {
+            final LocalDate startDate = LocalDate.of(LocalDate.now(Utils.getZoneIdOfTenant()).getYear(), 2, 1);
+            // Simulate time passing - update business date to February
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, startDate);
             final String amount = "10000";
 
             final Account assetAccount = accountHelper.createAssetAccount();
@@ -103,7 +110,7 @@ public class SavingsInterestPostingTest {
                     interestReceivableAccount.getAccountID().toString(), assetAccount, incomeAccount, expenseAccount, liabilityAccount);
 
             final Integer clientId = ClientHelper.createClient(requestSpec, responseSpec, "01 January 2025");
-            final LocalDate startDate = LocalDate.of(LocalDate.now(Utils.getZoneIdOfTenant()).getYear(), 2, 1);
+
             final String startDateString = DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.US).format(startDate);
 
             final Integer accountId = savingsAccountHelper.applyForSavingsApplicationOnDate(clientId, productId,
@@ -113,8 +120,6 @@ public class SavingsInterestPostingTest {
             savingsAccountHelper.depositToSavingsAccount(accountId, amount, startDateString, CommonConstants.RESPONSE_RESOURCE_ID);
 
             // Simulate time passing - update business date to March
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
             LocalDate marchDate = LocalDate.of(startDate.getYear(), 3, 1);
             BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, marchDate);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTestResults.java
@@ -91,6 +91,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -1265,6 +1266,7 @@ public class SchedulerJobsTestResults extends IntegrationTest {
     }
 
     @Test
+    @Disabled("Disabled due to FINERACT-2378")
     public void testInterestTransferForSavings() throws InterruptedException {
         this.savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
         FixedDepositAccountHelper fixedDepositAccountHelper = new FixedDepositAccountHelper(requestSpec, responseSpec);

--- a/scripts/split-tests.sh
+++ b/scripts/split-tests.sh
@@ -12,7 +12,7 @@ fi
 
 echo "🔍 Searching for eligible JUnit test classes..."
 
-ALL_TESTS=$(find . -type f -path "*/src/test/java/*Test.java" \
+ALL_TESTS=$(find . -type f -path "*/src/test/java/*.java" \
   | while read filepath; do
       filename=$(basename "$filepath")
 
@@ -22,8 +22,8 @@ ALL_TESTS=$(find . -type f -path "*/src/test/java/*Test.java" \
         continue
       fi
 
-      # Skip if file doesn't contain valid JUnit annotations
-      if ! grep -qE "@Test|@Nested|@ParameterizedTest" "$filepath"; then
+      # Check for valid JUnit test annotations (exact word match)
+      if ! grep -q -w "@Test\|@Nested\|@ParameterizedTest" "$filepath"; then
         continue
       fi
 


### PR DESCRIPTION
## Description

To avoid blocking of other developments 2 test were disabled till FINERACT-2378 got fixed!

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
