### PR TITLE
FINERACT-2053: Fix Prometheus scraping config path and hostname

### DIFF
--- a/config/docker/prometheus/etc/prometheus.yml
+++ b/config/docker/prometheus/etc/prometheus.yml
@@ -46,12 +46,14 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  - job_name: "fineract-server"
+  - job_name: "fineract-development"
 
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-    metrics_path: "/actuator/prometheus"
+    metrics_path: "/fineract-provider/actuator/prometheus"
     scheme: "https"
+    tls_config:
+      insecure_skip_verify: true
 
     static_configs:
-      - targets: ["fineract-server:8443"]
+      - targets: ["fineract-development:8443"]


### PR DESCRIPTION
## Description

This PR fixes the Prometheus scraping configuration for the development stack as described in [FINERACT-2053](https://issues.apache.org/jira/browse/FINERACT-2053).

The default `docker-compose` configuration for Prometheus was failing to scrape metrics from Fineract due to incorrect paths, SSL verification issues, and hostname mismatches.

**Changes made:**
1.  **Metrics Path:** Updated `metrics_path` to include the context path `/fineract-provider/actuator/prometheus` (previously just `/actuator/prometheus`).
2.  **TLS Config:** Added `insecure_skip_verify: true` to `tls_config`. This is necessary because the development environment uses self-signed certificates.
3.  **Hostname:** Updated the scrape target from `fineract-server:8443` to `fineract-development:8443`.
    * *Reasoning:* Debugging confirmed that the actual container name generated by `docker-compose-development.yml` is `fineract-development`. The previous hostname `fineract-server` resulted in "no such host" errors.

**Verification:**
I have verified that Prometheus can now successfully scrape the Fineract target. The target state is **UP** (Green).

![Prometheus Green Target](https://github.com/user-attachments/assets/d1f2cfdd-7ce9-49d0-b985-8d12d0f95b16)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made. *(Verified manually via Docker stack)*
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
