### PR TITLE
FINERACT-274: Not able to create the same datatable which was rejected by the maker checker before

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.service;
 
 import com.google.gson.JsonElement;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDoma
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.dataqueries.service.CleanupService;
 import org.apache.fineract.infrastructure.jobs.service.SchedulerJobRunnerReadService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -49,6 +51,7 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
     private final CommandProcessingService processAndLogCommandService;
     private final SchedulerJobRunnerReadService schedulerJobRunnerReadService;
     private final ConfigurationDomainService configurationService;
+    private final List<CleanupService> cleanupServices;
 
     @Override
     public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
@@ -146,6 +149,11 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
         final AppUser maker = this.context.authenticatedUser();
         commandSourceInput.markAsRejected(maker);
         this.commandSourceRepository.save(commandSourceInput);
+        if (cleanupServices != null) {
+            for (CleanupService cleanupService : cleanupServices) {
+                cleanupService.cleanup(commandSourceInput);
+            }
+        }
         return makerCheckerId;
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/CleanupService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/CleanupService.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.service;
+
+import org.apache.fineract.commands.domain.CommandSource;
+
+public interface CleanupService {
+
+    void cleanup(CommandSource commandSource);
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableRejectionCleanupService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableRejectionCleanupService.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DatatableRejectionCleanupService implements CleanupService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final DatabaseSpecificSQLGenerator sqlGenerator;
+    private final FromJsonHelper fromJsonHelper;
+
+    @Override
+    public void cleanup(CommandSource commandSource) {
+
+        boolean isCreateAction = "CREATE".equals(commandSource.getActionName());
+        boolean isDatatableEntity = "DATATABLE".equals(commandSource.getEntityName());
+        if (!isCreateAction || !isDatatableEntity) {
+            return;
+        }
+
+        final String datatableName = fromJsonHelper.parse(commandSource.getCommandAsJson()).getAsJsonObject().get("datatableName")
+                .getAsString();
+
+        final String sql = "DROP TABLE IF EXISTS " + sqlGenerator.escape(datatableName);
+        log.info("Cleaning up orphaned datatable after rejection: {}", datatableName);
+        jdbcTemplate.execute(sql);
+
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/MakercheckerTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/MakercheckerTest.java
@@ -36,16 +36,20 @@ import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationC
 import org.apache.fineract.integrationtests.common.AuditHelper;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.commands.MakercheckersHelper;
 import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
+import org.apache.fineract.integrationtests.common.system.DatatableHelper;
 import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
 import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings({ "unused" })
 public class MakercheckerTest {
@@ -191,6 +195,78 @@ public class MakercheckerTest {
 
             PutPermissionsRequest putPermissionsRequest = new PutPermissionsRequest().putPermissionsItem("WITHDRAWAL_SAVINGSACCOUNT",
                     false);
+            rolesHelper.updatePermissions(putPermissionsRequest);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "m_client", "m_group", "m_center", "m_loan", "m_office", "m_savings_account" })
+    public void testRejectDatatableCreationCleansUpOrphanedTable(String apptableName) {
+
+        // enable maker-checker globally
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                new PutGlobalConfigurationsRequest().enabled(false));
+
+        try {
+            // enable maker-checker for datatable creation
+            PutPermissionsRequest putPermissionsRequest = new PutPermissionsRequest().putPermissionsItem("CREATE_DATATABLE", true);
+            rolesHelper.updatePermissions(putPermissionsRequest);
+
+            // create role with permissions for maker and checker
+            Integer roleId = RolesHelper.createRole(requestSpec, responseSpec);
+            Map<String, Boolean> permissionMap = Map.of("CREATE_DATATABLE", true, "CREATE_DATATABLE_CHECKER", true);
+            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, roleId, permissionMap);
+
+            // create maker user
+            Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+            String maker = Utils.uniqueRandomStringGenerator("user", 8);
+            Integer makerUserId = (Integer) UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, maker,
+                    "A1b2c3d4e5f$", "resourceId");
+
+            // create checker user
+            String checker = Utils.uniqueRandomStringGenerator("user", 8);
+            UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, checker, "A1b2c3d4e5f$", "resourceId");
+
+            RequestSpecification makerRequestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build()
+                    .header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey(maker, "A1b2c3d4e5f$"));
+
+            // maker creates datatable with maker-checker enabled, this creates the physical table but queues for
+            // approval
+            DatatableHelper makerDatatableHelper = new DatatableHelper(makerRequestSpec, this.responseSpec);
+            String datatableJson = DatatableHelper.getTestDatatableAsJSON(apptableName, false);
+            String datatableName = com.google.gson.JsonParser.parseString(datatableJson).getAsJsonObject().get("datatableName")
+                    .getAsString();
+            makerDatatableHelper.createDatatable(datatableJson, "");
+
+            // find the pending command
+            List<Map<String, Object>> auditDetails = makercheckersHelper
+                    .getMakerCheckerList(Map.of("actionName", "CREATE", "entityName", "DATATABLE", "makerId", makerUserId.toString()));
+            assertEquals(1, auditDetails.size(), "Error: Expected only one pending CREATE DATATABLE command");
+            Long commandId = ((Double) auditDetails.get(0).get("id")).longValue();
+
+            // checker rejects the command which should drop the orphaned table
+            MakercheckersHelper.rejectMakerCheckerEntry(FineractClientHelper.createNewFineractClient(checker, "A1b2c3d4e5f$"), commandId);
+
+            // verify the datatable no longer exists by trying to create it again
+            // verify without maker checker, so transaction rollback in postgres doesn't break the test
+            putPermissionsRequest = new PutPermissionsRequest().putPermissionsItem("CREATE_DATATABLE", false);
+            rolesHelper.updatePermissions(putPermissionsRequest);
+
+            DatatableHelper adminDatatableHelper = new DatatableHelper(this.requestSpec, this.responseSpec);
+            String recreatedName = adminDatatableHelper.createDatatable(datatableJson, "resourceIdentifier");
+            assertEquals(datatableName, recreatedName, "Error: Was not able to recreate datatable after rejection cleanup");
+
+            // cleanup after test
+            adminDatatableHelper.deleteDatatable(datatableName);
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+
+            PutPermissionsRequest putPermissionsRequest = new PutPermissionsRequest().putPermissionsItem("CREATE_DATATABLE", false);
             rolesHelper.updatePermissions(putPermissionsRequest);
         }
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/commands/MakercheckersHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/commands/MakercheckersHelper.java
@@ -26,6 +26,9 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.fineract.client.models.PostMakerCheckersResponse;
+import org.apache.fineract.client.util.Calls;
+import org.apache.fineract.client.util.FineractClient;
 import org.apache.fineract.client.util.JSON;
 import org.apache.fineract.integrationtests.common.Utils;
 
