### PR TITLE
FINERACT-2513: Refactor CreditBureauConfiguration integration tests to use fineract-client

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CreditBureauConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CreditBureauConfigurationTest.java
@@ -18,16 +18,11 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.fineract.integrationtests.common.CreditBureauConfigurationHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,34 +30,22 @@ import org.slf4j.LoggerFactory;
 public class CreditBureauConfigurationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CreditBureauConfigurationTest.class);
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    private static final String NO_ACCOUNTING = "1";
-
-    static final int MYTHREADS = 30;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-    }
 
     @Test
     public void creditBureauConfigurationTest() {
 
         // create creditBureauConfiguration
-        final Integer configurationId = CreditBureauConfigurationHelper.createCreditBureauConfiguration(this.requestSpec, this.responseSpec,
-                Utils.randomStringGenerator("testConfigKey_", 5));
+        String createResponse = CreditBureauConfigurationHelper.createCreditBureauConfiguration(1L,
+                Utils.randomStringGenerator("testConfigKey_", 5), "testConfigKeyValue", "description");
+        JsonObject createJson = JsonParser.parseString(createResponse).getAsJsonObject();
+        Long configurationId = createJson.get("resourceId").getAsLong();
         Assertions.assertNotNull(configurationId);
 
         // update creditBureauConfiguration
-        final String updateconfiguration = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, configurationId);
+        String updateResponse = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(configurationId, null,
+                "updateConfigKeyValue");
+        String updateconfiguration = JsonParser.parseString(updateResponse).getAsJsonObject().get("changes").getAsJsonObject().get("value")
+                .getAsString();
 
         Assertions.assertEquals("updateConfigKeyValue", updateconfiguration);
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CreditBureauTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CreditBureauTest.java
@@ -27,6 +27,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
@@ -70,46 +71,43 @@ public class CreditBureauTest {
     }
 
     private void configureCreditBureauService() {
-        Object organisations = CreditBureauConfigurationHelper.getOrganizationCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec);
+        String organisations = CreditBureauConfigurationHelper.getOrganisationCreditBureauConfiguration();
 
