### PR TITLE
FINERACT-2320: Return false instead of throwing exception when LOAN_COB is disabled

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/cob/api/LoanCOBCatchUpApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/api/LoanCOBCatchUpApiResource.java
@@ -86,7 +86,6 @@ public class LoanCOBCatchUpApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Retrieves whether Loan COB catch up is running", description = "Retrieves whether Loan COB catch up is running, and the current execution date if it is running.")
     public IsCatchUpRunningDTO isCatchUpRunning() {
-        return loanCOBCatchUpServiceOp.map(LoanCOBCatchUpService::isCatchUpRunning)
-                .orElseThrow(() -> new JobIsNotFoundOrNotEnabledException(JobName.LOAN_COB.name()));
+        return loanCOBCatchUpServiceOp.map(LoanCOBCatchUpService::isCatchUpRunning).orElse(new IsCatchUpRunningDTO(false, null));
     }
 }


### PR DESCRIPTION
## Description
Fixes the error "Job LOAN_COB is not found or it is disabled" that appears when navigating to Manage Jobs with LOAN_COB disabled.

## Root Cause
When `fineract.job.loan-cob-enabled=false`, the `/api/v1/loans/is-catch-up-running` endpoint throws `JobIsNotFoundOrNotEnabledException`, which maps to HTTP 403 Forbidden.

## Fix
Changed the `isCatchUpRunning()` method to return a default `IsCatchUpRunningDTO(false, null)` when the service is not available, instead of throwing an exception.

**Before:**
```java
.orElseThrow(() -> new JobIsNotFoundOrNotEnabledException(JobName.LOAN_COB.name()));
```

**After:**
```java
.orElse(new IsCatchUpRunningDTO(false, null));
```

## Related Issue
Fixes FINERACT-2320