### PR TITLE
FINERACT-176: During allocation and settle cash for a cashier if valid inputs are not given then error message displayed as Unknown data integrity issue

### DIFF
--- a/fineract-branch/src/main/java/org/apache/fineract/organisation/teller/serialization/TellerCommandFromApiJsonDeserializer.java
+++ b/fineract-branch/src/main/java/org/apache/fineract/organisation/teller/serialization/TellerCommandFromApiJsonDeserializer.java
@@ -199,5 +199,7 @@ public final class TellerCommandFromApiJsonDeserializer {
 
         final String currencyCode = this.fromApiJsonHelper.extractStringNamed(CURRENCY_CODE, element);
         baseDataValidator.reset().parameter(CURRENCY_CODE).value(currencyCode).notExceedingLengthOf(3);
+
+        throwExceptionIfValidationWarningsExist(dataValidationErrors);
     }
 }

--- a/fineract-branch/src/test/java/org/apache/fineract/organisation/teller/serialization/TellerCommandFromApiJsonDeserializerTest.java
+++ b/fineract-branch/src/test/java/org/apache/fineract/organisation/teller/serialization/TellerCommandFromApiJsonDeserializerTest.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.teller.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+class TellerCommandFromApiJsonDeserializerTest {
+
+    private final FromJsonHelper fromJsonHelper = new FromJsonHelper();
+    private final TellerCommandFromApiJsonDeserializer underTest = new TellerCommandFromApiJsonDeserializer(fromJsonHelper);
+
+    @Test
+    public void testCashTxnValidJsonPassesValidation() throws JsonProcessingException {
+        String json = cashTxnJson(BigDecimal.valueOf(1000), "10 September 2022", "Test note", "USD");
+        assertDoesNotThrow(() -> underTest.validateForCashTxnForCashier(json));
+    }
+
+    @Test
+    public void testCashTxnBlankOrNullJsonThrowsInvalidJsonException() {
+        String whitespaceOnly = "   ";
+        assertThrows(InvalidJsonException.class, () -> underTest.validateForCashTxnForCashier(null));
+        assertThrows(InvalidJsonException.class, () -> underTest.validateForCashTxnForCashier(""));
+        assertThrows(InvalidJsonException.class, () -> underTest.validateForCashTxnForCashier(whitespaceOnly));
+    }
+
+    @Test
+    public void testCashTxnMissingTxnAmountThrowsValidationException() {
+        assertPlatformValidationException("The parameter `txnAmount` is mandatory.", "validation.msg.teller.txnAmount.cannot.be.blank",
+                () -> underTest.validateForCashTxnForCashier(cashTxnJson(null, "10 September 2022", "Test note", "USD")));
+    }
+
+    @Test
+    public void testCashTxnMissingTxnDateThrowsValidationException() {
+        assertPlatformValidationException("The parameter `txnDate` is mandatory.", "validation.msg.teller.txnDate.cannot.be.blank",
+                () -> underTest.validateForCashTxnForCashier(cashTxnJson(BigDecimal.valueOf(1000), null, "Test note", "USD")));
+    }
+
+    @Test
+    public void testCashTxnTxnNoteExceedingMaxLengthThrowsValidationException() {
+        assertPlatformValidationException("The parameter `txnNote` exceeds max length of 200.",
+                "validation.msg.teller.txnNote.exceeds.max.length", () -> underTest
+                        .validateForCashTxnForCashier(cashTxnJson(BigDecimal.valueOf(1000), "10 September 2022", "A".repeat(201), "USD")));
+    }
+
+    @Test
+    public void testCashTxnCurrencyCodeExceedingMaxLengthThrowsValidationException() {
+        assertPlatformValidationException("The parameter `currencyCode` exceeds max length of 3.",
+                "validation.msg.teller.currencyCode.exceeds.max.length", () -> underTest
+                        .validateForCashTxnForCashier(cashTxnJson(BigDecimal.valueOf(1000), "10 September 2022", "Test note", "ABCD")));
+    }
+
+    @NonNull
+    private String cashTxnJson(@Nullable BigDecimal txnAmount, @Nullable String txnDate, @Nullable String txnNote,
+            @Nullable String currencyCode) throws JsonProcessingException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("dateFormat", "dd MMMM yyyy");
+        map.put("locale", "en");
+        Optional.ofNullable(txnAmount).ifPresent(a -> map.put("txnAmount", a));
+        Optional.ofNullable(txnDate).ifPresent(d -> map.put("txnDate", d));
+        Optional.ofNullable(txnNote).ifPresent(n -> map.put("txnNote", n));
+        Optional.ofNullable(currencyCode).ifPresent(c -> map.put("currencyCode", c));
+        return createJsonCommand(map);
+    }
+
+    @NonNull
+    private String createJsonCommand(Map<String, Object> jsonMap) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonMap);
+    }
+
+    private void assertPlatformValidationException(String message, String code, Executable executable) {
+        PlatformApiDataValidationException validationException = assertThrows(PlatformApiDataValidationException.class, executable);
+        assertPlatformException(message, code, validationException);
+    }
+
+    private void assertPlatformException(String expectedMessage, String expectedCode,
+            PlatformApiDataValidationException platformApiDataValidationException) {
+        Assertions.assertEquals(expectedMessage, platformApiDataValidationException.getErrors().get(0).getDefaultUserMessage());
+        Assertions.assertEquals(expectedCode, platformApiDataValidationException.getErrors().get(0).getUserMessageGlobalisationCode());
+    }
+}


### PR DESCRIPTION
JIRA: FINERACT-176 

- Fixed missing throw exception for validation errors in Teller Module

ReportedBy: subramanyasn

## Issue

Before any changes, the backend was returning a error.msg.teller.unknown.data.integrity.issue when there is no input on cash transactions in the teller module. This was because the error was being built in the validator, but there was no throw statement. 

I verified using Postman, and replicated the issue on the backend.
<img width="842" height="592" alt="Screenshot 2026-02-10 at 4 44 18 PM" src="https://github.com/user-attachments/assets/f8806769-0e7d-4449-8134-ece9ea6cbf19" />

Here is the proper validation with error as expected (after changes).
<img width="863" height="668" alt="Screenshot 2026-02-10 at 5 23 58 PM" src="https://github.com/user-attachments/assets/69fb6628-f6e5-401e-9b3d-dee62fd6795a" />

I also verified this issue by testing on a dev server. The issue was circumvented by greying out the Submit button when no input is entered. However, I believe it's better to handle this issue in the backend, since it's expected behavior.
<img width="638" height="821" alt="Screenshot 2026-02-10 at 4 38 52 PM" src="https://github.com/user-attachments/assets/873c0897-ba25-47cc-9be4-f175f1994110" />

## Fix

Added throwExceptionIfValidationWarningsExist(() to the validateForCashTxnForCashier method in the TellerCommandFromApiJsonDeserializer. 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
