### PR TITLE
FINERACT-2006: Forgot password on login page

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
+++ b/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
@@ -30,6 +30,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -142,6 +144,17 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
         this.passwordResetRequired = required;
     }
 
+    @Getter
+    @Column(name = "temporary_password")
+    private String temporaryPassword;
+
+    @Column(name = "temporary_password_expiry_time")
+    private OffsetDateTime temporaryPasswordExpiryTime;
+
+    @Getter
+    @Column(name = "is_password_reset_enabled", nullable = false)
+    private boolean passwordResetAllowed = false;
+
     public static AppUser fromJson(final Office userOffice, final Staff linkedStaff, final Set<Role> allRoles, final JsonCommand command) {
 
         final String username = command.stringValueOfParameterNamed("username");
@@ -181,6 +194,9 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
         final AppUser appUser = new AppUser(userOffice, user, allRoles, email, firstname, lastname, linkedStaff, passwordNeverExpire,
                 cannotChangePassword);
         appUser.updateLoginRetryLimitEnabled(resolveLoginRetryLimitEnabled(username, loginRetryLimitEnabled));
+        if (command.parameterExists(AppUserConstants.IS_PASSWORD_RESET_ALLOWED)) {
+            appUser.updatePasswordResetAllowed(command.booleanPrimitiveValueOfParameterNamed(AppUserConstants.IS_PASSWORD_RESET_ALLOWED));
+        }
         return appUser;
     }
 
@@ -212,6 +228,7 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
         this.cannotChangePassword = cannotChangePassword;
         this.failedLoginAttempts = 0;
         this.loginRetryLimitEnabled = false;
+        this.passwordResetAllowed = false;
     }
 
     public EnumOptionData organisationalRoleData() {
@@ -246,9 +263,39 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
         }
 
         this.password = encodePassword;
+        clearTemporaryPassword();
         this.firstTimeLoginRemaining = false;
         this.lastTimePasswordUpdated = DateUtils.getBusinessLocalDate();
 
+    }
+
+    public void updateTemporaryPassword(final String encodedPassword, final OffsetDateTime expiryTime) {
+        this.temporaryPassword = encodedPassword;
+        this.temporaryPasswordExpiryTime = expiryTime;
+    }
+
+    public boolean isTemporaryPasswordExpired() {
+        if (this.temporaryPasswordExpiryTime == null) {
+            return false;
+        }
+        return OffsetDateTime.now(ZoneOffset.UTC).isAfter(this.temporaryPasswordExpiryTime);
+    }
+
+    public boolean hasValidTemporaryPassword() {
+        return StringUtils.isNotBlank(this.temporaryPassword) && !isTemporaryPasswordExpired();
+    }
+
+    public void clearTemporaryPasswordExpiry() {
+        clearTemporaryPassword();
+    }
+
+    public void clearTemporaryPassword() {
+        this.temporaryPassword = null;
+        this.temporaryPasswordExpiryTime = null;
+    }
+
+    public void updatePasswordResetAllowed(final boolean passwordResetAllowed) {
+        this.passwordResetAllowed = passwordResetAllowed && !isSystemUser() && !Boolean.TRUE.equals(this.cannotChangePassword);
     }
 
     public void changeOffice(final Office differentOffice) {
@@ -340,6 +387,13 @@ public class AppUser extends AbstractPersistableCustom<Long> implements Platform
                 actualChanges.put(AppUserConstants.IS_LOGIN_RETRIES_ENABLED, effectiveValue);
                 updateLoginRetryLimitEnabled(effectiveValue);
             }
+        }
+
+        if (command.hasParameter(AppUserConstants.IS_PASSWORD_RESET_ALLOWED)
+                && command.isChangeInBooleanParameterNamed(AppUserConstants.IS_PASSWORD_RESET_ALLOWED, this.passwordResetAllowed)) {
+            final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(AppUserConstants.IS_PASSWORD_RESET_ALLOWED);
+            actualChanges.put(AppUserConstants.IS_PASSWORD_RESET_ALLOWED, newValue);
+            updatePasswordResetAllowed(newValue);
         }
         return actualChanges;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/SecurityConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/SecurityConfig.java
