### PR TITLE
FINERACT-2397: update release manager docs post-1.13.0 release

### DIFF
--- a/buildSrc/src/main/resources/email/release.step10.vote.message.ftl
+++ b/buildSrc/src/main/resources/email/release.step10.vote.message.ftl
@@ -38,15 +38,13 @@ This vote will be open for 72 hours:
 [ ] +0 no opinion
 [ ] -1 disapprove (and reason why)
 
-Please indicate if you are a binding vote (member of the PMC). Note: PMC members are required to download, compile, and test the artifacts before submitting their +1 vote.
+Please indicate if yours is a binding vote, and "Verified: YES/NO/PARTIAL".
 
-Please also indicate with "Tested: YES/NO/PARTIAL" if you have locally built and/or tested these artifacts and/or a clone of the code checked out to the release commit, following the form:
+Verified: YES ... Verified integrity and signatures of release artifacts locally, built from source, ran jar/war: Did everything mentioned in the current release candidate verification guidance ( https://fineract.apache.org/docs/rc/#_artifact_verification ). If you did more than that, please specify. "Verified: YES" is required for binding votes.
 
-Tested: YES ... Verified integrity and signatures of release artifacts locally, built from source, ran jar/war: Did everything mentioned in the current release candidate verification guidance ( https://fineract.apache.org/docs/rc/#_artifact_verification ). If you did more than that, please specify.
+Verified: NO ... No testing performed on release candidate, e.g. relying on testing performed by other contributors and/or output of GitHub Actions, while exercising your right to vote.
 
-Tested: NO ... No testing performed on release candidate, e.g. relying on testing performed by other contributors and/or output of GitHub Actions, while exercising my right to vote.
-
-Tested: PARTIAL ... Please specify.
+Verified: PARTIAL ... Please specify.
 
 Cheers,
 

--- a/buildSrc/src/main/resources/email/release.step15.announce.message.ftl
+++ b/buildSrc/src/main/resources/email/release.step15.announce.message.ftl
@@ -23,10 +23,7 @@ the release of Apache Fineract ${project['fineract.release.version']}.
 The release is available for download from
 https://fineract.apache.org/#downloads
 
-Fineract provides a reliable, robust, and affordable solution for entrepreneurs,
-financial institutions, and service providers to offer financial services to the
-world’s 2 billion underbanked and unbanked. Fineract is aimed at innovative mobile
-and cloud-based solutions, and enables digital transaction accounts for all.
+Apache Fineract is an open-source core banking platform providing a flexible, extensible foundation for a wide range of financial services. By making robust banking technology openly available, it lowers barriers for institutions and innovators to reach underserved and unbanked populations.
 
 This release addressed ${project['fineract.release.issues']?size} issues.
 

--- a/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
@@ -9,7 +9,7 @@ Create source and binary tarballs.
 ./gradlew clean srcDistTar binaryDistTar
 ----
 
-Check that `fineract-provider/build/classes/java/main/git.properties` exists. If so, continue. If not, you're likely encountering https://github.com/n0mer/gradle-git-properties/issues/233[this bug], and you need to re-run the command above to create proper source and binary tarballs. That `git.properties` file is supposed to end up at `BOOT-INF/classes/git.properties` in `fineract-provider-{revnumber}.jar` in the binary release tarball. Its contents are displayed at the `/fineract-provider/actuator/info` endpoint. It may be possible to fix this heisenbug entirely by https://github.com/gradle/gradle/issues/34177#issuecomment-3051970053[modifying our git properties gradle plugin config] in `fineract-provider/build.gradle`, perhaps by changing where `git.properties` is written.
+Check that `fineract-provider/build/classes/java/main/git.properties` exists. If so, continue. If not, you're likely encountering https://github.com/n0mer/gradle-git-properties/issues/233[this bug], and you need to *re-run the command above* to create proper source and binary tarballs. That `git.properties` file is supposed to end up at `BOOT-INF/classes/git.properties` in `fineract-provider-{revnumber}.jar` in the binary release tarball. Its contents are displayed at the `/fineract-provider/actuator/info` endpoint. It may be possible to fix this heisenbug entirely by https://github.com/gradle/gradle/issues/34177#issuecomment-3051970053[modifying our git properties gradle plugin config] in `fineract-provider/build.gradle`, perhaps by changing where `git.properties` is written.
 
 Look in `fineract-war/build/distributions/` for the tarballs.
 

--- a/fineract-doc/src/docs/en/chapters/release/process-step09.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step09.adoc
@@ -74,7 +74,7 @@ cd ..
 
 === Run from binary
 
-Before running Fineract you must first start a <<Database support,supported relational database server>> and ensure the `fineract_default` and `fineract_tenants` databases exist. Detailed steps for database preparation are left as an exercise for the reader. You can find ideas on how to prepare your database in the `build-mariadb.yml`, `build-mysql.yml`, and `build-postgresql.yml` files in source control.
+Before running Fineract you must first start a <<Database support,supported relational database server>> and ensure the `fineract_default` and `fineract_tenants` databases exist. Detailed steps for database preparation are left as an exercise for the reader. You can find ideas on how to prepare your database in the `build-mariadb.yml`, `build-mysql.yml`, and `build-postgresql.yml` files in source control, and in <<Database Setup>>.
 
 Finally, start your Fineract server:
 


### PR DESCRIPTION
## Description

Docs updates. Stuff I've collected while releasing 1.13.0, and now submitting as a patch to improve the 1.14.0 release process (or 1.13.1).

* release step 6: emphasize "re-run the command above"
* release step 9: link to Database Setup in e2e or integration section (currently links to e2e since `cucumber.adoc` precedes `integration.adoc` in `fineract-doc/src/docs/en/chapters/testing/index.adoc`)
* release step 10: improve rc verify instructions in voting email, based on https://lists.apache.org/thread/jk2qzjxc89hd1c8xzvhtmlbbj1m8ktbl - thread: "release process improvement (was: 🗳️  1.13.0 for release)"
* release step 15: use current mission statement from top-level readme in release announcement email

see also: FINERACT-2397

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)