### PR TITLE
FINERACT-2464: Refactor LoanScheduleAssembler logic extraction

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
@@ -314,8 +314,6 @@ public class LoanScheduleAssembler {
             calculatedRepaymentsStartingFromDate = deriveFirstRepaymentDate(loanType, repaymentEvery, expectedDisbursementDate,
                     repaymentPeriodFrequencyType, loanProduct.getMinimumDaysBetweenDisbursalAndFirstRepayment(), calendar, submittedOnDate,
                     repaymentStartDateType);
-            // If calculated repayment start date does not match due to minimum days between disbursal and first
-            // repayment rule, we set repaymentsStartingFromDate (which will be used as seed date later)
             if (!tmpCalculatedRepaymentsStartingFromDate.equals(calculatedRepaymentsStartingFromDate)) {
                 repaymentsStartingFromDate = calculatedRepaymentsStartingFromDate;
             }
@@ -748,18 +746,9 @@ public class LoanScheduleAssembler {
         final MathContext mc = MoneyHelper.getMathContext();
         HolidayDetailDTO detailDTO = new HolidayDetailDTO(isHolidayEnabled, holidays, workingDays);
 
-        LoanScheduleGenerator loanScheduleGenerator = this.loanScheduleFactory.create(loanApplicationTerms.getLoanScheduleType(),
-                loanApplicationTerms.getInterestMethod());
+        LoanScheduleGenerator loanScheduleGenerator;
         if (loanApplicationTerms.isEqualAmortization()) {
-            if (loanApplicationTerms.getInterestMethod().isDecliningBalance()) {
-                final LoanScheduleGenerator decliningLoanScheduleGenerator = this.loanScheduleFactory
-                        .create(loanApplicationTerms.getLoanScheduleType(), InterestMethod.DECLINING_BALANCE);
-                LoanScheduleModel loanSchedule = decliningLoanScheduleGenerator.generate(mc, loanApplicationTerms, loanCharges, detailDTO);
-
-                loanApplicationTerms
-                        .updateTotalInterestDue(Money.of(loanApplicationTerms.getCurrency(), loanSchedule.getTotalInterestCharged()));
-
-            }
+            updateInterestForEqualAmortization(mc, loanApplicationTerms, loanCharges, detailDTO);
             loanScheduleGenerator = this.loanScheduleFactory.create(loanApplicationTerms.getLoanScheduleType(), InterestMethod.FLAT);
         } else {
             loanScheduleGenerator = this.loanScheduleFactory.create(loanApplicationTerms.getLoanScheduleType(),
@@ -1599,6 +1588,18 @@ public class LoanScheduleAssembler {
                     loanScheduleModelPeriod.addLoanCharges(loanCharge.getAmountOutstanding(), BigDecimal.ZERO);
                 }
             }
+        }
+    }
+
+    private void updateInterestForEqualAmortization(final MathContext mc, final LoanApplicationTerms loanApplicationTerms,
+            final Set<LoanCharge> loanCharges, final HolidayDetailDTO detailDTO) {
+        if (loanApplicationTerms.getInterestMethod().isDecliningBalance()) {
+            final LoanScheduleGenerator decliningLoanScheduleGenerator = this.loanScheduleFactory
+                    .create(loanApplicationTerms.getLoanScheduleType(), InterestMethod.DECLINING_BALANCE);
+            LoanScheduleModel loanSchedule = decliningLoanScheduleGenerator.generate(mc, loanApplicationTerms, loanCharges, detailDTO);
+
+            loanApplicationTerms
+                    .updateTotalInterestDue(Money.of(loanApplicationTerms.getCurrency(), loanSchedule.getTotalInterestCharged()));
         }
     }
 


### PR DESCRIPTION
## Description
Refactored [LoanScheduleAssembler.java](cci:7://file:///home/sai/Desktop/dev/OpenSource/fineract/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java:0:0-0:0) to improve code readability and maintainability extracting inline logic into a helper method.

Currently, the [assembleLoanScheduleFrom](cci:1://file:///home/sai/Desktop/dev/OpenSource/fineract/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java:707:4-739:5) method contains mixed logic for creating the `LoanScheduleGenerator` and handling "Equal Amortization" updates. This violates the Single Responsibility Principle and increases cogniive load.

Resolves [FINERACT-2464](https://issues.apache.org/jira/browse/FINERACT-2464).

## Changes
* Extracted the "Equal Amortization" interest update logic into a new private helper method: [updateInterestForEqualAmortization](cci:1://file:///home/sai/Desktop/dev/OpenSource/fineract/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java:1598:4-1608:5).
* Simplified the conditional flow in [assembleLoanScheduleFrom](cci:1://file:///home/sai/Desktop/dev/OpenSource/fineract/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java:707:4-739:5).
* Removed redundant initialization of `loanScheduleGenerator`.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

* [x] Commit message follows guidelines
* [x] Coding conventions followed
* [x] Build is passing locally