### PR TITLE
FINERACT-2462: Add github action to enforce one commit per user in a PR

### DIFF
--- a/.github/workflows/pr-one-commit-per-user-check.yml
+++ b/.github/workflows/pr-one-commit-per-user-check.yml
@@ -1,0 +1,57 @@
+name: Fineract PR One Commit Per User Check
+
+
+on:
+ pull_request:
+   types: [opened, reopened, synchronize]
+
+
+permissions:
+ pull-requests: write
+
+
+jobs:
+ verify-commits:
+   name: Validate One Commit Per User
+   runs-on: ubuntu-latest
+   timeout-minutes: 1
+   steps:
+     - name: Verify Commit Policy
+       id: check
+       env:
+         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       run: |
+
+         commits=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits") || { echo "::error::GitHub API request failed"; exit 1; }
+
+         if echo "$commits" | jq -e '.[] | select(.author == null)' > /dev/null; then
+           echo "null_authors=true" >> $GITHUB_OUTPUT
+           echo "::error::Some commits have a git email that is not linked to a GitHub account. Please ensure your git email matches one of your GitHub Account emails.\n\nPlease also squash your commits to prevent this message again."
+           exit 1
+         fi
+
+         user_ids=$(echo "$commits" | jq -r '.[] | select(.author.type != "Bot") | .author.id')
+         if echo "$user_ids" | sort | uniq -d | grep -q .; then
+           echo "multiple_commits=true" >> $GITHUB_OUTPUT
+           echo "::error::Multiple commits from the same author have been detected."
+           exit 1
+         fi
+
+         echo "Success: Each author has exactly one commit."
+
+     - name: Comment on PR
+       if: failure()
+       env:
+         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       run: |
+
+         if [ "${{ steps.check.outputs.null_authors }}" == "true" ]; then
+           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body \
+         $'**One Commit Per User Check Failed**\n\nSome committers have a git email that does not match their GitHub account. Please ensure your git email matches one of your GitHub Account emails. Please also squash your commits to prevent this message again.'
+         fi
+
+
+         if [ "${{ steps.check.outputs.multiple_commits }}" == "true" ]; then
+           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body \
+         $'**One Commit Per User Check Failed**\n\nEach user may only have one commit per PR. Please squash your commits.'
+         fi


### PR DESCRIPTION
## Description

JIRA: FINERACT-2462

Implemented a Github Action that runs on PR request changes, opens, and closes.

The Github Action checks for:
1) Does each user have a single PR associated with their Github account for that PR?
2) Does each user have a valid git email configured to match their Github email?

The action on failure is to comment in the PR thread with the type of error, as well as show in the error’s logs.

The feature allows for multiple users per PR, but only 1 commit per user.

# Edge Cases and Behavior

Test Cases I have tried:
- If git email does not match any emails registered for the github account, the check will fail. This is because they will have null values for [author.id](http://author.id/). The author fields are required to differentiate users, and make sure they are not bots.
- If there are multiple commits associated with an account, the check will fail. 
- If all goes well, there will be a successful check and a pass.
- When a user has a misconfigured git account, and pushes their code, they will get the error that one of the committers have their git email misconfigured. If they fix and recommit without squashing, this issue will still persist since the old commit is still there. Need to recommend a squash as well to remove the commit history. Fixed now.

Edge Cases covered in code:
- If a PR is made with only bots, like from another Github action, the test should pass.
- If Github API is down, the test should fail.
- If there are both bots and users, only the users commits should be looked at. 

Failure Path (misconfigured git email):
<img width="732" height="256" alt="Screenshot 2026-02-06 at 1 26 20 AM" src="https://github.com/user-attachments/assets/04195979-ed75-402a-ae77-f3d3b65c3b14" />

Failure Path (multiple commits per user):
<img width="707" height="201" alt="Screenshot 2026-02-06 at 1 31 10 AM" src="https://github.com/user-attachments/assets/dabaddcf-201a-422a-bd3d-14431eb3de02" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
