### PR TITLE
FINERACT-2389: Pay-Off amount incorrectly calculated when downpayment

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanCapitalizedIncome.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanCapitalizedIncome.feature
@@ -1699,7 +1699,6 @@ Feature: Capitalized Income
       | 100.0  | 83.33            | 16.67               | 0.0             | 0.0                |
 
     When Loan Pay-off is made on "26 January 2024"
-    And Customer makes "AUTOPAY" repayment on "26 January 2024" with 225 EUR transaction amount
     Then Loan is closed with zero outstanding balance and it's all installments have obligations met
 
   @TestRailId:C3673


### PR DESCRIPTION
## Description

The pay-off amount is incorrectly calculated while prepay loan with DownPayment, Capitalized Income after Charge-Off undo

[FINERACT-2389](https://issues.apache.org/jira/browse/FINERACT-2389)

<img width="1501" height="856" alt="Screenshot 2025-11-18 at 8 17 18 p m" src="https://github.com/user-attachments/assets/ebc32848-512a-42dc-a678-9afbd7b10106" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
