### PR TITLE
FINERACT-2407: add permission READ_FAMILYMEMBERS

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -223,4 +223,5 @@
     <include file="parts/0202_trial_balance_summary_with_asset_owner_journal_entry_aggregation.xml" relativeToChangelogFile="true" />
     <include file="parts/0203_transaction_summary_with_asset_owner_report_with_capitalized_income.xml" relativeToChangelogFile="true" />
     <include file="parts/0204_transaction_summary_with_asset_owner_and_from_asset_owner_id_for_buybacks.xml" relativeToChangelogFile="true" />
+    <include file="parts/0205_add_read_familymembers_permission.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
@@ -23,6 +23,11 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(1) FROM m_permission WHERE code = 'READ_FAMILYMEMBERS'
+            </sqlCheck>
+        </preConditions>
         <insert tableName="m_permission">
             <column name="grouping" value="portfolio"/>
             <column name="code" value="READ_FAMILYMEMBERS"/>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="1" author="fineract">
+        <insert tableName="m_permission">
+            <column name="id" valueNumeric="963"/>
+            <column name="grouping" value="portfolio"/>
+            <column name="code" value="READ_FAMILYMEMBERS"/>
+            <column name="entity_name" value="FAMILYMEMBERS"/>
+            <column name="action_name" value="READ"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0205_add_read_familymembers_permission.xml
@@ -24,7 +24,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="1" author="fineract">
         <insert tableName="m_permission">
-            <column name="id" valueNumeric="963"/>
             <column name="grouping" value="portfolio"/>
             <column name="code" value="READ_FAMILYMEMBERS"/>
             <column name="entity_name" value="FAMILYMEMBERS"/>


### PR DESCRIPTION
## Description

Add the missing `READ_FAMILYMEMBERS` permission to the `m_permission`. Not having this permission causes /fineract-provider/api/v1/clients/${clientId}/familymembers to fail.

This PR adds a Liquibase changelog under `src/main/resources/db/changelog/tenant/parts/` and includes it from `changelog-tenant.xml`.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
