### PR TITLE
FINERACT-2399: Add global config to block transactions on closed/overpaid loans

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationConstants.java
@@ -87,6 +87,7 @@ public final class GlobalConfigurationConstants {
     public static final String FORCE_WITHDRAWAL_ON_SAVINGS_ACCOUNT_LIMIT = "force-withdrawal-on-savings-account-limit";
     public static final String FORCE_PASSWORD_RESET_ON_FIRST_LOGIN = "force-password-reset-on-first-login";
     public static final String ALLOW_CASH_AND_NON_CASH_ACCRUAL = "allow-cash-and-non-cash-accrual";
+    public static final String BLOCK_TRANSACTIONS_ON_CLOSED_OVERPAID_LOANS = "block-transactions-on-closed-overpaid-loans";
 
     private GlobalConfigurationConstants() {}
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -165,4 +165,6 @@ public interface ConfigurationDomainService {
     Integer retrieveMaxLoginRetries();
 
     boolean isAllowCashAndNonCashAccrual();
+
+    boolean isBlockTransactionsOnClosedOverpaidLoansEnabled();
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidator.java
@@ -40,6 +40,11 @@ public interface LoanTransactionValidator {
 
     void validateTransaction(String json);
 
+    default void validateTransaction(Loan loan, LoanTransactionType loanTransactionType, String json) {
+        validateTransaction(json);
+        validateLoanNotClosedOrOverpaidForTransactions(loan, loanTransactionType);
+    }
+
     void validateChargebackTransaction(String json);
 
     void validateNewRepaymentTransaction(String json);
@@ -98,4 +103,8 @@ public interface LoanTransactionValidator {
     void validateManualInterestRefundTransaction(String json);
 
     void validateClassificationCodeValue(String codeName, Long transactionClassificationId, DataValidatorBuilder baseDataValidator);
+
+    void validateLoanNotClosedOrOverpaidForTransactions(Loan loan);
+
+    void validateLoanNotClosedOrOverpaidForTransactions(Loan loan, LoanTransactionType loanTransactionType);
 }

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ProgressiveLoanTransactionValidatorImpl.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ProgressiveLoanTransactionValidatorImpl.java
@@ -516,6 +516,16 @@ public class ProgressiveLoanTransactionValidatorImpl implements ProgressiveLoanT
     }
 
     @Override
+    public void validateLoanNotClosedOrOverpaidForTransactions(Loan loan) {
+        loanTransactionValidator.validateLoanNotClosedOrOverpaidForTransactions(loan);
+    }
+
+    @Override
+    public void validateLoanNotClosedOrOverpaidForTransactions(Loan loan, LoanTransactionType loanTransactionType) {
+        loanTransactionValidator.validateLoanNotClosedOrOverpaidForTransactions(loan, loanTransactionType);
+    }
+
+    @Override
     public void validateActivityNotBeforeLastTransactionDate(Loan loan, LocalDate activityDate, LoanEvent event) {
         loanTransactionValidator.validateActivityNotBeforeLastTransactionDate(loan, activityDate, event);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
@@ -591,4 +591,9 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
     public boolean isAllowCashAndNonCashAccrual() {
         return getGlobalConfigurationPropertyData(GlobalConfigurationConstants.ALLOW_CASH_AND_NON_CASH_ACCRUAL).isEnabled();
     }
+
+    @Override
+    public boolean isBlockTransactionsOnClosedOverpaidLoansEnabled() {
+        return getGlobalConfigurationPropertyData(GlobalConfigurationConstants.BLOCK_TRANSACTIONS_ON_CLOSED_OVERPAID_LOANS).isEnabled();
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
@@ -218,6 +218,7 @@ public class LoanAccountDomainServiceJpa implements LoanAccountDomainService {
             final boolean isRecoveryRepayment, final String chargeRefundChargeType, boolean isAccountTransfer,
             HolidayDetailDTO holidayDetailDto, Boolean isHolidayValidationDone, final boolean isLoanToLoanTransfer) {
         checkClientOrGroupActive(loan);
+        loanTransactionValidator.validateLoanNotClosedOrOverpaidForTransactions(loan, repaymentTransactionType);
 
         LoanBusinessEvent repaymentEvent = getLoanRepaymentTypeBusinessEvent(repaymentTransactionType, isRecoveryRepayment, loan);
         businessEventNotifierService.notifyPreBusinessEvent(repaymentEvent);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
@@ -37,6 +37,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepository;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
@@ -111,6 +112,7 @@ public class LoanTransactionValidatorImpl implements LoanTransactionValidator {
     private final LoanDownPaymentTransactionValidator loanDownPaymentTransactionValidator;
     private final LoanDisbursementValidator loanDisbursementValidator;
     private final CodeValueRepository codeValueRepository;
+    private final ConfigurationDomainService configurationDomainService;
 
     private void throwExceptionIfValidationWarningsExist(final List<ApiParameterError> dataValidationErrors) {
         if (!dataValidationErrors.isEmpty()) {
@@ -667,6 +669,23 @@ public class LoanTransactionValidatorImpl implements LoanTransactionValidator {
         }
     }
 
+    @Override
+    public void validateLoanNotClosedOrOverpaidForTransactions(Loan loan) {
+        validateLoanNotClosedOrOverpaidForTransactions(loan, null);
+    }
+
+    @Override
+    public void validateLoanNotClosedOrOverpaidForTransactions(Loan loan, LoanTransactionType loanTransactionType) {
+        boolean blockTransactions = configurationDomainService.isBlockTransactionsOnClosedOverpaidLoansEnabled();
+        if (LoanTransactionType.CREDIT_BALANCE_REFUND.equals(loanTransactionType)) {
+            return;
+        }
+        if (blockTransactions && (loan.isClosed() || loan.getStatus().isOverpaid())) {
+            throw new GeneralPlatformDomainRuleException("error.msg.loan.transaction.not.allowed.on.closed.or.overpaid",
+                    "Monetary transactions are not allowed on closed or overpaid loan accounts", loan.getId());
+        }
+    }
+
     protected void validateLoanHasNoLaterChargeRefundTransactionToReverseOrCreateATransaction(Loan loan, LocalDate transactionDate,
             String reversedOrCreated) {
         for (LoanTransaction txn : loan.getLoanTransactions()) {
@@ -789,6 +808,7 @@ public class LoanTransactionValidatorImpl implements LoanTransactionValidator {
         validateLoanClientIsActive(loan);
         validateLoanHasCurrency(loan);
         validateLoanGroupIsActive(loan);
+        validateLoanNotClosedOrOverpaidForTransactions(loan, LoanTransactionType.INTEREST_PAYMENT_WAIVER);
         loanDownPaymentTransactionValidator.validateLoanStatusIsActiveOrFullyPaidOrOverpaid(loan);
         validateLoanDisbursementIsBeforeTransactionDate(loan, transactionDate);
         validateLoanHasNoLaterChargeRefundTransactionToReverseOrCreateATransaction(loan, transactionDate, "created");
@@ -826,6 +846,7 @@ public class LoanTransactionValidatorImpl implements LoanTransactionValidator {
     public void validateRefund(final Loan loan, LoanTransactionType loanTransactionType, final LocalDate transactionDate,
             ScheduleGeneratorDTO scheduleGeneratorDTO) {
         checkClientOrGroupActive(loan);
+        validateLoanNotClosedOrOverpaidForTransactions(loan, loanTransactionType);
         loanDownPaymentTransactionValidator.validateLoanStatusIsActiveOrFullyPaidOrOverpaid(loan);
         validateActivityNotBeforeClientOrGroupTransferDate(loan, transactionDate);
         validateRepaymentTypeTransactionNotBeforeAChargeRefund(loan, loanTransactionType, transactionDate);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -699,7 +699,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
             final Throwable realCause = e.getCause();
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
             final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan.transaction");
-            if (realCause.getMessage().toLowerCase(java.util.Locale.ROOT).contains("external_id_unique")) {
+            if (realCause.getMessage().toLowerCase(Locale.ROOT).contains("external_id_unique")) {
                 baseDataValidator.reset().parameter(LoanApiConstants.externalIdParameterName).failWithCode("value.must.be.unique");
             }
             if (!dataValidationErrors.isEmpty()) {
@@ -717,7 +717,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
             final Throwable realCause = e.getCause();
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
             final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan.transaction");
-            if (realCause.getMessage().toLowerCase(java.util.Locale.ROOT).contains("external_id_unique")) {
+            if (realCause.getMessage().toLowerCase(Locale.ROOT).contains("external_id_unique")) {
                 baseDataValidator.reset().parameter(LoanApiConstants.externalIdParameterName).failWithCode("value.must.be.unique");
             }
             if (!dataValidationErrors.isEmpty()) {
@@ -1392,9 +1392,6 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
     @Transactional
     @Override
     public CommandProcessingResult waiveInterestOnLoan(final Long loanId, final JsonCommand command) {
-
-        this.loanTransactionValidator.validateTransaction(command.json());
-
         final Map<String, Object> changes = new LinkedHashMap<>();
         changes.put("transactionDate", command.stringValueOfParameterNamed("transactionDate"));
         changes.put("transactionAmount", command.stringValueOfParameterNamed("transactionAmount"));
@@ -1405,6 +1402,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
         final ExternalId externalId = externalIdFactory.createFromCommand(command, LoanApiConstants.externalIdParameterName);
 
         Loan loan = this.loanAssembler.assembleFrom(loanId);
+        loanTransactionValidator.validateTransaction(loan, LoanTransactionType.WAIVE_INTEREST, command.json());
         checkClientOrGroupActive(loan);
 
         final Money transactionAmountAsMoney = Money.of(loan.getCurrency(), transactionAmount);

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -246,4 +246,5 @@
     <include file="parts/0225_add_originator_external_ids_to_aggregation_summary.xml" relativeToChangelogFile="true" />
     <include file="parts/0226_trial_balance_summary_fix_originator_join_conditions.xml" relativeToChangelogFile="true" />
     <include file="parts/0227_postgresql_client_and_loan_trends_reports.xml" relativeToChangelogFile="true" />
+    <include file="parts/0228_add_configuration_block_transactions_on_closed_overpaid_loans.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0228_add_configuration_block_transactions_on_closed_overpaid_loans.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0228_add_configuration_block_transactions_on_closed_overpaid_loans.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="2">
+        <insert tableName="c_configuration">
+            <column name="name" value="block-transactions-on-closed-overpaid-loans"/>
+            <column name="value"/>
+            <column name="date_value"/>
+            <column name="string_value"/>
+            <column name="enabled" valueBoolean="false"/>
+            <column name="is_trap_door" valueBoolean="false"/>
+            <column name="description" value="If enabled: monetary transactions are blocked on closed and overpaid loan accounts"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BlockTransactionsOnClosedOverpaidLoansTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BlockTransactionsOnClosedOverpaidLoansTest.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.ArrayList;
+import java.util.HashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class BlockTransactionsOnClosedOverpaidLoansTest {
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private LoanTransactionHelper loanTransactionHelper;
+    private LoanTransactionHelper loanTransactionHelperForError;
+    private GlobalConfigurationHelper globalConfigurationHelper;
+    private AccountHelper accountHelper;
+    private ResponseSpecification responseSpecForError;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.responseSpecForError = new ResponseSpecBuilder().expectStatusCode(403).build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+        this.loanTransactionHelperForError = new LoanTransactionHelper(this.requestSpec, this.responseSpecForError);
+        this.globalConfigurationHelper = new GlobalConfigurationHelper();
+        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        this.globalConfigurationHelper.manageConfigurations("block-transactions-on-closed-overpaid-loans", false);
+    }
+
+    @Test
+    public void testTransactionsOnOverpaidLoan() {
+        this.globalConfigurationHelper.manageConfigurations("block-transactions-on-closed-overpaid-loans", true);
+
+        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
+        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+
+        final Integer loanProductID = createLoanProduct();
+        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "1000", "01 January 2024");
+
+        this.loanTransactionHelper.approveLoan("01 January 2024", loanID);
+        this.loanTransactionHelper.disburseLoanWithNetDisbursalAmount("01 January 2024", loanID, "1000");
+
+        this.loanTransactionHelper.makeRepayment("01 February 2024", 2000.0f, loanID);
+
+        HashMap loanStatusHashMap = (HashMap) this.loanTransactionHelper.getLoanDetail(this.requestSpec, this.responseSpec, loanID,
+                "status");
+        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+
+        ArrayList<HashMap> repaymentErrors = (ArrayList<HashMap>) this.loanTransactionHelperForError.makeRepaymentTypePayment("repayment",
+                "02 February 2024", 10.0f, loanID, CommonConstants.RESPONSE_ERROR);
+        Assertions.assertEquals("error.msg.loan.transaction.not.allowed.on.closed.or.overpaid",
+                repaymentErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
+        assertBlockedForClosedOrOverpaid("goodwillCredit", loanID, "02 February 2024", 10.0f);
+        assertBlockedForClosedOrOverpaid("merchantIssuedRefund", loanID, "02 February 2024", 10.0f);
+        assertBlockedForClosedOrOverpaid("payoutRefund", loanID, "02 February 2024", 10.0f);
+        assertBlockedForClosedOrOverpaid("waiveinterest", loanID, "02 February 2024", 10.0f);
+
+        Float totalOverpaid = (Float) this.loanTransactionHelper.getLoanDetail(this.requestSpec, this.responseSpec, loanID,
+                "totalOverpaid");
+        assertNotNull(totalOverpaid);
+        Assertions.assertTrue(totalOverpaid > 0);
+
+        this.loanTransactionHelper.creditBalanceRefund("03 February 2024", totalOverpaid, null, loanID, "");
+
+        loanStatusHashMap = (HashMap) this.loanTransactionHelper.getLoanDetail(this.requestSpec, this.responseSpec, loanID, "status");
+        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+    }
+
+    @Test
+    public void testTransactionsOnClosedLoan() {
+        this.globalConfigurationHelper.manageConfigurations("block-transactions-on-closed-overpaid-loans", true);
+
+        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
+        final Integer loanProductID = createLoanProduct();
+        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "1000", "01 January 2024");
+
+        this.loanTransactionHelper.approveLoan("01 January 2024", loanID);
+        this.loanTransactionHelper.disburseLoanWithNetDisbursalAmount("01 January 2024", loanID, "1000");
+
+        HashMap loanSummary = this.loanTransactionHelper.getLoanSummary(this.requestSpec, this.responseSpec, loanID);
+        Float totalOutstanding = (Float) loanSummary.get("totalOutstanding");
+        HashMap repaymentTransaction = this.loanTransactionHelper.makeRepayment("01 February 2024", totalOutstanding, loanID);
+        Integer repaymentTransactionId = ((Number) repaymentTransaction.get("resourceId")).intValue();
+
+        HashMap loanStatusHashMap = (HashMap) this.loanTransactionHelper.getLoanDetail(this.requestSpec, this.responseSpec, loanID,
+                "status");
+        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+
+        ArrayList<HashMap> repaymentErrors = (ArrayList<HashMap>) this.loanTransactionHelperForError.makeRepaymentTypePayment("repayment",
+                "02 February 2024", 10.0f, loanID, CommonConstants.RESPONSE_ERROR);
+        Assertions.assertEquals("error.msg.loan.transaction.not.allowed.on.closed.or.overpaid",
+                repaymentErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
+
+        this.loanTransactionHelper.reverseRepayment(loanID, repaymentTransactionId, "03 February 2024");
+
+        this.globalConfigurationHelper.manageConfigurations("block-transactions-on-closed-overpaid-loans", false);
+        this.loanTransactionHelper.makeRepayment("04 February 2024", 10.0f, loanID);
+    }
+
+    private void assertBlockedForClosedOrOverpaid(final String command, final Integer loanId, final String date, final Float amount) {
+        ArrayList<HashMap> errors = (ArrayList<HashMap>) this.loanTransactionHelperForError.makeRepaymentTypePayment(command, date, amount,
+                loanId, CommonConstants.RESPONSE_ERROR);
+        Assertions.assertEquals("error.msg.loan.transaction.not.allowed.on.closed.or.overpaid",
+                errors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
+    }
+
+    private Integer createLoanProduct() {
+        final String principal = "1000.00";
+        LoanProductTestBuilder loanProductTestBuilder = new LoanProductTestBuilder() //
+                .withPrincipal(principal) //
+                .withShortName(Utils.uniqueRandomStringGenerator("", 4)) //
+                .withNumberOfRepayments("4") //
+                .withRepaymentAfterEvery("1") //
+                .withRepaymentTypeAsMonth() //
+                .withinterestRatePerPeriod("1") //
+                .withInterestRateFrequencyTypeAsMonths() //
+                .withAmortizationTypeAsEqualInstallments() //
+                .withInterestTypeAsDecliningBalance();
+
+        final String loanProductJSON = loanProductTestBuilder.build(null);
+        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    }
+
+    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String principal, String submitDate) {
+        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
+                .withPrincipal(principal) //
+                .withLoanTermFrequency("4") //
+                .withLoanTermFrequencyAsMonths() //
+                .withNumberOfRepayments("4") //
+                .withRepaymentEveryAfter("1") //
+                .withRepaymentFrequencyTypeAsMonths() //
+                .withInterestRatePerPeriod("1") //
+                .withAmortizationTypeAsEqualInstallments() //
+                .withInterestTypeAsDecliningBalance() //
+                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
+                .withExpectedDisbursementDate(submitDate) //
+                .withSubmittedOnDate(submitDate) //
+                .build(clientID.toString(), loanProductID.toString(), null);
+        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
@@ -572,6 +572,13 @@ public class GlobalConfigurationHelper {
         enableImmediateChargeAccrualPostMaturity.put("trapDoor", false);
         defaults.add(enableImmediateChargeAccrualPostMaturity);
 
+        HashMap<String, Object> blockTransactionsOnClosedOverpaidLoans = new HashMap<>();
+        blockTransactionsOnClosedOverpaidLoans.put("name", GlobalConfigurationConstants.BLOCK_TRANSACTIONS_ON_CLOSED_OVERPAID_LOANS);
+        blockTransactionsOnClosedOverpaidLoans.put("value", 0L);
+        blockTransactionsOnClosedOverpaidLoans.put("enabled", false);
+        blockTransactionsOnClosedOverpaidLoans.put("trapDoor", false);
+        defaults.add(blockTransactionsOnClosedOverpaidLoans);
+
         HashMap<String, Object> assetOwnerTransferInterestOutstandingStrategy = new HashMap<>();
         assetOwnerTransferInterestOutstandingStrategy.put("name",
                 GlobalConfigurationConstants.ASSET_OWNER_TRANSFER_OUTSTANDING_INTEREST_CALCULATION_STRATEGY);


### PR DESCRIPTION
## Description
Fixes FINERACT-2399

This PR adds a new global configuration `block-transactions-on-closed-overpaid-loans` that allows organizations to prevent monetary transactions on loan accounts with closed or overpaid status.

## Problem
Currently, Fineract allows monetary transactions (repayments, refunds, charges, etc.) on loans that are in closed or overpaid status. This can cause:
- Data integrity issues
- Accounting reconciliation problems
- Unintended transactions on settled accounts

## Solution
Added a global configuration toggle:
- **When disabled (default)**: Current behavior preserved - transactions allowed on closed/overpaid loans
- **When enabled**: Monetary transactions are blocked with appropriate error message

