### PR TITLE
FINERACT-2158: Add workflow to enforce PR title convention

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Verify Title Format
         run: |
           title="${{ github.event.pull_request.title }}"
-          regex="^FINERACT-[0-9]+:"
+          regex="^FINERACT-[0-9]+: "
 
           if [[ ! "$title" =~ $regex ]]; then
             echo "::error::PR title '$title' is invalid."

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,26 @@
+name: Fineract PR Compliance
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-title:
+    name: Validate Jira Ticket ID
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify Title Format
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          regex="^FINERACT-[0-9]+:"
+
+          if [[ ! "$title" =~ $regex ]]; then
+            echo "::error::PR title '$title' is invalid."
+            echo "::error::It must start with a Jira Ticket ID (e.g., 'FINERACT-123: Description...')."
+            exit 1
+          fi
+          echo "Success: PR title matches the required format."


### PR DESCRIPTION
## Description
Adds a lightweight GitHub Action to automatically enforce the project's PR title convention (e.g. `FINERACT-123: Description`). This helps ensure cleaner changelogs and release notes.

The workflow uses a regex check (`^FINERACT-[0-9]+:`) and fails fast if the format is incorrect.

FINERACT-2158

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made. (Verified workflow execution on fork)
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] This PR must not be a "code dump"(https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
