### PR TITLE
FINERACT-2428: Fix 'acount' typo to 'account' in legacy docs

### DIFF
--- a/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
+++ b/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
@@ -34779,7 +34779,7 @@ No Request Body:
 	        </code>
 	    </div>
 	</div>
-<!-- end of acount transfers api -->
+<!-- end of account transfers api -->
 
 <!-- Start Account Trasfer Standing Instrution-->
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
@@ -3851,7 +3851,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
     // every 2 months)
     // ADVANCED_PAYMENT_ALLOCATION_STRATEGY
     // 1. Create a Loan product with Adv. Pment. Alloc. and No Interest
-    // 2. Submit Loan and approve -> expect validation error - Loan acount Fixed
+    // 2. Submit Loan and approve -> expect validation error - Loan account Fixed
     // Length with a wrong Loan Term setup
     @Test
     public void uc132() {


### PR DESCRIPTION
## Description

This pull request corrects a spelling error in the legacy documentation and comments where the word “acount” was mistakenly used instead of the correct term “account”.

- Corrected the spelling in the legacy apiLive.htm documentation file.
- Updated the typo in an integration test comment.

⚠️ Note: This change is purely cosmetic and does not affect business logic, API behavior, or compiled code. It improves clarity and correctness in documentation only.

Jira ticket: https://issues.apache.org/jira/browse/FINERACT-2428

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
