### PR TITLE
FINERACT-2507: Reduced default poll interval for Loan COB Spring Job from 10s to 500ms

### DIFF
--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -92,7 +92,7 @@ fineract.partitioned-job.partitioned-job-properties[0].thread-pool-core-pool-siz
 fineract.partitioned-job.partitioned-job-properties[0].thread-pool-max-pool-size=${LOAN_COB_THREAD_POOL_MAX_POOL_SIZE:5}
 fineract.partitioned-job.partitioned-job-properties[0].thread-pool-queue-capacity=${LOAN_COB_THREAD_POOL_QUEUE_CAPACITY:20}
 fineract.partitioned-job.partitioned-job-properties[0].retry-limit=${LOAN_COB_RETRY_LIMIT:5}
-fineract.partitioned-job.partitioned-job-properties[0].poll-interval=${LOAN_COB_POLL_INTERVAL:10000}
+fineract.partitioned-job.partitioned-job-properties[0].poll-interval=${LOAN_COB_POLL_INTERVAL:500}
 
 fineract.remote-job-message-handler.spring-events.enabled=${FINERACT_REMOTE_JOB_MESSAGE_HANDLER_SPRING_EVENTS_ENABLED:true}
 fineract.remote-job-message-handler.jms.enabled=${FINERACT_REMOTE_JOB_MESSAGE_HANDLER_JMS_ENABLED:false}

--- a/fineract-provider/src/test/resources/application-test.properties
+++ b/fineract-provider/src/test/resources/application-test.properties
@@ -56,7 +56,7 @@ fineract.partitioned-job.partitioned-job-properties[0].thread-pool-core-pool-siz
 fineract.partitioned-job.partitioned-job-properties[0].thread-pool-max-pool-size=1
 fineract.partitioned-job.partitioned-job-properties[0].thread-pool-queue-capacity=1
 fineract.partitioned-job.partitioned-job-properties[0].retry-limit=5
-fineract.partitioned-job.partitioned-job-properties[0].poll-interval=10000
+fineract.partitioned-job.partitioned-job-properties[0].poll-interval=500
 
 fineract.remote-job-message-handler.spring-events.enabled=${FINERACT_REMOTE_JOB_MESSAGE_HANDLER_SPRING_EVENTS_ENABLED:true}
 fineract.remote-job-message-handler.jms.enabled=${FINERACT_REMOTE_JOB_MESSAGE_HANDLER_JMS_ENABLED:false}


### PR DESCRIPTION
## Description

Reduced default poll interval for Loan COB Job from 10s to 500ms.
The poll interval controls how often the spring job manager checks for partition step completion. 
Therefore, it also defines minimal execution time. 
The lower value makes the check happen more often, which may put pressure on DB.

See related ticket: FINERACT-2507

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [X] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [X] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [X] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
