### PR TITLE
FINERACT-2389: Upgrade OpenPDF to v3

### DIFF
--- a/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
+++ b/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
             exclude 'javax.activation:activation'
         }
         dependency 'commons-io:commons-io:2.18.0'
-        dependency 'com.github.librepdf:openpdf:2.0.3'
+        dependency 'com.github.librepdf:openpdf:3.0.0'
         dependency ('org.mnode.ical4j:ical4j:3.2.19') {
             exclude 'com.sun.mail:javax.mail'
             exclude 'org.codehaus.groovy:groovy'

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -18,10 +18,6 @@
  */
 package org.apache.fineract.infrastructure.dataqueries.service;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.PageSize;
-import com.lowagie.text.pdf.PdfPTable;
-import com.lowagie.text.pdf.PdfWriter;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -61,6 +57,10 @@ import org.apache.fineract.infrastructure.security.service.PlatformSecurityConte
 import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
 import org.apache.fineract.infrastructure.security.utils.LogParameterEscapeUtil;
 import org.apache.fineract.useradministration.domain.AppUser;
+import org.openpdf.text.Document;
+import org.openpdf.text.PageSize;
+import org.openpdf.text.pdf.PdfPTable;
+import org.openpdf.text.pdf.PdfWriter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.rowset.SqlRowSet;


### PR DESCRIPTION
Update to OpenPDF 3:
https://github.com/LibrePDF/OpenPDF/releases/tag/3.0.0

See: https://github.com/apache/fineract/pull/5124

Thank you for using OpenPDF! https://github.com/LibrePDF/OpenPDF