### PR TITLE
FINERACT-2391: check for AppUser type before casting Authentication Principal in getCurrentAuditor

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
@@ -35,7 +35,7 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
         final SecurityContext securityContext = SecurityContextHolder.getContext();
         if (securityContext != null) {
             final Authentication authentication = securityContext.getAuthentication();
-            if (authentication != null) {
+            if (authentication != null && authentication.getPrincipal() instanceof AppUser) {
                 currentUserId = Optional.ofNullable(((AppUser) authentication.getPrincipal()).getId());
             } else {
                 currentUserId = retrieveSuperUser();


### PR DESCRIPTION
## Description

Now checking for AppUser type before casting Authentication Principal to avoid `java.lang.ClassCastException` in `getCurrentAuditor`.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
