### PR TITLE
FINERACT-2421: Simplify InputStream to String conversion using Java 11+ API

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.Authenticator;
@@ -55,21 +53,13 @@ public class TemplateMergeService {
 
     private final FineractProperties fineractProperties;
 
-    // TODO Replace this with appropriate alternative available in Guava
     private static String getStringFromInputStream(final InputStream is) {
-        final StringBuilder sb = new StringBuilder();
-
-        String line;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-
-            while ((line = br.readLine()) != null) {
-                sb.append(line);
-            }
+        try {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         } catch (final IOException e) {
             log.error("getStringFromInputStream() failed", e);
+            return "";
         }
-
-        return sb.toString();
     }
 
     public String compile(final Template template, final Map<String, Object> scopes) {


### PR DESCRIPTION
## JIRA Ticket
https://issues.apache.org/jira/browse/FINERACT-2421

## Description
This PR simplifies the [getStringFromInputStream()](cci:1://file:///C:/Users/airaj/OneDrive/Desktop/gsoc/fineract/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java:55:4-63:5) method in [TemplateMergeService.java](cci:7://file:///C:/Users/airaj/OneDrive/Desktop/gsoc/fineract/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateMergeService.java:0:0-0:0) by replacing manual BufferedReader-based conversion with Java 11+ `InputStream.readAllBytes()`.

## Changes
- Replace manual InputStream to String conversion with `InputStream.readAllBytes()`
- Remove unused imports: `BufferedReader`, `InputStreamReader`
- Reduces code from 15 lines to 8 lines

## Why This Approach
Java 11+ provides native `InputStream.readAllBytes()` which is:
- Cleaner and more readable
- Part of the standard library (no external dependency)
- Properly handles UTF-8 encoding

## Testing
- ✅ `./gradlew :fineract-provider:compileJava` passes
- ✅ `./gradlew :fineract-provider:compileTestJava` passes