-        if (new Gson().fromJson(String.valueOf(organisations), List.class).isEmpty()) {
-            CreditBureauConfigurationHelper.addOrganisationCreditBureau(this.requestSpec, this.responseSpec, "1", "SAMPLE_ALIAS", true);
+        if (new Gson().fromJson(organisations, List.class).isEmpty()) {
+            CreditBureauConfigurationHelper.addOrganisationCreditBureau(1L, "SAMPLE_ALIAS", true);
         } else {
-            CreditBureauConfigurationHelper.updateOrganisationCreditBureau(this.requestSpec, this.responseSpec, "1", true);
+            CreditBureauConfigurationHelper.updateOrganisationCreditBureau("1", true);
         }
-        List<Map<String, Object>> configurations = CreditBureauConfigurationHelper.getCreditBureauConfiguration(requestSpec, responseSpec,
-                "1");
+        String configJson = CreditBureauConfigurationHelper.getCreditBureauConfiguration(1L);
+        List<Map<String, Object>> configurations = new Gson().fromJson(configJson, new TypeToken<List<Map<String, Object>>>() {}.getType());
         Assertions.assertNotNull(configurations);
-        Map<String, Integer> currentConfiguration = configurations.stream().collect(Collectors
-                .toMap(k -> String.valueOf(k.get("configurationKey")).toUpperCase(), v -> (int) v.get("creditBureauConfigurationId")));
-        final Object usernameConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("USERNAME").intValue(), "USERNAME", "testUser");
-        Assertions.assertNotNull(usernameConfigurationId);
-        final Object passwordConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("PASSWORD").intValue(), "PASSWORD", "testPassword");
-        Assertions.assertNotNull(passwordConfigurationId);
-        final Object creditReportUrlConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("CREDITREPORTURL").intValue(), "CREDITREPORTURL",
-                "http://localhost:3558/report/");
-        Assertions.assertNotNull(creditReportUrlConfigurationId);
-        final Object searchUrlConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("SEARCHURL").intValue(), "SEARCHURL", "http://localhost:3558/search/");
-        Assertions.assertNotNull(searchUrlConfigurationId);
-        final Object tokenUrlConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("TOKENURL").intValue(), "TOKENURL", "http://localhost:3558/token/");
-        Assertions.assertNotNull(tokenUrlConfigurationId);
-        final Object subscriptionIdConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("SUBSCRIPTIONID").intValue(), "SUBSCRIPTIONID", "subscriptionID123");
-        Assertions.assertNotNull(subscriptionIdConfigurationId);
-        final Object subscriptionKeyConfigurationId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("SUBSCRIPTIONKEY").intValue(), "SUBSCRIPTIONKEY", "subscriptionKey456");
-        Assertions.assertNotNull(subscriptionKeyConfigurationId);
-        final Object addCreditReportUrlId = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(this.requestSpec,
-                this.responseSpec, currentConfiguration.get("ADDCREDITREPORTURL").intValue(), "addCreditReporturl",
-                "http://localhost:3558/upload/");
-        Assertions.assertNotNull(addCreditReportUrlId);
-
+        Map<String, Long> currentConfiguration = configurations.stream()
+                .collect(Collectors.toMap(k -> String.valueOf(k.get("configurationKey")).toUpperCase(),
+                        v -> ((Number) v.get("creditBureauConfigurationId")).longValue()));
+        final String usernameResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("USERNAME"), "USERNAME", "testUser");
+        Assertions.assertNotNull(usernameResponse);
+        final String passwordResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("PASSWORD"), "PASSWORD", "testPassword");
+        Assertions.assertNotNull(passwordResponse);
+        final String creditReportUrlResponse = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(
+                currentConfiguration.get("CREDITREPORTURL"), "CREDITREPORTURL", "http://localhost:3558/report/");
+        Assertions.assertNotNull(creditReportUrlResponse);
+        final String searchUrlResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("SEARCHURL"), "SEARCHURL", "http://localhost:3558/search/");
+        Assertions.assertNotNull(searchUrlResponse);
+        final String tokenUrlResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("TOKENURL"), "TOKENURL", "http://localhost:3558/token/");
+        Assertions.assertNotNull(tokenUrlResponse);
+        final String subscriptionIdResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("SUBSCRIPTIONID"), "SUBSCRIPTIONID", "subscriptionID123");
+        Assertions.assertNotNull(subscriptionIdResponse);
+        final String subscriptionKeyResponse = CreditBureauConfigurationHelper
+                .updateCreditBureauConfiguration(currentConfiguration.get("SUBSCRIPTIONKEY"), "SUBSCRIPTIONKEY", "subscriptionKey456");
+        Assertions.assertNotNull(subscriptionKeyResponse);
+        final String addCreditReportUrlResponse = CreditBureauConfigurationHelper.updateCreditBureauConfiguration(
+                currentConfiguration.get("ADDCREDITREPORTURL"), "addCreditReporturl", "http://localhost:3558/upload/");
+        Assertions.assertNotNull(addCreditReportUrlResponse);
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/CreditBureauConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/CreditBureauConfigurationHelper.java
@@ -19,212 +19,66 @@
 package org.apache.fineract.integrationtests.common;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.fineract.client.services.CreditBureauConfigurationApi;
 import org.apache.fineract.client.util.Calls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CreditBureauConfigurationHelper {
+public final class CreditBureauConfigurationHelper {
 
-    private static final String CREATE_CREDITBUREAUCONFIGURATION_URL = "/fineract-provider/api/v1/CreditBureauConfiguration/configuration?"
-            + Utils.TENANT_IDENTIFIER;
     private static final Logger LOG = LoggerFactory.getLogger(CreditBureauConfigurationHelper.class);
-    private final RequestSpecification requestSpec;
-    private final ResponseSpecification responseSpec;
 
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public CreditBureauConfigurationHelper(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
-        this.requestSpec = requestSpec;
-        this.responseSpec = responseSpec;
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static List<Map<String, Object>> getCreditBureauConfiguration(RequestSpecification requestSpec,
-            ResponseSpecification responseSpec, String creditBureauId) {
-        LOG.info("---------------------------------GET A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String CREDITBUREAU_CONFIGURATION_URL = "/fineract-provider/api/v1/CreditBureauConfiguration/config/" + creditBureauId + "?"
-                + Utils.TENANT_IDENTIFIER;
-        return JsonPath.from(Utils.performServerGet(requestSpec, responseSpec, CREDITBUREAU_CONFIGURATION_URL)).getList("");
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Integer createCreditBureauConfiguration(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            String configKey) {
-        return createCreditBureauConfiguration(requestSpec, responseSpec, "1", configKey);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Integer createCreditBureauConfiguration(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String creditBureauId, String configKey, String value, String description) {
-        LOG.info("---------------------------------CREATING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String CREDITBUREAU_CONFIGURATION_URL = "/fineract-provider/api/v1/CreditBureauConfiguration/configuration/" + creditBureauId
-                + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(requestSpec, responseSpec, CREDITBUREAU_CONFIGURATION_URL,
-                creditBureauConfigurationAsJson(configKey, value, description), "resourceId");
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Integer createCreditBureauConfiguration(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String creditBureauId, String configKey) {
-        LOG.info("---------------------------------CREATING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        return createCreditBureauConfiguration(requestSpec, responseSpec, creditBureauId, configKey, "testConfigKeyValue", "description");
-    }
-
-    /*
-     * public static Object updateCreditBureauConfiguration(final RequestSpecification requestSpec, final
-     * ResponseSpecification responseSpec, final Integer ConfigurationId) { return
-     * updateCreditBureauConfiguration(requestSpec, responseSpec, ConfigurationId); }
-     */
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String updateCreditBureauConfiguration(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final Integer ConfigurationId) {
-
-        Object configurationObject = updateCreditBureauConfiguration(requestSpec, responseSpec, ConfigurationId, null,
-                "updateConfigKeyValue");
-        // Convert the Object to String and fetch updated value
-        Gson gson = new Gson();
-        String result = gson.toJson(configurationObject);
-        JsonObject reportObject = JsonParser.parseString(result).getAsJsonObject();
-        String value = reportObject.get("value").getAsString();
-
-        return value;
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Object updateCreditBureauConfiguration(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final Integer ConfigurationId, String configKey, final String updateConfigKeyValue) {
-        LOG.info("---------------------------------UPDATING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String CREDITBUREAU_CONFIGURATION_URL = "/fineract-provider/api/v1/CreditBureauConfiguration/configuration/" + ConfigurationId
-                + "?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPut(requestSpec, responseSpec, CREDITBUREAU_CONFIGURATION_URL,
-                updateCreditBureauConfigurationAsJson(configKey, updateConfigKeyValue), "changes");
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Object getOrganizationCreditBureauConfiguration(final RequestSpecification requestSpec,
-            final ResponseSpecification responseSpec) {
-        LOG.info("---------------------------------GETTING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String CREDITBUREAU_CONFIGURATION_URL = "/fineract-provider/api/v1/CreditBureauConfiguration/organisationCreditBureau?"
-                + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerGet(requestSpec, responseSpec, CREDITBUREAU_CONFIGURATION_URL, null);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Object addOrganisationCreditBureau(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String creditBureauId, String alias, boolean isActive) {
-        LOG.info("---------------------------------CREATING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String URL = "/fineract-provider/api/v1/CreditBureauConfiguration/organisationCreditBureau/" + creditBureauId + "?"
-                + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPost(requestSpec, responseSpec, URL, addOrganizationCreditBureauCreateAsJson(alias, isActive), null);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Object updateOrganisationCreditBureau(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String creditBureauId, boolean isActive) {
-        LOG.info("---------------------------------CREATING A CREDIT_BUREAU_CONFIGURATION---------------------------------------------");
-        final String URL = "/fineract-provider/api/v1/CreditBureauConfiguration/organisationCreditBureau?" + Utils.TENANT_IDENTIFIER;
-        return Utils.performServerPut(requestSpec, responseSpec, URL, updateOrganizationCreditBureauCreateAsJson(creditBureauId, isActive),
-                null);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String addOrganizationCreditBureauCreateAsJson(final String alias, final boolean isActive) {
-        final HashMap<String, Object> map = new HashMap<>();
-        map.put("alias", alias);
-        map.put("isActive", isActive);
-        LOG.info("map :  {}", map);
-        return new Gson().toJson(map);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String updateOrganizationCreditBureauCreateAsJson(final String creditBureauId, final boolean isActive) {
-        final HashMap<String, Object> map = new HashMap<>();
-        map.put("creditBureauId", creditBureauId);
-        map.put("isActive", isActive);
-        LOG.info("map :  {}", map);
-        return new Gson().toJson(map);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String creditBureauConfigurationAsJson(final String configkey, final String value, final String description) {
-        final HashMap<String, String> map = new HashMap<>();
-        map.put("configkey", configkey);
-        map.put("value", value);
-        map.put("description", description);
-        LOG.info("map :  {}", map);
-        return new Gson().toJson(map);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String updateCreditBureauConfigurationAsJson(final String configKey, final String value) {
-        final HashMap<String, String> map = new HashMap<>();
-        if (configKey != null) {
-            map.put("configkey", configKey);
-        }
-        map.put("value", value);
-        LOG.info("map :  {}", map);
-        return new Gson().toJson(map);
-    }
+    private CreditBureauConfigurationHelper() {}
 
     private static CreditBureauConfigurationApi api() {
         return FineractClientHelper.getFineractClient().creditBureauConfiguration;
     }
 
+    public static String getOrganisationCreditBureauConfiguration() {
+        LOG.info(
+                "---------------------------------GET ORGANISATION CREDIT BUREAU CONFIGURATION---------------------------------------------");
+        return Calls.ok(api().getOrganisationCreditBureau());
+    }
+
+    public static String getCreditBureauConfiguration(Long organisationCreditBureauId) {
+        LOG.info("---------------------------------GET CREDIT BUREAU CONFIGURATION---------------------------------------------");
+        return Calls.ok(api().getConfiguration(organisationCreditBureauId));
+    }
+
+    public static String createCreditBureauConfiguration(Long creditBureauId, String configKey, String value, String description) {
+        LOG.info("---------------------------------CREATING A CREDIT BUREAU CONFIGURATION---------------------------------------------");
+        final HashMap<String, String> map = new HashMap<>();
+        map.put("configkey", configKey);
+        map.put("value", value);
+        map.put("description", description);
+        return Calls.ok(api().createCreditBureauConfiguration(creditBureauId, new Gson().toJson(map)));
+    }
+
+    public static String updateCreditBureauConfiguration(Long configurationId, String configKey, String value) {
+        LOG.info("---------------------------------UPDATING A CREDIT BUREAU CONFIGURATION---------------------------------------------");
+        final HashMap<String, String> map = new HashMap<>();
+        if (configKey != null) {
+            map.put("configkey", configKey);
+        }
+        map.put("value", value);
+        return Calls.ok(api().updateCreditBureauConfiguration(configurationId, new Gson().toJson(map)));
+    }
+
     public static String addOrganisationCreditBureau(Long creditBureauId, String alias, boolean isActive) {
+        LOG.info("---------------------------------CREATING ORGANISATION CREDIT BUREAU---------------------------------------------");
         final HashMap<String, Object> map = new HashMap<>();
         map.put("alias", alias);
         map.put("isActive", isActive);
         return Calls.ok(api().addOrganisationCreditBureau(creditBureauId, new Gson().toJson(map)));
+    }
+
+    public static String updateOrganisationCreditBureau(String creditBureauId, boolean isActive) {
+        LOG.info("---------------------------------UPDATING ORGANISATION CREDIT BUREAU---------------------------------------------");
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put("creditBureauId", creditBureauId);
+        map.put("isActive", isActive);
+        return Calls.ok(api().updateCreditBureau(new Gson().toJson(map)));
     }
 
     public static String createCreditBureauConfigurationRaw(Long creditBureauId, String jsonBody) {


### PR DESCRIPTION
## Description

Migrates `CreditBureauConfigurationHelper` and its callers from deprecated REST-assured to `fineract-client`. Removes 12 deprecated methods, adds 5 new static methods using `Calls.ok()` + `CreditBureauConfigurationApi`.

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
