### PR TITLE
FINERACT-2410: Rework ProgressiveEMICalculator to work only with DTOs

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
@@ -42,6 +42,7 @@ import org.apache.fineract.infrastructure.core.service.MathUtil;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
 import org.apache.fineract.portfolio.loanproduct.domain.AllocationType;
 import org.apache.fineract.portfolio.repaymentwithpostdatedchecks.domain.PostDatedChecks;
@@ -1139,7 +1140,7 @@ public class LoanRepaymentScheduleInstallment extends AbstractAuditableWithUTCDa
     public void copyFrom(final LoanScheduleModelPeriod period) {
         // Reset fields and relations
         resetBalances();
-        updateLoanCompoundingDetails(period.getLoanCompoundingDetails());
+        updateLoanCompoundingDetails(InterestRecalculationAdditionalDetailData.toEntities(period.getLoanCompoundingDetails()));
         getInstallmentCharges().clear();
         getPostDatedChecks().clear();
         // Update fields

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/InterestRecalculationAdditionalDetailData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/InterestRecalculationAdditionalDetailData.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.loanschedule.data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
+
+@Getter
+@AllArgsConstructor
+public final class InterestRecalculationAdditionalDetailData {
+
+    private final LocalDate effectiveDate;
+    private final BigDecimal amount;
+
+    public static InterestRecalculationAdditionalDetailData of(LocalDate effectiveDate, BigDecimal amount) {
+        return new InterestRecalculationAdditionalDetailData(effectiveDate, amount);
+    }
+
+    public LoanInterestRecalcualtionAdditionalDetails toEntity() {
+        return new LoanInterestRecalcualtionAdditionalDetails(effectiveDate, amount);
+    }
+
+    public static Set<LoanInterestRecalcualtionAdditionalDetails> toEntities(Set<InterestRecalculationAdditionalDetailData> dataSet) {
+        if (dataSet == null) {
+            return null;
+        }
+        Set<LoanInterestRecalcualtionAdditionalDetails> entities = new HashSet<>();
+        for (InterestRecalculationAdditionalDetailData data : dataSet) {
+            entities.add(data.toEntity());
+        }
+        return entities;
+    }
+}

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/LoanScheduleModelDownPaymentPeriod.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/data/LoanScheduleModelDownPaymentPeriod.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 import java.util.Set;
 import lombok.Getter;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
 
 @Getter
@@ -124,7 +123,7 @@ public final class LoanScheduleModelDownPaymentPeriod implements LoanScheduleMod
     }
 
     @Override
-    public Set<LoanInterestRecalcualtionAdditionalDetails> getLoanCompoundingDetails() {
+    public Set<InterestRecalculationAdditionalDetailData> getLoanCompoundingDetails() {
         return null;
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractCumulativeLoanScheduleGenerator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractCumulativeLoanScheduleGenerator.java
@@ -58,6 +58,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleIns
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.LoanRepaymentScheduleTransactionProcessor;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleDTO;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleModelDownPaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleParams;
@@ -459,8 +460,8 @@ public abstract class AbstractCumulativeLoanScheduleGenerator implements LoanSch
                             if (loanApplicationTerms.allowCompoundingOnEod()) {
                                 effectiveDate = effectiveDate.minusDays(1);
                             }
-                            LoanInterestRecalcualtionAdditionalDetails additionalDetails = new LoanInterestRecalcualtionAdditionalDetails(
-                                    effectiveDate, entry.getValue().getAmount());
+                            InterestRecalculationAdditionalDetailData additionalDetails = InterestRecalculationAdditionalDetailData
+                                    .of(effectiveDate, entry.getValue().getAmount());
                             loanScheduleModelPeriod.getLoanCompoundingDetails().add(additionalDetails);
                         }
                     }
@@ -2728,8 +2729,8 @@ public abstract class AbstractCumulativeLoanScheduleGenerator implements LoanSch
                     scheduledLoanInstallment.periodDueDate(), scheduledLoanInstallment.principalDue(),
                     scheduledLoanInstallment.interestDue(), scheduledLoanInstallment.feeChargesDue(),
                     scheduledLoanInstallment.penaltyChargesDue(), scheduledLoanInstallment.isRecalculatedInterestComponent(),
-                    scheduledLoanInstallment.getLoanCompoundingDetails(), scheduledLoanInstallment.rescheduleInterestPortion(),
-                    scheduledLoanInstallment.isDownPaymentPeriod());
+                    InterestRecalculationAdditionalDetailData.toEntities(scheduledLoanInstallment.getLoanCompoundingDetails()),
+                    scheduledLoanInstallment.rescheduleInterestPortion(), scheduledLoanInstallment.isDownPaymentPeriod());
             installments.add(installment);
         }
     }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelDisbursementPeriod.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelDisbursementPeriod.java
