### PR TITLE
WEB-694: Enforce one commit per pull request

### DIFF
--- a/.github/workflows/one-commit-per-pr.yml
+++ b/.github/workflows/one-commit-per-pr.yml
@@ -1,0 +1,14 @@
+- name: Fetch base branch
+  run: |
+    git fetch origin ${{ github.base_ref }}
+
+- name: Check number of commits in PR
+  run: |
+    COMMIT_COUNT=$(git rev-list --count origin/${{ github.base_ref }}..HEAD)
+    echo "Commit count in PR: $COMMIT_COUNT"
+
+    if [ "$COMMIT_COUNT" -gt 1 ]; then
+      echo "This pull request contains more than one commit."
+      echo "Please squash your commits into a single commit before updating the PR."
+      exit 1
+    fi


### PR DESCRIPTION
This PR adds a GitHub Action to enforce a single commit per pull request.
It automatically fails PRs that contain more than one commit, encouraging contributors to squash their commits before requesting review.

