### PR TITLE
FINERACT-2354: [BE] pay-off to close re-aged loan with charge outcomes with Active loan status

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanReAging.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanReAging.feature
@@ -3304,7 +3304,7 @@ Then Loan Repayment schedule has 4 periods, with the following data for periods:
     When Loan Pay-off is made on "02 January 2025"
     Then Loan is closed with zero outstanding balance and it's all installments have obligations met
 
-  @Skip @TestRailId:C4080 @AdvancedPaymentAllocation
+  @TestRailId:C4080 @AdvancedPaymentAllocation
   Scenario: Verify Loan re-aging transaction at 1st installment with charge - before maturity date and removes additional normal installments and not modifies n+1 - UC13
     When Admin sets the business date to "01 January 2025"
     When Admin creates a client with random data
@@ -3340,12 +3340,12 @@ Then Loan Repayment schedule has 4 periods, with the following data for periods:
       | frequencyNumber | frequencyType | startDate        | numberOfInstallments |
       | 1               | MONTHS        | 11 January 2025  | 2                    |
     Then Loan Repayment schedule has 4 periods, with the following data for periods:
-      | Nr | Days | Date              | Paid date       | Balance of loan | Principal due | Interest | Fees | Penalties | Due    | Paid  | In advance | Late | Outstanding |
-      |    |      | 01 January 2025   |                 | 1000.0          |               |          | 0.0  |           | 0.0    | 0.0   |            |      |             |
-      | 1  |  0   | 01 January 2025   | 01 January 2025 |  750.0          | 250.0         | 0.0      | 0.0  | 0.0       | 250.0  | 250.0 | 0.0        | 0.0  |   0.0       |
-      | 2  | 9    | 10 January 2025   | 10 January 2025 | 750.0           | 0.0           | 0.0      | 0.0  | 0.0       | 0.0    | 0.0   | 0.0        | 0.0  | 0.0         |
-      | 3  | 1    | 11 January 2025   |                 |  375.0          | 375.0         | 0.0      | 0.0  | 20.0      | 395.0  | 0.0   | 0.0        | 0.0  | 395.0       |
-      | 4  | 31   | 11 February 2025  |                 |    0.0          | 375.0         | 0.0      | 0.0  | 0.0       | 375.0  | 0.0   | 0.0        | 0.0  | 375.0       |
+      | Nr | Days | Date             | Paid date       | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid  | In advance | Late | Outstanding |
+      |    |      | 01 January 2025  |                 | 1000.0          |               |          | 0.0  |           | 0.0   | 0.0   |            |      |             |
+      | 1  | 0    | 01 January 2025  | 01 January 2025 | 750.0           | 250.0         | 0.0      | 0.0  | 0.0       | 250.0 | 250.0 | 0.0        | 0.0  | 0.0         |
+      | 2  | 9    | 10 January 2025  |                 | 750.0           | 0.0           | 0.0      | 0.0  | 20.0      | 20.0  | 0.0   | 0.0        | 0.0  | 20.0        |
+      | 3  | 1    | 11 January 2025  |                 | 375.0           | 375.0         | 0.0      | 0.0  | 0.0       | 375.0 | 0.0   | 0.0        | 0.0  | 375.0       |
+      | 4  | 31   | 11 February 2025 |                 | 0.0             | 375.0         | 0.0      | 0.0  | 0.0       | 375.0 | 0.0   | 0.0        | 0.0  | 375.0       |
     Then Loan Repayment schedule has the following data in Total row:
       | Principal due | Interest | Fees | Penalties | Due    | Paid  | In advance | Late | Outstanding |
       | 1000.0        | 0.0      | 0.0  | 20.0      | 1020.0 | 250.0 | 0.0        | 0.0  | 770.0       |

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
@@ -945,6 +945,48 @@ public class LoanRepaymentScheduleInstallment extends AbstractAuditableWithUTCDa
         }
     }
 
+    public void addPenaltyCharges(final Money amount) {
+        if (amount != null) {
+            addPenaltyCharges(amount.getAmount());
+        }
+    }
+
+    public void addPenaltyCharges(final BigDecimal amount) {
+        if (this.penaltyCharges == null) {
+            setPenaltyCharges(amount);
+        } else {
+            setPenaltyCharges(this.penaltyCharges.add(amount));
+        }
+    }
+
+    public void addToPenaltyPaid(final Money amount) {
+        if (amount != null) {
+            addToPenaltyPaid(amount.getAmount());
+        }
+    }
+
+    public void addToPenaltyPaid(final BigDecimal amount) {
+        if (this.penaltyChargesPaid == null) {
+            setPenaltyChargesPaid(amount);
+        } else {
+            setPenaltyChargesPaid(this.penaltyChargesPaid.add(amount));
+        }
+    }
+
+    public void addToFeeChargesPaid(final Money amount) {
+        if (amount != null) {
+            addToFeeChargesPaid(amount.getAmount());
+        }
+    }
+
+    public void addToFeeChargesPaid(final BigDecimal amount) {
+        if (this.feeChargesPaid == null) {
+            setFeeChargesPaid(amount);
+        } else {
+            setFeeChargesPaid(this.feeChargesPaid.add(amount));
+        }
+    }
+
     /********** UNPAY COMPONENTS ****/
 
     public Money unpayPenaltyChargesComponent(final LocalDate transactionDate, final Money transactionAmountRemaining) {

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -3764,10 +3764,18 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
                     balances.getPrincipal().getAmount(), balances.getInterest().getAmount(), balances.getFee().getAmount(),
                     balances.getPenalty().getAmount(), null, null, null);
 