@@ -23,7 +23,7 @@ import java.time.LocalDate;
 import java.util.Set;
 import lombok.Getter;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePeriodData;
 
 /**
@@ -124,7 +124,7 @@ public final class LoanScheduleModelDisbursementPeriod implements LoanScheduleMo
     }
 
     @Override
-    public Set<LoanInterestRecalcualtionAdditionalDetails> getLoanCompoundingDetails() {
+    public Set<InterestRecalculationAdditionalDetailData> getLoanCompoundingDetails() {
         return null;
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelPeriod.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelPeriod.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePeriodData;
 
 public interface LoanScheduleModelPeriod {
@@ -55,7 +55,7 @@ public interface LoanScheduleModelPeriod {
 
     void addInterestAmount(Money interestDue);
 
-    Set<LoanInterestRecalcualtionAdditionalDetails> getLoanCompoundingDetails();
+    Set<InterestRecalculationAdditionalDetailData> getLoanCompoundingDetails();
 
     void setEMIFixedSpecificToInstallmentTrue();
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelRepaymentPeriod.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanScheduleModelRepaymentPeriod.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePeriodData;
 
 /**
@@ -44,7 +44,7 @@ public final class LoanScheduleModelRepaymentPeriod implements LoanScheduleModel
     private Money penaltyChargesDue;
     private Money totalDue;
     private final boolean recalculatedInterestComponent;
-    private final Set<LoanInterestRecalcualtionAdditionalDetails> loanCompoundingDetails = new HashSet<>();
+    private final Set<InterestRecalculationAdditionalDetailData> loanCompoundingDetails = new HashSet<>();
     private boolean isEMIFixedSpecificToInstallment = false;
     BigDecimal rescheduleInterestPortion;
     private final MathContext mc;
@@ -179,7 +179,7 @@ public final class LoanScheduleModelRepaymentPeriod implements LoanScheduleModel
     }
 
     @Override
-    public Set<LoanInterestRecalcualtionAdditionalDetails> getLoanCompoundingDetails() {
+    public Set<InterestRecalculationAdditionalDetailData> getLoanCompoundingDetails() {
         return this.loanCompoundingDetails;
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/schedule/LoanScheduleComponent.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/schedule/LoanScheduleComponent.java
@@ -23,6 +23,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModel;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
 import org.apache.fineract.portfolio.loanaccount.service.LoanBalanceService;
@@ -46,8 +47,8 @@ public class LoanScheduleComponent {
                             scheduledLoanInstallment.periodDueDate(), scheduledLoanInstallment.principalDue(),
                             scheduledLoanInstallment.interestDue(), scheduledLoanInstallment.feeChargesDue(),
                             scheduledLoanInstallment.penaltyChargesDue(), scheduledLoanInstallment.isRecalculatedInterestComponent(),
-                            scheduledLoanInstallment.getLoanCompoundingDetails(), scheduledLoanInstallment.rescheduleInterestPortion(),
-                            scheduledLoanInstallment.isDownPaymentPeriod());
+                            InterestRecalculationAdditionalDetailData.toEntities(scheduledLoanInstallment.getLoanCompoundingDetails()),
+                            scheduledLoanInstallment.rescheduleInterestPortion(), scheduledLoanInstallment.isDownPaymentPeriod());
                     loan.addLoanRepaymentScheduleInstallment(installment);
                 } else {
                     existingInstallment.copyFrom(scheduledLoanInstallment);

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -112,6 +112,7 @@ import org.apache.fineract.portfolio.loanaccount.service.LoanBalanceService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeService;
 import org.apache.fineract.portfolio.loanaccount.service.schedule.LoanScheduleComponent;
 import org.apache.fineract.portfolio.loanproduct.calc.EMICalculator;
+import org.apache.fineract.portfolio.loanproduct.calc.EMICalculatorDataMapper;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EqualAmortizationValues;
 import org.apache.fineract.portfolio.loanproduct.calc.data.OutstandingDetails;
 import org.apache.fineract.portfolio.loanproduct.calc.data.PeriodDueDetails;
@@ -228,8 +229,9 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         List<LoanTermVariationsData> loanTermVariations = loan.getActiveLoanTermVariations().stream().map(LoanTermVariations::toData)
                 .collect(Collectors.toCollection(ArrayList::new));
         final Integer installmentAmountInMultiplesOf = loan.getLoanProductRelatedDetail().getInstallmentAmountInMultiplesOf();
-        ProgressiveLoanInterestScheduleModel scheduleModel = emiCalculator.generateInstallmentInterestScheduleModel(installments,
-                LoanConfigurationDetailsMapper.map(loan), installmentAmountInMultiplesOf, overpaymentHolder.getMoneyObject().getMc());
+        ProgressiveLoanInterestScheduleModel scheduleModel = emiCalculator.generateInstallmentInterestScheduleModel(
+                EMICalculatorDataMapper.toRepaymentScheduleInstallmentDataList(installments), LoanConfigurationDetailsMapper.map(loan),
+                installmentAmountInMultiplesOf, overpaymentHolder.getMoneyObject().getMc());
         List<Long> loanChargeIdProcessed = new ArrayList<>();
 
         ProgressiveTransactionCtx ctx = new ProgressiveTransactionCtx(currency, installments, charges, overpaymentHolder,
@@ -407,7 +409,7 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         final LocalDate interestRateChangeSubmittedOnDate = termVariationsData.getTermVariationApplicableFrom();
         final int repaymentPeriodsToAdd = termVariationsData.getDecimalValue().intValue();
         emiCalculator.addRepaymentPeriods(scheduleModel, interestRateChangeSubmittedOnDate, repaymentPeriodsToAdd,
-                alreadyProcessedTransactions);
+                EMICalculatorDataMapper.toProcessedTransactionDataList(alreadyProcessedTransactions));
         final Loan loan = installments.getFirst().getLoan();
 
         int nextInstallmentNumber = installments.stream().mapToInt(LoanRepaymentScheduleInstallment::getInstallmentNumber).max().orElse(0)
@@ -3714,7 +3716,7 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         LocalDate transactionDate = loanTransaction.getTransactionDate();
 
         OutstandingDetails outstandingDetails = emiCalculator.precalculateReAgeEqualAmortizationAmount(model, transactionDate,
-                loanReAgeParameter);
+                EMICalculatorDataMapper.toLoanReAgeParameterData(loanReAgeParameter));
 
         OutstandingBalances outstandingBalances = liftOutstandingBalances(installments, transactionDate, currency,
                 settings.isSkipDownPayments(), settings.isOnlyPayableInterest(), settings.isEqualInstallmentForInterest(),
@@ -3748,7 +3750,7 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         BalancesWithPaidInAdvance paidInAdvanceBalances = liftEarlyRepaidBalances(installments, transactionDate, currency,
                 ctx.getAlreadyProcessedTransactions());
 
-        emiCalculator.reAgeEqualAmortization(model, transactionDate, loanReAgeParameter,
+        emiCalculator.reAgeEqualAmortization(model, transactionDate, EMICalculatorDataMapper.toLoanReAgeParameterData(loanReAgeParameter),
                 outstandingBalances.fees.add(outstandingBalances.penalties), calculatedFees.add(calculatedPenalties));
 
         installments.removeIf(i -> (i.getInstallmentNumber() != null && !i.isDownPayment() && !i.getDueDate().isBefore(transactionDate)

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/EMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/EMICalculator.java
@@ -26,16 +26,16 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
-import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EqualAmortizationValues;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
 import org.apache.fineract.portfolio.loanproduct.calc.data.OutstandingDetails;
 import org.apache.fineract.portfolio.loanproduct.calc.data.PeriodDueDetails;
+import org.apache.fineract.portfolio.loanproduct.calc.data.ProcessedTransactionData;
 import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
 import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentPeriod;
+import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentScheduleInstallmentData;
 import org.apache.fineract.portfolio.loanproduct.domain.ILoanConfigurationDetails;
 
 public interface EMICalculator {
@@ -54,7 +54,7 @@ public interface EMICalculator {
      */
     @NotNull
     ProgressiveLoanInterestScheduleModel generateInstallmentInterestScheduleModel(
-            @NotNull List<LoanRepaymentScheduleInstallment> installments, @NotNull ILoanConfigurationDetails loanProductRelatedDetail,
+            @NotNull List<RepaymentScheduleInstallmentData> installments, @NotNull ILoanConfigurationDetails loanProductRelatedDetail,
             Integer installmentAmountInMultiplesOf, MathContext mc);
 
     /**
@@ -82,7 +82,7 @@ public interface EMICalculator {
             BigDecimal newInterestRate);
 
     void addRepaymentPeriods(ProgressiveLoanInterestScheduleModel scheduleModel, LocalDate submittedOnDate,
-            int numberOfRepaymentPeriodsToAdd, List<LoanTransaction> alreadyProcessedTransactions);
+            int numberOfRepaymentPeriodsToAdd, List<ProcessedTransactionData> alreadyProcessedTransactions);
 
     /**
      * This method applies outstanding balance correction on the interest model. Negative amount decreases the
@@ -162,10 +162,10 @@ public interface EMICalculator {
     Money getOutstandingInterestTillDate(@NotNull ProgressiveLoanInterestScheduleModel scheduleModel, @NotNull LocalDate tillDate);
 
     OutstandingDetails precalculateReAgeEqualAmortizationAmount(ProgressiveLoanInterestScheduleModel interestSchedule,
-            LocalDate transactionDate, LoanReAgeParameter reageParameter);
+            LocalDate transactionDate, LoanReAgeParameterData reageParameter);
 
     void reAgeEqualAmortization(ProgressiveLoanInterestScheduleModel interestSchedule, LocalDate transactionDate,
-            LoanReAgeParameter reageParameter, Money feesPenaltiesOutstanding,
+            LoanReAgeParameterData reageParameter, Money feesPenaltiesOutstanding,
             EqualAmortizationValues feesPenaltiesEqualAmortizationValues);
 
     EqualAmortizationValues calculateEqualAmortizationValues(Money totalOutstanding, Integer numberOfInstallments,

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/EMICalculatorDataMapper.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/EMICalculatorDataMapper.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc;
+
+import java.util.List;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter;
+import org.apache.fineract.portfolio.loanproduct.calc.converter.LoanReAgeParameterConverter;
+import org.apache.fineract.portfolio.loanproduct.calc.converter.LoanTransactionConverter;
+import org.apache.fineract.portfolio.loanproduct.calc.converter.RepaymentScheduleInstallmentConverter;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
+import org.apache.fineract.portfolio.loanproduct.calc.data.ProcessedTransactionData;
+import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentScheduleInstallmentData;
+
+public final class EMICalculatorDataMapper {
+
+    private EMICalculatorDataMapper() {}
+
+    public static RepaymentScheduleInstallmentData toRepaymentScheduleInstallmentData(LoanRepaymentScheduleInstallment installment) {
+        return RepaymentScheduleInstallmentConverter.toData(installment);
+    }
+
+    public static List<RepaymentScheduleInstallmentData> toRepaymentScheduleInstallmentDataList(
+            List<LoanRepaymentScheduleInstallment> installments) {
+        return RepaymentScheduleInstallmentConverter.toDataList(installments);
+    }
+
+    public static LoanReAgeParameterData toLoanReAgeParameterData(LoanReAgeParameter parameter) {
+        return LoanReAgeParameterConverter.toData(parameter);
+    }
+
+    public static ProcessedTransactionData toProcessedTransactionData(LoanTransaction transaction) {
+        return LoanTransactionConverter.toData(transaction);
+    }
+
+    public static List<ProcessedTransactionData> toProcessedTransactionDataList(List<LoanTransaction> transactions) {
+        return LoanTransactionConverter.toDataList(transactions);
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -48,10 +48,7 @@ import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeInterestHandlingType;
-import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
@@ -60,10 +57,13 @@ import org.apache.fineract.portfolio.loanproduct.calc.data.EmiAdjustment;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EmiChangeOperation;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EqualAmortizationValues;
 import org.apache.fineract.portfolio.loanproduct.calc.data.InterestPeriod;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
 import org.apache.fineract.portfolio.loanproduct.calc.data.OutstandingDetails;
 import org.apache.fineract.portfolio.loanproduct.calc.data.PeriodDueDetails;
+import org.apache.fineract.portfolio.loanproduct.calc.data.ProcessedTransactionData;
 import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
 import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentPeriod;
+import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentScheduleInstallmentData;
 import org.apache.fineract.portfolio.loanproduct.domain.ILoanConfigurationDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -89,11 +89,11 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     @Override
     @NotNull
     public ProgressiveLoanInterestScheduleModel generateInstallmentInterestScheduleModel(
-            @NotNull List<LoanRepaymentScheduleInstallment> installments, @NotNull ILoanConfigurationDetails loanProductRelatedDetail,
+            @NotNull List<RepaymentScheduleInstallmentData> installments, @NotNull ILoanConfigurationDetails loanProductRelatedDetail,
             final Integer installmentAmountInMultiplesOf, final MathContext mc) {
         installments = installments.stream().filter(installment -> !installment.isDownPayment() && !installment.isAdditional()).toList();
-        return generateInterestScheduleModel(installments, LoanRepaymentScheduleInstallment::getFromDate,
-                LoanRepaymentScheduleInstallment::getDueDate, loanProductRelatedDetail, installmentAmountInMultiplesOf, mc);
+        return generateInterestScheduleModel(installments, RepaymentScheduleInstallmentData::getFromDate,
+                RepaymentScheduleInstallmentData::getDueDate, loanProductRelatedDetail, installmentAmountInMultiplesOf, mc);
     }
 
     @NotNull
@@ -291,17 +291,17 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
     @Override
     public void addRepaymentPeriods(final ProgressiveLoanInterestScheduleModel scheduleModel, final LocalDate submittedOnDate,
-            final int numberOfRepaymentPeriodsToAdd, final List<LoanTransaction> alreadyProcessedTransactions) {
+            final int numberOfRepaymentPeriodsToAdd, final List<ProcessedTransactionData> alreadyProcessedTransactions) {
         addRepaymentPeriods(scheduleModel,
                 EmiChangeOperation.addRepaymentPeriods(submittedOnDate, scheduleModel.zero(), numberOfRepaymentPeriodsToAdd),
                 alreadyProcessedTransactions);
     }
 
     private void addRepaymentPeriods(final ProgressiveLoanInterestScheduleModel scheduleModel, final EmiChangeOperation operation,
-            final List<LoanTransaction> alreadyProcessedTransactions) {
-        final Optional<LoanReAgeParameter> reAgeTransactionParameter = alreadyProcessedTransactions.stream()
-                .filter(t -> t.isReAge() && !t.isReversed()).findFirst().map(LoanTransaction::getLoanReAgeParameter);
-        final LocalDate seedDate = reAgeTransactionParameter.map(LoanReAgeParameter::getStartDate).orElse(scheduleModel.getStartDate());
+            final List<ProcessedTransactionData> alreadyProcessedTransactions) {
+        final Optional<LoanReAgeParameterData> reAgeTransactionParameter = alreadyProcessedTransactions.stream()
+                .filter(ProcessedTransactionData::isReAge).findFirst().flatMap(ProcessedTransactionData::getReAgeParameterOptional);
+        final LocalDate seedDate = reAgeTransactionParameter.map(LoanReAgeParameterData::getStartDate).orElse(scheduleModel.getStartDate());
         final int repaymentPeriodCount = reAgeTransactionParameter.map(param -> param.getNumberOfInstallments() - 1)
                 .orElse(scheduleModel.repaymentPeriods().size());
 
@@ -2000,7 +2000,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
     @Override
     public OutstandingDetails precalculateReAgeEqualAmortizationAmount(ProgressiveLoanInterestScheduleModel interestSchedule,
-            LocalDate transactionDate, LoanReAgeParameter reageParameter) {
+            LocalDate transactionDate, LoanReAgeParameterData reageParameter) {
         return getOutstandingAmountsTillDate(interestSchedule,
                 reageParameter.getInterestHandlingType().equals(LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST)
                         ? transactionDate
@@ -2009,7 +2009,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
     @Override
     public void reAgeEqualAmortization(ProgressiveLoanInterestScheduleModel interestSchedule, LocalDate transactionDate,
-            LoanReAgeParameter reageParameter, Money feesPenaltiesOutstanding,
+            LoanReAgeParameterData reageParameter, Money feesPenaltiesOutstanding,
             EqualAmortizationValues feesPenaltiesEqualAmortizationValues) {
         LocalDate originalMaturityDate = interestSchedule.getMaturityDate();
         List<RepaymentPeriod> reAgedRepaymentPeriods = new ArrayList<>(reageParameter.getNumberOfInstallments());
@@ -2063,7 +2063,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     }
 
     private void updateModelForReageEqualAmortization(ProgressiveLoanInterestScheduleModel interestSchedule,
-            LoanReAgeParameter reageParameter, List<RepaymentPeriod> reAgedRepaymentPeriods) {
+            LoanReAgeParameterData reageParameter, List<RepaymentPeriod> reAgedRepaymentPeriods) {
         int numberOfInstallmentsToAdd = reageParameter.getNumberOfInstallments();
         LocalDate toDate = reageParameter.getStartDate();
         RepaymentPeriod previous = interestSchedule.getLastRepaymentPeriod();

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/LoanReAgeParameterConverter.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/LoanReAgeParameterConverter.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.converter;
+
+import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
+
+public final class LoanReAgeParameterConverter {
+
+    private LoanReAgeParameterConverter() {}
+
+    public static LoanReAgeParameterData toData(LoanReAgeParameter parameter) {
+        if (parameter == null) {
+            return null;
+        }
+        return LoanReAgeParameterData.of(parameter.getFrequencyType(), parameter.getFrequencyNumber(), parameter.getStartDate(),
+                parameter.getNumberOfInstallments(), parameter.getInterestHandlingType());
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/LoanTransactionConverter.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/LoanTransactionConverter.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.converter;
+
+import java.util.List;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
+import org.apache.fineract.portfolio.loanproduct.calc.data.ProcessedTransactionData;
+
+public final class LoanTransactionConverter {
+
+    private LoanTransactionConverter() {}
+
+    public static ProcessedTransactionData toData(LoanTransaction transaction) {
+        LoanReAgeParameterData reAgeParameterData = LoanReAgeParameterConverter.toData(transaction.getLoanReAgeParameter());
+        return ProcessedTransactionData.of(transaction.getTypeOf(), transaction.getTransactionDate(), reAgeParameterData);
+    }
+
+    public static List<ProcessedTransactionData> toDataList(List<LoanTransaction> transactions) {
+        return transactions.stream().map(LoanTransactionConverter::toData).toList();
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/RepaymentScheduleInstallmentConverter.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/converter/RepaymentScheduleInstallmentConverter.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.converter;
+
+import java.util.List;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanproduct.calc.data.RepaymentScheduleInstallmentData;
+
+public final class RepaymentScheduleInstallmentConverter {
+
+    private RepaymentScheduleInstallmentConverter() {}
+
+    public static RepaymentScheduleInstallmentData toData(LoanRepaymentScheduleInstallment installment) {
+        return RepaymentScheduleInstallmentData.of(installment.getFromDate(), installment.getDueDate(), installment.isDownPayment(),
+                installment.isAdditional());
+    }
+
+    public static List<RepaymentScheduleInstallmentData> toDataList(List<LoanRepaymentScheduleInstallment> installments) {
+        return installments.stream().map(RepaymentScheduleInstallmentConverter::toData).toList();
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/LoanReAgeParameterData.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/LoanReAgeParameterData.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.data;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
+import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeInterestHandlingType;
+
+@Getter
+@Builder
+public final class LoanReAgeParameterData {
+
+    private final PeriodFrequencyType frequencyType;
+    private final Integer frequencyNumber;
+    private final LocalDate startDate;
+    private final Integer numberOfInstallments;
+    private final LoanReAgeInterestHandlingType interestHandlingType;
+
+    public static LoanReAgeParameterData of(PeriodFrequencyType frequencyType, Integer frequencyNumber, LocalDate startDate,
+            Integer numberOfInstallments, LoanReAgeInterestHandlingType interestHandlingType) {
+        return LoanReAgeParameterData.builder().frequencyType(frequencyType).frequencyNumber(frequencyNumber).startDate(startDate)
+                .numberOfInstallments(numberOfInstallments).interestHandlingType(interestHandlingType).build();
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/ProcessedTransactionData.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/ProcessedTransactionData.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.data;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
+
+@Getter
+@Builder
+public final class ProcessedTransactionData {
+
+    private final LoanTransactionType transactionType;
+    private final LocalDate transactionDate;
+    private final LoanReAgeParameterData reAgeParameter;
+
+    public static ProcessedTransactionData of(LoanTransactionType transactionType, LocalDate transactionDate,
+            LoanReAgeParameterData reAgeParameter) {
+        return ProcessedTransactionData.builder().transactionType(transactionType).transactionDate(transactionDate)
+                .reAgeParameter(reAgeParameter).build();
+    }
+
+    public static ProcessedTransactionData of(LoanTransactionType transactionType, LocalDate transactionDate) {
+        return of(transactionType, transactionDate, null);
+    }
+
+    public boolean isReAge() {
+        return LoanTransactionType.REAGE.equals(transactionType);
+    }
+
+    public Optional<LoanReAgeParameterData> getReAgeParameterOptional() {
+        return Optional.ofNullable(reAgeParameter);
+    }
+}

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/RepaymentScheduleInstallmentData.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/RepaymentScheduleInstallmentData.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.calc.data;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public final class RepaymentScheduleInstallmentData {
+
+    private final LocalDate fromDate;
+    private final LocalDate dueDate;
+    private final boolean downPayment;
+    private final boolean additional;
+
+    public static RepaymentScheduleInstallmentData of(LocalDate fromDate, LocalDate dueDate, boolean downPayment, boolean additional) {
+        return RepaymentScheduleInstallmentData.builder().fromDate(fromDate).dueDate(dueDate).downPayment(downPayment)
+                .additional(additional).build();
+    }
+}

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.fineract.portfolio.loanproduct.calc;
 
-import static java.math.BigDecimal.ZERO;
-
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
@@ -39,16 +37,14 @@ import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeInterestHandlingType;
-import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeParameter;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.DefaultScheduledDateGenerator;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.service.ProgressiveLoanInterestScheduleModelParserServiceGsonImpl;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EqualAmortizationValues;
 import org.apache.fineract.portfolio.loanproduct.calc.data.InterestPeriod;
+import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
 import org.apache.fineract.portfolio.loanproduct.calc.data.OutstandingDetails;
 import org.apache.fineract.portfolio.loanproduct.calc.data.PeriodDueDetails;
 import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
@@ -190,10 +186,10 @@ class ProgressiveEMICalculatorTest {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
         final Integer installmentAmountInMultiplesOf = null;
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
 
         Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
 
@@ -213,18 +209,18 @@ class ProgressiveEMICalculatorTest {
     public void test_emi_calculator_performance() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
-        expectedRepaymentPeriods.add(repayment(7, LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
-        expectedRepaymentPeriods.add(repayment(8, LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
-        expectedRepaymentPeriods.add(repayment(9, LocalDate.of(2024, 9, 1), LocalDate.of(2024, 10, 1)));
-        expectedRepaymentPeriods.add(repayment(10, LocalDate.of(2024, 10, 1), LocalDate.of(2024, 11, 1)));
-        expectedRepaymentPeriods.add(repayment(11, LocalDate.of(2024, 11, 1), LocalDate.of(2024, 12, 1)));
-        expectedRepaymentPeriods.add(repayment(12, LocalDate.of(2024, 12, 1), LocalDate.of(2025, 1, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 10, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 10, 1), LocalDate.of(2024, 11, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 11, 1), LocalDate.of(2024, 12, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 12, 1), LocalDate.of(2025, 1, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -264,12 +260,12 @@ class ProgressiveEMICalculatorTest {
     public void test_emiAdjustment_newCalculatedEmiNotBetterThanOriginal() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(15.678);
         final Integer installmentAmountInMultiplesOf = null;
@@ -300,12 +296,12 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -336,12 +332,12 @@ class ProgressiveEMICalculatorTest {
     public void test_multi_disbursedAmt200_2ndOnDueDate_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -382,12 +378,12 @@ class ProgressiveEMICalculatorTest {
     public void test_reschedule_interest_on0201_4per_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -424,12 +420,12 @@ class ProgressiveEMICalculatorTest {
     public void test_reschedule_interest_on0201_2nd_EMI_not_changeable_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -474,12 +470,12 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -521,12 +517,12 @@ class ProgressiveEMICalculatorTest {
     public void test_reschedule_interest_on0215_4per_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -567,12 +563,12 @@ class ProgressiveEMICalculatorTest {
     public void test_balance_correction_on0215_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -683,12 +679,12 @@ class ProgressiveEMICalculatorTest {
     public void test_payoff_on0215_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -765,12 +761,12 @@ class ProgressiveEMICalculatorTest {
     public void test_payoff_on0115_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -854,12 +850,12 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -903,12 +899,12 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -952,12 +948,12 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -998,12 +994,12 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt100_dayInYearsActual_daysInMonthActual_repayEvery1Month() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 12, 12), LocalDate.of(2024, 1, 12)),
-                repayment(2, LocalDate.of(2024, 1, 12), LocalDate.of(2024, 2, 12)),
-                repayment(3, LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 12)),
-                repayment(4, LocalDate.of(2024, 3, 12), LocalDate.of(2024, 4, 12)),
-                repayment(5, LocalDate.of(2024, 4, 12), LocalDate.of(2024, 5, 12)),
-                repayment(6, LocalDate.of(2024, 5, 12), LocalDate.of(2024, 6, 12)));
+                periodData(LocalDate.of(2023, 12, 12), LocalDate.of(2024, 1, 12)),
+                periodData(LocalDate.of(2024, 1, 12), LocalDate.of(2024, 2, 12)),
+                periodData(LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 12)),
+                periodData(LocalDate.of(2024, 3, 12), LocalDate.of(2024, 4, 12)),
+                periodData(LocalDate.of(2024, 4, 12), LocalDate.of(2024, 5, 12)),
+                periodData(LocalDate.of(2024, 5, 12), LocalDate.of(2024, 6, 12)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1034,12 +1030,12 @@ class ProgressiveEMICalculatorTest {
     public void test_multidisbursement_total_repay1st_dayInYears360_daysInMonth30_repayEvery1Month() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1084,10 +1080,10 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt1000_NoInterest_repayEvery1Month() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(2, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(3, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(4, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(5, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
 
         final BigDecimal interestRate = BigDecimal.ZERO;
         final Integer installmentAmountInMultiplesOf = null;
@@ -1115,12 +1111,12 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt100_dayInYears364_daysInMonthActual_repayEvery1Week() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 8)),
-                repayment(2, LocalDate.of(2024, 1, 8), LocalDate.of(2024, 1, 15)),
-                repayment(3, LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 22)),
-                repayment(4, LocalDate.of(2024, 1, 22), LocalDate.of(2024, 1, 29)),
-                repayment(5, LocalDate.of(2024, 1, 29), LocalDate.of(2024, 2, 5)),
-                repayment(6, LocalDate.of(2024, 2, 5), LocalDate.of(2024, 2, 12)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 8)),
+                periodData(LocalDate.of(2024, 1, 8), LocalDate.of(2024, 1, 15)),
+                periodData(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 22)),
+                periodData(LocalDate.of(2024, 1, 22), LocalDate.of(2024, 1, 29)),
+                periodData(LocalDate.of(2024, 1, 29), LocalDate.of(2024, 2, 5)),
+                periodData(LocalDate.of(2024, 2, 5), LocalDate.of(2024, 2, 12)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1151,9 +1147,9 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt100_dayInYears364_daysInMonthActual_repayEvery2Week() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15)),
-                repayment(2, LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 29)),
-                repayment(3, LocalDate.of(2024, 1, 29), LocalDate.of(2024, 2, 12)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15)),
+                periodData(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 29)),
+                periodData(LocalDate.of(2024, 1, 29), LocalDate.of(2024, 2, 12)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1181,12 +1177,12 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt100_dayInYears360_daysInMonthDoesntMatter_repayEvery15Days() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 16)),
-                repayment(2, LocalDate.of(2024, 1, 16), LocalDate.of(2024, 1, 31)),
-                repayment(3, LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 15)),
-                repayment(4, LocalDate.of(2024, 2, 15), LocalDate.of(2024, 3, 1)),
-                repayment(5, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 16)),
-                repayment(6, LocalDate.of(2024, 3, 16), LocalDate.of(2024, 3, 31)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 16)),
+                periodData(LocalDate.of(2024, 1, 16), LocalDate.of(2024, 1, 31)),
+                periodData(LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 15)),
+                periodData(LocalDate.of(2024, 2, 15), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 16)),
+                periodData(LocalDate.of(2024, 3, 16), LocalDate.of(2024, 3, 31)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1217,18 +1213,18 @@ class ProgressiveEMICalculatorTest {
     public void test_disbursedAmt1000_actual_actual_repayEvery1Month_verify_due_principal_amounts() {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)),
-                repayment(7, LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)),
-                repayment(8, LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)),
-                repayment(9, LocalDate.of(2024, 9, 1), LocalDate.of(2024, 10, 1)),
-                repayment(10, LocalDate.of(2024, 10, 1), LocalDate.of(2024, 11, 1)),
-                repayment(11, LocalDate.of(2024, 11, 1), LocalDate.of(2024, 12, 1)),
-                repayment(12, LocalDate.of(2024, 12, 1), LocalDate.of(2025, 1, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)),
+                periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)),
+                periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)),
+                periodData(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 10, 1)),
+                periodData(LocalDate.of(2024, 10, 1), LocalDate.of(2024, 11, 1)),
+                periodData(LocalDate.of(2024, 11, 1), LocalDate.of(2024, 12, 1)),
+                periodData(LocalDate.of(2024, 12, 1), LocalDate.of(2025, 1, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(25);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1277,7 +1273,7 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1339,7 +1335,7 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1406,7 +1402,7 @@ class ProgressiveEMICalculatorTest {
 
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1474,12 +1470,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_singleInterestPauseAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1512,12 +1508,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseBetweenTwoPeriodsAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1550,12 +1546,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseFirstDayOfMonthAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1588,12 +1584,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseLastDayOfMonthAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1626,12 +1622,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseWholeMonthAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1664,12 +1660,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseTwoWholeMonthsAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1702,12 +1698,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseAndExistedMultipleInterestPeriodsAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1747,12 +1743,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseBetweenRepaymentPeriodsAndExistedMultipleInterestPeriods_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1791,12 +1787,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseOnFirstDayOfMonthAndExistedMultipleInterestPeriods_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1831,12 +1827,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseBorderedByPeriod_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1868,12 +1864,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseOnTheFirstAndThirdRepaymentPeriodAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1907,12 +1903,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interestPauseOnTheFirstDayOfFirstPeriodAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1943,12 +1939,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_reschedule_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7);
         final Integer installmentAmountInMultiplesOf = null;
@@ -1986,12 +1982,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_two_reschedules_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2030,12 +2026,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_reschedule_partial_period_disbursedAmt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2073,12 +2069,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_repayment_schedule_across_multiple_years() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
-                repayment(2, LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
-                repayment(3, LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
-                repayment(4, LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
-                repayment(5, LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
-                repayment(6, LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
+                periodData(LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
+                periodData(LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
+                periodData(LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
+                periodData(LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
+                periodData(LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
+                periodData(LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2122,12 +2118,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_repayment_schedule_across_multiple_years_overdue() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
-                repayment(2, LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
-                repayment(3, LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
-                repayment(4, LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
-                repayment(5, LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
-                repayment(6, LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
+                periodData(LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
+                periodData(LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
+                periodData(LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
+                periodData(LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
+                periodData(LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
+                periodData(LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2167,12 +2163,12 @@ class ProgressiveEMICalculatorTest {
     public void test_repayment_actual_actual_repayment_schedule_across_multiple_years_overdue() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
-                repayment(2, LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
-                repayment(3, LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
-                repayment(4, LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
-                repayment(5, LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
-                repayment(6, LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
+                periodData(LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
+                periodData(LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
+                periodData(LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
+                periodData(LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
+                periodData(LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
+                periodData(LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2217,12 +2213,12 @@ class ProgressiveEMICalculatorTest {
     public void test_360_30_repayment_schedule_disbursement_month_end() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
-                repayment(2, LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
-                repayment(3, LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
-                repayment(4, LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
-                repayment(5, LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
-                repayment(6, LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
+                periodData(LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
+                periodData(LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
+                periodData(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
+                periodData(LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
+                periodData(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
+                periodData(LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2254,12 +2250,12 @@ class ProgressiveEMICalculatorTest {
     public void test_360_30_repayment_schedule_disbursement_near_month_end() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 10, 30), LocalDate.of(2023, 11, 30)),
-                repayment(2, LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 30)),
-                repayment(3, LocalDate.of(2023, 12, 30), LocalDate.of(2024, 1, 30)),
-                repayment(4, LocalDate.of(2024, 1, 30), LocalDate.of(2024, 2, 29)),
-                repayment(5, LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 30)),
-                repayment(6, LocalDate.of(2024, 3, 30), LocalDate.of(2024, 4, 30)));
+                periodData(LocalDate.of(2023, 10, 30), LocalDate.of(2023, 11, 30)),
+                periodData(LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 30)),
+                periodData(LocalDate.of(2023, 12, 30), LocalDate.of(2024, 1, 30)),
+                periodData(LocalDate.of(2024, 1, 30), LocalDate.of(2024, 2, 29)),
+                periodData(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 30)),
+                periodData(LocalDate.of(2024, 3, 30), LocalDate.of(2024, 4, 30)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(45.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2291,12 +2287,12 @@ class ProgressiveEMICalculatorTest {
     public void test_360_30_repayment_schedule_disbursement_repay_every_2_months() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 10, 29), LocalDate.of(2023, 12, 29)),
-                repayment(2, LocalDate.of(2023, 12, 29), LocalDate.of(2024, 2, 29)),
-                repayment(3, LocalDate.of(2024, 2, 29), LocalDate.of(2024, 4, 29)),
-                repayment(4, LocalDate.of(2024, 4, 29), LocalDate.of(2024, 6, 29)),
-                repayment(5, LocalDate.of(2024, 6, 29), LocalDate.of(2024, 8, 29)),
-                repayment(6, LocalDate.of(2024, 8, 29), LocalDate.of(2024, 10, 29)));
+                periodData(LocalDate.of(2023, 10, 29), LocalDate.of(2023, 12, 29)),
+                periodData(LocalDate.of(2023, 12, 29), LocalDate.of(2024, 2, 29)),
+                periodData(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 4, 29)),
+                periodData(LocalDate.of(2024, 4, 29), LocalDate.of(2024, 6, 29)),
+                periodData(LocalDate.of(2024, 6, 29), LocalDate.of(2024, 8, 29)),
+                periodData(LocalDate.of(2024, 8, 29), LocalDate.of(2024, 10, 29)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(19.99);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2328,12 +2324,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_repayment_schedule_disbursement_month_end() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
-                repayment(2, LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
-                repayment(3, LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
-                repayment(4, LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
-                repayment(5, LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
-                repayment(6, LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
+                periodData(LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
+                periodData(LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
+                periodData(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
+                periodData(LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
+                periodData(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
+                periodData(LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(45.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2365,12 +2361,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_repayment_schedule_disbursement_near_month_end() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2021, 10, 30), LocalDate.of(2021, 11, 30)),
-                repayment(2, LocalDate.of(2021, 11, 30), LocalDate.of(2021, 12, 30)),
-                repayment(3, LocalDate.of(2021, 12, 30), LocalDate.of(2022, 1, 30)),
-                repayment(4, LocalDate.of(2022, 1, 30), LocalDate.of(2022, 2, 28)),
-                repayment(5, LocalDate.of(2022, 2, 28), LocalDate.of(2022, 3, 30)),
-                repayment(6, LocalDate.of(2022, 3, 30), LocalDate.of(2022, 4, 30)));
+                periodData(LocalDate.of(2021, 10, 30), LocalDate.of(2021, 11, 30)),
+                periodData(LocalDate.of(2021, 11, 30), LocalDate.of(2021, 12, 30)),
+                periodData(LocalDate.of(2021, 12, 30), LocalDate.of(2022, 1, 30)),
+                periodData(LocalDate.of(2022, 1, 30), LocalDate.of(2022, 2, 28)),
+                periodData(LocalDate.of(2022, 2, 28), LocalDate.of(2022, 3, 30)),
+                periodData(LocalDate.of(2022, 3, 30), LocalDate.of(2022, 4, 30)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2402,12 +2398,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_repayment_schedule_disbursement_near_month_end_repay_every_2_months() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2022, 10, 29), LocalDate.of(2022, 12, 29)),
-                repayment(2, LocalDate.of(2022, 12, 29), LocalDate.of(2023, 2, 28)),
-                repayment(3, LocalDate.of(2023, 2, 28), LocalDate.of(2023, 4, 29)),
-                repayment(4, LocalDate.of(2023, 4, 29), LocalDate.of(2023, 6, 29)),
-                repayment(5, LocalDate.of(2023, 6, 29), LocalDate.of(2023, 8, 29)),
-                repayment(6, LocalDate.of(2023, 8, 29), LocalDate.of(2023, 10, 29)));
+                periodData(LocalDate.of(2022, 10, 29), LocalDate.of(2022, 12, 29)),
+                periodData(LocalDate.of(2022, 12, 29), LocalDate.of(2023, 2, 28)),
+                periodData(LocalDate.of(2023, 2, 28), LocalDate.of(2023, 4, 29)),
+                periodData(LocalDate.of(2023, 4, 29), LocalDate.of(2023, 6, 29)),
+                periodData(LocalDate.of(2023, 6, 29), LocalDate.of(2023, 8, 29)),
+                periodData(LocalDate.of(2023, 8, 29), LocalDate.of(2023, 10, 29)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2439,12 +2435,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_fraction_period_calculation_with_interestRecognitionFromDisbursementDate_false() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
-                repayment(2, LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
-                repayment(3, LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
-                repayment(4, LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
-                repayment(5, LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
-                repayment(6, LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
+                periodData(LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
+                periodData(LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
+                periodData(LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
+                periodData(LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
+                periodData(LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
+                periodData(LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
 
@@ -2471,12 +2467,12 @@ class ProgressiveEMICalculatorTest {
     public void test_actual_actual_fraction_period_calculation_with_interestRecognitionFromDisbursementDate_true() {
         MathContext mc = new MathContext(12, RoundingMode.HALF_UP);
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
-                repayment(2, LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
-                repayment(3, LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
-                repayment(4, LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
-                repayment(5, LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
-                repayment(6, LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
+                periodData(LocalDate.of(2023, 11, 13), LocalDate.of(2023, 12, 13)),
+                periodData(LocalDate.of(2023, 12, 13), LocalDate.of(2024, 1, 13)),
+                periodData(LocalDate.of(2024, 1, 13), LocalDate.of(2024, 2, 13)),
+                periodData(LocalDate.of(2024, 2, 13), LocalDate.of(2024, 3, 13)),
+                periodData(LocalDate.of(2024, 3, 13), LocalDate.of(2024, 4, 13)),
+                periodData(LocalDate.of(2024, 4, 13), LocalDate.of(2024, 5, 13)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.99);
 
@@ -2506,12 +2502,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_S1_full_chargeback_on_due_date_before_maturity_date() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                    repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                    repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                    repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                    repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                    repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                    periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                    periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                    periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                    periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                    periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                    periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -2564,12 +2560,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_S2_S3_partial_and_full_chargeback_on_due_date_before_maturity_date() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                    repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                    repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                    repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                    repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                    repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                    periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                    periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                    periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                    periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                    periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                    periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -2633,12 +2629,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_S4_full_chargeback_in_middle_of_instalment_before_maturity_date() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                    repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                    repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                    repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                    repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                    repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                    periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                    periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                    periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                    periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                    periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                    periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -2693,12 +2689,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_chargeback_principalAndInterest_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2751,12 +2747,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_chargeback_principalAndInterest_Amt100_dayInYears360_daysInMonth30_repayEvery1Month__() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2803,12 +2799,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_chargeback_less_principal_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2861,12 +2857,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_chargeback_less_principal_and_no_chargeback_interest_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2918,12 +2914,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_multi_chargeback_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -2984,12 +2980,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_for_loan_S1() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2023, 12, 12), LocalDate.of(2024, 1, 12)),
-                    repayment(1, LocalDate.of(2024, 1, 12), LocalDate.of(2024, 2, 12)),
-                    repayment(1, LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 12)),
-                    repayment(1, LocalDate.of(2024, 3, 12), LocalDate.of(2024, 4, 12)),
-                    repayment(1, LocalDate.of(2024, 4, 12), LocalDate.of(2024, 5, 12)),
-                    repayment(1, LocalDate.of(2024, 5, 12), LocalDate.of(2024, 6, 12)));
+                    periodData(LocalDate.of(2023, 12, 12), LocalDate.of(2024, 1, 12)),
+                    periodData(LocalDate.of(2024, 1, 12), LocalDate.of(2024, 2, 12)),
+                    periodData(LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 12)),
+                    periodData(LocalDate.of(2024, 3, 12), LocalDate.of(2024, 4, 12)),
+                    periodData(LocalDate.of(2024, 4, 12), LocalDate.of(2024, 5, 12)),
+                    periodData(LocalDate.of(2024, 5, 12), LocalDate.of(2024, 6, 12)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(9.482);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3025,10 +3021,10 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_for_loan_S2() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 7, 23), LocalDate.of(2024, 8, 23)),
-                    repayment(1, LocalDate.of(2024, 8, 23), LocalDate.of(2024, 9, 23)),
-                    repayment(1, LocalDate.of(2024, 9, 23), LocalDate.of(2024, 10, 23)),
-                    repayment(1, LocalDate.of(2024, 10, 23), LocalDate.of(2024, 11, 23)));
+                    periodData(LocalDate.of(2024, 7, 23), LocalDate.of(2024, 8, 23)),
+                    periodData(LocalDate.of(2024, 8, 23), LocalDate.of(2024, 9, 23)),
+                    periodData(LocalDate.of(2024, 9, 23), LocalDate.of(2024, 10, 23)),
+                    periodData(LocalDate.of(2024, 10, 23), LocalDate.of(2024, 11, 23)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(12.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3061,12 +3057,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_for_loan_S3() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
-                    repayment(1, LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
-                    repayment(1, LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
-                    repayment(1, LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
-                    repayment(1, LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
-                    repayment(1, LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
+                    periodData(LocalDate.of(2023, 10, 31), LocalDate.of(2023, 11, 30)),
+                    periodData(LocalDate.of(2023, 11, 30), LocalDate.of(2023, 12, 31)),
+                    periodData(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 31)),
+                    periodData(LocalDate.of(2024, 1, 31), LocalDate.of(2024, 2, 29)),
+                    periodData(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 3, 31)),
+                    periodData(LocalDate.of(2024, 3, 31), LocalDate.of(2024, 4, 30)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(45.00);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3102,12 +3098,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_for_loan_S4() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 10, 31), LocalDate.of(2024, 11, 30)),
-                    repayment(1, LocalDate.of(2024, 11, 30), LocalDate.of(2024, 12, 31)),
-                    repayment(1, LocalDate.of(2024, 12, 31), LocalDate.of(2025, 1, 31)),
-                    repayment(1, LocalDate.of(2025, 1, 31), LocalDate.of(2025, 2, 28)),
-                    repayment(1, LocalDate.of(2025, 2, 28), LocalDate.of(2025, 3, 31)),
-                    repayment(1, LocalDate.of(2025, 3, 31), LocalDate.of(2025, 4, 30)));
+                    periodData(LocalDate.of(2024, 10, 31), LocalDate.of(2024, 11, 30)),
+                    periodData(LocalDate.of(2024, 11, 30), LocalDate.of(2024, 12, 31)),
+                    periodData(LocalDate.of(2024, 12, 31), LocalDate.of(2025, 1, 31)),
+                    periodData(LocalDate.of(2025, 1, 31), LocalDate.of(2025, 2, 28)),
+                    periodData(LocalDate.of(2025, 2, 28), LocalDate.of(2025, 3, 31)),
+                    periodData(LocalDate.of(2025, 3, 31), LocalDate.of(2025, 4, 30)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(9.99);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3142,12 +3138,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_for_loan_S5() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2022, 10, 29), LocalDate.of(2022, 12, 29)),
-                    repayment(1, LocalDate.of(2022, 12, 29), LocalDate.of(2023, 2, 28)),
-                    repayment(1, LocalDate.of(2023, 2, 28), LocalDate.of(2023, 4, 29)),
-                    repayment(1, LocalDate.of(2023, 4, 29), LocalDate.of(2023, 6, 29)),
-                    repayment(1, LocalDate.of(2023, 6, 29), LocalDate.of(2023, 8, 29)),
-                    repayment(1, LocalDate.of(2023, 8, 29), LocalDate.of(2023, 10, 29)));
+                    periodData(LocalDate.of(2022, 10, 29), LocalDate.of(2022, 12, 29)),
+                    periodData(LocalDate.of(2022, 12, 29), LocalDate.of(2023, 2, 28)),
+                    periodData(LocalDate.of(2023, 2, 28), LocalDate.of(2023, 4, 29)),
+                    periodData(LocalDate.of(2023, 4, 29), LocalDate.of(2023, 6, 29)),
+                    periodData(LocalDate.of(2023, 6, 29), LocalDate.of(2023, 8, 29)),
+                    periodData(LocalDate.of(2023, 8, 29), LocalDate.of(2023, 10, 29)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.00);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3179,12 +3175,12 @@ class ProgressiveEMICalculatorTest {
         @Test
         public void test_leap_year_only_actual_no_effect_on_360_loan() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                    repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                    repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                    repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                    repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                    repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                    repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                    periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                    periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                    periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                    periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                    periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                    periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -3218,12 +3214,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_s5_chargeback_in_period_Amt100_dayInYears360_daysInMonth30_repayEvery1Month() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -3283,12 +3279,12 @@ class ProgressiveEMICalculatorTest {
     @Test
     public void test_interest_schedule_model_service_serialization() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
-                repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
-                repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
-                repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
-                repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
-                repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
-                repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+                periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)),
+                periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)),
+                periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)),
+                periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)),
+                periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)),
+                periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(7.0);
         final Integer installmentAmountInMultiplesOf = null;
@@ -4313,12 +4309,12 @@ class ProgressiveEMICalculatorTest {
         private ProgressiveLoanInterestScheduleModel generateSchedule() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4364,8 +4360,8 @@ class ProgressiveEMICalculatorTest {
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4399,8 +4395,8 @@ class ProgressiveEMICalculatorTest {
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4434,8 +4430,8 @@ class ProgressiveEMICalculatorTest {
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4455,12 +4451,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionInMiddleOfPeriod_EQUAL_AMORTIZATION_FULL_INTEREST_noTransactionTilDate_noInterestRecalc() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4488,22 +4484,17 @@ class ProgressiveEMICalculatorTest {
 
             // No repayment no interest recalculation
             LocalDate reAgingStartDate = LocalDate.of(2024, 4, 20);
+            LocalDate transactionDate = LocalDate.of(2024, 4, 15);
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanTransaction loanTransaction = new LoanTransaction(null, null, LoanTransactionType.REAGE, LocalDate.of(2024, 4, 15),
-                    outstandingAmountsTillDate.getOutstandingPrincipal().add(outstandingAmountsTillDate.getOutstandingInterest())
-                            .getAmount(),
-                    outstandingAmountsTillDate.getOutstandingPrincipal().getAmount(),
-                    outstandingAmountsTillDate.getOutstandingInterest().getAmount(), ZERO, ZERO, ZERO, false, null, null);
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(loanTransaction, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
-            loanTransaction.setLoanReAgeParameter(reageParameter);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
-            emiCalculator.reAgeEqualAmortization(interestSchedule, loanTransaction.getTransactionDate(), reageParameter,
-                    Money.zero(currency), new EqualAmortizationValues(Money.zero(currency), 6, Money.zero(currency), Money.zero(currency)));
+            emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
+                    new EqualAmortizationValues(Money.zero(currency), 6, Money.zero(currency), Money.zero(currency)));
 
             OutstandingDetails outstandingAmountsTillDateAfterReage = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
@@ -4519,12 +4510,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionInMiddleOfPeriod_EQUAL_AMORTIZATION_FULL_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4577,22 +4568,17 @@ class ProgressiveEMICalculatorTest {
                             .getDuePrincipal().negated());
 
             LocalDate reAgingStartDate = LocalDate.of(2024, 4, 20);
+            LocalDate transactionDate = LocalDate.of(2024, 4, 15);
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanTransaction loanTransaction = new LoanTransaction(null, null, LoanTransactionType.REAGE, LocalDate.of(2024, 4, 15),
-                    outstandingAmountsTillDate.getOutstandingPrincipal().add(outstandingAmountsTillDate.getOutstandingInterest())
-                            .getAmount(),
-                    outstandingAmountsTillDate.getOutstandingPrincipal().getAmount(),
-                    outstandingAmountsTillDate.getOutstandingInterest().getAmount(), ZERO, ZERO, ZERO, false, null, null);
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(loanTransaction, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
-            loanTransaction.setLoanReAgeParameter(reageParameter);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
-            emiCalculator.reAgeEqualAmortization(interestSchedule, loanTransaction.getTransactionDate(), reageParameter,
-                    Money.zero(currency), new EqualAmortizationValues(Money.zero(currency), 6, Money.zero(currency), Money.zero(currency)));
+            emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
+                    new EqualAmortizationValues(Money.zero(currency), 6, Money.zero(currency), Money.zero(currency)));
 
             OutstandingDetails outstandingAmountsTillDateAfterReage = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
@@ -4608,12 +4594,12 @@ class ProgressiveEMICalculatorTest {
         public void test_chargeback_transactionInMiddleOfPeriod_EQUAL_EQUAL_AMORTIZATION_PAYABLE_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4646,8 +4632,8 @@ class ProgressiveEMICalculatorTest {
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule, transactionDate);
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4667,12 +4653,12 @@ class ProgressiveEMICalculatorTest {
         public void test_chargebackPartial_transactionInMiddleOfPeriod_EQUAL_EQUAL_AMORTIZATION_FULL_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(7.0);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4706,8 +4692,8 @@ class ProgressiveEMICalculatorTest {
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule,
                     interestSchedule.getMaturityDate());
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_FULL_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4727,12 +4713,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionInMiddleOfPeriod_EQUAL_EQUAL_AMORTIZATION_PAYABLE_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4789,8 +4775,8 @@ class ProgressiveEMICalculatorTest {
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule, transactionDate);
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4810,12 +4796,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionInMiddleOfPeriod_stringOnNextDueDate_EQUAL_EQUAL_AMORTIZATION_PAYABLE_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4872,8 +4858,8 @@ class ProgressiveEMICalculatorTest {
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule, transactionDate);
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4893,12 +4879,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionOnMaturityDate_stringAfterMaturityDate_EQUAL_EQUAL_AMORTIZATION_PAYABLE_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -4945,8 +4931,8 @@ class ProgressiveEMICalculatorTest {
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule, transactionDate);
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -4966,12 +4952,12 @@ class ProgressiveEMICalculatorTest {
         public void test_transactionAfterMaturityDate_EQUAL_EQUAL_AMORTIZATION_PAYABLE_INTEREST() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-            expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-            expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-            expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-            expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-            expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-            expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+            expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
 
             final BigDecimal interestRate = BigDecimal.valueOf(15.678);
             final Integer installmentAmountInMultiplesOf = null;
@@ -5018,8 +5004,8 @@ class ProgressiveEMICalculatorTest {
 
             OutstandingDetails outstandingAmountsTillDate = emiCalculator.getOutstandingAmountsTillDate(interestSchedule, transactionDate);
 
-            LoanReAgeParameter reageParameter = new LoanReAgeParameter(null, PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
-                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST, null);
+            LoanReAgeParameterData reageParameter = LoanReAgeParameterData.of(PeriodFrequencyType.MONTHS, 1, reAgingStartDate, 6,
+                    LoanReAgeInterestHandlingType.EQUAL_AMORTIZATION_PAYABLE_INTEREST);
 
             // Update the existing model with re-aged periods
             emiCalculator.reAgeEqualAmortization(interestSchedule, transactionDate, reageParameter, Money.zero(currency),
@@ -5095,29 +5081,27 @@ class ProgressiveEMICalculatorTest {
     List<LoanScheduleModelRepaymentPeriod> expectedRepaymentDays(final LocalDate disbursementDate, final int periods, final int length) {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>(periods);
         IntStream.range(0, periods).forEach(i -> expectedRepaymentPeriods
-                .add(repayment(i + 1, disbursementDate.plusDays((long) i * length), disbursementDate.plusDays((long) (i + 1) * length))));
+                .add(periodData(disbursementDate.plusDays((long) i * length), disbursementDate.plusDays((long) (i + 1) * length))));
         return expectedRepaymentPeriods;
     }
 
     List<LoanScheduleModelRepaymentPeriod> expectedRepaymentsMonthly(final LocalDate disbursementDate, final int periods,
             final int length) {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>(periods);
-        IntStream.range(0, periods).forEach(i -> expectedRepaymentPeriods.add(
-                repayment(i + 1, disbursementDate.plusMonths((long) i * length), disbursementDate.plusMonths((long) (i + 1) * length))));
+        IntStream.range(0, periods).forEach(i -> expectedRepaymentPeriods
+                .add(periodData(disbursementDate.plusMonths((long) i * length), disbursementDate.plusMonths((long) (i + 1) * length))));
         return expectedRepaymentPeriods;
     }
 
     List<LoanScheduleModelRepaymentPeriod> expectedRepaymentWeeks(final LocalDate disbursementDate, final int periods, final int length) {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>(periods);
         IntStream.range(0, periods).forEach(i -> expectedRepaymentPeriods
-                .add(repayment(i + 1, disbursementDate.plusWeeks((long) i * length), disbursementDate.plusWeeks((long) (i + 1) * length))));
+                .add(periodData(disbursementDate.plusWeeks((long) i * length), disbursementDate.plusWeeks((long) (i + 1) * length))));
         return expectedRepaymentPeriods;
     }
 
-    private static LoanScheduleModelRepaymentPeriod repayment(int periodNumber, LocalDate fromDate, LocalDate dueDate) {
-        final Money zeroAmount = Money.zero(currency);
-        return LoanScheduleModelRepaymentPeriod.repayment(periodNumber, fromDate, dueDate, zeroAmount, zeroAmount, zeroAmount, zeroAmount,
-                zeroAmount, zeroAmount, false, mc);
+    private static LoanScheduleModelRepaymentPeriod periodData(LocalDate fromDate, LocalDate dueDate) {
+        return LoanScheduleModelRepaymentPeriod.repayment(0, fromDate, dueDate, null, null, null, null, null, null, false, mc);
     }
 
     @NonNull
@@ -5228,13 +5212,13 @@ class ProgressiveEMICalculatorTest {
         // Create 7 periods (6 original + 1 extension for second tranche)
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
 
-        expectedRepaymentPeriods.add(repayment(1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
-        expectedRepaymentPeriods.add(repayment(2, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
-        expectedRepaymentPeriods.add(repayment(3, LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
-        expectedRepaymentPeriods.add(repayment(4, LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
-        expectedRepaymentPeriods.add(repayment(5, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
-        expectedRepaymentPeriods.add(repayment(6, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
-        expectedRepaymentPeriods.add(repayment(7, LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
 
         final BigDecimal interestRate = BigDecimal.valueOf(9.4822);
         final Integer installmentAmountInMultiplesOf = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -196,6 +196,7 @@ import org.apache.fineract.portfolio.loanaccount.exception.MultiDisbursementData
 import org.apache.fineract.portfolio.loanaccount.exception.MultiDisbursementDataRequiredException;
 import org.apache.fineract.portfolio.loanaccount.exception.UndoLastTrancheDisbursementException;
 import org.apache.fineract.portfolio.loanaccount.guarantor.service.GuarantorDomainService;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.InterestRecalculationAdditionalDetailData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModel;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.service.LoanScheduleHistoryWritePlatformService;
@@ -2465,7 +2466,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
                         scheduledLoanInstallment.periodDueDate(), scheduledLoanInstallment.principalDue(),
                         scheduledLoanInstallment.interestDue(), scheduledLoanInstallment.feeChargesDue(),
                         scheduledLoanInstallment.penaltyChargesDue(), scheduledLoanInstallment.isRecalculatedInterestComponent(),
-                        scheduledLoanInstallment.getLoanCompoundingDetails());
+                        InterestRecalculationAdditionalDetailData.toEntities(scheduledLoanInstallment.getLoanCompoundingDetails()));
                 installments.add(installment);
             }
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -199,8 +199,12 @@ public class ClientSearchTest extends IntegrationTest {
         clientHelper.createClient(request1);
 
         PostClientsRequest request2 = ClientHelper.defaultClientCreationRequest();
+        String uniqueFirstName = Utils.randomStringGenerator("FN_", 10);
+        String uniqueLastName = Utils.randomStringGenerator("LN_", 10);
+        request2.setFirstname(uniqueFirstName);
+        request2.setLastname(uniqueLastName);
         clientHelper.createClient(request2);
-        String client2DisplayName = "%s %s".formatted(request2.getFirstname(), request2.getLastname());
+        String client2DisplayName = "%s %s".formatted(uniqueFirstName, uniqueLastName);
 
         PostClientsRequest request3 = ClientHelper.defaultClientCreationRequest();
         clientHelper.createClient(request3);


### PR DESCRIPTION
## Description

- Refactored `ProgressiveEMICalculator` inputs/outputs to use DTOs exclusively.
- Removed direct reliance on domain entities inside calculation flow.
- Updated internal mapping/adaptation points where entity-based data was previously passed through.
- Adjusted related call sites and tests to align with the DTO-only.

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
