### PR TITLE
FINERACT-263: Add Notes for Centers permission is missing

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -102,4 +102,9 @@
     <Match>
         <Bug pattern="UR_UNINIT_READ" />
     </Match>
+    <Match>
+        <Class name="org.apache.fineract.commands.domain.CommandWrapper" />
+        <Field name="centerId" />
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
 </FindBugsFilter>

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandWrapper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandWrapper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.commands.domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Set;
 import lombok.Getter;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
@@ -33,6 +34,8 @@ public class CommandWrapper {
     private final Long clientId;
     private final Long loanId;
     private final Long savingsId;
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Will be used for center-specific permissions")
+    private final Long centerId;
     private final String actionName;
     private final String entityName;
     private final String taskPermissionName;
@@ -80,6 +83,7 @@ public class CommandWrapper {
         this.clientId = null;
         this.loanId = null;
         this.savingsId = null;
+        this.centerId = null;
         this.actionName = actionName;
         this.entityName = entityName;
         this.taskPermissionName = actionName + "_" + entityName;
@@ -98,10 +102,10 @@ public class CommandWrapper {
     }
 
     public CommandWrapper(final Long officeId, final Long groupId, final Long clientId, final Long loanId, final Long savingsId,
-            final String actionName, final String entityName, final Long entityId, final Long subentityId, final String href,
-            final String json, final String transactionId, final Long productId, final Long templateId, final Long creditBureauId,
-            final Long organisationCreditBureauId, final String jobName, final String idempotencyKey, final ExternalId loanExternalId,
-            final Set<String> sanitizeJsonKeys) {
+            final Long centerId, final String actionName, final String entityName, final Long entityId, final Long subentityId,
+            final String href, final String json, final String transactionId, final Long productId, final Long templateId,
+            final Long creditBureauId, final Long organisationCreditBureauId, final String jobName, final String idempotencyKey,
+            final ExternalId loanExternalId, final Set<String> sanitizeJsonKeys) {
 
         this.commandId = null;
         this.officeId = officeId;
@@ -109,6 +113,7 @@ public class CommandWrapper {
         this.clientId = clientId;
         this.loanId = loanId;
         this.savingsId = savingsId;
+        this.centerId = centerId;
         this.actionName = actionName;
         this.entityName = entityName;
         this.taskPermissionName = actionName + "_" + entityName;
@@ -139,6 +144,7 @@ public class CommandWrapper {
         this.clientId = clientId;
         this.loanId = loanId;
         this.savingsId = savingsId;
+        this.centerId = null;
         this.actionName = actionName;
         this.entityName = entityName;
         this.taskPermissionName = actionName + "_" + entityName;

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -41,6 +41,7 @@ public class CommandWrapperBuilder {
     private Long clientId;
     private Long loanId;
     private Long savingsId;
+    private Long centerId;
     private String actionName;
     private String entityName;
     private Long entityId;
@@ -59,15 +60,15 @@ public class CommandWrapperBuilder {
 
     @SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD", justification = "TODO: fix this!")
     public CommandWrapper build() {
-        return new CommandWrapper(this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId, this.actionName, this.entityName,
-                this.entityId, this.subentityId, this.href, this.json, this.transactionId, this.productId, this.templateId,
+        return new CommandWrapper(this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId, this.centerId, this.actionName,
+                this.entityName, this.entityId, this.subentityId, this.href, this.json, this.transactionId, this.productId, this.templateId,
                 this.creditBureauId, this.organisationCreditBureauId, this.jobName, this.idempotencyKey, this.loanExternalId,
                 this.sanitizeJsonKeys);
     }
 
     public CommandWrapper build(String idempotencyKey) {
-        return new CommandWrapper(this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId, this.actionName, this.entityName,
-                this.entityId, this.subentityId, this.href, this.json, this.transactionId, this.productId, this.templateId,
+        return new CommandWrapper(this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId, this.centerId, this.actionName,
+                this.entityName, this.entityId, this.subentityId, this.href, this.json, this.transactionId, this.productId, this.templateId,
                 this.creditBureauId, this.organisationCreditBureauId, this.jobName, idempotencyKey, this.loanExternalId,
                 this.sanitizeJsonKeys);
     }
@@ -200,6 +201,11 @@ public class CommandWrapperBuilder {
 
     public CommandWrapperBuilder withClientId(final Long withClientId) {
         this.clientId = withClientId;
+        return this;
+    }
+
+    public CommandWrapperBuilder withCenterId(final Long centerId) {
+        this.centerId = centerId;
         return this;
     }
 

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/note/domain/NoteType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/note/domain/NoteType.java
@@ -28,6 +28,7 @@ public enum NoteType {
     CLIENT(100, "noteType.client", "clients", "Client note"), //
     LOAN(200, "noteType.loan", "loans", "Loan note"), //
     LOAN_TRANSACTION(300, "noteType.loan.transaction", "loanTransactions", "Loan transaction note"), //
+    CENTER(400, "noteType.center", "centers", "Center note"), //
     SAVING_ACCOUNT(500, "noteType.saving", "savings", " account note"), //
     GROUP(600, "noteType.group", "groups", "Group note"), //
     SHARE_ACCOUNT(700, "noteType.shares", "accounts/share", "Share account note"), //

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/exception/IdempotencyCommandProcessFailedExceptionTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/exception/IdempotencyCommandProcessFailedExceptionTest.java
@@ -59,7 +59,7 @@ public class IdempotencyCommandProcessFailedExceptionTest {
 
         IdempotentCommandExceptionMapper mapper = new IdempotentCommandExceptionMapper();
         CommandWrapper command = new CommandWrapper(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
         CommandSource source = CommandSource.fullEntryFrom(command, JsonCommand.from("{}"), null, "dummy-key", null, false);
         IdempotentCommandProcessFailedException exception = new IdempotentCommandProcessFailedException(command, null, source);
         Response result = mapper.toResponse(exception);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/center/CenterImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/center/CenterImportHandler.java
@@ -267,7 +267,7 @@ public class CenterImportHandler implements ImportHandler {
 
         String payload = gsonBuilder.create().toJson(calendarData);
         CommandWrapper commandWrapper = new CommandWrapper(result.getOfficeId(), result.getGroupId(), result.getClientId(),
-                result.getLoanId(), result.getSavingsId(), null, null, null, null, null, payload, result.getTransactionId(),
+                result.getLoanId(), result.getSavingsId(), null, null, null, null, null, null, payload, result.getTransactionId(),
                 result.getProductId(), null, null, null, null, idempotencyKeyGenerator.create(), null, null);
         final CommandWrapper commandRequest = new CommandWrapperBuilder() //
                 .createCalendar(commandWrapper, TemplatePopulateImportConstants.CENTER_ENTITY_TYPE, result.getGroupId()) //

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/group/GroupImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/group/GroupImportHandler.java
@@ -260,7 +260,7 @@ public class GroupImportHandler implements ImportHandler {
         payload = gsonBuilder.create().toJson(modifiedCalendarData);
 
         CommandWrapper commandWrapper = new CommandWrapper(result.getOfficeId(), result.getGroupId(), result.getClientId(),
-                result.getLoanId(), result.getSavingsId(), null, null, null, null, null, payload, result.getTransactionId(),
+                result.getLoanId(), result.getSavingsId(), null, null, null, null, null, null, payload, result.getTransactionId(),
                 result.getProductId(), null, null, null, null, idempotencyKeyGenerator.create(), null, null);
         final CommandWrapper commandRequest = new CommandWrapperBuilder() //
                 .createCalendar(commandWrapper, TemplatePopulateImportConstants.CENTER_ENTITY_TYPE, result.getGroupId()) //

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropWrapperBuilder.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropWrapperBuilder.java
@@ -36,8 +36,8 @@ public class InteropWrapperBuilder {
     private String json = "{}";
 
     public CommandWrapper build() {
-        return new CommandWrapper(null, null, null, null, null, actionName, entityName, null, null, href, json, null, null, null, null,
-                null, null, null, null, null);
+        return new CommandWrapper(null, null, null, null, null, null, actionName, entityName, null, null, href, json, null, null, null,
+                null, null, null, null, null, null);
     }
 
     public InteropWrapperBuilder withJson(final String json) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/api/NotesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/api/NotesApiResource.java
@@ -65,6 +65,7 @@ public class NotesApiResource {
     public static final String LOANTRANSACTIONNOTE = "LOANTRANSACTIONNOTE";
     public static final String SAVINGNOTE = "SAVINGNOTE";
     public static final String GROUPNOTE = "GROUPNOTE";
+    public static final String CENTERNOTE = "CENTERNOTE";
     public static final String INVALIDNOTE = "INVALIDNOTE";
     private static final Set<String> NOTE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList("id", "resourceId", "clientId", "groupId", "loanId", "loanTransactionId", "depositAccountId", "savingAccountId",
@@ -228,7 +229,11 @@ public class NotesApiResource {
                 resourceNameForPermissions = GROUPNOTE;
                 resourceDetails.withGroupId(resourceId);
             }
-            default -> resourceNameForPermissions = INVALIDNOTE;
+            case CENTER -> {
+                resourceNameForPermissions = CENTERNOTE;
+                resourceDetails.withCenterId(resourceId);
+            }
+            default -> throw new NoteResourceNotSupportedException(type.name());
         }
         return resourceDetails.withEntityName(resourceNameForPermissions).build();
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/service/NoteWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/note/service/NoteWritePlatformServiceJpaRepositoryImpl.java
@@ -461,6 +461,8 @@ public class NoteWritePlatformServiceJpaRepositoryImpl implements NoteWritePlatf
             case SAVINGS_TRANSACTION:
                 log.error("TODO Implement getNoteForDelete for SAVINGS_TRANSACTION");
             break;
+            default:
+                throw new UnsupportedOperationException("Note type not supported: " + type);
         }
         if (noteForUpdate == null) {
             throw new NoteNotFoundException(noteId, resourceId, type.name().toLowerCase());

--- a/fineract-provider/src/test/java/org/apache/fineract/commands/service/CommandServiceStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/commands/service/CommandServiceStepDefinitions.java
@@ -106,7 +106,7 @@ public class CommandServiceStepDefinitions implements En {
     public static class DummyCommand extends CommandWrapper {
 
         public DummyCommand() {
-            super(null, null, null, null, null, null, null, null, null, null, "{}", null, null, null, null, null, null,
+            super(null, null, null, null, null, null, null, null, null, null, null, "{}", null, null, null, null, null, null,
                     UUID.randomUUID().toString(), null, null);
         }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/commands/service/IdempotencyKeyResolverTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/commands/service/IdempotencyKeyResolverTest.java
@@ -77,7 +77,7 @@ public class IdempotencyKeyResolverTest {
     public void testIPKResolveFromWrapper() {
         String idk = "idk";
         CommandWrapper wrapper = new CommandWrapper(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, idk, null, null);
+                null, null, null, null, idk, null, null);
         String resolvedIdk = underTest.resolve(wrapper);
         Assertions.assertEquals(idk, resolvedIdk);
     }


### PR DESCRIPTION
## Description

This PR fixes missing permission handling for Center Notes in the Notes API.

Previously, when accessing notes for a CENTER resource, the request fell into the default case, resulting in a NoteResourceNotSupportedException. This allowed center notes to be accessed without proper, explicit permission mapping.

changes made: 

- Added CENTER enum value to NoteType
- Added centerId field and withCenterId() method to CommandWrapperBuilder  
- Added CENTER case in NotesApiResource.getResourceDetails()
- Enable separate permissions for Read, Create, Update, Delete center notes
- Follows same permission pattern as existing GROUP notes

Jira issue:-  https://issues.apache.org/jira/projects/FINERACT/issues/FINERACT-263

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
