### PR TITLE
FINERACT-1430: Added social status and restricted high profile client access

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/Client.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/Client.java
@@ -189,6 +189,10 @@ public class Client extends AbstractAuditableWithUTCDateTimeCustom<Long> {
     @JoinColumn(name = "client_classification_cv_id")
     private CodeValue clientClassification;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "social_status_cv_id")
+    private CodeValue socialStatus;
+
     @Column(name = "legal_form_enum")
     private Integer legalForm;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -67,6 +67,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ClientReadPlatformServiceImpl implements ClientReadPlatformService {
 
+    private static final String READ_HIGH_PROFILE_CLIENT = "READ_HIGH_PROFILE_CLIENT";
+
     private final JdbcTemplate jdbcTemplate;
     private final PlatformSecurityContext context;
     private final CodeValueReadPlatformService codeValueReadPlatformService;
@@ -213,6 +215,9 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
             final String hierarchySearchString = hierarchy + "%";
 
             final Client client = clientRepositoryWrapper.getClientByClientIdAndHierarchy(clientId, hierarchySearchString);
+            if (client.getSocialStatus() != null) {
+                context.authenticatedUser().validateHasPermissionTo(READ_HIGH_PROFILE_CLIENT);
+            }
             final ClientData clientData = clientMapper.map(client);
 
             // Get client collaterals

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -237,4 +237,5 @@
     <include file="parts/0216_add_unique_constraint_sms_campaign_name.xml" relativeToChangelogFile="true" />
     <include file="parts/0217_force_withdrawal_configs.xml" relativeToChangelogFile="true" />
     <include file="parts/0218_standardize_character_set_and_collation.xml" relativeToChangelogFile="true" />
+    <include file="parts/0219_add_social_status_restriction.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0219_add_social_status_restriction.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0219_add_social_status_restriction.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="m_client" columnName="social_status_cv_id"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="m_client">
+            <column name="social_status_cv_id" type="INT"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="2" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_client_social_status"/>
+            </not>
+        </preConditions>
+        <addForeignKeyConstraint baseTableName="m_client" baseColumnNames="social_status_cv_id" referencedTableName="m_code_value"
+                                 referencedColumnNames="id" constraintName="fk_client_social_status"/>
+    </changeSet>
+
+    <changeSet id="3" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(1) FROM m_permission WHERE code = 'READ_HIGH_PROFILE_CLIENT'
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="portfolio"/>
+            <column name="code" value="READ_HIGH_PROFILE_CLIENT"/>
+            <column name="entity_name" value="HIGH_PROFILE_CLIENT"/>
+            <column name="action_name" value="READ"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Summary

This PR introduces access restriction for high profile clients using a new social status field.

### Changes included:

- Added Liquibase changelog to create `m_client.social_status_cv_id`
- Added foreign key constraint from `m_client.social_status_cv_id` to `m_code_value.id`
- Inserted new permission entry `CAN_VIEW_HIGH_PROFILE_CLIENT` into `m_permission`
- Included the new `FINERACT-1430` changelog in `db.changelog-master.xml`
- Added `socialStatus` field in `Client` entity mapped to `social_status_cv_id`
- Enforced permission validation when reading a client with social status set
- Added `PermissionConstants.CAN_VIEW_HIGH_PROFILE_CLIENT` constant

---

## Behavior

- If `social_status_cv_id` is **null**, the client can be viewed normally.
- If `social_status_cv_id` is **not null**, the system validates the required permission:

```java
context.authenticatedUser()
       .validateHasPermissionTo(
           PermissionConstants.CAN_VIEW_HIGH_PROFILE_CLIENT
       );