### PR TITLE
FINERACT-2509: Publish fineract-mix library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ buildscript {
                 'fineract-loan',
                 'fineract-savings',
                 'fineract-report',
+                'fineract-mix',
                 'fineract-branch',
                 'fineract-document',
                 'fineract-progressive-loan',


### PR DESCRIPTION
## Description
This PR addresses **FINERACT-2509** by including `fineract-mix` in the publishable project set.

`fineract-mix` was missing from `fineractPublishProjects` in root `build.gradle`, which prevented it from being published to Maven repositories. This change adds it to the list.

## Changes
- Updated [build.gradle] to add:
  - `fineract-mix` in `fineractPublishProjects`

## Validation
Ran checks scoped to the affected module:

- `./gradlew :fineract-mix:spotlessApply`
- `./gradlew :fineract-mix:spotbugsMain :fineract-mix:spotbugsTest`
- `./gradlew :fineract-mix:checkstyleMain :fineract-mix:checkstyleTest`