@@ -45,6 +45,7 @@ import org.apache.fineract.infrastructure.security.filter.TenantAwareBasicAuthen
 import org.apache.fineract.infrastructure.security.filter.TwoFactorAuthenticationFilter;
 import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
 import org.apache.fineract.infrastructure.security.service.PlatformUserDetailsChecker;
+import org.apache.fineract.infrastructure.security.service.TemporaryPasswordAwareAuthenticationProvider;
 import org.apache.fineract.infrastructure.security.service.TenantAwareJpaPlatformUserDetailsService;
 import org.apache.fineract.infrastructure.security.service.TwoFactorService;
 import org.apache.fineract.notification.service.UserNotificationService;
@@ -134,6 +135,7 @@ public class SecurityConfig {
             auth.requestMatchers(API_MATCHER.matcher(HttpMethod.OPTIONS, "/api/**")).permitAll()
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.POST, "/api/*/echo")).permitAll()
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.POST, "/api/*/authentication")).permitAll()
+                    .requestMatchers(API_MATCHER.matcher(HttpMethod.POST, "/api/*/password/forgot")).permitAll()
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.PUT, "/api/*/instance-mode")).permitAll()
                     // businessdate
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.GET, "/api/*/businessdate/*"))
@@ -453,7 +455,7 @@ public class SecurityConfig {
 
     @Bean(name = "customAuthenticationProvider")
     public DaoAuthenticationProvider authProvider() {
-        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        DaoAuthenticationProvider authProvider = new TemporaryPasswordAwareAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService);
         authProvider.setPasswordEncoder(passwordEncoder());
         authProvider.setPostAuthenticationChecks(platformUserDetailsChecker);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/GmailBackedPlatformEmailService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/GmailBackedPlatformEmailService.java
@@ -73,13 +73,7 @@ public class GmailBackedPlatformEmailService implements PlatformEmailService {
         props.put("mail.smtp.auth", "true");
         props.put("mail.debug", "true");
 
-        // these are the added lines
         props.put("mail.smtp.starttls.enable", "true");
-        // props.put("mail.smtp.ssl.enable", "true");
-
-        props.put("mail.smtp.socketFactory.port", Integer.parseInt(smtpCredentialsData.getPort()));
-        props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");// NOSONAR
-        props.put("mail.smtp.socketFactory.fallback", "true");
 
         try {
             SimpleMailMessage message = new SimpleMailMessage();
@@ -92,5 +86,19 @@ public class GmailBackedPlatformEmailService implements PlatformEmailService {
         } catch (Exception e) {
             throw new PlatformEmailSendException(e);
         }
+    }
+
+    @Override
+    public void sendForgotPasswordEmail(String organisationName, String contactName, String address, String username,
+            String temporaryPassword) {
+        final String subject = "Password Reset Request - " + organisationName;
+        final String body = "Dear " + contactName + ",\n\n" + "You have requested to reset your password for your account on "
+                + organisationName + ".\n\n" + "Your temporary password is: " + temporaryPassword + "\n\n"
+                + "This temporary password will expire in 1 hour.\n\n" + "Please login with your username: " + username
+                + " and this temporary password.\n" + "You will be required to change your password immediately after logging in.\n\n"
+                + "If you did not request this password reset, please contact your system administrator.\n\n" + "Thank you.";
+
+        final EmailDetail emailDetail = new EmailDetail(subject, body, address, contactName);
+        sendDefinedEmail(emailDetail);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/PlatformEmailService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/PlatformEmailService.java
@@ -26,4 +26,6 @@ public interface PlatformEmailService {
 
     void sendDefinedEmail(EmailDetail emailDetails);
 
+    void sendForgotPasswordEmail(String organisationName, String contactName, String address, String username, String temporaryPassword);
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/config/AuthorizationServerConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/config/AuthorizationServerConfig.java
@@ -42,6 +42,7 @@ import org.apache.fineract.infrastructure.security.filter.BusinessDateFilter;
 import org.apache.fineract.infrastructure.security.filter.TenantAwareAuthenticationFilter;
 import org.apache.fineract.infrastructure.security.filter.TwoFactorAuthenticationFilter;
 import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
+import org.apache.fineract.infrastructure.security.service.TemporaryPasswordAwareAuthenticationProvider;
 import org.apache.fineract.infrastructure.security.service.TenantAwareJpaPlatformUserDetailsService;
 import org.apache.fineract.infrastructure.security.service.TwoFactorService;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -56,6 +57,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -166,7 +168,8 @@ public class AuthorizationServerConfig {
                     if (fineractProperties.getSecurity().getTwoFactor().isEnabled()) {
                         auth.anyRequest().hasAuthority("TWOFACTOR_AUTHENTICATED");
                     }
-                }).formLogin(form -> form.loginPage("/login").authenticationDetailsSource(tenantAuthDetailsSource()).permitAll())
+                }).authenticationProvider(customAuthenticationProvider())
+                .formLogin(form -> form.loginPage("/login").authenticationDetailsSource(tenantAuthDetailsSource()).permitAll())
                 .oauth2ResourceServer(
                         resourceServer -> resourceServer.jwt(jwt -> jwt.jwtAuthenticationConverter(authenticationConverter())))
                 .addFilterAfter(tenantAwareAuthenticationFilter(), SecurityContextHolderFilter.class)//
@@ -228,6 +231,14 @@ public class AuthorizationServerConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider customAuthenticationProvider() {
+        DaoAuthenticationProvider authProvider = new TemporaryPasswordAwareAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TemporaryPasswordAwareAuthenticationProvider.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TemporaryPasswordAwareAuthenticationProvider.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.service;
+
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Supports authentication with either the permanent password or a non-expired temporary password.
+ */
+public class TemporaryPasswordAwareAuthenticationProvider extends DaoAuthenticationProvider {
+
+    @Override
+    protected void additionalAuthenticationChecks(final UserDetails userDetails, final UsernamePasswordAuthenticationToken authentication)
+            throws AuthenticationException {
+        if (authentication.getCredentials() == null) {
+            throw new BadCredentialsException(
+                    messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials"));
+        }
+
+        final String presentedPassword = authentication.getCredentials().toString();
+        if (getPasswordEncoder().matches(presentedPassword, userDetails.getPassword())) {
+            return;
+        }
+
+        if (userDetails instanceof AppUser appUser && appUser.hasValidTemporaryPassword()
+                && getPasswordEncoder().matches(presentedPassword, appUser.getTemporaryPassword())) {
+            return;
+        }
+
+        throw new BadCredentialsException(
+                messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials"));
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/ForgotPasswordApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/ForgotPasswordApiResource.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.useradministration.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.useradministration.service.ForgotPasswordService;
+import org.springframework.stereotype.Component;
+
+@Path("/v1/password")
+@Component
+@Tag(name = "Password Management", description = "APIs for password management operations including forgot password functionality.")
+@RequiredArgsConstructor
+public class ForgotPasswordApiResource {
+
+    private final ForgotPasswordService forgotPasswordService;
+
+    @POST
+    @Path("/forgot")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Request password reset", description = """
+            Requests a password reset for the user with the given email.
+            If the email exists and the user is active, a temporary password will be sent to the email address.
+            The temporary password expires in 1 hour.""")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = ForgotPasswordRequest.class)))
+    @ApiResponse(responseCode = "200", description = "OK")
+    public Response forgotPassword(final ForgotPasswordRequest request) {
+        this.forgotPasswordService.requestPasswordReset(request.email());
+        return Response.ok().build();
+    }
+
+    public record ForgotPasswordRequest(String email) {
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResource.java
@@ -148,7 +148,7 @@ public class UsersApiResource {
     @Operation(summary = "Create a User", operationId = "createUser", description = "Adds new application user.\n" + "\n"
             + "Note: Password information is not required (or processed). Password details at present are auto-generated and then sent to the email account given (which is why it can take a few seconds to complete).\n"
             + "\n" + "Mandatory Fields: \n" + "username, firstname, lastname, email, officeId, roles, sendPasswordToEmail\n" + "\n"
-            + "Optional Fields: \n" + "staffId,passwordNeverExpires,isLoginRetriesEnabled")
+            + "Optional Fields: \n" + "staffId,passwordNeverExpires,isLoginRetriesEnabled,isPasswordResetAllowed")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = UsersApiResourceSwagger.PostUsersRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UsersApiResourceSwagger.PostUsersResponse.class))) })

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResourceSwagger.java
@@ -135,6 +135,7 @@ final class UsersApiResourceSwagger {
         public Boolean passwordNeverExpires;
         @Schema(example = "true")
         public Boolean isLoginRetriesEnabled;
+        public Boolean isPasswordResetAllowed;
     }
 
     @Schema(description = "PostUsersResponse")
@@ -216,6 +217,7 @@ final class UsersApiResourceSwagger {
         public Boolean sendPasswordToEmail;
         @Schema(example = "true")
         public Boolean isLoginRetriesEnabled;
+        public Boolean isPasswordResetAllowed;
     }
 
     @Schema(description = "PutUsersUserIdResponse")

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/domain/AppUserRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/domain/AppUserRepository.java
@@ -31,4 +31,7 @@ public interface AppUserRepository extends JpaRepository<AppUser, Long>, JpaSpec
     AppUser findAppUserByName(@Param("username") String username);
 
     Collection<AppUser> findByOfficeId(Long officeId);
+
+    @Query("Select appUser from AppUser appUser where appUser.email = :email and appUser.enabled = true and appUser.deleted = false")
+    AppUser findActiveUserByEmail(@Param("email") String email);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/ForgotPasswordService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/ForgotPasswordService.java
@@ -18,20 +18,7 @@
  */
 package org.apache.fineract.useradministration.service;
 
-public final class AppUserConstants {
+public interface ForgotPasswordService {
 
-    private AppUserConstants() {
-
-    }
-
-    public static final String PASSWORD = "password";
-    public static final String REPEAT_PASSWORD = "repeatPassword";
-    public static final String PASSWORD_NEVER_EXPIRES = "passwordNeverExpires";
-    public static final String IS_LOGIN_RETRIES_ENABLED = "isLoginRetriesEnabled";
-    public static final String IS_PASSWORD_RESET_ALLOWED = "isPasswordResetAllowed";
-
-    // TODO: Remove hard coding of system user name and make this a configurable parameter
-    public static final String SYSTEM_USER_NAME = "system";
-    public static final Long ADMIN_USER_ID = 1L;
-    public static final Long SYSTEM_USER_ID = 2L;
+    void requestPasswordReset(String email);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/ForgotPasswordServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/ForgotPasswordServiceImpl.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.useradministration.service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.service.PlatformEmailService;
+import org.apache.fineract.infrastructure.security.service.RandomPasswordGenerator;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ForgotPasswordServiceImpl implements ForgotPasswordService {
+
+    private static final int TEMPORARY_PASSWORD_LENGTH = 13;
+    private static final int TEMPORARY_PASSWORD_EXPIRY_HOURS = 1;
+
+    private final AppUserRepository appUserRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final PlatformEmailService emailService;
+
+    @Override
+    @Transactional
+    public void requestPasswordReset(final String email) {
+        final AppUser user = this.appUserRepository.findActiveUserByEmail(email);
+        if (user == null) {
+            log.debug("Password reset requested for non-existent or inactive email: {}", email);
+            return;
+        }
+
+        if (!user.isPasswordResetAllowed()) {
+            log.debug("Password reset is disabled for user: {}", user.getUsername());
+            return;
+        }
+
+        final String temporaryPassword = new RandomPasswordGenerator(TEMPORARY_PASSWORD_LENGTH).generate();
+        final String encodedPassword = this.passwordEncoder.encode(temporaryPassword);
+        final OffsetDateTime expiryTime = OffsetDateTime.now(ZoneOffset.UTC).plusHours(TEMPORARY_PASSWORD_EXPIRY_HOURS);
+
+        user.updateTemporaryPassword(encodedPassword, expiryTime);
+        this.appUserRepository.saveAndFlush(user);
+
+        final String organisationName = user.getOffice().getName();
+        final String contactName = user.getFirstname() + " " + user.getLastname();
+
+        this.emailService.sendForgotPasswordEmail(organisationName, contactName, email, user.getUsername(), temporaryPassword);
+
+        log.info("Password reset email sent to user: {}", user.getUsername());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/UserDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/UserDataValidator.java
@@ -59,12 +59,12 @@ public final class UserDataValidator {
     /**
      * The parameters supported for this command.
      */
-    private static final Set<String> CREATE_SUPPORTED_PARAMETERS = new HashSet<>(
-            Arrays.asList(USERNAME, FIRSTNAME, LASTNAME, PASSWORD, REPEAT_PASSWORD, EMAIL, OFFICE_ID, NOT_SELECTED_ROLES, ROLES,
-                    SEND_PASSWORD_TO_EMAIL, STAFF_ID, PASSWORD_NEVER_EXPIRES, AppUserConstants.IS_LOGIN_RETRIES_ENABLED));
-    private static final Set<String> UPDATE_SUPPORTED_PARAMETERS = new HashSet<>(
-            Arrays.asList(USERNAME, FIRSTNAME, LASTNAME, PASSWORD, REPEAT_PASSWORD, EMAIL, OFFICE_ID, NOT_SELECTED_ROLES, ROLES,
-                    SEND_PASSWORD_TO_EMAIL, STAFF_ID, PASSWORD_NEVER_EXPIRES, AppUserConstants.IS_LOGIN_RETRIES_ENABLED));
+    private static final Set<String> CREATE_SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(USERNAME, FIRSTNAME, LASTNAME, PASSWORD,
+            REPEAT_PASSWORD, EMAIL, OFFICE_ID, NOT_SELECTED_ROLES, ROLES, SEND_PASSWORD_TO_EMAIL, STAFF_ID, PASSWORD_NEVER_EXPIRES,
+            AppUserConstants.IS_LOGIN_RETRIES_ENABLED, AppUserConstants.IS_PASSWORD_RESET_ALLOWED));
+    private static final Set<String> UPDATE_SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(USERNAME, FIRSTNAME, LASTNAME, PASSWORD,
+            REPEAT_PASSWORD, EMAIL, OFFICE_ID, NOT_SELECTED_ROLES, ROLES, SEND_PASSWORD_TO_EMAIL, STAFF_ID, PASSWORD_NEVER_EXPIRES,
+            AppUserConstants.IS_LOGIN_RETRIES_ENABLED, AppUserConstants.IS_PASSWORD_RESET_ALLOWED));
     private static final Set<String> CHANGE_PASSWORD_SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(PASSWORD, REPEAT_PASSWORD));
     public static final String PASSWORD_NEVER_EXPIRE = "passwordNeverExpire";
 
@@ -135,6 +135,17 @@ public final class UserDataValidator {
                 baseDataValidator.reset().parameter(AppUserConstants.IS_LOGIN_RETRIES_ENABLED).trueOrFalseRequired(false);
             } else {
                 baseDataValidator.reset().parameter(AppUserConstants.IS_LOGIN_RETRIES_ENABLED).value(isLoginRetriesEnabled)
+                        .validateForBooleanValue();
+            }
+        }
+
+        if (this.fromApiJsonHelper.parameterExists(AppUserConstants.IS_PASSWORD_RESET_ALLOWED, element)) {
+            final Boolean passwordResetAllowed = this.fromApiJsonHelper.extractBooleanNamed(AppUserConstants.IS_PASSWORD_RESET_ALLOWED,
+                    element);
+            if (passwordResetAllowed == null) {
+                baseDataValidator.reset().parameter(AppUserConstants.IS_PASSWORD_RESET_ALLOWED).trueOrFalseRequired(false);
+            } else {
+                baseDataValidator.reset().parameter(AppUserConstants.IS_PASSWORD_RESET_ALLOWED).value(passwordResetAllowed)
                         .validateForBooleanValue();
             }
         }
@@ -258,6 +269,17 @@ public final class UserDataValidator {
                 baseDataValidator.reset().parameter(AppUserConstants.IS_LOGIN_RETRIES_ENABLED).trueOrFalseRequired(false);
             } else {
                 baseDataValidator.reset().parameter(AppUserConstants.IS_LOGIN_RETRIES_ENABLED).value(isLoginRetriesEnabled)
+                        .validateForBooleanValue();
+            }
+        }
+
+        if (this.fromApiJsonHelper.parameterExists(AppUserConstants.IS_PASSWORD_RESET_ALLOWED, element)) {
+            final Boolean passwordResetAllowed = this.fromApiJsonHelper.extractBooleanNamed(AppUserConstants.IS_PASSWORD_RESET_ALLOWED,
+                    element);
+            if (passwordResetAllowed == null) {
+                baseDataValidator.reset().parameter(AppUserConstants.IS_PASSWORD_RESET_ALLOWED).trueOrFalseRequired(false);
+            } else {
+                baseDataValidator.reset().parameter(AppUserConstants.IS_PASSWORD_RESET_ALLOWED).value(passwordResetAllowed)
                         .validateForBooleanValue();
             }
         }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -248,4 +248,5 @@
     <include file="parts/0227_postgresql_client_and_loan_trends_reports.xml" relativeToChangelogFile="true" />
     <include file="parts/0228_add_configuration_block_transactions_on_closed_overpaid_loans.xml" relativeToChangelogFile="true" />
     <include file="parts/0229_trial_balance_summary_fix_empty_space.xml" relativeToChangelogFile="true" />
+    <include file="parts/0230_add_forgot_password.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0230_add_forgot_password.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0230_add_forgot_password.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1" context="mysql">
+        <addColumn tableName="m_appuser">
+            <column name="temporary_password" type="VARCHAR(255)"/>
+            <column name="temporary_password_expiry_time" type="DATETIME"/>
+            <column name="is_password_reset_enabled" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="fineract" id="1" context="postgresql">
+        <addColumn tableName="m_appuser">
+            <column name="temporary_password" type="VARCHAR(255)"/>
+            <column name="temporary_password_expiry_time" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="is_password_reset_enabled" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/service/TemporaryPasswordAwareAuthenticationProviderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/security/service/TemporaryPasswordAwareAuthenticationProviderTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.security.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class TemporaryPasswordAwareAuthenticationProviderTest {
+
+    private TemporaryPasswordAwareAuthenticationProvider subject;
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = mock(PasswordEncoder.class);
+        subject = new TemporaryPasswordAwareAuthenticationProvider();
+        subject.setPasswordEncoder(passwordEncoder);
+    }
+
+    @Test
+    void authenticateShouldSucceedWithPermanentPassword() {
+        AppUser user = mockEnabledUser();
+        when(user.getPassword()).thenReturn("{bcrypt}main");
+        when(passwordEncoder.matches("secret", "{bcrypt}main")).thenReturn(true);
+        subject.setUserDetailsService(username -> user);
+
+        subject.authenticate(UsernamePasswordAuthenticationToken.unauthenticated("demo", "secret"));
+    }
+
+    @Test
+    void authenticateShouldSucceedWithValidTemporaryPassword() {
+        AppUser user = mockEnabledUser();
+        when(user.getPassword()).thenReturn("{bcrypt}main");
+        when(user.hasValidTemporaryPassword()).thenReturn(true);
+        when(user.getTemporaryPassword()).thenReturn("{bcrypt}temp");
+        when(passwordEncoder.matches("temporary-secret", "{bcrypt}main")).thenReturn(false);
+        when(passwordEncoder.matches("temporary-secret", "{bcrypt}temp")).thenReturn(true);
+        subject.setUserDetailsService(username -> user);
+
+        subject.authenticate(UsernamePasswordAuthenticationToken.unauthenticated("demo", "temporary-secret"));
+    }
+
+    @Test
+    void authenticateShouldFailWithExpiredTemporaryPassword() {
+        AppUser user = mockEnabledUser();
+        when(user.getPassword()).thenReturn("{bcrypt}main");
+        when(user.hasValidTemporaryPassword()).thenReturn(false);
+        when(passwordEncoder.matches("temporary-secret", "{bcrypt}main")).thenReturn(false);
+        subject.setUserDetailsService(username -> user);
+
+        assertThrows(BadCredentialsException.class,
+                () -> subject.authenticate(UsernamePasswordAuthenticationToken.unauthenticated("demo", "temporary-secret")));
+    }
+
+    private AppUser mockEnabledUser() {
+        AppUser user = mock(AppUser.class);
+        when(user.getUsername()).thenReturn("demo");
+        when(user.getAuthorities()).thenReturn(Collections.emptyList());
+        when(user.isAccountNonExpired()).thenReturn(true);
+        when(user.isAccountNonLocked()).thenReturn(true);
+        when(user.isCredentialsNonExpired()).thenReturn(true);
+        when(user.isEnabled()).thenReturn(true);
+        return user;
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/useradministration/service/ForgotPasswordServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/useradministration/service/ForgotPasswordServiceImplTest.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.useradministration.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.apache.fineract.infrastructure.core.service.PlatformEmailService;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class ForgotPasswordServiceImplTest {
+
+    private static final String EMAIL = "user@example.com";
+
+    @Mock
+    private AppUserRepository appUserRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private PlatformEmailService emailService;
+    @Mock
+    private AppUser user;
+    @Mock
+    private Office office;
+    @Captor
+    private ArgumentCaptor<OffsetDateTime> expiryCaptor;
+
+    private ForgotPasswordServiceImpl subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ForgotPasswordServiceImpl(appUserRepository, passwordEncoder, emailService);
+    }
+
+    @Test
+    void requestPasswordResetShouldBeNoopWhenUserNotFound() {
+        when(appUserRepository.findActiveUserByEmail(EMAIL)).thenReturn(null);
+
+        subject.requestPasswordReset(EMAIL);
+
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(emailService, never()).sendForgotPasswordEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+        verify(appUserRepository, never()).saveAndFlush(any(AppUser.class));
+    }
+
+    @Test
+    void requestPasswordResetShouldBeNoopWhenResetIsDisabledForUser() {
+        when(appUserRepository.findActiveUserByEmail(EMAIL)).thenReturn(user);
+        when(user.isPasswordResetAllowed()).thenReturn(false);
+
+        subject.requestPasswordReset(EMAIL);
+
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(emailService, never()).sendForgotPasswordEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+        verify(appUserRepository, never()).saveAndFlush(any(AppUser.class));
+    }
+
+    @Test
+    void requestPasswordResetShouldGenerateTemporaryPasswordAndSendMail() {
+        when(appUserRepository.findActiveUserByEmail(EMAIL)).thenReturn(user);
+        when(user.isPasswordResetAllowed()).thenReturn(true);
+        when(passwordEncoder.encode(anyString())).thenReturn("{bcrypt}encoded-temporary-password");
+        when(user.getOffice()).thenReturn(office);
+        when(office.getName()).thenReturn("Head Office");
+        when(user.getFirstname()).thenReturn("Demo");
+        when(user.getLastname()).thenReturn("User");
+        when(user.getUsername()).thenReturn("demo");
+
+        OffsetDateTime minExpected = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).minusSeconds(5);
+        subject.requestPasswordReset(EMAIL);
+        OffsetDateTime maxExpected = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).plusSeconds(5);
+
+        verify(user).updateTemporaryPassword(eq("{bcrypt}encoded-temporary-password"), expiryCaptor.capture());
+        verify(appUserRepository).saveAndFlush(user);
+        verify(emailService).sendForgotPasswordEmail(eq("Head Office"), eq("Demo User"), eq(EMAIL), eq("demo"), anyString());
+
+        OffsetDateTime actualExpiry = expiryCaptor.getValue();
+        assertFalse(actualExpiry.isBefore(minExpected));
+        assertTrue(actualExpiry.isBefore(maxExpected));
+    }
+}


### PR DESCRIPTION
## Description
Implemented the "Forgot Password" functionality to allow users to reset their forgotten passwords via email. This feature introduces a new public API endpoint that verifies the user's email, generates a temporary password, and emails it to them.

## Changes
- **New API Endpoint:** Added `POST /api/v1/password/forgot` which accepts an email address in the request body.
    - Updated `SecurityConfig` to permit unauthenticated access to this endpoint.
- **Database Schema:** Added `temporary_password_expiry_time` column to the `m_appuser` table (via Liquibase migration `0209_add_forgot_password.xml`).
- **Domain Logic:**
    - Updated `AppUser` entity to handle temporary password expiry.
    - Added `AppUserRepository.findActiveUserByEmail` to lookup users.
- **Service Layer:**
    - Created `ForgotPasswordService` and its implementation `ForgotPasswordServiceImpl`.
    - Logic handles finding the user, generating a 13-character random password, encrypting it, setting the expiry time (24 hours), and triggering the email.
- **Email Service Improvements:** Updated `GmailBackedPlatformEmailService` to make strict SSL/TLS settings conditional. This allows the service to support standard SMTP servers (like Mailhog) for easier local testing and development, while still enforcing strict security when connecting to Gmail.

## Checklist
Please confirm these details:
- [x] Catch up with `develop` branch
- [x] Format the code (`./gradlew spotlessApply`)
- [ ] Staging/Production Smoke Tests

## Testing
- Tested locally using Docker Compose and Mailhog.
- Verified the API returns `200 OK` on success.
- Verified database updates (temp password expiry time set).
- Verified email usage logic.
- Verified transaction rollback if email sending fails.
