### PR TITLE
FINERACT-2164: Add Gradle SBOM (Software Bill of Materials) generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ plugins {
     id 'org.openapi.generator' version '7.8.0' apply false
     id 'com.gradleup.shadow' version '8.3.5' apply false
     id 'me.champeau.jmh' version '0.7.1' apply false
+    id 'org.cyclonedx.bom' version '3.1.0' apply false
 }
 
 apply from: "${rootDir}/buildSrc/src/main/groovy/org.apache.fineract.release.gradle"
@@ -884,6 +885,16 @@ configure(project.fineractPublishProjects) {
             sign publishing.publications.mavenJava
         }
     }
+}
+
+// Configuration for CycloneDX SBOM generator
+// https://github.com/CycloneDX/cyclonedx-gradle-plugin
+apply plugin: 'org.cyclonedx.bom'
+
+cyclonedxBom {
+    projectType = "application"
+    includeBomSerialNumber = true
+    includeLicenseText = true
 }
 
 task printSourceSetInformation() {


### PR DESCRIPTION
## Description

This PR adds CycloneDX SBOM (Software Bill of Materials) generator to the Fineract build system. SBOM is important for security compliance and allows vendors to promote the solution in regulated environments.

## Changes

- Add CycloneDX plugin (version 3.1.0) to plugins block
- Configure SBOM generation with license information
- Task is optional and NOT part of default build

## Usage

```bash
# Generate SBOM for a specific module
./gradlew :fineract-provider:cyclonedxDirectBom

# Output files
build/reports/cyclonedx-direct/bom.json
build/reports/cyclonedx-direct/bom.xml