### PR TITLE
FINERACT-2421: Allow multiple interest rate schedule adjustments same date

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/ErrorMessageHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/ErrorMessageHelper.java
@@ -470,6 +470,18 @@ public final class ErrorMessageHelper {
                 + "%nNumber of transaction tab lines: %s %nNumber of expected datatable lines: %s%n", resourceId, actual, expected);
     }
 
+    public static String wrongValueInLineInRescheduleTab(String resourceId, int line, List<List<String>> actualList,
+            List<String> expected) {
+        String actual = actualList.stream().map(Object::toString).collect(Collectors.joining(System.lineSeparator()));
+        return String.format("%nWrong value in Reschedule tab of resource %s line %s." //
+                + "%nActual values in line are: %n%s %nExpected values in line: %n%s", resourceId, line, actual, expected);
+    }
+
+    public static String nrOfLinesWrongInRescheduleTab(String resourceId, int actual, int expected) {
+        return String.format("%nNumber of lines does not match in Reschedule tab and expected datatable of resource %s." //
+                + "%nNumber of reschedule tab lines: %s %nNumber of expected datatable lines: %s%n", resourceId, actual, expected);
+    }
+
     public static String wrongValueInLineInChargesTab(String resourceId, int line, List<List<String>> actualList, List<String> expected) {
         String actual = actualList.stream().map(Object::toString).collect(Collectors.joining(System.lineSeparator()));
         return String.format("%nWrong value in Charges tab of resource %s line %s." //

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRescheduleStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRescheduleStepDef.java
@@ -29,11 +29,13 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.GetLoanRescheduleRequestResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
 import org.apache.fineract.client.models.PostLoansResponse;
@@ -158,5 +160,52 @@ public class LoanRescheduleStepDef extends AbstractStepDef {
 
         log.debug("ERROR CODE: {}", exception.getStatus());
         log.debug("ERROR MESSAGE: {}", exception.getDeveloperMessage());
+    }
+
+    @Then("Loan Reschedule tab has the following data:")
+    public void loanRescheduleTabCheck(DataTable table) {
+        PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
+        long loanId = loanCreateResponse.getLoanId();
+        String resourceId = String.valueOf(loanId);
+
+        List<GetLoanRescheduleRequestResponse> loanRescheduleRequestResponses = ok(
+                () -> fineractClient.rescheduleLoans().retrieveAllRescheduleRequest("", loanId));
+        List<List<String>> data = table.asLists();
+        List<String> header = table.row(0);
+        checkLoanRescheduleTab(data, loanRescheduleRequestResponses, header, resourceId);
+    }
+
+    public void checkLoanRescheduleTab(List<List<String>> data, List<GetLoanRescheduleRequestResponse> reschedules, List<String> header,
+            String resourceId) {
+        assertThat(reschedules.size()).as(ErrorMessageHelper.nrOfLinesWrongInRescheduleTab(resourceId, reschedules.size(), data.size() - 1))
+                .isEqualTo(data.size() - 1);
+        checkLoanRescheduleTabRows(data, reschedules, header, resourceId);
+    }
+
+    public void checkLoanRescheduleTabRows(List<List<String>> data, List<GetLoanRescheduleRequestResponse> reschedules, List<String> header,
+            String resourceId) {
+        for (int i = 1; i < data.size(); i++) {
+            List<String> expectedValues = data.get(i);
+            GetLoanRescheduleRequestResponse reschedule = reschedules.get(i - 1);
+            List<String> actualValues = fetchValuesOfReschedule(header, reschedule);
+            assertThat(actualValues)
+                    .as(ErrorMessageHelper.wrongValueInLineInRescheduleTab(resourceId, i, List.of(actualValues), expectedValues))
+                    .isEqualTo(expectedValues);
+        }
+    }
+
+    private List<String> fetchValuesOfReschedule(List<String> header, GetLoanRescheduleRequestResponse r) {
+        List<String> actualValues = new ArrayList<>();
+        for (String headerName : header) {
+            switch (headerName) {
+                case "From Date" ->
+                    actualValues.add(r.getRescheduleFromDate() == null ? null : FORMATTER_EN.format(r.getRescheduleFromDate()));
+                case "Reason" ->
+                    actualValues.add(r.getRescheduleReasonCodeValue() == null ? null : r.getRescheduleReasonCodeValue().getName());
+                case "Status" -> actualValues.add(r.getStatusEnum() == null ? null : r.getStatusEnum().getValue());
+                default -> throw new IllegalStateException(String.format("Header name %s cannot be found", headerName));
+            }
+        }
+        return actualValues;
     }
 }

--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanReschedule.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanReschedule.feature
@@ -1460,3 +1460,315 @@ Feature: LoanReschedule
     Then Loan reschedule with the following data results a 400 error and "LOAN_RESCHEDULE_FROM_DATE_INSTALLMENT_NOT_FOUND" error message
       | rescheduleFromDate | submittedOnDate | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
       | 01 August 2024     | 02 April 2024   |                 |                  |                 | 2          |                 |
+
+  @TestRailId:C4574
+  Scenario: Verify multiple interest rate changes on same day, UC1: on due date
+    When Admin sets the business date to "1 January 2025"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 1 January 2025    | 100            | 10                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "1 January 2025" with "100" amount and expected disbursement date on "1 January 2025"
+    And Admin successfully disburse the loan on "1 January 2025" with "100" EUR transaction amount
+    And Admin sets the business date to "1 February 2025"
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.67           | 16.33         | 0.83     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.46         | 0.7      | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 3  | 31   | 01 April 2025    |           | 50.61           | 16.6          | 0.56     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 4  | 30   | 01 May 2025      |           | 33.87           | 16.74         | 0.42     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 5  | 31   | 01 June 2025     |           | 16.99           | 16.88         | 0.28     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.99         | 0.14     | 0.0  | 0.0       | 17.13 | 0.0  | 0.0        | 0.0  | 17.13       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 2.93     | 0.0  | 0.0       | 102.93 | 0.0  | 0.0        | 0.0  | 102.93      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+#    --- first interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 5               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.84           | 16.16         | 0.82     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.63         | 0.35     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 3  | 31   | 01 April 2025    |           | 50.51           | 16.7          | 0.28     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 4  | 30   | 01 May 2025      |           | 33.74           | 16.77         | 0.21     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 5  | 31   | 01 June 2025     |           | 16.9            | 16.84         | 0.14     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.9          | 0.07     | 0.0  | 0.0       | 16.97 | 0.0  | 0.0        | 0.0  | 16.97       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 1.87     | 0.0  | 0.0       | 101.87 | 0.0  | 0.0        | 0.0  | 101.87     |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+  #    --- second interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 0               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 84.01           | 15.99         | 0.81     | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 3  | 31   | 01 April 2025    |           | 50.41           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 4  | 30   | 01 May 2025      |           | 33.61           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 5  | 31   | 01 June 2025     |           | 16.81           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.81         | 0.0      | 0.0  | 0.0       | 16.81 | 0.0  | 0.0        | 0.0  | 16.81       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 0.81     | 0.0  | 0.0       | 100.81 | 0.0  | 0.0        | 0.0  | 100.81      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+      | 01 February 2025 | None   | Approved |
+
+  @TestRailId:C4575
+  Scenario: Verify multiple interest rate changes on same day, UC2: on due date after repayment
+    When Admin sets the business date to "1 January 2025"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 1 January 2025    | 100            | 10                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "1 January 2025" with "100" amount and expected disbursement date on "1 January 2025"
+    And Admin successfully disburse the loan on "1 January 2025" with "100" EUR transaction amount
+    And Admin sets the business date to "1 February 2025"
+    And Customer makes "AUTOPAY" repayment on "01 February 2025" with 17.16 EUR transaction amount
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date        | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid  | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |                  | 100.0           |               |          | 0.0  |           | 0.0   | 0.0   |            |      |             |
+      | 1  | 31   | 01 February 2025 | 01 February 2025 | 83.67           | 16.33         | 0.83     | 0.0  | 0.0       | 17.16 | 17.16 | 0.0        | 0.0  | 0.0         |
+      | 2  | 28   | 01 March 2025    |                  | 67.21           | 16.46         | 0.7      | 0.0  | 0.0       | 17.16 | 0.0   | 0.0        | 0.0  | 17.16       |
+      | 3  | 31   | 01 April 2025    |                  | 50.61           | 16.6          | 0.56     | 0.0  | 0.0       | 17.16 | 0.0   | 0.0        | 0.0  | 17.16       |
+      | 4  | 30   | 01 May 2025      |                  | 33.87           | 16.74         | 0.42     | 0.0  | 0.0       | 17.16 | 0.0   | 0.0        | 0.0  | 17.16       |
+      | 5  | 31   | 01 June 2025     |                  | 16.99           | 16.88         | 0.28     | 0.0  | 0.0       | 17.16 | 0.0   | 0.0        | 0.0  | 17.16       |
+      | 6  | 30   | 01 July 2025     |                  | 0.0             | 16.99         | 0.14     | 0.0  | 0.0       | 17.13 | 0.0   | 0.0        | 0.0  | 17.13       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid  | In advance | Late | Outstanding |
+      | 100.0         | 2.93     | 0.0  | 0.0       | 102.93 | 17.16 | 0.0        | 0.0  | 85.77       |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+      | 01 February 2025 | Repayment        | 17.16  | 16.33     | 0.83     | 0.0  | 0.0       | 83.67        | false    | false    |
+#    --- first interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 5               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date        | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid  | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |                  | 100.0           |               |          | 0.0  |           | 0.0   | 0.0   |            |      |             |
+      | 1  | 31   | 01 February 2025 | 01 February 2025 | 83.84           | 16.16         | 0.82     | 0.0  | 0.0       | 16.98 | 16.98 | 0.0        | 0.0  | 0.0         |
+      | 2  | 28   | 01 March 2025    |                  | 67.21           | 16.63         | 0.35     | 0.0  | 0.0       | 16.98 | 0.18  | 0.18       | 0.0  | 16.8        |
+      | 3  | 31   | 01 April 2025    |                  | 50.51           | 16.7          | 0.28     | 0.0  | 0.0       | 16.98 | 0.0   | 0.0        | 0.0  | 16.98       |
+      | 4  | 30   | 01 May 2025      |                  | 33.74           | 16.77         | 0.21     | 0.0  | 0.0       | 16.98 | 0.0   | 0.0        | 0.0  | 16.98       |
+      | 5  | 31   | 01 June 2025     |                  | 16.9            | 16.84         | 0.14     | 0.0  | 0.0       | 16.98 | 0.0   | 0.0        | 0.0  | 16.98       |
+      | 6  | 30   | 01 July 2025     |                  | 0.0             | 16.9          | 0.07     | 0.0  | 0.0       | 16.97 | 0.0   | 0.0        | 0.0  | 16.97       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid  | In advance | Late | Outstanding |
+      | 100.0         | 1.87     | 0.0  | 0.0       | 101.87 | 17.16 | 0.18       | 0.0  | 84.71       |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+      | 01 February 2025 | Repayment        | 17.16  | 16.34     | 0.82     | 0.0  | 0.0       | 83.66        | false    | true     |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+  #    --- second interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 0               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date        | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |                  | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 | 01 February 2025 | 84.01           | 15.99         | 0.81     | 0.0  | 0.0       | 16.8  | 16.8 | 0.0        | 0.0  | 0.0         |
+      | 2  | 28   | 01 March 2025    |                  | 67.21           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.36 | 0.36       | 0.0  | 16.44       |
+      | 3  | 31   | 01 April 2025    |                  | 50.41           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 4  | 30   | 01 May 2025      |                  | 33.61           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 5  | 31   | 01 June 2025     |                  | 16.81           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 6  | 30   | 01 July 2025     |                  | 0.0             | 16.81         | 0.0      | 0.0  | 0.0       | 16.81 | 0.0  | 0.0        | 0.0  | 16.81       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid  | In advance | Late | Outstanding |
+      | 100.0         | 0.81     | 0.0  | 0.0       | 100.81 | 17.16 | 0.36       | 0.0  | 83.65       |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+      | 01 February 2025 | Repayment        | 17.16  | 16.35     | 0.81     | 0.0  | 0.0       | 83.65        | false    | true    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+      | 01 February 2025 | None   | Approved |
+
+  @TestRailId:C4576
+  Scenario: Verify multiple interest rate changes on same day, UC3: on midterm date
+    When Admin sets the business date to "1 January 2025"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 1 January 2025    | 100            | 10                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "1 January 2025" with "100" amount and expected disbursement date on "1 January 2025"
+    And Admin successfully disburse the loan on "1 January 2025" with "100" EUR transaction amount
+    And Admin sets the business date to "15 January 2025"
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.67           | 16.33         | 0.83     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.46         | 0.7      | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 3  | 31   | 01 April 2025    |           | 50.61           | 16.6          | 0.56     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 4  | 30   | 01 May 2025      |           | 33.87           | 16.74         | 0.42     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 5  | 31   | 01 June 2025     |           | 16.99           | 16.88         | 0.28     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.99         | 0.14     | 0.0  | 0.0       | 17.13 | 0.0  | 0.0        | 0.0  | 17.13       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 2.93     | 0.0  | 0.0       | 102.93 | 0.0  | 0.0        | 0.0  | 102.93      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+#    --- first interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 15 January 2025    | 15 January 2025  |                 |                  |                 |            | 5               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.65           | 16.35         | 0.59     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+      | 2  | 28   | 01 March 2025    |           | 67.06           | 16.59         | 0.35     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+      | 3  | 31   | 01 April 2025    |           | 50.4            | 16.66         | 0.28     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+      | 4  | 30   | 01 May 2025      |           | 33.67           | 16.73         | 0.21     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+      | 5  | 31   | 01 June 2025     |           | 16.87           | 16.8          | 0.14     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.87         | 0.07     | 0.0  | 0.0       | 16.94 | 0.0  | 0.0        | 0.0  | 16.94       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 1.64     | 0.0  | 0.0       | 101.64 | 0.0  | 0.0        | 0.0  | 101.64      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date       | Reason | Status   |
+      | 15 January 2025 | None   | Approved |
+  #    --- second interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 15 January 2025    | 15 January 2025  |                 |                  |                 |            | 0               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.63           | 16.37         | 0.35     | 0.0  | 0.0       | 16.72 | 0.0  | 0.0        | 0.0  | 16.72       |
+      | 2  | 28   | 01 March 2025    |           | 66.91           | 16.72         | 0.0      | 0.0  | 0.0       | 16.72 | 0.0  | 0.0        | 0.0  | 16.72       |
+      | 3  | 31   | 01 April 2025    |           | 50.19           | 16.72         | 0.0      | 0.0  | 0.0       | 16.72 | 0.0  | 0.0        | 0.0  | 16.72       |
+      | 4  | 30   | 01 May 2025      |           | 33.47           | 16.72         | 0.0      | 0.0  | 0.0       | 16.72 | 0.0  | 0.0        | 0.0  | 16.72       |
+      | 5  | 31   | 01 June 2025     |           | 16.75           | 16.72         | 0.0      | 0.0  | 0.0       | 16.72 | 0.0  | 0.0        | 0.0  | 16.72       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.75         | 0.0      | 0.0  | 0.0       | 16.75 | 0.0  | 0.0        | 0.0  | 16.75       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 0.35     | 0.0  | 0.0       | 100.35 | 0.0  | 0.0        | 0.0  | 100.35      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date       | Reason | Status   |
+      | 15 January 2025 | None   | Approved |
+      | 15 January 2025 | None   | Approved |
+
+  @TestRailId:C4577
+  Scenario: Verify multiple interest rate changes on same day, UC4: on due date with third change
+    When Admin sets the business date to "1 January 2025"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 1 January 2025    | 100            | 10                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "1 January 2025" with "100" amount and expected disbursement date on "1 January 2025"
+    And Admin successfully disburse the loan on "1 January 2025" with "100" EUR transaction amount
+    And Admin sets the business date to "1 February 2025"
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.67           | 16.33         | 0.83     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.46         | 0.7      | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 3  | 31   | 01 April 2025    |           | 50.61           | 16.6          | 0.56     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 4  | 30   | 01 May 2025      |           | 33.87           | 16.74         | 0.42     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 5  | 31   | 01 June 2025     |           | 16.99           | 16.88         | 0.28     | 0.0  | 0.0       | 17.16 | 0.0  | 0.0        | 0.0  | 17.16       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.99         | 0.14     | 0.0  | 0.0       | 17.13 | 0.0  | 0.0        | 0.0  | 17.13       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 2.93     | 0.0  | 0.0       | 102.93 | 0.0  | 0.0        | 0.0  | 102.93      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+#    --- first interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 5               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.84           | 16.16         | 0.82     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.63         | 0.35     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 3  | 31   | 01 April 2025    |           | 50.51           | 16.7          | 0.28     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 4  | 30   | 01 May 2025      |           | 33.74           | 16.77         | 0.21     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 5  | 31   | 01 June 2025     |           | 16.9            | 16.84         | 0.14     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.9          | 0.07     | 0.0  | 0.0       | 16.97 | 0.0  | 0.0        | 0.0  | 16.97       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 1.87     | 0.0  | 0.0       | 101.87 | 0.0  | 0.0        | 0.0  | 101.87      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+#    --- second interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 0               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 84.01           | 15.99         | 0.81     | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 3  | 31   | 01 April 2025    |           | 50.41           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 4  | 30   | 01 May 2025      |           | 33.61           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 5  | 31   | 01 June 2025     |           | 16.81           | 16.8          | 0.0      | 0.0  | 0.0       | 16.8  | 0.0  | 0.0        | 0.0  | 16.8        |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.81         | 0.0      | 0.0  | 0.0       | 16.81 | 0.0  | 0.0        | 0.0  | 16.81       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 0.81     | 0.0  | 0.0       | 100.81 | 0.0  | 0.0        | 0.0  | 100.81      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+      | 01 February 2025 | None   | Approved |
+#    --- third interest rate change ---
+    When Admin creates and approves Loan reschedule with the following data:
+      | rescheduleFromDate | submittedOnDate  | adjustedDueDate | graceOnPrincipal | graceOnInterest | extraTerms | newInterestRate |
+      | 01 February 2025   | 01 February 2025 |                 |                  |                 |            | 5               |
+    Then Loan Repayment schedule has 6 periods, with the following data for periods:
+      | Nr | Days | Date             | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2025 |           | 83.84           | 16.16         | 0.82     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 2  | 28   | 01 March 2025    |           | 67.21           | 16.63         | 0.35     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 3  | 31   | 01 April 2025    |           | 50.51           | 16.7          | 0.28     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 4  | 30   | 01 May 2025      |           | 33.74           | 16.77         | 0.21     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 5  | 31   | 01 June 2025     |           | 16.9            | 16.84         | 0.14     | 0.0  | 0.0       | 16.98 | 0.0  | 0.0        | 0.0  | 16.98       |
+      | 6  | 30   | 01 July 2025     |           | 0.0             | 16.9          | 0.07     | 0.0  | 0.0       | 16.97 | 0.0  | 0.0        | 0.0  | 16.97       |
+    And Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due    | Paid | In advance | Late | Outstanding |
+      | 100.0         | 1.87     | 0.0  | 0.0       | 101.87 | 0.0  | 0.0        | 0.0  | 101.87      |
+    And Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 January 2025  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        | false    | false    |
+    And Loan Reschedule tab has the following data:
+      | From Date        | Reason | Status   |
+      | 01 February 2025 | None   | Approved |
+      | 01 February 2025 | None   | Approved |
+      | 01 February 2025 | None   | Approved |

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/ProgressiveLoanRescheduleRequestDataValidator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/ProgressiveLoanRescheduleRequestDataValidator.java
@@ -33,7 +33,6 @@ import static org.apache.fineract.portfolio.loanaccount.rescheduleloan.data.Loan
 import static org.apache.fineract.portfolio.loanaccount.rescheduleloan.data.LoanRescheduleRequestDataValidatorImpl.validateSupportedParameters;
 
 import com.google.gson.JsonElement;
-import jakarta.persistence.criteria.Predicate;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -44,17 +43,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
-import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRescheduleRequestToTermVariationMapping;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTermVariationType;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansApiConstants;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest;
-import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequestRepository;
 import org.springframework.stereotype.Component;
 
 @Component("progressiveLoanRescheduleRequestDataValidatorImpl")
@@ -62,7 +58,6 @@ import org.springframework.stereotype.Component;
 public class ProgressiveLoanRescheduleRequestDataValidator implements LoanRescheduleRequestDataValidator {
 
     private final FromJsonHelper fromJsonHelper;
-    private final LoanRescheduleRequestRepository loanRescheduleRequestRepository;
 
     @Override
     public void validateForCreateAction(JsonCommand jsonCommand, Loan loan) {
@@ -115,9 +110,6 @@ public class ProgressiveLoanRescheduleRequestDataValidator implements LoanResche
 
     private void validateInterestRate(DataValidatorBuilder dataValidatorBuilder, Loan loan, LocalDate rescheduleFromDate) {
         validateLoanStatusIsActiveOrClosed(loan, dataValidatorBuilder);
-        if (rescheduleFromDate != null) {
-            validateInterestRateChangeRescheduleFromDate(loan, rescheduleFromDate);
-        }
         LoanRepaymentScheduleInstallment installment;
         installment = loan.getRelatedRepaymentScheduleInstallment(rescheduleFromDate);
         validateReschedulingInstallment(dataValidatorBuilder, installment);
@@ -221,20 +213,6 @@ public class ProgressiveLoanRescheduleRequestDataValidator implements LoanResche
     @Override
     public void validateForRejectAction(JsonCommand jsonCommand, LoanRescheduleRequest loanRescheduleRequest) {
         throw new UnsupportedOperationException("Nothing to override here");
-    }
-
-    private void validateInterestRateChangeRescheduleFromDate(Loan loan, LocalDate rescheduleFromDate) {
-        boolean alreadyExistInterestRateChange = loanRescheduleRequestRepository.exists((root, query, criteriaBuilder) -> {
-            Predicate loanPredicate = criteriaBuilder.equal(root.get("loan"), loan);
-            Predicate statusPredicate = root.get("statusEnum")
-                    .in(List.of(LoanStatus.SUBMITTED_AND_PENDING_APPROVAL.getValue(), LoanStatus.APPROVED.getValue()));
-            Predicate datePredicate = criteriaBuilder.equal(root.get("rescheduleFromDate"), rescheduleFromDate);
-            return criteriaBuilder.and(loanPredicate, statusPredicate, datePredicate);
-        });
-        if (alreadyExistInterestRateChange) {
-            throw new GeneralPlatformDomainRuleException("loan.reschedule.interest.rate.change.already.exists",
-                    "Interest rate change for the provided date is already exists.", rescheduleFromDate);
-        }
     }
 
     private BigDecimal validateInterestRateParam(final FromJsonHelper fromJsonHelper, final JsonElement jsonElement,

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/ProgressiveLoanRescheduleRequestDataValidatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/ProgressiveLoanRescheduleRequestDataValidatorTest.java
@@ -28,7 +28,6 @@ import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansApiConstants;
-import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequestRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,15 +49,11 @@ class ProgressiveLoanRescheduleRequestDataValidatorTest {
     @Mock
     private FromJsonHelper fromJsonHelper;
 
-    @Mock
-    private LoanRescheduleRequestRepository loanRescheduleRequestRepository;
-
     private ProgressiveLoanRescheduleRequestDataValidator progressiveLoanRescheduleRequestDataValidator;
 
     @BeforeEach
     void setUp() {
-        progressiveLoanRescheduleRequestDataValidator = new ProgressiveLoanRescheduleRequestDataValidator(fromJsonHelper,
-                loanRescheduleRequestRepository);
+        progressiveLoanRescheduleRequestDataValidator = new ProgressiveLoanRescheduleRequestDataValidator(fromJsonHelper);
         when(dataValidatorBuilder.reset()).thenReturn(dataValidatorBuilder);
         when(dataValidatorBuilder.parameter(anyString())).thenReturn(dataValidatorBuilder);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -74,6 +74,7 @@ import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansA
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.data.LoanRescheduleRequestDataValidator;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequestRepository;
+import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanTermVariationsRepository;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.exception.LoanRescheduleRequestNotFoundException;
 import org.apache.fineract.portfolio.loanaccount.service.LoanAccrualsProcessingService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanAssembler;
@@ -117,6 +118,7 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
     private final LoanScheduleComponent loanSchedule;
     private final LoanTransactionRepository loanTransactionRepository;
     private final LoanLifecycleStateMachine loanLifecycleStateMachine;
+    private final LoanTermVariationsRepository loanTermVariationsRepository;
 
     /**
      * create a new instance of the LoanRescheduleRequest object from the JsonCommand object and persist
@@ -397,6 +399,17 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
                 LoanTermVariationType termType = mapping.getLoanTermVariations().getTermType();
                 if (termType.isInterestRateVariation() || termType.isInterestRateFromInstallment() || termType.isExtendRepaymentPeriod()) {
                     hasInterestRateChange = true;
+                }
+            }
+            if (hasInterestRateChange && loan.isProgressiveSchedule()) {
+                final LocalDate termApplicableFromDate = rescheduleFromDate;
+                LoanTermVariations previousLoanTermVariations = activeLoanTermVariations.stream()
+                        .filter(lt -> lt.getTermType().isInterestRateFromInstallment() //
+                                && lt.getTermApplicableFrom().equals(termApplicableFromDate))
+                        .findFirst().orElse(null);
+                if (previousLoanTermVariations != null) {
+                    previousLoanTermVariations.markAsInactive();
+                    loanTermVariationsRepository.save(previousLoanTermVariations);
                 }
             }
             BigDecimal annualNominalInterestRate = null;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
@@ -290,13 +290,9 @@ public class LoanRescheduleRequestTest extends BaseLoanIntegrationTest {
                     .loanId(loanResponse.get().getLoanId()).dateFormat(DATETIME_PATTERN).locale("en").submittedOnDate("15 February 2023")
                     .newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L).rescheduleFromDate("16 February 2023")));
 
-            exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanRescheduleRequestHelper
-                            .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanResponse.get().getLoanId())
-                                    .dateFormat(DATETIME_PATTERN).locale("en").submittedOnDate("15 February 2023")
-                                    .newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L).rescheduleFromDate("16 February 2023")));
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("loan.reschedule.interest.rate.change.already.exists"));
+            loanRescheduleRequestHelper.createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest()
+                    .loanId(loanResponse.get().getLoanId()).dateFormat(DATETIME_PATTERN).locale("en").submittedOnDate("15 February 2023")
+                    .newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L).rescheduleFromDate("16 February 2023"));
         });
         // Do not allow approve an interest rate change if the reschedule from date is not in the future
         // Do not allow create interest rate change if a previous interest rate change got already approved for that
@@ -310,14 +306,17 @@ public class LoanRescheduleRequestTest extends BaseLoanIntegrationTest {
             loanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("17 February 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanRescheduleRequestHelper
-                            .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(rescheduleLoansResponse.getLoanId())
-                                    .dateFormat(DATETIME_PATTERN).locale("en").submittedOnDate("17 February 2023")
-                                    .newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L).rescheduleFromDate("17 February 2023")));
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("loan.reschedule.interest.rate.change.already.exists"));
+            PostCreateRescheduleLoansResponse secondRescheduleLoansResponse = loanRescheduleRequestHelper
+                    .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanResponse.get().getLoanId())
+                            .dateFormat(DATETIME_PATTERN).locale("en").submittedOnDate("17 February 2023").newInterestRate(BigDecimal.TEN)
+                            .rescheduleReasonId(1L).rescheduleFromDate("17 February 2023"));
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.get().getLoanId());
+            assertEquals(loanDetails.getSummary().getInterestCharged().stripTrailingZeros(), BigDecimal.valueOf(1.53).stripTrailingZeros());
 
+            loanRescheduleRequestHelper.approveLoanRescheduleRequest(secondRescheduleLoansResponse.getResourceId(),
+                    new PostUpdateRescheduleLoansRequest().approvedOnDate("17 February 2024").locale("en").dateFormat(DATETIME_PATTERN));
+            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.get().getLoanId());
+            assertEquals(loanDetails.getSummary().getInterestCharged().stripTrailingZeros(), BigDecimal.valueOf(4.22).stripTrailingZeros());
         });
 
         // Allow new interest rate change if the previous got rejected

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/LoanRescheduleRequestHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/LoanRescheduleRequestHelper.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
+import java.util.List;
 import org.apache.fineract.client.models.GetLoanRescheduleRequestResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
@@ -118,4 +119,9 @@ public class LoanRescheduleRequestHelper {
         return Calls
                 .ok(FineractClientHelper.getFineractClient().rescheduleLoans.updateLoanRescheduleRequest(scheduleId, request, "reject"));
     }
+
+    public List<GetLoanRescheduleRequestResponse> retrieveLoanRescheduleRequestsByLoan(final String command, final Long loanId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().rescheduleLoans.retrieveAllRescheduleRequest(command, loanId));
+    }
+
 }


### PR DESCRIPTION
## Description

We need the ability to be able to adjust interest rates on a loan on the same day. Currently fineract allows only one interest rate change for a given day. If another interest rate needs to happen using the adjust-schedule api, we need to wait 1 more day before submitting the change. 

It would be great to have a way to submit multiple adjust schedules on the same day and then have a way to determine which adjust schedule is currently active.

[FINERACT-2421](https://issues.apache.org/jira/browse/FINERACT-2421)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