+            if (!settings.isEqualInstallmentForFeesAndPenalties) {
+                // If charges should NOT reamortize by reage, we should manage to keep them related to the correct
+                // installment.
+                LoanRepaymentScheduleInstallment target = earlyRepaidInstallment;
+                Set<LoanCharge> charges = ctx.getCharges();
+                moveRelatedChargesToInstallment(charges, target, installments, currency);
+            }
+
             earlyRepaidInstallment.setPrincipalCompleted(balances.getPrincipal().getAmount());
             earlyRepaidInstallment.setInterestPaid(balances.getInterest().getAmount());
-            earlyRepaidInstallment.setFeeChargesPaid(balances.getFee().getAmount());
-            earlyRepaidInstallment.setPenaltyChargesPaid(balances.getPenalty().getAmount());
+            earlyRepaidInstallment.addToFeeChargesPaid(balances.getFee());
+            earlyRepaidInstallment.addToPenaltyPaid(balances.getPenalty());
 
             earlyRepaidInstallment.setTotalPaidInAdvance(balances.getPaidInAdvance().getAmount());
 
@@ -3818,6 +3826,38 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
                 .toList();
         toRemove.forEach(installments::remove);
         reprocessInstallments(installments);
+    }
+
+    private void moveRelatedChargesToInstallment(Set<LoanCharge> charges, LoanRepaymentScheduleInstallment target,
+            List<LoanRepaymentScheduleInstallment> installments, MonetaryCurrency currency) {
+        int firstNormalInstallmentNumber = LoanRepaymentScheduleProcessingWrapper.fetchFirstNormalInstallmentNumber(installments);
+        Set<LoanCharge> chargesOfNewInstallment = getLoanChargesOfInstallment(charges, target, firstNormalInstallmentNumber);
+        Integer targetInstallmentNumber = target.getInstallmentNumber();
+        installments.stream().filter(i -> Objects.equals(i.getInstallmentNumber(), targetInstallmentNumber)).findFirst()
+                .filter(source -> source != target).ifPresent(source -> {
+                    // move fees
+                    chargesOfNewInstallment.stream().filter(LoanCharge::isNotFullyPaid).filter(LoanCharge::isFeeCharge)
+                            .forEach(loanCharge -> moveFeeCharge(loanCharge, source, target, currency));
+                    // move penalties
+                    chargesOfNewInstallment.stream().filter(LoanCharge::isNotFullyPaid).filter(LoanCharge::isPenaltyCharge)
+                            .forEach(loanCharge -> movePenaltyCharge(loanCharge, source, target, currency));
+                });
+    }
+
+    private void movePenaltyCharge(LoanCharge loanCharge, LoanRepaymentScheduleInstallment source, LoanRepaymentScheduleInstallment target,
+            MonetaryCurrency currency) {
+        source.setPenaltyCharges(MathUtil.subtract(source.getPenaltyCharges(), loanCharge.chargeAmount()));
+        source.setPenaltyChargesPaid(MathUtil.subtract(source.getPenaltyChargesPaid(), loanCharge.getAmountPaid()));
+        target.addPenaltyCharges(loanCharge.getAmount(currency));
+        target.addToPenaltyPaid(loanCharge.getAmountPaid());
+    }
+
+    private void moveFeeCharge(LoanCharge loanCharge, LoanRepaymentScheduleInstallment source, LoanRepaymentScheduleInstallment target,
+            MonetaryCurrency currency) {
+        source.setFeeChargesCharged(MathUtil.subtract(source.getFeeChargesCharged(), loanCharge.chargeAmount()));
+        source.setFeeChargesPaid(MathUtil.subtract(source.getFeeChargesPaid(), loanCharge.getAmountPaid()));
+        target.addToFeeCharges(loanCharge.getAmount(currency));
+        target.addToFeeChargesPaid(loanCharge.getAmountPaid());
     }
 
     private void createChargeMappingsForInstallment(final LoanRepaymentScheduleInstallment installment,


### PR DESCRIPTION
## Bugfix

### Pre-condition

progressive loan product, e.g. LP2_DOWNPAYMENT_AUTO_ADVANCED_PAYMENT_ALLOCATION
interest rate - 0, amount -1000, for 6 months, starts from January 1, 2025
please, note - here is enabled ‘Allow approval / disbursal above loan applied amount’ setting with 50 over amount Percentage value;

### Steps to reproduce

* create loan with 1000 amount, approve and disburse 1000 amount 
* add NSF fee charge with due date January 1, 2025 and 20 amount
* set biz date January 10, 2025
* add re-age for 2 months starts from January 15, 2025 with default behavior
* pay-off the loan and verify that it’s closed
 
### Expected result

loan is closed with 0 outstanding amount, status is Closed, all obligations are met