### PR TITLE
FINERACT-2500: Update cucumber docs. Add require tenant header for business-date API, enforce test profile for E2E

### DIFF
--- a/fineract-doc/src/docs/en/chapters/testing/cucumber.adoc
+++ b/fineract-doc/src/docs/en/chapters/testing/cucumber.adoc
@@ -149,11 +149,14 @@ mysql -u root -pmysql fineract_default -e \
 Method 2 - Via API (After Fineract is Running):
 [source,bash]
 ----
-curl -X PUT https://localhost:8443/fineract-provider/api/v1/configurations/name/enable-business-date \
+curl -k -X PUT https://localhost:8443/fineract-provider/api/v1/configurations/name/enable-business-date \
   -H "Authorization: Basic bWlmb3M6cGFzc3dvcmQ=" \
+  -H "Fineract-Platform-TenantId: default" \
   -H "Content-Type: application/json" \
   -d '{"enabled": true}'
 ----
+
+NOTE: The `Fineract-Platform-TenantId` header is required. Without it, the request can fail with HTTP 400 because tenant context is missing.
 
 *Verification*:
 [source,bash]
@@ -170,9 +173,11 @@ mysql -u root -pmysql fineract_default -e \
 
 [source,bash]
 ----
-# Start Fineract in background
-./gradlew bootRun
+# Start Fineract with test profile enabled for E2E
+./gradlew bootRun -Dspring.profiles.active=test
 ----
+
+IMPORTANT: When running E2E tests that hit endpoints/APIs backed by beans annotated with `@Profile(FineractProfiles.TEST)`, the provider startup must include `-Dspring.profiles.active=test`. Without this, test-profile-only components are not loaded.
 
 Wait for Fineract to be fully started. You can verify by checking:
 [source,bash]


### PR DESCRIPTION
## Description

Updated E2E testing docs in `/Users/dara/IdeaProjects/fineract/fineract-doc/src/docs/en/chapters/testing/` to prevent common startup and API errors:

- Added required `Fineract-Platform-TenantId: default` header to the `enable-business-date` curl example (with note that missing header can cause `400`).
- Updated provider startup command for E2E to include `-Dspring.profiles.active=test`, and documented why it is required for `@Profile(FineractProfiles.TEST)` components.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
