### PR TITLE
FINERACT-1266: Fix NullPointerException in SavingsHelper.determineInterestPostingPeriods

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsHelper.java
@@ -52,6 +52,11 @@ public final class SavingsHelper {
             final Integer financialYearBeginningMonth, List<LocalDate> postInterestAsOn) {
 
         final List<LocalDateInterval> postingPeriods = new ArrayList<>();
+
+        if (startInterestCalculationLocalDate == null || interestPostingUpToDate == null) {
+            return postingPeriods;
+        }
+
         LocalDate periodStartDate = startInterestCalculationLocalDate;
         LocalDate periodEndDate = periodStartDate;
         LocalDate actualPeriodStartDate = periodStartDate;


### PR DESCRIPTION
## Description
Fixes NullPointerException that occurs in `SavingsHelper.determineInterestPostingPeriods()` when date parameters are null.

The NPE occurs when closing a Fixed Deposit account if the maturity date is null (e.g., when `depositPeriodFrequencyType` is INVALID).

## Root Cause
The method `determineInterestPostingPeriods()` uses `DateUtils.isAfter()` which throws NPE when either `startInterestCalculationLocalDate` or `interestPostingUpToDate` is null.

## Fix
Added null check at the start of the method to return an empty list early if either date parameter is null.

## Testing
- Fix compiles successfully
- Verified the null check prevents the NPE scenario from the stack trace

## Related Issue
Fixes FINERACT-1266
```