### PR TITLE
FINERACT-2481: Remove Pentaho reports from initial data

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -228,4 +228,5 @@
     <include file="parts/0207_add_allow_full_term_for_tranche.xml" relativeToChangelogFile="true" />
     <include file="parts/0208_trial_balance_summary_with_asset_owner_journal_entry_aggregation_fix.xml" relativeToChangelogFile="true" />
     <include file="parts/0209_transaction_summary_with_asset_owner_and_from_asset_owner_id_for_asset_sales.xml" relativeToChangelogFile="true" />
+    <include file="parts/0210_remove_pentaho_legacy_data.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0210_remove_pentaho_legacy_data.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0210_remove_pentaho_legacy_data.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="fineract" id="0210">
+        <comment>FINERACT-2481: Precisely removing 44 core Pentaho reports and their associated permissions to clean up initial data</comment>
+        
+        <delete tableName="m_report_parameter">
+            <where>report_id IN (SELECT id FROM stretchy_report WHERE report_name IN (
+                'Balance Sheet', 'Income Statement', 'Trial Balance', 'Loan Account Schedule', 
+                'Branch Expected Cash Flow', 'Expected Payments By Date - Formatted', 'Savings Transactions', 
+                'Client Savings Summary', 'Active Loans - Details(Pentaho)', 'Active Loans - Summary(Pentaho)', 
+                'Active Loans by Disbursal Period(Pentaho)', 'Active Loans in last installment Summary(Pentaho)', 
+                'Active Loans in last installment(Pentaho)', 'Active Loans Passed Final Maturity Summary(Pentaho)', 
+                'Active Loans Passed Final Maturity(Pentaho)', 'Aging Detail(Pentaho)', 
+                'Aging Summary (Arrears in Months)(Pentaho)', 'Aging Summary (Arrears in Weeks)(Pentaho)', 
+                'Client Listing(Pentaho)', 'Client Loans Listing(Pentaho)', 'Expected Payments By Date - Basic(Pentaho)', 
+                'Funds Disbursed Between Dates Summary by Office(Pentaho)', 'Funds Disbursed Between Dates Summary(Pentaho)', 
+                'Loans Awaiting Disbursal Summary by Month(Pentaho)', 'Loans Awaiting Disbursal Summary(Pentaho)', 
+                'Loans Awaiting Disbursal(Pentaho)', 'Loans Pending Approval(Pentaho)', 
+                'Obligation Met Loans Details(Pentaho)', 'Obligation Met Loans Summary(Pentaho)', 
+                'Portfolio at Risk by Branch(Pentaho)', 'Portfolio at Risk(Pentaho)', 'Rescheduled Loans(Pentaho)', 
+                'TxnRunningBalances(Pentaho)', 'Written-Off Loans(Pentaho)', 'Client Saving Transactions', 
+                'Client Loan Account Schedule', 'Savings Transaction Receipt', 'Loan Transaction Receipt', 
+                'Staff Assignment History', 'GeneralLedgerReport', 'Active Loan Summary per Branch', 
+                'Balance Outstanding', 'Collection Report', 'Disbursal Report'
+            ))</where>
+        </delete>
+
+        <delete tableName="stretchy_report">
+            <where>report_name IN (
+                'Balance Sheet', 'Income Statement', 'Trial Balance', 'Loan Account Schedule', 
+                'Branch Expected Cash Flow', 'Expected Payments By Date - Formatted', 'Savings Transactions', 
+                'Client Savings Summary', 'Active Loans - Details(Pentaho)', 'Active Loans - Summary(Pentaho)', 
+                'Active Loans by Disbursal Period(Pentaho)', 'Active Loans in last installment Summary(Pentaho)', 
+                'Active Loans in last installment(Pentaho)', 'Active Loans Passed Final Maturity Summary(Pentaho)', 
+                'Active Loans Passed Final Maturity(Pentaho)', 'Aging Detail(Pentaho)', 
+                'Aging Summary (Arrears in Months)(Pentaho)', 'Aging Summary (Arrears in Weeks)(Pentaho)', 
+                'Client Listing(Pentaho)', 'Client Loans Listing(Pentaho)', 'Expected Payments By Date - Basic(Pentaho)', 
+                'Funds Disbursed Between Dates Summary by Office(Pentaho)', 'Funds Disbursed Between Dates Summary(Pentaho)', 
+                'Loans Awaiting Disbursal Summary by Month(Pentaho)', 'Loans Awaiting Disbursal Summary(Pentaho)', 
+                'Loans Awaiting Disbursal(Pentaho)', 'Loans Pending Approval(Pentaho)', 
+                'Obligation Met Loans Details(Pentaho)', 'Obligation Met Loans Summary(Pentaho)', 
+                'Portfolio at Risk by Branch(Pentaho)', 'Portfolio at Risk(Pentaho)', 'Rescheduled Loans(Pentaho)', 
+                'TxnRunningBalances(Pentaho)', 'Written-Off Loans(Pentaho)', 'Client Saving Transactions', 
+                'Client Loan Account Schedule', 'Savings Transaction Receipt', 'Loan Transaction Receipt', 
+                'Staff Assignment History', 'GeneralLedgerReport', 'Active Loan Summary per Branch', 
+                'Balance Outstanding', 'Collection Report', 'Disbursal Report'
+            )</where>
+        </delete>
+
+        <delete tableName="m_permission">
+            <where>code LIKE 'READ_%(Pentaho)' 
+                   OR code = 'READ_Staff Assignment History'</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description
This PR removes 44 legacy Pentaho report entries from the initial system data to clean up the reporting metadata.

## Changes Proposed
* **New Migration:** Added `0210_remove_pentaho_legacy_data.xml`.
* **Surgical Cleanup:** Explicitly listed 44 reports in `m_report_parameter` and `stretchy_report` for targeted removal.
* **Permission Cleanup:** Removed associated permissions in `m_permission` using pattern matching.
* **Integrity:** Deletion order follows (Child -> Parent) to respect Foreign Key constraints.

## Impact
* **Database:** Cleaner initial state without obsolete metadata.
* **UI:** Removed deprecated Pentaho reports and permissions from management screens.

## Checklist
- [x] Migration ID follows sequential order (0210).
- [x] Deletion order respects Foreign Key constraints.
- [x] Explicit naming used for reports for maximum safety.