### PR TITLE
FINERACT-2026: Replace HTTPie with curl in Minikube documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ minikube service fineract-server --url --https
 
 Fineract is now running at the printed URL, which you can check e.g. using:
 ```bash
-http --verify=no --timeout 240 --check-status get $(minikube service fineract-server --url --https)/fineract-provider/actuator/health
+curl --insecure --max-time 240 --fail $(minikube service fineract-server --url --https)/fineract-provider/actuator/health
 ```
 
 To check the status of your containers on your local minikube Kubernetes cluster, run:


### PR DESCRIPTION
## Description

The "Using Minikube" section currently uses http (HTTPie), which is not a standard tool and is missing from the REQUIREMENTS section. This causes a command not found error for most developers. This PR replaces it with curl to ensure consistency with the "How to run for local development" section and to remove undocumented dependencies.

## Checklist
- [ ] Write the commit message as per [our guidelines](https://www.google.com/search?q=https://github.com/apache/fineract%23pull-requests)

- [ ] Acknowledge that we will not review PRs that are not passing the build ("green") - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made. (N/A for documentation changes)

- [ ] Follow our [coding conventions](https://www.google.com/search?q=https://github.com/apache/fineract%23coding-conventions).

- [ ] Add required Swagger annotation and update API documentation... (N/A)

- [ ] This PR must not be a "code dump". Large changes can be made in a branch, with assistance.

