### PR TITLE
FINERACT-2026: Replace HTTPie with curl in Minikube documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ minikube service fineract-server --url --https
 
 Fineract is now running at the printed URL, which you can check e.g. using:
 ```bash
-http --verify=no --timeout 240 --check-status get $(minikube service fineract-server --url --https)/fineract-provider/actuator/health
+curl --insecure --max-time 240 --fail $(minikube service fineract-server --url --https)/fineract-provider/actuator/health
 ```
 
 To check the status of your containers on your local minikube Kubernetes cluster, run:


### PR DESCRIPTION
## Description

The "Using Minikube" section currently uses http (HTTPie), which is not a standard tool and is missing from the REQUIREMENTS section. This causes a command not found error for most developers. This PR replaces it with curl to ensure consistency with the "How to run for local development" section and to remove undocumented dependencies.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
