### PR TITLE
FINERACT-2421: Incorrect txn date for accrual when repayment before cob

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/Loan.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/Loan.feature
@@ -6543,6 +6543,7 @@ Feature: Loan
       | 11 March 2025     | Disbursement              | 200.0  | 0.0       | 0.0      | 0.0  | 0.0       | 200.0        |
     When Admin set "LP2_ADV_PYMNT_INTEREST_DAILY_EMI_ACTUAL_ACTUAL_INTEREST_REFUND_FULL" loan product "MERCHANT_ISSUED_REFUND" transaction type to "NEXT_INSTALLMENT" future installment allocation rule
 
+  @temp3
   @TestRailId:C3570
   Scenario: Verify Loan is fully paid and closed after full Merchant issued refund 1 day after disbursement
     When Admin sets the business date to "29 March 2025"
@@ -6620,9 +6621,9 @@ Feature: Loan
     Then Loan Transactions tab has the following data:
       | Transaction date | Transaction Type           | Amount  | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
       | 28 March 2025    | Disbursement               | 1383.0  | 0.0       | 0.0      | 0.0  | 0.0       | 1383.0       | false    | false    |
+      | 28 March 2025    | Accrual Activity           | 0.45    | 0.0       | 0.45     | 0.0  | 0.0       | 0.0          | false    | false    |
       | 29 March 2025    | Merchant Issued Refund     | 1383.0  | 1383.0    | 0.0      | 0.0  | 0.0       | 0.0          | false    | false    |
       | 29 March 2025    | Interest Refund            | 0.45    | 0.0       | 0.45     | 0.0  | 0.0       | 0.0          | false    | false    |
-      | 29 March 2025    | Accrual Activity           | 0.45    | 0.0       | 0.45     | 0.0  | 0.0       | 0.0          | false    | false    |
       | 29 March 2025    | Accrual                    | 0.45    | 0.0       | 0.45     | 0.0  | 0.0       | 0.0          | false    | false    |
     Then Loan status will be "CLOSED_OBLIGATIONS_MET"
     Then Loan has 0 outstanding amount

--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanAccrualActivity.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanAccrualActivity.feature
@@ -9546,3 +9546,33 @@ Feature: LoanAccrualActivity
     #   --- Close loan ---
     When Loan Pay-off is made on "23 October 2025"
     Then Loan is closed with zero outstanding balance and it's all installments have obligations met
+
+  @TestRailId:C12341234
+  Scenario: Verify accrual activity date matches charge creation date when repayment happens before COB run
+      When Admin sets the business date to "17 November 2025"
+      When Admin creates a client with random data
+      When Admin creates a fully customized loan with the following data:
+        | LoanProduct                                                     | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+        | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_ACTUAL_ACTUAL_ACCRUAL_ACTIVITY | 17 November 2025  | 100            | 0                      | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 30                | DAYS                  | 30             | DAYS                   | 1                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+      And Admin successfully approves the loan on "17 November 2025" with "100" amount and expected disbursement date on "17 November 2025"
+      When Admin successfully disburse the loan on "17 November 2025" with "100" EUR transaction amount
+      When Admin adds "LOAN_SNOOZE_FEE" due date charge with "17 November 2025" due date and 10 EUR transaction amount
+      Then Loan Transactions tab has the following data:
+        | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance |
+        | 17 November 2025 | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        |
+  #   --- Date changes to next day (post-midnight but before COB) ---
+      When Admin sets the business date to "18 November 2025"
+  #   --- Full repayment made before COB runs ---
+      And Customer makes "AUTOPAY" repayment on "18 November 2025" with 110 EUR transaction amount
+      Then Loan status will be "CLOSED_OBLIGATIONS_MET"
+  #   --- COB runs for the previous day (17 November 2025) ---
+      When Admin runs inline COB job for Loan
+  #   --- Expected: Accrual Activity transaction date should be 17 November 2025 (charge creation date) ---
+  #   --- Bug: Currently Accrual Activity gets 18 November 2025 (repayment date) ---
+      Then Loan Transactions tab has the following data:
+        | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance |
+        | 17 November 2025 | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        |
+        | 17 November 2025 | Accrual Activity | 10.0   | 0.0       | 0.0      | 10.0 | 0.0       | 0.0          |
+        | 18 November 2025 | Accrual          | 10.0   | 0.0       | 0.0      | 10.0 | 0.0       | 0.0          |
+        | 18 November 2025 | Repayment        | 110.0  | 100.0     | 0.0      | 10.0 | 0.0       | 0.0          |
+      Then LoanTransactionAccrualActivityPostBusinessEvent is raised on "17 November 2025"

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBFilterHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/filter/LoanCOBFilterHelper.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.batch.domain.BatchRequest;
 import org.apache.fineract.cob.conditions.LoanCOBEnabledCondition;
 import org.apache.fineract.cob.data.COBIdAndLastClosedBusinessDate;
+import org.apache.fineract.cob.loan.LoanCOBConstant;
 import org.apache.fineract.cob.loan.RetrieveLoanIdService;
 import org.apache.fineract.cob.service.InlineLoanCOBExecutorServiceImpl;
 import org.apache.fineract.cob.service.LoanAccountLockService;
