### PR TITLE
Simplify InputStream to String conversion using Java 11+ API

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.Authenticator;
@@ -55,21 +53,14 @@ public class TemplateMergeService {
 
     private final FineractProperties fineractProperties;
 
-    // TODO Replace this with appropriate alternative available in Guava
+    // Simplified using Java 11+ InputStream.readAllBytes() instead of manual buffering
     private static String getStringFromInputStream(final InputStream is) {
-        final StringBuilder sb = new StringBuilder();
-
-        String line;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-
-            while ((line = br.readLine()) != null) {
-                sb.append(line);
-            }
+        try {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         } catch (final IOException e) {
             log.error("getStringFromInputStream() failed", e);
+            return "";
         }
-
-        return sb.toString();
     }
 
     public String compile(final Template template, final Map<String, Object> scopes) {


### PR DESCRIPTION
## Description
This PR addresses the TODO comment in [TemplateMergeService.java](cci:7://file:///C:/Users/airaj/OneDrive/Desktop/gsoc/fineract/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java:0:0-0:0) (line 58) that requested replacing the manual InputStream-to-String conversion with an appropriate alternative.

## Changes
- Replace manual `BufferedReader`-based InputStream to String conversion with Java 11+ `InputStream.readAllBytes()`
- Remove unused imports: `BufferedReader`, `InputStreamReader`
- Reduces code from 15 lines to 8 lines

## Why This Approach
The original TODO suggested using Guava, but Java 11+ provides native `InputStream.readAllBytes()` which:
- Is cleaner and more readable
- Is part of the standard library (no external dependency needed)
- Handles encoding with `StandardCharsets.UTF_8` properly

## Testing
- ✅ `./gradlew :fineract-provider:compileJava` passes
- ✅ `./gradlew :fineract-provider:compileTestJava` passes