### PR TITLE
FINERACT-1086: take PESSIMISTIC_WRITE lock on Loan before save

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.domain;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -30,10 +31,15 @@ import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.portfolio.accountdetails.domain.AccountType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface LoanRepository extends JpaRepository<Loan, Long>, JpaSpecificationExecutor<Loan> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from Loan l where l.id = :id")
+    java.util.Optional<Loan> findByIdForUpdate(@Param("id") Long id);
 
     String FIND_GROUP_LOANS_DISBURSED_AFTER = "select l from Loan l where ( l.actualDisbursementDate IS NOT NULL and l.actualDisbursementDate > :disbursementDate) and "
             + "l.group.id = :groupId and l.loanType = :loanType order by l.actualDisbursementDate";

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
@@ -81,6 +81,11 @@ public class LoanRepositoryWrapper {
         return loan;
     }
 
+    @Transactional
+    public Loan findOneForUpdate(Long id) {
+        return this.repository.findByIdForUpdate(id).orElseThrow(() -> new LoanNotFoundException(id));
+    }
+
     // Root Entities are enough
     public Collection<Loan> findActiveLoansByLoanIdAndGroupId(Long clientId, Long groupId) {
         final Collection<LoanStatus> loanStatuses = new ArrayList<>(

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
@@ -19,6 +19,9 @@
 package org.apache.fineract.portfolio.loanaccount.domain;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -160,6 +163,9 @@ public class LoanAccountDomainServiceJpa implements LoanAccountDomainService {
     private final LoanTransactionService loanTransactionService;
     private final LoanAccountDomainServiceJpaHelper loanAccountDomainServiceJpaHelper;
     private final LoanJournalEntryPoster journalEntryPoster;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Transactional
     @Override
@@ -471,11 +477,13 @@ public class LoanAccountDomainServiceJpa implements LoanAccountDomainService {
         }
     }
 
+    @Transactional
     @Override
     public LoanTransaction makeRefund(final Long accountId, final CommandProcessingResultBuilder builderResult,
             final LocalDate transactionDate, final BigDecimal transactionAmount, final PaymentDetail paymentDetail, final String noteText,
             final ExternalId txnExternalId) {
         final Loan loan = this.loanAccountAssembler.assembleFrom(accountId);
+        entityManager.lock(loan, LockModeType.PESSIMISTIC_WRITE);
         checkClientOrGroupActive(loan);
         if (loan.isChargedOff() && DateUtils.isBefore(transactionDate, loan.getChargedOffOnDate())) {
             throw new GeneralPlatformDomainRuleException("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date", "Loan: "


### PR DESCRIPTION
## JIRA
FINERACT-1086

## What
Acquire a DB write lock on `Loan` to serialize concurrent writers and avoid `JpaOptimisticLockingFailureException`.

## How
- In `LoanAccountDomainServiceJpa#makeRefund(...)`, immediately after assembling the loan, call:
  `entityManager.lock(loan, LockModeType.PESSIMISTIC_WRITE);`
- Leave existing `loanRepositoryWrapper.saveAndFlush(loan)` unchanged.

## Why
Optimistic locking was tripping when two requests updated the same Loan at once. A `PESSIMISTIC_WRITE` lock ensures only one writer proceeds at a time.

## Notes
- Local Windows build hit Spotless/line-ending issues. I will run `./gradlew spotlessApply` in Linux (WSL/Codespaces) and push formatting updates shortly.
- Follow-up plan: add an integration test that performs two concurrent updates on the same Loan and asserts no optimistic-locking failure.
