### PR TITLE
FINERACT-2389: Total disbursements less than one result wrong allocations

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/initializer/global/LoanProductGlobalInitializerStep.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/initializer/global/LoanProductGlobalInitializerStep.java
@@ -2994,6 +2994,7 @@ public class LoanProductGlobalInitializerStep implements FineractGlobalInitializ
                 .loanScheduleProcessingType("HORIZONTAL")//
                 .interestRateFrequencyType(3)//
                 .maxInterestRatePerPeriod(10.0)//
+                .minPrincipal(1.0)//
                 .paymentAllocation(List.of(//
                         createPaymentAllocation("DEFAULT", "NEXT_INSTALLMENT"), //
                         createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT"), //

--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanRepayment.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanRepayment.feature
@@ -6481,3 +6481,48 @@ Feature: LoanRepayment
       | 04 October 2025    | Accrual          |  133.98 |   0.0     | 133.98    | 0.0  | 0.0       |    0.0       | false    | false    |
       | 04 October 2025    | Accrual Activity |    0.09 |   0.0     |   0.09    | 0.0  | 0.0       |    0.0       | false    | false    |
     Then Loan is closed with zero outstanding balance and it's all installments have obligations met
+
+  @TestRailId:C4350
+  Scenario: Verify the loan creation with total disbursement amount less then 1 for progressive loan
+    When Admin sets the business date to "26 October 2025"
+    When Admin creates a client with random data
+    When Admin creates a fully customized loan with loan product`s charges and following data:
+      | LoanProduct                                                         | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_INSTALLMENT_FEE_PERCENT_AMOUNT_CHARGES | 26 October 2025   | 1              | 0                      | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 1                 | MONTHS                | 1              | MONTHS                 | 1                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "26 October 2025" with "1" amount and expected disbursement date on "26 October 2025"
+    Then Loan Repayment schedule has 1 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 26 October 2025  |           | 1.0             |               |          | 0.0  |           | 0.0   |      |            |      | 0.0         |
+      | 1  | 31   | 26 November 2025 |           | 0.0             | 1.0           | 0.0      | 0.01 | 0.0       | 1.01  | 0.0  | 0.0        | 0.0  | 1.01        |
+    Then Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 1.0           | 0.0      | 0.01 | 0.0       | 1.01   | 0.0  | 0.0        | 0.0  | 1.01        |
+
+    When Admin successfully disburse the loan on "26 October 2025" with "0.5" EUR transaction amount
+    Then Loan Repayment schedule has 1 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 26 October 2025  |           | 0.5             |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 26 November 2025 |           | 0.0             | 0.5           | 0.0      | 0.0  | 0.0       | 0.5   | 0.0  | 0.0        | 0.0  | 0.5         |
+    Then Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 0.5           | 0.0      | 0.0  | 0.0       | 0.5    | 0.0  | 0.0        | 0.0  | 0.5         |
+    Then Loan Transactions tab has the following data:
+      | Transaction date   | Transaction Type | Amount  | Principal | Interest | Fees | Penalties  | Loan Balance | Reverted | Replayed |
+      | 26 October 2025    | Disbursement     | 0.5     | 0.0       |  0.0      | 0.0  | 0.0       | 0.5          | false    | false    |
+
+    When Admin sets the business date to "27 October 2025"
+    When Loan Pay-off is made on "27 October 2025"
+    Then Loan Repayment schedule has 1 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date       | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 26 October 2025  |                 | 0.5             |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 26 November 2025 | 27 October 2025 | 0.0             | 0.5           | 0.0      | 0.0  | 0.0       | 0.5   | 0.5  | 0.5        | 0.0  | 0.0         |
+    Then Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 0.5           | 0.0      | 0.0  | 0.0       | 0.5    | 0.5  | 0.5        | 0.0  | 0.0         |
+    Then Loan Transactions tab has the following data:
+      | Transaction date   | Transaction Type | Amount  | Principal | Interest | Fees | Penalties  | Loan Balance | Reverted | Replayed |
+      | 26 October 2025    | Disbursement     | 0.5     | 0.0       |  0.0      | 0.0  | 0.0       | 0.5          | false    | false    |
+      | 27 October 2025    | Repayment        | 0.5     | 0.5       |  0.0      | 0.0  | 0.0       | 0.0          | false    | false    |
+    Then Loan is closed with zero outstanding balance and it's all installments have obligations met
+
+

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -553,7 +553,6 @@ public final class ProgressiveEMICalculator implements EMICalculator {
                 || operation.getAction() == EmiChangeOperation.Action.ADD_REPAYMENT_PERIODS || scheduleModel.isCopy();
 
         calculateRateFactorForPeriods(relatedRepaymentPeriods, scheduleModel);
-        calculateOutstandingBalance(scheduleModel);
         if (onlyOnActualModelShouldApply) {
             calculateEMIOnActualModel(relatedRepaymentPeriods, scheduleModel);
         } else {
@@ -941,11 +940,14 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         EmiAdjustment emiAdjustment;
 
         do {
-            emiAdjustment = getEmiAdjustment(relatedRepaymentPeriods);
-            if (!emiAdjustment.shouldBeAdjusted()) {
+            emiAdjustment = getEmiAdjustment(relatedRepaymentPeriods, mc);
+            if (!emiAdjustment.isZero() && !emiAdjustment.shouldBeAdjusted()) {
                 break;
             }
-            Money adjustedEqualMonthlyInstallmentValue = applyInstallmentAmountInMultiplesOf(scheduleModel, emiAdjustment.adjustedEmi());
+
+            final Money adjustedEqualMonthlyInstallmentValue = emiAdjustment.isZero() ? emiAdjustment.nonRoundAmount()
+                    : applyInstallmentAmountInMultiplesOf(scheduleModel, emiAdjustment.adjustedEmi());
+
             if (adjustedEqualMonthlyInstallmentValue.isEqualTo(emiAdjustment.originalEmi())) {
                 break;
             }
@@ -964,7 +966,8 @@ public final class ProgressiveEMICalculator implements EMICalculator {
             });
             calculateOutstandingBalance(newScheduleModel);
             calculateLastUnpaidRepaymentPeriodEMI(newScheduleModel, relatedPeriodsFirstDueDate);
-            if (!getEmiAdjustment(newScheduleModel.repaymentPeriods()).hasLessEmiDifference(emiAdjustment)) {
+            if (!getEmiAdjustment(newScheduleModel.repaymentPeriods(), mc)
+                    .hasLessEmiDifference(emiAdjustment.isZero() ? emiAdjustment.nonRoundAmount() : emiAdjustment.emiDifference())) {
                 break;
             }
 
@@ -1360,15 +1363,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
     private void calculateEMIOnActualModelWithDecliningBalanceInterestMethod(List<RepaymentPeriod> repaymentPeriods,
             ProgressiveLoanInterestScheduleModel scheduleModel) {
-        final MathContext mc = scheduleModel.mc();
-        final BigDecimal rateFactorN = MathUtil.stripTrailingZeros(calculateRateFactorPlus1N(repaymentPeriods, mc));
-        final BigDecimal fnResult = MathUtil.stripTrailingZeros(calculateFnResult(repaymentPeriods, mc));
-        final RepaymentPeriod startPeriod = repaymentPeriods.getFirst();
-
-        final Money outstandingBalance = startPeriod.getInitialBalanceForEmiRecalculation();
-
-        final Money equalMonthlyInstallment = Money.of(outstandingBalance.getCurrencyData(),
-                calculateEMIValue(rateFactorN, outstandingBalance.getAmount(), fnResult, mc), mc);
+        final Money equalMonthlyInstallment = calculateInstallmentAmount(repaymentPeriods, scheduleModel.mc());
         final Money finalEqualMonthlyInstallment = applyInstallmentAmountInMultiplesOf(scheduleModel, equalMonthlyInstallment);
 
         repaymentPeriods.forEach(period -> {
@@ -1377,6 +1372,17 @@ public final class ProgressiveEMICalculator implements EMICalculator {
                 period.setOriginalEmi(finalEqualMonthlyInstallment);
             }
         });
+    }
+
+    private Money calculateInstallmentAmount(List<RepaymentPeriod> repaymentPeriods, final MathContext mc) {
+        final BigDecimal rateFactorN = MathUtil.stripTrailingZeros(calculateRateFactorPlus1N(repaymentPeriods, mc));
+        final BigDecimal fnResult = MathUtil.stripTrailingZeros(calculateFnResult(repaymentPeriods, mc));
+        final RepaymentPeriod startPeriod = repaymentPeriods.getFirst();
+
+        final Money outstandingBalance = startPeriod.getInitialBalanceForEmiRecalculation();
+
+        return Money.of(outstandingBalance.getCurrencyData(), calculateEMIValue(rateFactorN, outstandingBalance.getAmount(), fnResult, mc),
+                mc);
     }
 
     private void calculateEMIOnNewModelAndMerge(List<RepaymentPeriod> repaymentPeriods, ProgressiveLoanInterestScheduleModel scheduleModel,
@@ -1403,17 +1409,23 @@ public final class ProgressiveEMICalculator implements EMICalculator {
                 : equalMonthlyInstallment;
     }
 
-    public EmiAdjustment getEmiAdjustment(final List<RepaymentPeriod> repaymentPeriods) {
+    private EmiAdjustment getEmiAdjustment(final List<RepaymentPeriod> repaymentPeriods, final MathContext mc) {
         for (int idx = repaymentPeriods.size() - 1; idx > 0; --idx) {
             RepaymentPeriod lastPeriod = repaymentPeriods.get(idx);
             RepaymentPeriod penultimatePeriod = repaymentPeriods.get(idx - 1);
             if (!lastPeriod.isFullyPaid() && !penultimatePeriod.isFullyPaid()) {
                 Money emiDifference = lastPeriod.getEmi().minus(penultimatePeriod.getEmi());
                 return new EmiAdjustment(penultimatePeriod.getEmi(), emiDifference, repaymentPeriods,
-                        getUncountablePeriods(repaymentPeriods, penultimatePeriod.getEmi()));
+                        getUncountablePeriods(repaymentPeriods, penultimatePeriod.getEmi()),
+                        validateInstallmentAmount(penultimatePeriod.getEmi(), repaymentPeriods, mc));
             }
         }
-        return new EmiAdjustment(repaymentPeriods.getFirst().getEmi(), repaymentPeriods.getFirst().getEmi().copy(0.0), repaymentPeriods, 0);
+        return new EmiAdjustment(repaymentPeriods.getFirst().getEmi(), repaymentPeriods.getFirst().getEmi().copy(0.0), repaymentPeriods, 0,
+                validateInstallmentAmount(repaymentPeriods.getFirst().getEmi(), repaymentPeriods, mc));
+    }
+
+    private Money validateInstallmentAmount(final Money emiAmount, final List<RepaymentPeriod> repaymentPeriods, final MathContext mc) {
+        return emiAmount.isZero() ? calculateInstallmentAmount(repaymentPeriods, mc) : emiAmount;
     }
 
     private void calculateRateFactorForScheduleTillDateInclusive(ProgressiveLoanInterestScheduleModel scheduleModelCopy,

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/EmiAdjustment.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/EmiAdjustment.java
@@ -25,7 +25,8 @@ public record EmiAdjustment(//
         Money originalEmi, //
         Money emiDifference, //
         List<RepaymentPeriod> relatedRepaymentPeriods, //
-        long uncountablePeriods//
+        long uncountablePeriods, //
+        Money nonRoundAmount //
 ) {
 
     public boolean shouldBeAdjusted() {
@@ -43,8 +44,8 @@ public record EmiAdjustment(//
         return originalEmi.plus(adjustment());
     }
 
-    public boolean hasLessEmiDifference(EmiAdjustment previousAdjustment) {
-        return emiDifference.abs().isLessThan(previousAdjustment.emiDifference.abs());
+    public boolean hasLessEmiDifference(Money previousEmiDifference) {
+        return emiDifference.abs().isLessThan(previousEmiDifference.abs());
     }
 
     public boolean hasUncountablePeriods() {
@@ -53,5 +54,9 @@ public record EmiAdjustment(//
 
     private int numberOfRelatedPeriods() {
         return relatedRepaymentPeriods.size();
+    }
+
+    public boolean isZero() {
+        return originalEmi().isZero();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
@@ -108,6 +108,7 @@ import org.slf4j.LoggerFactory;
 public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoanIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
+    private static final String LOCALE = "en";
     private static final String DATETIME_PATTERN = "dd MMMM yyyy";
     private static ResponseSpecification responseSpec;
     private static RequestSpecification requestSpec;
@@ -6317,6 +6318,67 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     8.75, 0.00, 8.75, 0.00, 0.00);
             validatePeriod(loanDetails, 4, LocalDate.of(2024, 4, 1), null, 0.00, 500.00, 0.00, 500.00, 0.0, 0.0, 0.00, 0.00, 0.00, 0.00,
                     8.75, 0.00, 8.75, 0.00, 0.00);
+        });
+    }
+
+    // UC159: Accounts with total disbursements of $0.50 and below result in improper allocations
+    @Test
+    public void uc159() {
+        AtomicLong loanIdRef = new AtomicLong();
+        Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        final BigDecimal principalAmount = BigDecimal.valueOf(100.0);
+
+        runAt("26 October 2025", () -> {
+            // Create a Cumulative Multidisbursal and Flat Interest Type
+            PostLoanProductsResponse loanProductResponse = loanProductHelper
+                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                            .interestType(InterestType.DECLINING_BALANCE).daysInMonthType(1)//
+                            .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+                            .interestRateFrequencyType(YEARS).daysInYearType(1).loanScheduleType(LoanScheduleType.PROGRESSIVE.toString())
+                            .repaymentEvery(30).repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue())
+                            .installmentAmountInMultiplesOf(1).isEqualAmortization(false).repaymentFrequencyType(2L)
+                            .loanScheduleProcessingType("HORIZONTAL").multiDisburseLoan(true)//
+                            .maxTrancheCount(10).outstandingLoanBalance(1000.0).disallowExpectedDisbursements(true)//
+                            .enableBuyDownFee(true).merchantBuyDownFee(false)
+                            .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY).allowPartialPeriodInterestCalcualtion(false)//
+                            .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+                            .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
+                            .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
+                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue())
+                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())
+                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue()));
+            assertNotNull(loanProductResponse.getResourceId());
+
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "26 October 2025",
+                    principalAmount.doubleValue(), 1)//
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
+                    .interestRatePerPeriod(BigDecimal.valueOf(0.0))//
+                    .repaymentEvery(30)//
+                    .repaymentFrequencyType(DAYS)//
+                    .loanTermFrequency(30)//
+                    .loanTermFrequencyType(DAYS);
+            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            loanIdRef.set(loanResponse.getLoanId());
+
+            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("26 October 2025").locale(LOCALE));
+
+            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
+                    new PostLoansLoanIdRequest().actualDisbursementDate("26 October 2025").dateFormat(DATETIME_PATTERN).locale(LOCALE)
+                            .transactionAmount(BigDecimal.valueOf(0.50)));
+        });
+
+        runAt("27 October 2025", () -> {
+            final Long loanId = loanIdRef.get();
+
+            loanTransactionHelper.makeLoanRepayment(loanId, new PostLoansLoanIdTransactionsRequest() //
+                    .transactionDate("27 October 2025") //
+                    .transactionAmount(0.50) //
+                    .locale(LOCALE) //
+                    .dateFormat(DATETIME_PATTERN)); //
+
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            assertTrue(loanDetails.getStatus().getClosedObligationsMet());
         });
     }
 


### PR DESCRIPTION
## Description

Accounts with total disbursements of $0.50 and below result in improper allocations

[FINERACT-2389](https://issues.apache.org/jira/browse/FINERACT-2389)

<img width="2560" height="1363" alt="image" src="https://github.com/user-attachments/assets/4afadd0f-ec3f-4950-9041-e77116f001cc" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
