### PR TITLE
FINERACT-2421: Fix GRETERTHAN typo in ConditionType enum

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/common/domain/ConditionType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/common/domain/ConditionType.java
@@ -25,8 +25,7 @@ public enum ConditionType {
     INVALID(0, "ConditionType.invalid"), //
     LESSTHAN(1, "ConditionType.lessthan"), //
     EQUAL(2, "ConditionType.equal"), //
-    // TODO: fix typo "GREATERTHAN"
-    GRETERTHAN(3, "ConditionType.greterthan"), //
+    GREATERTHAN(3, "ConditionType.greaterthan"), //
     NOT_EQUAL(4, "ConditionType.notequal");//
 
     private final Integer value;
@@ -43,7 +42,7 @@ public enum ConditionType {
             case 2:
                 return EQUAL;
             case 3:
-                return GRETERTHAN;
+                return GREATERTHAN;
             case 4:
                 return NOT_EQUAL;
             default:

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/common/service/CommonEnumerations.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/common/service/CommonEnumerations.java
@@ -94,9 +94,9 @@ public final class CommonEnumerations {
                 optionData = new EnumOptionData(ConditionType.NOT_EQUAL.getValue().longValue(),
                         codePrefix + ConditionType.NOT_EQUAL.getCode(), "notEqual");
             break;
-            case GRETERTHAN:
-                optionData = new EnumOptionData(ConditionType.GRETERTHAN.getValue().longValue(),
-                        codePrefix + ConditionType.GRETERTHAN.getCode(), "greterthan");
+            case GREATERTHAN:
+                optionData = new EnumOptionData(ConditionType.GREATERTHAN.getValue().longValue(),
+                        codePrefix + ConditionType.GREATERTHAN.getCode(), "greaterthan");
             break;
             case LESSTHAN:
                 optionData = new EnumOptionData(ConditionType.LESSTHAN.getValue().longValue(),

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/service/DropdownReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/service/DropdownReadPlatformServiceImpl.java
@@ -45,7 +45,7 @@ public class DropdownReadPlatformServiceImpl implements DropdownReadPlatformServ
     @Override
     public List<EnumOptionData> retrieveConditionTypeOptions() {
         return Arrays.asList(conditionType(ConditionType.EQUAL, "condition"), conditionType(ConditionType.NOT_EQUAL, "condition"),
-                conditionType(ConditionType.GRETERTHAN, "condition"), conditionType(ConditionType.LESSTHAN, "condition"));
+                conditionType(ConditionType.GREATERTHAN, "condition"), conditionType(ConditionType.LESSTHAN, "condition"));
     }
 
     @Override

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/interestratechart/incentive/AttributeIncentiveCalculation.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/interestratechart/incentive/AttributeIncentiveCalculation.java
@@ -38,7 +38,7 @@ public abstract class AttributeIncentiveCalculation {
             case NOT_EQUAL:
                 applyIncentive = compareVal != 0;
             break;
-            case GRETERTHAN:
+            case GREATERTHAN:
                 applyIncentive = compareVal > 0;
             break;
             default:


### PR DESCRIPTION
## Description
Fixes typo in `ConditionType` enum: `GRETERTHAN` → `GREATERTHAN`
This addresses the TODO comment at line 28 of ConditionType.java.
## Changes
- `ConditionType.java` - Fixed enum name and code string
- `CommonEnumerations.java` - Updated switch case references  
- `DropdownReadPlatformServiceImpl.java` - Updated enum reference
- `AttributeIncentiveCalculation.java` - Updated switch case
## Related Issue
FINERACT-2421