@@ -79,5 +82,9 @@ public class MakercheckersHelper {
             Long auditId) {
         String url = MAKERCHECKER_URL + "/" + auditId + "?command=approve&" + Utils.TENANT_IDENTIFIER;
         return Utils.performServerPost(requestSpec, responseSpec, url, "", "");
+    }
+
+    public static PostMakerCheckersResponse rejectMakerCheckerEntry(FineractClient client, Long auditId) {
+        return Calls.ok(client.makerCheckers.approveMakerCheckerEntry(auditId, "reject"));
     }
 }


### PR DESCRIPTION
JIRA: FINERACT-274, FINERACT-672, FINERACT-673, FINERACT-674, FINERACT-675, FINERACT-676

## Problem

According to FINERACT-274, when a new datatable was rejected in the maker checker process, it creates an orphaned table by mistake, forcing developers to delete the table manually in their database. I've gone ahead and fixed this issue by adding a datatable cleanup service for maker checker rejections. More on this below.

To reproduce the problem: 
1) Startup a MariaDB instance of Fineract
2) Make sure global maker-checker is on.
3) Make sure maker-checker is on for datatable creation
4) Login as a maker (not a super-user) user to frontend dev server
5) Create a new datatable
6) Login as a checker user.
7) Deny the datatable creation.
8) Examine the database and find orphaned table.

<img width="488" height="25" alt="Screenshot 2026-02-13 at 7 41 23 PM" src="https://github.com/user-attachments/assets/7766fafa-a2a2-46c8-acc6-31e3d398d74e" />
<br></br>
<img width="243" height="79" alt="Screenshot 2026-02-13 at 7 41 13 PM" src="https://github.com/user-attachments/assets/f2f3ebbe-f4d9-4a9a-b932-6d255972f0bf" />

9) Reconfirm by trying to create datatable with same name, which displays an error message: data table already exists.

<img width="470" height="104" alt="Screenshot 2026-02-13 at 6 26 30 PM" src="https://github.com/user-attachments/assets/77375e19-6d1a-4f96-bc35-5191265e0cd7" />

## Changes

The problem was found to affect the group, center, loan account, office, and savings accounts levels. 

After diagnosing the issue, I found that during data table creation events, the transaction in maker-checker gets rolled backed. However, it turns out that MariaDB does not add DDL (data table changes) queries to a transaction, meaning when the maker-checker system rolls everything back for checking, the DDL actually executes and makes the table anyways. This means that when the data table is rejected, the orphaned data table exists in the database. PostgreSQL includes DDL as part of the transaction boundary, meaning it is not an issue when PostgreSQL is used.

To fix the issue, I added a cleanup service after every maker-checker rejection that checks if the rejection was a data table rejection. If that was the case, it cleans up the data table in question. If not, it continues as normal. This structure allows us to keep as much original logic as possible, while working in both PostgreSQL and MariaDB use cases.

To test my changes, I also added an integration test that tests the process of data table creation, maker-checker events, and another data table creation to determine if the data table was properly removed. I do this over the group, center, loan account, office, and saving account levels to make sure they don't produce the bugs mentioned in the various tickets.

I tried to follow convention as much as possible, but I may have missed some things so feedback is very welcome!

## Results

Tests all pass:

For MariaDB:
<img width="603" height="235" alt="Screenshot 2026-02-14 at 8 23 45 PM" src="https://github.com/user-attachments/assets/59799063-271a-4523-b4e1-ce60b01534e1" />

For PostgreSQL:
<img width="565" height="236" alt="Screenshot 2026-02-14 at 8 25 20 PM" src="https://github.com/user-attachments/assets/1a832f71-d1d9-4a2f-a6c8-98e7d0788561" />

Reproducing the issue no longer results in a "data table already exists" error:

Demo video is too big for Github, but here is the list of tables after submitting the maker command. You can see the test table.
<img width="213" height="196" alt="Screenshot 2026-02-14 at 11 15 41 PM" src="https://github.com/user-attachments/assets/37197fc5-6069-4a85-a0e6-09653ed994a4" />


And here is the list of tables after rejecting with the checker user. You can see there is no test table.
<img width="224" height="242" alt="Screenshot 2026-02-14 at 11 16 24 PM" src="https://github.com/user-attachments/assets/98f017e8-feba-4420-b01c-7a53823d5b24" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
