### PR TITLE
FINERACT-1659: Add optimistic lock to savings interest posting batch …

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
@@ -141,6 +141,7 @@ public final class SavingsAccountData implements Serializable {
     private transient List<SavingsAccountTransactionData> newSavingsAccountTransactionData = new ArrayList<>();
     private transient GroupGeneralData groupGeneralData;
     private transient Long officeId;
+    private transient Integer version;
     private transient Set<Long> existingTransactionIds = new HashSet<>();
     private transient Set<Long> existingReversedTransactionIds = new HashSet<>();
     private transient Long glAccountIdForSavingsControl;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -311,6 +311,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
             sqlBuilder.append("sa.last_interest_calculation_date as lastInterestCalculationDate, ");
             sqlBuilder.append("sa.total_savings_amount_on_hold as onHoldAmount, ");
             sqlBuilder.append("sa.interest_posted_till_date as interestPostedTillDate, ");
+            sqlBuilder.append("sa.version as version, ");
             sqlBuilder.append("tg.id as taxGroupId, ");
             sqlBuilder.append("(select COALESCE(max(sat.transaction_date),sa.activatedon_date) ");
             sqlBuilder.append("from m_savings_account_transaction as sat ");
@@ -584,6 +585,9 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
                     savingsAccountData.setGlAccountIdForInterestOnSavings(glAccountIdForInterestOnSavings);
                     savingsAccountData.setGlAccountIdForSavingsControl(glAccountIdForSavingsControl);
+
+                    final Integer version = JdbcSupport.getInteger(rs, "version");
+                    savingsAccountData.setVersion(version);
                 }
 
                 if (!transMap.containsValue(transactionId)) {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPoster.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPoster.java
@@ -29,7 +29,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -167,6 +169,8 @@ public class SavingsSchedularInterestPoster {
         List<Object[]> paramsForSavingsSummary = new ArrayList<>();
         List<Object[]> paramsForTransactionUpdate = new ArrayList<>();
         List<String> transRefNo = new ArrayList<>();
+        List<Long> transInsertAccountIds = new ArrayList<>();
+        List<Long> transUpdateAccountIds = new ArrayList<>();
         LocalDate currentDate = DateUtils.getBusinessLocalDate();
         Long userId = platformSecurityContext.authenticatedUser().getId();
         for (SavingsAccountData savingsAccountData : savingsAccountDataList) {
@@ -181,13 +185,14 @@ public class SavingsSchedularInterestPoster {
                     savingsAccountSummaryData.getLastInterestCalculationDate(),
                     savingsAccountSummaryData.getInterestPostedTillDate() != null ? savingsAccountSummaryData.getInterestPostedTillDate()
                             : savingsAccountSummaryData.getLastInterestCalculationDate(),
-                    auditTime, userId, savingsAccountData.getId() });
+                    auditTime, userId, savingsAccountData.getId(), savingsAccountData.getVersion() });
             List<SavingsAccountTransactionData> savingsAccountTransactionDataList = savingsAccountData.getSavingsAccountTransactionData();
             for (SavingsAccountTransactionData savingsAccountTransactionData : savingsAccountTransactionDataList) {
                 if (savingsAccountTransactionData.getId() == null && !MathUtil.isZero(savingsAccountTransactionData.getAmount())) {
                     UUID uuid = UUID.randomUUID();
                     savingsAccountTransactionData.setRefNo(uuid.toString());
                     transRefNo.add(uuid.toString());
+                    transInsertAccountIds.add(savingsAccountData.getId());
                     paramsForTransactionInsertion.add(new Object[] { savingsAccountData.getId(), savingsAccountData.getOfficeId(),
                             savingsAccountTransactionData.isReversed(), savingsAccountTransactionData.getTransactionType().getId(),
                             savingsAccountTransactionData.getTransactionDate(), savingsAccountTransactionData.getAmount(),
@@ -197,6 +202,7 @@ public class SavingsSchedularInterestPoster {
                             savingsAccountTransactionData.getRefNo(), savingsAccountTransactionData.isReversalTransaction(),
                             savingsAccountTransactionData.getOverdraftAmount(), currentDate });
                 } else {
+                    transUpdateAccountIds.add(savingsAccountData.getId());
                     paramsForTransactionUpdate.add(new Object[] { savingsAccountTransactionData.isReversed(),
                             savingsAccountTransactionData.getAmount(), savingsAccountTransactionData.getOverdraftAmount(),
                             savingsAccountTransactionData.getBalanceEndDate(), savingsAccountTransactionData.getBalanceNumberOfDays(),
@@ -208,24 +214,65 @@ public class SavingsSchedularInterestPoster {
             savingsAccountData.setUpdatedTransactions(savingsAccountTransactionDataList);
         }
 
-        if (transRefNo.size() > 0) {
-            this.jdbcTemplate.batchUpdate(queryForSavingsUpdate, paramsForSavingsSummary);
-            this.jdbcTemplate.batchUpdate(queryForTransactionInsertion, paramsForTransactionInsertion);
-            this.jdbcTemplate.batchUpdate(queryForTransactionUpdate, paramsForTransactionUpdate);
-            log.debug("`Total No Of Interest Posting:` {}", transRefNo.size());
-            List<SavingsAccountTransactionData> savingsAccountTransactionDataList = fetchTransactionsFromIds(transRefNo);
-            if (savingsAccountDataList != null) {
-                log.debug("Fetched Transactions from DB: {}", savingsAccountTransactionDataList.size());
+        if (!transRefNo.isEmpty()) {
+            int[] updateCounts = this.jdbcTemplate.batchUpdate(queryForSavingsUpdate, paramsForSavingsSummary);
+
+            Set<Long> skippedAccountIds = new HashSet<>();
+            for (int i = 0; i < updateCounts.length; i++) {
+                if (updateCounts[i] == 0) {
+                    Long accountId = savingsAccountDataList.get(i).getId();
+                    skippedAccountIds.add(accountId);
+                    log.warn("Skipping interest posting for account {} - concurrent modification detected (optimistic lock)", accountId);
+                }
             }
 
-            HashMap<String, SavingsAccountTransactionData> savingsAccountTransactionMap = new HashMap<>();
-            for (SavingsAccountTransactionData savingsAccountTransactionData : savingsAccountTransactionDataList) {
-                final String key = savingsAccountTransactionData.getRefNo();
-                savingsAccountTransactionMap.put(key, savingsAccountTransactionData);
+            if (!skippedAccountIds.isEmpty()) {
+                paramsForTransactionInsertion = filterByAccountId(paramsForTransactionInsertion, transInsertAccountIds, skippedAccountIds);
+                transRefNo = filterRefNos(transRefNo, transInsertAccountIds, skippedAccountIds);
+                paramsForTransactionUpdate = filterByAccountId(paramsForTransactionUpdate, transUpdateAccountIds, skippedAccountIds);
             }
-            batchUpdateJournalEntries(savingsAccountDataList, savingsAccountTransactionMap);
+
+            if (!transRefNo.isEmpty()) {
+                this.jdbcTemplate.batchUpdate(queryForTransactionInsertion, paramsForTransactionInsertion);
+                this.jdbcTemplate.batchUpdate(queryForTransactionUpdate, paramsForTransactionUpdate);
+                log.debug("`Total No Of Interest Posting:` {}", transRefNo.size());
+                List<SavingsAccountTransactionData> savingsAccountTransactionDataList = fetchTransactionsFromIds(transRefNo);
+                if (savingsAccountDataList != null) {
+                    log.debug("Fetched Transactions from DB: {}", savingsAccountTransactionDataList.size());
+                }
+
+                HashMap<String, SavingsAccountTransactionData> savingsAccountTransactionMap = new HashMap<>();
+                for (SavingsAccountTransactionData savingsAccountTransactionData : savingsAccountTransactionDataList) {
+                    final String key = savingsAccountTransactionData.getRefNo();
+                    savingsAccountTransactionMap.put(key, savingsAccountTransactionData);
+                }
+
+                List<SavingsAccountData> filteredAccountDataList = skippedAccountIds.isEmpty() ? savingsAccountDataList
+                        : savingsAccountDataList.stream().filter(sa -> !skippedAccountIds.contains(sa.getId())).toList();
+                batchUpdateJournalEntries(filteredAccountDataList, savingsAccountTransactionMap);
+            }
         }
 
+    }
+
+    List<Object[]> filterByAccountId(List<Object[]> params, List<Long> accountIds, Set<Long> skippedIds) {
+        List<Object[]> filtered = new ArrayList<>();
+        for (int i = 0; i < params.size(); i++) {
+            if (!skippedIds.contains(accountIds.get(i))) {
+                filtered.add(params.get(i));
+            }
+        }
+        return filtered;
+    }
+
+    List<String> filterRefNos(List<String> refNos, List<Long> accountIds, Set<Long> skippedIds) {
+        List<String> filtered = new ArrayList<>();
+        for (int i = 0; i < refNos.size(); i++) {
+            if (!skippedIds.contains(accountIds.get(i))) {
+                filtered.add(refNos.get(i));
+            }
+        }
+        return filtered;
     }
 
     private String batchQueryForTransactionInsertion() {
@@ -240,7 +287,7 @@ public class SavingsSchedularInterestPoster {
         return "update m_savings_account set total_deposits_derived=?, total_withdrawals_derived=?, total_interest_earned_derived=?, total_interest_posted_derived=?, total_withdrawal_fees_derived=?, "
                 + "total_fees_charge_derived=?, total_penalty_charge_derived=?, total_annual_fees_derived=?, account_balance_derived=?, total_overdraft_interest_derived=?, total_withhold_tax_derived=?, "
                 + "last_interest_calculation_date=?, interest_posted_till_date=?, " + LAST_MODIFIED_DATE_DB_FIELD + " = ?, "
-                + LAST_MODIFIED_BY_DB_FIELD + " = ? WHERE id=? ";
+                + LAST_MODIFIED_BY_DB_FIELD + " = ?, version = version + 1 WHERE id=? AND version=?";
     }
 
     private String batchQueryForTransactionsUpdate() {

--- a/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPosterTest.java
+++ b/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPosterTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsSchedularInterestPosterTest {
+
+    @Mock
+    private SavingsAccountWritePlatformService savingsAccountWritePlatformService;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private SavingsAccountReadPlatformService savingsAccountReadPlatformService;
+    @Mock
+    private PlatformSecurityContext platformSecurityContext;
+
+    private SavingsSchedularInterestPoster poster;
+
+    @BeforeEach
+    void setUp() {
+        poster = new SavingsSchedularInterestPoster(savingsAccountWritePlatformService, jdbcTemplate, savingsAccountReadPlatformService,
+                platformSecurityContext);
+    }
+
+    @Test
+    void testFilterByAccountIdRemovesSkippedEntries() {
+        List<Object[]> params = new ArrayList<>(List.of(new Object[] { "a" }, new Object[] { "b" }, new Object[] { "c" }));
+        List<Long> accountIds = new ArrayList<>(List.of(1L, 2L, 3L));
+        Set<Long> skippedIds = Set.of(2L);
+
+        List<Object[]> result = poster.filterByAccountId(params, accountIds, skippedIds);
+
+        assertEquals(2, result.size());
+        assertEquals("a", result.get(0)[0]);
+        assertEquals("c", result.get(1)[0]);
+    }
+
+    @Test
+    void testFilterByAccountIdSkipsAllAccounts() {
+        List<Object[]> params = new ArrayList<>(List.of(new Object[] { "a" }, new Object[] { "b" }));
+        List<Long> accountIds = new ArrayList<>(List.of(1L, 2L));
+        Set<Long> skippedIds = Set.of(1L, 2L);
+
+        List<Object[]> result = poster.filterByAccountId(params, accountIds, skippedIds);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFilterByAccountIdSkipsNone() {
+        List<Object[]> params = new ArrayList<>(List.of(new Object[] { "a" }, new Object[] { "b" }));
+        List<Long> accountIds = new ArrayList<>(List.of(1L, 2L));
+        Set<Long> skippedIds = new HashSet<>();
+
+        List<Object[]> result = poster.filterByAccountId(params, accountIds, skippedIds);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testFilterByAccountIdHandlesEmptyLists() {
+        List<Object[]> params = new ArrayList<>();
+        List<Long> accountIds = new ArrayList<>();
+        Set<Long> skippedIds = Set.of(1L);
+
+        List<Object[]> result = poster.filterByAccountId(params, accountIds, skippedIds);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFilterRefNosRemovesSkippedEntries() {
+        List<String> refNos = new ArrayList<>(List.of("ref1", "ref2", "ref3"));
+        List<Long> accountIds = new ArrayList<>(List.of(1L, 2L, 3L));
+        Set<Long> skippedIds = Set.of(2L);
+
+        List<String> result = poster.filterRefNos(refNos, accountIds, skippedIds);
+
+        assertEquals(2, result.size());
+        assertEquals("ref1", result.get(0));
+        assertEquals("ref3", result.get(1));
+    }
+
+    @Test
+    void testFilterRefNosSkipsAllAccounts() {
+        List<String> refNos = new ArrayList<>(List.of("ref1", "ref2"));
+        List<Long> accountIds = new ArrayList<>(List.of(1L, 2L));
+        Set<Long> skippedIds = Set.of(1L, 2L);
+
+        List<String> result = poster.filterRefNos(refNos, accountIds, skippedIds);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFilterMethodsMaintainParallelListAlignment() {
+        List<Object[]> params = new ArrayList<>(
+                List.of(new Object[] { "p1" }, new Object[] { "p2" }, new Object[] { "p3" }, new Object[] { "p4" }));
+        List<String> refNos = new ArrayList<>(List.of("ref1", "ref2", "ref3", "ref4"));
+        List<Long> accountIds = new ArrayList<>(List.of(10L, 20L, 10L, 30L));
+        Set<Long> skippedIds = Set.of(20L);
+
+        List<Object[]> filteredParams = poster.filterByAccountId(params, accountIds, skippedIds);
+        List<String> filteredRefNos = poster.filterRefNos(refNos, accountIds, skippedIds);
+
+        assertEquals(3, filteredParams.size());
+        assertEquals(3, filteredRefNos.size());
+
+        assertEquals("p1", filteredParams.get(0)[0]);
+        assertEquals("ref1", filteredRefNos.get(0));
+
+        assertEquals("p3", filteredParams.get(1)[0]);
+        assertEquals("ref3", filteredRefNos.get(1));
+
+        assertEquals("p4", filteredParams.get(2)[0]);
+        assertEquals("ref4", filteredRefNos.get(2));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
@@ -49,6 +49,7 @@ import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
 import org.apache.fineract.integrationtests.common.savings.SavingsTestLifecycleExtension;
+import org.apache.fineract.portfolio.savings.SavingsAccountTransactionType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,7 +131,6 @@ public class SavingsInterestPostingJobIntegrationTest {
 
     @Test
     public void testDuplicateOverdraftInterestPostingJob() {
-        // client activation, savings activation and 1st transaction date
         final String startDate = "01 July 2022";
         final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
         Assertions.assertNotNull(clientID);
@@ -141,15 +141,40 @@ public class SavingsInterestPostingJobIntegrationTest {
 
         this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
         this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, "1000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
-        Object transactionObj = this.savingsAccountHelper.getSavingsDetails(savingsId, "transactions");
-        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) transactionObj;
-        Integer dateCount = 0;
-        for (HashMap<String, Object> transaction : transactions) {
-            if (transaction.get("date").toString().equals("[2022, 7, 10]") && transaction.get("reversed").toString().equals("false")) {
-                dateCount++;
-            }
+
+        assertNoDuplicateOverdraftInterestPostings(savingsId);
+    }
+
+    @Test
+    public void testPostInterestJobRunTwiceSameDayNoDuplicate() {
+        final LocalDate businessDate = LocalDate.of(2022, 4, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "10 April 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPosting(clientID, startDate);
+            this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            // First run of Post Interest job
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            // Second run of Post Interest job on the same business day — should NOT create duplicates
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            int postingCount = countTotalUnreversedPostings(savingsId, SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+            LOG.info("Interest posting count after running job twice: {}", postingCount);
+            assertTrue(postingCount > 0, "Should have at least one interest posting");
+
+            assertNoDuplicateInterestPostings(savingsId);
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
         }
-        assertEquals(1, dateCount, "No Duplicate Overdraft Interest Posting");
     }
 
     @Test
@@ -241,6 +266,236 @@ public class SavingsInterestPostingJobIntegrationTest {
         assertEquals("800.4384", interestPostingTransaction.get("runningBalance").toString(), "Equality check for Balance");
     }
 
+    @Test
+    public void testMultipleAccountsPostInterestJobRunTwiceNoDuplicate() {
+        final LocalDate businessDate = LocalDate.of(2022, 4, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "10 April 2022";
+            final Integer savingsProductID = createSavingsProductDailyPosting();
+            Assertions.assertNotNull(savingsProductID);
+
+            List<Integer> savingsIds = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+                Assertions.assertNotNull(clientID);
+                final Integer savingsId = createSavingsAccountForProduct(clientID, savingsProductID, startDate);
+                this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+                savingsIds.add(savingsId);
+            }
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            for (Integer savingsId : savingsIds) {
+                int postingCount = countTotalUnreversedPostings(savingsId, SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+                assertTrue(postingCount > 0, "Account " + savingsId + " should have at least one interest posting");
+                assertNoDuplicateInterestPostings(savingsId);
+            }
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    @Test
+    public void testOverdraftInterestPostingJobRunTwiceNoDuplicate() {
+        final LocalDate businessDate = LocalDate.of(2022, 4, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "10 April 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPostingOverdraft(clientID, startDate);
+            this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            int postingCount = countTotalUnreversedPostings(savingsId, SavingsAccountTransactionType.OVERDRAFT_INTEREST.getValue());
+            assertTrue(postingCount > 0, "Should have at least one overdraft interest posting");
+            assertNoDuplicateOverdraftInterestPostings(savingsId);
+
+            HashMap summary = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            Float accountBalance = Float.parseFloat(summary.get("accountBalance").toString());
+            LOG.info("Overdraft account balance after running job twice: {}", accountBalance);
+            assertTrue(accountBalance < 0, "Overdraft account balance should be negative");
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    @Test
+    public void testPostInterestJobRunThreeTimesNoDuplicate() {
+        final LocalDate businessDate = LocalDate.of(2022, 4, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "10 April 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPosting(clientID, startDate);
+            this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            // Run job three times
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            HashMap summaryAfterFirst = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            Float balanceAfterFirst = Float.parseFloat(summaryAfterFirst.get("accountBalance").toString());
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            HashMap summaryAfterSecond = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            Float balanceAfterSecond = Float.parseFloat(summaryAfterSecond.get("accountBalance").toString());
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            HashMap summaryAfterThird = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            Float balanceAfterThird = Float.parseFloat(summaryAfterThird.get("accountBalance").toString());
+
+            assertNoDuplicateInterestPostings(savingsId);
+            assertEquals(balanceAfterFirst, balanceAfterSecond, 0.001f, "Balance should not change between first and second run");
+            assertEquals(balanceAfterSecond, balanceAfterThird, 0.001f, "Balance should not change between second and third run");
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    @Test
+    public void testPostInterestAcrossMultipleDaysNoDuplicate() {
+        final LocalDate businessDateDay1 = LocalDate.of(2022, 4, 12);
+        final LocalDate businessDateDay2 = LocalDate.of(2022, 4, 13);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDateDay1);
+
+            final String startDate = "10 April 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPosting(clientID, startDate);
+            this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            // Day 1: run job twice
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            Map<String, Integer> postingsAfterDay1 = countUnreversedPostingsByDate(savingsId,
+                    SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+            int postingDatesAfterDay1 = postingsAfterDay1.size();
+            assertTrue(postingDatesAfterDay1 > 0, "Should have at least one interest posting date after day 1");
+
+            // Day 2: advance business date, run job twice
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDateDay2);
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            Map<String, Integer> postingsAfterDay2 = countUnreversedPostingsByDate(savingsId,
+                    SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+            int postingDatesAfterDay2 = postingsAfterDay2.size();
+            assertTrue(postingDatesAfterDay2 > postingDatesAfterDay1, "Should have more posting dates after day 2 than day 1");
+
+            // No date should have duplicates
+            assertNoDuplicateInterestPostings(savingsId);
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    @Test
+    public void testPostInterestWithChargeJobRunTwiceNoDuplicate() {
+        final LocalDate businessDate = LocalDate.of(2022, 7, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "21 June 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPostingWithCharge(clientID, startDate);
+            this.savingsAccountHelper.depositToSavingsAccount(savingsId, "1000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+            this.savingsAccountHelper.withdrawalFromSavingsAccount(savingsId, "100", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            int postingCount = countTotalUnreversedPostings(savingsId, SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+            assertTrue(postingCount > 0, "Should have at least one interest posting");
+            assertNoDuplicateInterestPostings(savingsId);
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    @Test
+    public void testPostInterestBalanceConsistencyAfterRepeatedRuns() {
+        final LocalDate businessDate = LocalDate.of(2022, 4, 12);
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            BusinessDateHelper.updateBusinessDate(requestSpec, responseSpec, BusinessDateType.BUSINESS_DATE, businessDate);
+
+            final String startDate = "10 April 2022";
+            final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, startDate);
+            Assertions.assertNotNull(clientID);
+
+            final Integer savingsId = createSavingsAccountDailyPosting(clientID, startDate);
+            this.savingsAccountHelper.depositToSavingsAccount(savingsId, "10000", startDate, CommonConstants.RESPONSE_RESOURCE_ID);
+
+            // Run job once and capture balance
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            HashMap summaryAfterFirstRun = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            float balanceAfterFirstRun = ((Number) summaryAfterFirstRun.get("accountBalance")).floatValue();
+            float totalInterestAfterFirstRun = ((Number) summaryAfterFirstRun.get("totalInterestPosted")).floatValue();
+            LOG.info("Balance after first run: {}, totalInterestPosted: {}", balanceAfterFirstRun, totalInterestAfterFirstRun);
+
+            // Run job again and capture balance
+            this.scheduleJobHelper.executeAndAwaitJobByShortName(POST_INTEREST_FOR_SAVINGS_JOB_SHORT_NAME);
+
+            HashMap summaryAfterSecondRun = this.savingsAccountHelper.getSavingsSummary(savingsId);
+            float balanceAfterSecondRun = ((Number) summaryAfterSecondRun.get("accountBalance")).floatValue();
+            float totalInterestAfterSecondRun = ((Number) summaryAfterSecondRun.get("totalInterestPosted")).floatValue();
+            LOG.info("Balance after second run: {}, totalInterestPosted: {}", balanceAfterSecondRun, totalInterestAfterSecondRun);
+
+            assertEquals(balanceAfterFirstRun, balanceAfterSecondRun, 0.001f, "Account balance must not change on repeated job run");
+            assertEquals(totalInterestAfterFirstRun, totalInterestAfterSecondRun, 0.001f,
+                    "Total interest posted must not change on repeated job run");
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+        }
+    }
+
+    private Integer createSavingsAccountForProduct(final Integer clientID, final Integer savingsProductID, final String startDate) {
+        final Integer savingsId = this.savingsAccountHelper.applyForSavingsApplicationOnDate(clientID, savingsProductID,
+                ACCOUNT_TYPE_INDIVIDUAL, startDate);
+        Assertions.assertNotNull(savingsId);
+        HashMap savingsStatusHashMap = this.savingsAccountHelper.approveSavingsOnDate(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
+        savingsStatusHashMap = this.savingsAccountHelper.activateSavingsAccount(savingsId, startDate);
+        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        return savingsId;
+    }
+
     private Integer createSavingsAccountDailyPosting(final Integer clientID, final String startDate) {
         final Integer savingsProductID = createSavingsProductDailyPosting();
         Assertions.assertNotNull(savingsProductID);
@@ -322,6 +577,41 @@ public class SavingsInterestPostingJobIntegrationTest {
                 .withInterestCalculationPeriodTypeAsDailyBalance() //
                 .withMinimumOpenningBalance(minOpenningBalance).withAccountingRuleAsNone().build();
         return SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> countUnreversedPostingsByDate(Integer savingsId, int transactionTypeId) {
+        Object obj = this.savingsAccountHelper.getSavingsDetails(savingsId, "transactions");
+        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) obj;
+        Map<String, Integer> postingsByDate = new HashMap<>();
+        for (HashMap<String, Object> transaction : transactions) {
+            int typeId = ((Number) ((Map<String, Object>) transaction.get("transactionType")).get("id")).intValue();
+            boolean reversed = Boolean.parseBoolean(transaction.get("reversed").toString());
+            if (typeId == transactionTypeId && !reversed) {
+                postingsByDate.merge(transaction.get("date").toString(), 1, Integer::sum);
+            }
+        }
+        return postingsByDate;
+    }
+
+    private void assertNoDuplicateInterestPostings(Integer savingsId) {
+        Map<String, Integer> postingsByDate = countUnreversedPostingsByDate(savingsId,
+                SavingsAccountTransactionType.INTEREST_POSTING.getValue());
+        for (Map.Entry<String, Integer> entry : postingsByDate.entrySet()) {
+            assertEquals(1, entry.getValue().intValue(), "Duplicate interest posting detected for date " + entry.getKey());
+        }
+    }
+
+    private void assertNoDuplicateOverdraftInterestPostings(Integer savingsId) {
+        Map<String, Integer> postingsByDate = countUnreversedPostingsByDate(savingsId,
+                SavingsAccountTransactionType.OVERDRAFT_INTEREST.getValue());
+        for (Map.Entry<String, Integer> entry : postingsByDate.entrySet()) {
+            assertEquals(1, entry.getValue().intValue(), "Duplicate overdraft interest posting detected for date " + entry.getKey());
+        }
+    }
+
+    private int countTotalUnreversedPostings(Integer savingsId, int transactionTypeId) {
+        return countUnreversedPostingsByDate(savingsId, transactionTypeId).values().stream().mapToInt(Integer::intValue).sum();
     }
 
     // Reset configuration fields


### PR DESCRIPTION
…UPDATE

The root cause of duplicate interest postings was fixed in FINERACT-2394 (commit 5281be4b2), which removed a race condition where both the main thread and a fetchData callable concurrently populated a non-thread-safe ArrayDeque in PostInterestForSavingTasklet.

This commit adds defense-in-depth by wiring the existing @Version column into the raw JDBC batch UPDATE in SavingsSchedularInterestPoster, which bypasses JPA's optimistic lock. The batch UPDATE now includes AND version=? in its WHERE clause and version = version + 1 in SET. If a concurrent modification is detected (updateCounts[i] == 0), the account is skipped and logged rather than double-posted.

Changes:
- SavingsAccountData: add transient version field
- SavingsAccountReadPlatformServiceImpl: select sa.version and extract it in the ResultSetExtractor
- SavingsSchedularInterestPoster: add version check to batch UPDATE, skip accounts with version mismatch, filter downstream operations
- New integration test: testPostInterestJobRunTwiceSameDayNoDuplicate

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
