### PR TITLE
FINERACT-2459: Refactor SmsReadPlatformServiceImpl to use Prepared Statements

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/service/SmsReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/service/SmsReadPlatformServiceImpl.java
@@ -22,6 +22,7 @@ import jakarta.annotation.PostConstruct;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -131,14 +132,18 @@ public class SmsReadPlatformServiceImpl implements SmsReadPlatformService {
     @Override
     public List<SmsData> retrieveAllPending(final Long campaignId, final Integer limit) {
         final String sqlPlusLimit = limit > 0 ? " " + sqlGenerator.limit(limit) : "";
-        String sql = "select " + this.smsRowMapper.schema() + " where smo.status_enum = " + SmsMessageStatusType.PENDING.getValue();
+        String sql = "select " + this.smsRowMapper.schema() + " where smo.status_enum = ?";
+        List<Object> params = new ArrayList<>();
+        params.add(SmsMessageStatusType.PENDING.getValue());
+
         if (campaignId != null) {
-            sql += " and smo.campaign_id = " + campaignId;
+            sql += " and smo.campaign_id = ?";
+            params.add(campaignId);
         }
 
         sql += sqlPlusLimit;
 
-        return this.jdbcTemplate.query(sql, this.smsRowMapper); // NOSONAR
+        return this.jdbcTemplate.query(sql, this.smsRowMapper, params.toArray()); // NOSONAR
     }
 
     @Override


### PR DESCRIPTION
## Description
Replaced potential SQL injection vulnerability in `SmsReadPlatformServiceImpl.java` by switching from String concatenation to Prepared Statements.

Resolves [FINERACT-2459](https://issues.apache.org/jira/browse/FINERACT-2459)

## Changes
* Refactored `retrieveAllPending` to use `?` placeholders for `status_enum` and `campaign_id`.
* Implemented `List<Object>` to pass parameters dynamically to `jdbcTemplate`.
* Applied Spotless formatting.

## Checklist
* [x] Commit message follows guidelines
* [x] Coding conventions followed