### PR TITLE
FINERACT-2516: Upgrade MariaDB support to version 12

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:11.5.2
+        image: mariadb:12.2
         ports:
           - 3306:3306
         env:
@@ -70,9 +70,14 @@ jobs:
 
       - name: Verify MariaDB connection
         run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P3306 ; do
+          while ! mysqladmin ping -h"127.0.0.1" -P3306 -uroot -pmysql --silent; do
             sleep 1
           done
+
+      - name: Configure MariaDB compatibility defaults
+        run: |
+          mysql -h127.0.0.1 -P3306 -uroot -pmysql -e "SET GLOBAL innodb_snapshot_isolation=OFF;"
+          mysql -h127.0.0.1 -P3306 -uroot -pmysql -e "SHOW VARIABLES LIKE 'innodb_snapshot_isolation';"
 
       - name: Initialise databases
         run: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In the moment you get started writing code, please consult our [CONTRIBUTING](CO
 REQUIREMENTS
 ============
 * min. 16GB RAM and 8 core CPU
-* `MariaDB >= 11.5.2` or `PostgreSQL >= 18.0`
+* `MariaDB >= 12.2` or `PostgreSQL >= 18.0`
 * `Java >= 21` (Azul Zulu JVM is tested by our CI on GitHub Actions)
 
 Tomcat (min. v10) is only required, if you wish to deploy the Fineract WAR to a separate external servlet container.  You do not need to install Tomcat to run Fineract. We recommend the use of the self-contained JAR, which transparently embeds a servlet container using Spring Boot.
@@ -293,11 +293,11 @@ DATABASE AND TABLES
 
 You can run the required version of the database server in a container, instead of having to install it, like this:
 
-    docker run --name mariadb-11.5 -p 3306:3306 -e MARIADB_ROOT_PASSWORD=mysql -d mariadb:11.5.2
+    docker run --name mariadb-12.2 -p 3306:3306 -e MARIADB_ROOT_PASSWORD=mysql -d mariadb:12.2.2 --innodb-snapshot-isolation=OFF
 
 and stop and destroy it like this:
 
-    docker rm -f mariadb-11.5
+    docker rm -f mariadb-12.2
 
 Beware that this container database keeps its state inside the container and not on the host filesystem.  It is lost when you destroy (rm) this container.  This is typically fine for development.  See [Caveats: Where to Store Data on the database container documentation](https://hub.docker.com/_/mariadb) regarding how to make it persistent instead of ephemeral.
 

--- a/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
+++ b/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle
@@ -246,7 +246,7 @@ dependencyManagement {
 
         dependency "org.apache.avro:avro:1.12.0"
 
-        dependency ('org.mariadb.jdbc:mariadb-java-client:3.5.2') {
+        dependency ('org.mariadb.jdbc:mariadb-java-client:3.5.7') {
             exclude 'org.slf4j:jcl-over-slf4j'
             exclude 'org.slf4j:slf4j-api'
         }

--- a/config/docker/compose/mariadb.yml
+++ b/config/docker/compose/mariadb.yml
@@ -18,9 +18,10 @@ version: "3.8"
 services:
   mariadb:
     container_name: mariadb
-    image: mariadb:11.4
+    image: mariadb:12.2
     volumes:
       - ${PWD}/config/docker/mysql/conf.d/server_collation.cnf:/etc/mysql/conf.d/server_collation.cnf:ro
+      - ${PWD}/config/docker/mariadb/conf.d/mariadb_compat.cnf:/etc/mysql/conf.d/mariadb_compat.cnf:ro
       - ${PWD}/config/docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:Z,ro
     restart: always
     env_file:

--- a/config/docker/mariadb/conf.d/mariadb_compat.cnf
+++ b/config/docker/mariadb/conf.d/mariadb_compat.cnf
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[mysqld]
+innodb_snapshot_isolation=OFF

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -19,9 +19,10 @@
 services:
   mariadb:
     container_name: mariadb
-    image: mariadb:11.4
+    image: mariadb:12.2
     volumes:
       - ./config/docker/mysql/conf.d/server_collation.cnf:/etc/mysql/conf.d/server_collation.cnf:ro
+      - ./config/docker/mariadb/conf.d/mariadb_compat.cnf:/etc/mysql/conf.d/mariadb_compat.cnf:ro
       - ./config/docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:Z,ro
     restart: always
     env_file:

--- a/fineract-command/src/test/java/org/apache/fineract/command/CommandBaseTest.java
+++ b/fineract-command/src/test/java/org/apache/fineract/command/CommandBaseTest.java
@@ -33,6 +33,7 @@ import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
@@ -49,8 +50,9 @@ abstract class CommandBaseTest {
             .withNetwork(network).withUsername("root").withPassword("mifos").withDatabaseName("fineract-test");
 
     @Container
-    private static final MariaDBContainer<?> MARIADB_CONTAINER = new MariaDBContainer<>(DockerImageName.parse("mariadb:11.4"))
-            .withNetwork(network).withUsername("root").withPassword("mifos").withDatabaseName("fineract-test");
+    private static final MariaDBContainer<?> MARIADB_CONTAINER = new MariaDBContainer<>(DockerImageName.parse("mariadb:12.2"))
+            .withNetwork(network).withUsername("root").withPassword("mifos").withDatabaseName("fineract-test")
+            .withCommand("--innodb-snapshot-isolation=OFF").waitingFor(Wait.forListeningPort());
 
     @Container
     private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8")).withNetwork(network)

--- a/fineract-doc/src/docs/en/chapters/testing/cucumber.adoc
+++ b/fineract-doc/src/docs/en/chapters/testing/cucumber.adoc
@@ -24,7 +24,7 @@ Apache Fineract's E2E test suite provides comprehensive coverage of business fun
 === Required Software
 
 * *Java 21*: Apache Fineract requires Java 21 (Azul Zulu JDK recommended)
-* *Database*: MariaDB 11.5.2, PostgreSQL 17.4, or MySQL 9.1
+* *Database*: MariaDB 12.2, PostgreSQL 17.4, or MySQL 9.1
 * *Git*: For source code management
 * *Gradle 8.14.3*: Included via wrapper
 

--- a/fineract-doc/src/docs/en/chapters/testing/integration.adoc
+++ b/fineract-doc/src/docs/en/chapters/testing/integration.adoc
@@ -26,7 +26,7 @@ Integration tests in Apache Fineract validate the complete API layer and busines
 === Required Software
 
 * *Java 21*: Apache Fineract requires Java 21 (Azul Zulu JDK recommended)
-* *Database*: MariaDB 11.5.2, PostgreSQL 17.4, or MySQL 9.1
+* *Database*: MariaDB 12.2, PostgreSQL 17.4, or MySQL 9.1
 * *Git*: For source code management
 * *Gradle 8.14.3*: Included via wrapper
 * *12GB RAM*: Recommended for test execution

--- a/kubernetes/fineractmysql-deployment.yml
+++ b/kubernetes/fineractmysql-deployment.yml
@@ -86,8 +86,10 @@ spec:
         tier: fineractmysql
     spec:
       containers:
-        - image: mariadb:11.4
+        - image: mariadb:12.2
           name: mysql
+          args:
+            - --innodb-snapshot-isolation=OFF
           resources:
             requests:
               memory: "1Gi"


### PR DESCRIPTION
FINERACT-2516

## Summary
This PR upgrades MariaDB support from 11.x to 12.x across runtime, development, and test container references, and updates the MariaDB JDBC driver version.

## Scope
- No functional business-logic changes
- No API contract changes
- No schema/Liquibase changes
- Version/reference upgrade only

## Risk
Low.  
Changes are limited to version references for MariaDB image/driver and associated docs/test setup.