### PR TITLE
FINERACT-2502: Resolve the issue 403 Forbidden error when a client is missing a profile image

### DIFF
--- a/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/exception/DocumentNotFoundException.java
+++ b/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/exception/DocumentNotFoundException.java
@@ -18,9 +18,9 @@
  */
 package org.apache.fineract.infrastructure.documentmanagement.exception;
 
-import org.apache.fineract.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
 
-public class DocumentNotFoundException extends AbstractPlatformDomainRuleException {
+public class DocumentNotFoundException extends AbstractPlatformResourceNotFoundException {
 
     public DocumentNotFoundException(final Long id) {
         super("error.msg.document.id.invalid", "Document with identifier " + id + " does not exist", id);

--- a/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImpl.java
+++ b/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImpl.java
@@ -28,7 +28,6 @@ import org.apache.fineract.infrastructure.contentstore.service.ContentStoreServi
 import org.apache.fineract.infrastructure.documentmanagement.adapter.EntityImageIdAdapter;
 import org.apache.fineract.infrastructure.documentmanagement.data.DocumentContent;
 import org.apache.fineract.infrastructure.documentmanagement.domain.ImageRepository;
-import org.apache.fineract.infrastructure.documentmanagement.exception.DocumentInvalidRequestException;
 import org.apache.fineract.infrastructure.documentmanagement.exception.DocumentNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -45,25 +44,15 @@ public class ImageReadPlatformServiceImpl implements ImageReadPlatformService {
 
     @Override
     public DocumentContent retrieveImage(final String entityType, final Long entityId) {
-        try {
-            return imageIdAdapters.stream().filter(imageIdAdapter -> imageIdAdapter.accept(entityType)).findFirst()
-                    .flatMap(imageIdAdapter -> imageIdAdapter.get(entityId))
-                    .flatMap(
-                            imageIdResult -> imageRepository.findById(imageIdResult.getId())
-                                    .map(image -> DocumentContent
-                                            .builder().fileName(
-                                                    FilenameUtils.getName(image.getLocation()))
-                                            .format(FilenameUtils.getExtension(image.getLocation()))
-                                            .displayName(imageIdResult.getDisplayName())
-                                            .contentType(
-                                                    contentDetectorManager
-                                                            .detect(ContentDetectorContext.builder()
-                                                                    .fileName(FilenameUtils.getName(image.getLocation())).build())
-                                                            .getMimeType())
-                                            .stream(storeService.download(image.getLocation())).build()))
-                    .orElseThrow(() -> new DocumentNotFoundException(entityType, entityId, -1L));
-        } catch (final Exception e) {
-            throw new DocumentInvalidRequestException(e);
-        }
+        return imageIdAdapters.stream().filter(imageIdAdapter -> imageIdAdapter.accept(entityType)).findFirst()
+                .flatMap(imageIdAdapter -> imageIdAdapter.get(entityId))
+                .flatMap(imageIdResult -> imageRepository.findById(imageIdResult.getId()).map(image -> DocumentContent.builder()
+                        .fileName(FilenameUtils.getName(image.getLocation())).format(FilenameUtils.getExtension(image.getLocation()))
+                        .displayName(imageIdResult.getDisplayName())
+                        .contentType(contentDetectorManager
+                                .detect(ContentDetectorContext.builder().fileName(FilenameUtils.getName(image.getLocation())).build())
+                                .getMimeType())
+                        .stream(storeService.download(image.getLocation())).build()))
+                .orElseThrow(() -> new DocumentNotFoundException(entityType, entityId, -1L));
     }
 }

--- a/fineract-document/src/test/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImplTest.java
+++ b/fineract-document/src/test/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImplTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.documentmanagement.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.contentstore.detector.ContentDetectorManager;
+import org.apache.fineract.infrastructure.contentstore.service.ContentStoreService;
+import org.apache.fineract.infrastructure.documentmanagement.adapter.EntityImageIdAdapter;
+import org.apache.fineract.infrastructure.documentmanagement.domain.ImageRepository;
+import org.apache.fineract.infrastructure.documentmanagement.exception.DocumentNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ImageReadPlatformServiceImplTest {
+
+    @Mock
+    private ImageRepository imageRepository;
+    @Mock
+    private ContentStoreService storeService;
+    @Mock
+    private ContentDetectorManager contentDetectorManager;
+    @Mock
+    private EntityImageIdAdapter imageIdAdapter;
+
+    private ImageReadPlatformServiceImpl imageReadPlatformService;
+
+    @BeforeEach
+    void setUp() {
+        List<EntityImageIdAdapter> imageIdAdapters = Collections.singletonList(imageIdAdapter);
+        imageReadPlatformService = new ImageReadPlatformServiceImpl(imageIdAdapters, storeService, imageRepository, contentDetectorManager);
+    }
+
+    @Test
+    void testRetrieveImage_NotFound_ThrowsDocumentNotFoundException() {
+        // Arrange
+        String entityType = "clients";
+        Long entityId = 1L;
+
+        when(imageIdAdapter.accept(anyString())).thenReturn(true);
+        when(imageIdAdapter.get(entityId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(DocumentNotFoundException.class, () -> {
+            imageReadPlatformService.retrieveImage(entityType, entityId);
+        });
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/DocumentTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/DocumentTest.java
@@ -117,7 +117,7 @@ class DocumentTest extends IntegrationTest {
         ok(fineractClient().documents.deleteDocument("clients", clientId, documentId));
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
                 () -> ok(fineractClient().documents.getDocument("clients", clientId, documentId)));
-        assertEquals(403, exception.getResponse().code());
+        assertEquals(404, exception.getResponse().code());
     }
 
     @Order(9999)

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/FeignDocumentTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/FeignDocumentTest.java
@@ -133,7 +133,7 @@ public class FeignDocumentTest extends FeignIntegrationTest {
 
         FeignException exception = assertThrows(FeignException.class,
                 () -> fineractClient().documentsFixed().getDocument("clients", clientId, documentId));
-        assertEquals(403, exception.status());
+        assertEquals(404, exception.status());
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR resolves the issue where a "403 Forbidden" error alert appears on the UI when a client is missing a profile image. 

**Jira Ticket:** [FINERACT-2502](https://issues.apache.org/jira/browse/FINERACT-2502)


**Changes:**
- Updated [DocumentNotFoundException](cci:2://file:///c:/Users/bhoomi/fineract/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/exception/DocumentNotFoundException.java:22:0-32:1) to extend [AbstractPlatformResourceNotFoundException](cci:2://file:///c:/Users/bhoomi/fineract/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/AbstractPlatformResourceNotFoundException.java:23:0-29:1) so it correctly maps to 404.
- Removed generic exception wrapping in [ImageReadPlatformServiceImpl](cci:2://file:///c:/Users/bhoomi/fineract/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImpl.java:34:0-64:1) to stop hiding the "Not Found" error.
- Added [ImageReadPlatformServiceImplTest](cci:2://file:///c:/Users/bhoomi/fineract/fineract-document/src/test/java/org/apache/fineract/infrastructure/documentmanagement/service/ImageReadPlatformServiceImplTest.java:38:0-73:1) to verify that [DocumentNotFoundException](cci:2://file:///c:/Users/bhoomi/fineract/fineract-document/src/main/java/org/apache/fineract/infrastructure/documentmanagement/exception/DocumentNotFoundException.java:22:0-32:1) is thrown for missing images.
**Verification:**
- Verified with Postman that missing images now return 404 Not Found (Previously 403 Forbidden).


## Checklist
- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build ("green")
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit).
