### PR TITLE
FINERACT-2434: Add input validation to split-tests.sh script

### DIFF
--- a/scripts/split-tests.sh
+++ b/scripts/split-tests.sh
@@ -28,6 +28,21 @@ if [[ -z "$TOTAL_SHARDS" || -z "$SHARD_INDEX" ]]; then
   exit 1
 fi
 
+if ! [[ "$TOTAL_SHARDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: <total-shards> must be a positive integer."
+  exit 1
+fi
+
+if ! [[ "$SHARD_INDEX" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: <shard-index> must be a positive integer."
+  exit 1
+fi
+
+if [[ "$SHARD_INDEX" -gt "$TOTAL_SHARDS" ]]; then
+  echo "ERROR: <shard-index> ($SHARD_INDEX) must be between 1 and <total-shards> ($TOTAL_SHARDS)."
+  exit 1
+fi
+
 echo "🔍 Searching for eligible JUnit test classes..."
 
 ALL_TESTS=$(find . -type f -path "*/src/test/java/*.java" \


### PR DESCRIPTION
The split-tests.sh script currently only checks if arguments are provided but doesn't validate their values. This can lead to confusing behavior when users pass invalid inputs like negative numbers, zero, or non-numeric values.

This change adds basic input validation to make the script more robust and user-friendly. Now when someone runs the script with invalid arguments (like ./split-tests.sh 0 5 or ./split-tests.sh 3 abc), they'll get a clear error message explaining what went wrong instead of the script failing mysteriously later.

The validation ensures:

Both arguments are positive integers (no zero, negative, or text values)

The shard index doesn't exceed the total number of shards

Users get helpful error messages when something is wrong

This is a small improvement that makes the script safer and easier to use, especially for new contributors who might not be familiar with the expected input format.