### PR TITLE
FINERACT-2488: Fix duplicate results in /api/v2/clients/search

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
@@ -67,6 +67,7 @@ public class SearchingClientRepositoryImpl implements SearchingClientRepository 
         Path<Office> office = root.get("office");
 
         Specification<Client> spec = (r, q, builder) -> {
+            q.distinct(true);
             Path<Office> o = r.get("office");
             Join<Client, ClientIdentifier> identity = r.join("identifiers", JoinType.LEFT);
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -36,6 +36,7 @@ import org.apache.fineract.client.models.PostOfficesResponse;
 import org.apache.fineract.client.models.SortOrder;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -269,6 +270,36 @@ public class ClientSearchTest extends IntegrationTest {
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).getMobileNo()).isEqualTo(request1.getMobileNo());
+    }
+
+    @Test
+    public void testClientSearchDoesNotDuplicateResults_WhenIdentifierHasMultipleMatches() {
+        // given
+        PostClientsRequest request = ClientHelper.defaultClientCreationRequest();
+        PostClientsResponse clientResponse = clientHelper.createClient(request);
+
+        Integer codeId = (Integer) CodeHelper.createCode(requestSpec, responseSpec, Utils.randomStringGenerator("ClientIdentifierTest_", 6),
+                CodeHelper.RESPONSE_ID_ATTRIBUTE_NAME);
+        Integer documentTypeIdOne = CodeHelper.createCodeValue(requestSpec, responseSpec, codeId,
+                Utils.randomStringGenerator("DocType_", 6), 1);
+        Integer documentTypeIdTwo = CodeHelper.createCodeValue(requestSpec, responseSpec, codeId,
+                Utils.randomStringGenerator("DocType_", 6), 2);
+
+        String documentKeyToken = Utils.randomStringGenerator("DUP_ID_", 6);
+        PostClientsClientIdIdentifiersRequest identifierOne = new PostClientsClientIdIdentifiersRequest()
+                .documentTypeId(documentTypeIdOne.longValue()).documentKey(documentKeyToken + "_A").description("Test").status("Active");
+        PostClientsClientIdIdentifiersRequest identifierTwo = new PostClientsClientIdIdentifiersRequest()
+                .documentTypeId(documentTypeIdTwo.longValue()).documentKey(documentKeyToken + "_B").description("Test").status("Active");
+        clientHelper.createClientIdentifer(clientResponse.getClientId(), identifierOne);
+        clientHelper.createClientIdentifer(clientResponse.getClientId(), identifierTwo);
+
+        // when
+        PageClientSearchData result = clientHelper.searchClients(documentKeyToken);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().size()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getExternalId().getValue()).isEqualTo(request.getExternalId());
     }
 
     @Test


### PR DESCRIPTION
The `/api/v2/clients/search` endpoint returns duplicate entries when a client has multiple identifiers matching the search criteria. When searching by identifier document key, clients with multiple matching identifiers appear multiple times in the result set.

## Checklist

- [X] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [X] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [X] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [X] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).