### PR TITLE
FINERACT-2421: Fix potential NullPointerException in CalendarCommandFromApiJsonDeserializer

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/command/CalendarCommand.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/command/CalendarCommand.java
@@ -39,7 +39,7 @@ public class CalendarCommand {
     @SuppressWarnings("unused")
     private final Integer typeId;
     @SuppressWarnings("unused")
-    private final boolean repeating;
+    private final Boolean repeating;
     @SuppressWarnings("unused")
     private final Integer remindById;
     @SuppressWarnings("unused")
@@ -48,7 +48,7 @@ public class CalendarCommand {
     private final Integer secondReminder;
 
     public CalendarCommand(final String title, final String description, final String location, final LocalDate startDate,
-            final LocalDate endDate, final LocalDate createdDate, final Integer duration, final Integer typeId, final boolean repeating,
+            final LocalDate endDate, final LocalDate createdDate, final Integer duration, final Integer typeId, final Boolean repeating,
             final Integer remindById, final Integer firstReminder, final Integer secondReminder) {
         this.title = title;
         this.description = description;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/serialization/CalendarCommandFromApiJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/serialization/CalendarCommandFromApiJsonDeserializer.java
@@ -81,7 +81,7 @@ public class CalendarCommandFromApiJsonDeserializer extends AbstractFromApiJsonD
                 element);
         final Integer typeId = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(CalendarSupportedParameters.TYPE_ID.getValue(),
                 element);
-        final boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
+        final Boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
         final Integer remindById = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(CalendarSupportedParameters.REMIND_BY_ID.getValue(),
                 element);
         final Integer firstReminder = this.fromApiJsonHelper
@@ -153,11 +153,10 @@ public class CalendarCommandFromApiJsonDeserializer extends AbstractFromApiJsonD
                 .inMinMaxRange(CalendarEntityType.getMinValue(), CalendarEntityType.getMaxValue());
 
         if (this.fromApiJsonHelper.parameterExists(CalendarSupportedParameters.REPEATING.getValue(), element)) {
-            // FIXME - Throws NullPointerException when boolean value is null
-            final boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
+            final Boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
             baseDataValidator.reset().parameter(CalendarSupportedParameters.REPEATING.getValue()).value(repeating).notNull();
 
-            if (repeating) {
+            if (Boolean.TRUE.equals(repeating)) {
                 final Integer frequency = this.fromApiJsonHelper
                         .extractIntegerSansLocaleNamed(CalendarSupportedParameters.FREQUENCY.getValue(), element);
                 baseDataValidator.reset().parameter(CalendarSupportedParameters.FREQUENCY.getValue()).value(frequency).notBlank()
@@ -295,11 +294,10 @@ public class CalendarCommandFromApiJsonDeserializer extends AbstractFromApiJsonD
                     .inMinMaxRange(CalendarEntityType.getMinValue(), CalendarEntityType.getMaxValue());
         }
         if (this.fromApiJsonHelper.parameterExists(CalendarSupportedParameters.REPEATING.getValue(), element)) {
-            // FIXME - Throws NullPointerException when boolean value is null
-            final boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
+            final Boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(CalendarSupportedParameters.REPEATING.getValue(), element);
             baseDataValidator.reset().parameter(CalendarSupportedParameters.REPEATING.getValue()).value(repeating).notNull();
 
-            if (repeating) {
+            if (Boolean.TRUE.equals(repeating)) {
                 final Integer frequency = this.fromApiJsonHelper
                         .extractIntegerSansLocaleNamed(CalendarSupportedParameters.FREQUENCY.getValue(), element);
                 baseDataValidator.reset().parameter(CalendarSupportedParameters.FREQUENCY.getValue()).value(frequency).notBlank()


### PR DESCRIPTION
## JIRA Ticket
https://issues.apache.org/jira/browse/FINERACT-2421

## Description
This PR fixes a potential `NullPointerException` in `CalendarCommandFromApiJsonDeserializer` when extracting boolean values from JSON. This addresses the FIXME comments on lines 156 and 298 in the original file.

## Problem
The `extractBooleanNamed` method can return `null` when the JSON value is null or missing. Using primitive `boolean` causes automatic unboxing which throws `NullPointerException`:
```java
// FIXME - Throws NullPointerException when boolean value is null
final boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(...); // NPE!
```

## Solution
Use `Boolean` wrapper type instead of primitive `boolean` and use null-safe comparison:
```java
final Boolean repeating = this.fromApiJsonHelper.extractBooleanNamed(...);
if (Boolean.TRUE.equals(repeating)) { ... }  // Null-safe
```


