### PR TITLE
FINERACT-2447: Bulk Import processing result file not working on Postgresql

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -247,7 +247,7 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
         final ImportTemplateLocationMapper importTemplateLocationMapper = new ImportTemplateLocationMapper();
         final String sql = "select " + importTemplateLocationMapper.schema();
 
-        return this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper, new Object[] { Integer.parseInt(importDocumentId) }); // NOSONAR
+        return this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper, new Object[] { Long.parseLong(importDocumentId) }); // NOSONAR
     }
 
     @Override
@@ -255,7 +255,8 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
         this.securityContext.authenticatedUser();
         final ImportTemplateLocationMapper importTemplateLocationMapper = new ImportTemplateLocationMapper();
         final String sql = "select " + importTemplateLocationMapper.schema();
-        DocumentData documentData = this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper, new Object[] { importDocumentId }); // NOSONAR
+        DocumentData documentData = this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper,
+                new Object[] { Long.parseLong(importDocumentId) }); // NOSONAR
         return buildResponse(documentData);
     }
 


### PR DESCRIPTION
Problem:
PostgreSQL throws a type mismatch error when downloading bulk import output templates 
because importDocumentId is passed as String or Integer, but i.id column is bigint.

Fix:
- Cast importDocumentId to Long in BulkImportWorkbookServiceImpl.java
- This matches PostgreSQL bigint type and resolves the error.