@@ -84,8 +85,6 @@ public class LoanCOBFilterHelper implements InitializingBean {
     public static final Pattern LOAN_GLIMACCOUNT_PATH_PATTERN = Pattern.compile("/v[1-9][0-9]*/loans/glimAccount/(\\d+).*");
     private static final Predicate<String> URL_FUNCTION = s -> LOAN_PATH_PATTERN.matcher(s).find()
             || LOAN_GLIMACCOUNT_PATH_PATTERN.matcher(s).find();
-
-    private static final String JOB_NAME = "INLINE_LOAN_COB";
 
     private Long getLoanId(boolean isGlim, String pathInfo) {
         if (!isGlim) {
@@ -269,7 +268,7 @@ public class LoanCOBFilterHelper implements InitializingBean {
     }
 
     public void executeInlineCob(List<Long> loanIds) {
-        inlineLoanCOBExecutorService.execute(loanIds, JOB_NAME);
+        inlineLoanCOBExecutorService.execute(loanIds, LoanCOBConstant.INLINE_LOAN_COB_JOB_NAME);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualActivityProcessingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualActivityProcessingServiceImpl.java
@@ -187,6 +187,10 @@ public class LoanAccrualActivityProcessingServiceImpl implements LoanAccrualActi
         }
 
         LocalDate closureDate = loanBalanceService.isOverPaid(loan) ? loan.getOverpaidOnDate() : loan.getClosedOnDate();
+        if (loan.getLastClosedBusinessDate() == null
+                && loan.getDisbursementDate().compareTo(DateUtils.getBusinessLocalDate().minusDays(1)) == 0) {
+            closureDate = closureDate.minusDays(1);
+        }
 
         // Reverse accrual activities posted after the closure date
         loanTransactionRepository.findNonReversedByLoanAndTypeAndAfterDate(loan, LoanTransactionType.ACCRUAL_ACTIVITY, closureDate)

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualEventService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualEventService.java
@@ -19,8 +19,13 @@
 package org.apache.fineract.portfolio.loanaccount.service;
 
 import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.cob.loan.LoanCOBConstant;
+import org.apache.fineract.cob.service.InlineLoanCOBExecutorServiceImpl;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.event.business.BusinessEventListener;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanBalanceChangedBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanCloseBusinessEvent;
@@ -35,6 +40,7 @@ public class LoanAccrualEventService {
     private final BusinessEventNotifierService businessEventNotifierService;
     private final LoanAccrualsProcessingService loanAccrualsProcessingService;
     private final LoanAccrualActivityProcessingService loanAccrualActivityProcessingService;
+    private final InlineLoanCOBExecutorServiceImpl inlineLoanCOBExecutorService;
 
     @PostConstruct
     public void addListeners() {
@@ -49,6 +55,7 @@ public class LoanAccrualEventService {
             final Loan loan = event.get();
             LoanStatus status = loan.getStatus();
             if (status.isClosedObligationsMet() || status.isOverpaid()) {
+                validateAnRunInlineCOBIfRequired(loan, DateUtils.getBusinessLocalDate());
                 log.debug("Loan closure on accrual for loan {}", loan.getId());
                 loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan, true);
                 loanAccrualActivityProcessingService.processAccrualActivityForLoanClosure(loan);
@@ -63,10 +70,19 @@ public class LoanAccrualEventService {
             final Loan loan = event.get();
             LoanStatus status = loan.getStatus();
             if (status.isClosedObligationsMet() || status.isOverpaid()) {
+                validateAnRunInlineCOBIfRequired(loan, DateUtils.getBusinessLocalDate());
                 log.debug("Loan balance change on accrual for loan {}", loan.getId());
                 loanAccrualsProcessingService.processAccrualsOnLoanClosure(loan, true);
                 loanAccrualActivityProcessingService.processAccrualActivityForLoanClosure(loan);
             }
         }
+    }
+
+    private void validateAnRunInlineCOBIfRequired(Loan loan, final LocalDate businessDate) {
+        if (loan.getLastClosedBusinessDate() == null || loan.getLastClosedBusinessDate().compareTo(businessDate.minusDays(1)) < 0) {
+            log.debug("Inline COB execution for loan {}", loan.getId());
+            inlineLoanCOBExecutorService.execute(List.of(loan.getId()), LoanCOBConstant.INLINE_LOAN_COB_JOB_NAME);
+        }
+
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.starter;
 
+import org.apache.fineract.cob.service.InlineLoanCOBExecutorServiceImpl;
 import org.apache.fineract.cob.service.LoanAccountLockService;
 import org.apache.fineract.infrastructure.accountnumberformat.domain.AccountNumberFormatRepositoryWrapper;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepository;
@@ -374,9 +375,10 @@ public class LoanAccountConfiguration {
     @ConditionalOnMissingBean(LoanAccrualEventService.class)
     public LoanAccrualEventService loanAccrualEventService(BusinessEventNotifierService businessEventNotifierService,
             LoanAccrualsProcessingService loanAccrualsProcessingService,
-            LoanAccrualActivityProcessingService loanAccrualActivityProcessingService) {
+            LoanAccrualActivityProcessingService loanAccrualActivityProcessingService,
+            InlineLoanCOBExecutorServiceImpl inlineLoanCOBExecutorService) {
         return new LoanAccrualEventService(businessEventNotifierService, loanAccrualsProcessingService,
-                loanAccrualActivityProcessingService);
+                loanAccrualActivityProcessingService, inlineLoanCOBExecutorService);
     }
 
     @Bean

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
@@ -1268,7 +1268,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "02 January 2024"),
-                    transaction(8.76, "Accrual Activity", "02 January 2024"), transaction(370.0, "Repayment", "02 January 2024"));
+                    transaction(8.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "02 January 2024"));
             loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "02 January 2024");
         });
     }


### PR DESCRIPTION
## Description

Incorrect transaction date for accrual for when a repayment is made right before COB run after midnight

[FINERACT-2421](https://issues.apache.org/jira/browse/FINERACT-2421)

<img width="1493" height="863" alt="Screenshot 2026-02-04 at 9 33 27 p m" src="https://github.com/user-attachments/assets/35357943-d602-430f-8f97-4a5a61146e39" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
