### PR TITLE
FINERACT-1398: Standardize charset and collation defaults

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -185,7 +185,7 @@ tasks.register('createDB') {
     description = "Creates the MariaDB Database. Needs database name to be passed (like: -PdbName=someDBname)"
     doLast {
         def sql = Sql.newInstance('jdbc:mariadb://localhost:3306/', mysqlUser, mysqlPassword, 'org.mariadb.jdbc.Driver')
-        sql.execute('CREATE DATABASE ' + "`$dbName` CHARACTER SET utf8mb4")
+        sql.execute('CREATE DATABASE ' + "`$dbName` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
     }
 }
 
@@ -217,7 +217,7 @@ tasks.register('createMySQLDB') {
     description = "Creates the MySQL Database. Needs database name to be passed (like: -PdbName=someDBname)"
     doLast {
         def sql = Sql.newInstance('jdbc:mysql://localhost:3306/', mysqlUser, mysqlPassword, 'com.mysql.cj.jdbc.Driver')
-        sql.execute('CREATE DATABASE ' + "`$dbName` CHARACTER SET utf8mb4")
+        sql.execute('CREATE DATABASE ' + "`$dbName` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
     }
 }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImpl.java
@@ -277,7 +277,7 @@ public class DatatableWriteServiceImpl implements DatatableWriteService {
             sqlBuilder.append(constrainBuilder);
             sqlBuilder.append(")");
             if (databaseTypeResolver.isMySQL()) {
-                sqlBuilder.append(" ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;");
+                sqlBuilder.append(" ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4 COLLATE=UTF8MB4_UNICODE_CI;");
             }
             log.debug("SQL:: {}", sqlBuilder);
 

--- a/fineract-provider/src/main/resources/db/changelog/tenant-store/parts/0011_standardize_character_set_and_collation.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant-store/parts/0011_standardize_character_set_and_collation.xml
@@ -22,14 +22,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-     <include file="parts/0003_reset_postgresql_sequences.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0004_readonly_database_connection.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0005_jdbc_connection_string.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0006_drop_retry_parameter_columns.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0007_encrypt_existing_tenant_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0007_x_extend_tenant_ro_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0008_encrypt_existing_ro_tenant_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0009_set_and_encrypt_ro_if_not_exists.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0010_set_datetime_precision.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0011_standardize_character_set_and_collation.xml" relativeToChangelogFile="true"/>
+    <changeSet author="fineract" id="1" context="tenant_store_db">
+        <sql dbms="mysql,mariadb">ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>
+    </changeSet>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -236,4 +236,5 @@
     <include file="parts/0215_transaction_summary_reports_add_buydown_fee_types.xml" relativeToChangelogFile="true" />
     <include file="parts/0216_add_unique_constraint_sms_campaign_name.xml" relativeToChangelogFile="true" />
     <include file="parts/0217_force_withdrawal_configs.xml" relativeToChangelogFile="true" />
+    <include file="parts/0218_standardize_character_set_and_collation.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0218_standardize_character_set_and_collation.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0218_standardize_character_set_and_collation.xml
@@ -22,14 +22,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-     <include file="parts/0003_reset_postgresql_sequences.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0004_readonly_database_connection.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0005_jdbc_connection_string.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0006_drop_retry_parameter_columns.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0007_encrypt_existing_tenant_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0007_x_extend_tenant_ro_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0008_encrypt_existing_ro_tenant_passwords.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0009_set_and_encrypt_ro_if_not_exists.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0010_set_datetime_precision.xml" relativeToChangelogFile="true"/>
-     <include file="parts/0011_standardize_character_set_and_collation.xml" relativeToChangelogFile="true"/>
+    <changeSet author="fineract" id="1">
+        <sql dbms="mysql,mariadb">ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>
+    </changeSet>
 </databaseChangeLog>

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImplTest.java
@@ -24,21 +24,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.fineract.infrastructure.codes.service.CodeReadPlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.serialization.DatatableCommandFromApiJsonDeserializer;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseType;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.dataqueries.data.DataTableValidator;
+import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.search.service.SearchUtil;
@@ -244,5 +250,52 @@ class DatatableWriteServiceImplTest {
         String sql = sqlCaptor.getValue();
         assertTrue(sql.contains("INSERT INTO x_table_column_code_mappings"), "SQL should insert into code mappings table");
         assertTrue(sql.contains("VALUES (?, ?)"), "SQL should use ? placeholders");
+    }
+
+    @Test
+    void testCreateDatatableUsesUtf8mb4UnicodeCiForMySql() {
+        final JsonElement payload = JsonParser.parseString("""
+                {
+                  "datatableName": "dt_charset_test",
+                  "apptableName": "m_client",
+                  "entitySubType": "PERSON",
+                  "multiRow": false,
+                  "columns": [
+                    {
+                      "name": "itsAString",
+                      "type": "String",
+                      "mandatory": true,
+                      "length": 10
+                    }
+                  ]
+                }
+                """);
+
+        final JsonCommand command = mock(JsonCommand.class);
+        when(command.json()).thenReturn(payload.toString());
+        when(command.commandId()).thenReturn(1L);
+
+        when(databaseTypeResolver.isMySQL()).thenReturn(true);
+        when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.MYSQL);
+        when(configurationDomainService.isConstraintApproachEnabledForDatatables()).thenReturn(false);
+        when(sqlGenerator.currentSchema()).thenReturn("database()");
+        when(sqlGenerator.escape(anyString())).thenAnswer(invocation -> "`" + invocation.getArgument(0) + "`");
+        when(datatableUtil.resolveEntity("m_client")).thenReturn(EntityTables.CLIENT);
+        when(datatableUtil.getFKField(EntityTables.CLIENT)).thenReturn("client_id");
+        when(fromJsonHelper.parse(anyString())).thenReturn(payload);
+        when(fromJsonHelper.extractJsonArrayNamed(eq("columns"), eq(payload)))
+                .thenReturn(payload.getAsJsonObject().getAsJsonArray("columns"));
+        when(fromJsonHelper.extractStringNamed(eq("datatableName"), eq(payload))).thenReturn("dt_charset_test");
+        when(fromJsonHelper.extractStringNamed(eq("entitySubType"), eq(payload))).thenReturn("PERSON");
+        when(fromJsonHelper.extractStringNamed(eq("apptableName"), eq(payload))).thenReturn("m_client");
+        when(fromJsonHelper.extractBooleanNamed(eq("multiRow"), eq(payload))).thenReturn(false);
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("dt_charset_test"))).thenReturn("true");
+
+        underTest.createDatatable(command);
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).execute(sqlCaptor.capture());
+        assertTrue(sqlCaptor.getValue().contains("ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4 COLLATE=UTF8MB4_UNICODE_CI;"),
+                "MySQL table creation must include utf8mb4 charset and utf8mb4_unicode_ci collation");
     }
 }


### PR DESCRIPTION
### Summary
This PR standardizes MySQL/MariaDB charset/collation defaults for Fineract to:
- Charset: `utf8mb4`
- Collation: `utf8mb4_unicode_ci`

It applies the standard to database creation paths, runtime datatable creation SQL, and Liquibase-managed tenant/tenant-store databases.

### What Changed

1. **Database creation tasks updated**
2. **Datatable DDL standardized**
3. **Liquibase migrations added**
4. **Unit test added**

### Validation Performed
- `./gradlew :fineract-provider:test --tests org.apache.fineract.infrastructure.dataqueries.service.DatatableWriteServiceImplTest`
- `./gradlew spotlessApply spotbugsMain spotbugsTest checkstyleMain checkstyleTest`

All passed locally.

### Backward Compatibility / Risk

- No API contract changes.
- No functional change to business workflows.
- Scope is limited to DB charset/collation defaults and datatable DDL generation.
- Migration is idempotent in practice for target DB engines and is safe for incremental rollout.

### Notes
- This PR focuses on runtime/schema defaults and Liquibase migration paths for MySQL/MariaDB.
- Existing historical/sample SQL files were not bulk-rewritten in this PR to keep scope tight and reviewable.
