### PR TITLE
FINERACT-2518: Fix to Savings account tests date timezone

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsExternalIdTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountsExternalIdTest.java
@@ -19,8 +19,6 @@
 package org.apache.fineract.integrationtests;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import org.apache.fineract.client.models.DeleteSavingsAccountsAccountIdResponse;
@@ -33,6 +31,7 @@ import org.apache.fineract.client.models.PutSavingsAccountsAccountIdResponse;
 import org.apache.fineract.client.models.SavingsAccountData;
 import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.integrationtests.client.IntegrationTest;
+import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.savings.SavingsTestLifecycleExtension;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -48,7 +47,7 @@ public class SavingsAccountsExternalIdTest extends IntegrationTest {
     public static final String EXTERNAL_ID = UUID.randomUUID().toString();
     private final String dateFormat = "dd MMMM yyyy";
     private final String locale = "en";
-    private final String formattedDate = LocalDate.now(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern(dateFormat));
+    private final String formattedDate = Utils.getLocalDateOfTenant().format(DateTimeFormatter.ofPattern(dateFormat));
 
     @Test
     @Order(1)


### PR DESCRIPTION
JIRA: FINERACT-2518

## Problem

After investigating, it turns out PRs have been failing due to a mismatch between the CI/CD date locality (Asia/Kolkata), which is the default tenant timezone, and date locality used in SavingsAccountsExternalIdTests (UTC). At certain times of the day, we get a date mismatch, which corresponds to the errors we have been getting. 

The time of the CI/CD commit failures was around 1-2pm US Central. Notably, this is after 12am in Asia/Kolkata, resulting in a future date.

Failed CI/CD tests are similar between commits. We get failed data validation due to: ...cannot.be.before.client.activation.date. We can also see that in submitSavingsAccountApplication(), we use a date of 2026-03-03, but the submittedOnDate we pass in is 02 March 2026. Subsequent errors seem to be cascaded from this one, since these Savings tests rely on submitSavingsAccountApplication() due to their @Order. 

Below is a picture showing these errors from github.

<img width="1241" height="1112" alt="Screenshot 2026-03-02 at 6 53 46 PM" src="https://github.com/user-attachments/assets/1b386d57-d447-4717-a3a1-85bc833d900b" />

## More Investigating

After further investigation, it seems the flakiness issue is in client activation date, which depends on where client1 is created. After looking through the codebase, I found that it can be created in two different methods. FeignClientHelper.createClient(), and the older ClientHelper. This is important because FeignLoanOriginatorApi which is the only API that creates client with FeignClientHelper.createClient() and other APIs that do this have a classwide @order of 1, meaning it always runs first in its shard. This is also important because ClientHelper hardcodes client date to "04 March 2011" while FeignClientHelper uses the current Asia/Kolkata time. 

When FeignClientHelper lands in the same shard as SavingsAccountExternalIdTest, it creates CI/CD failures. 

This is important because sharding in split-tests.sh is deterministic based on the current pool of integration tests, meaning adding or removing integration tests from the pool can shift which shards get FeignClientHelper and which shards get ClientHelper. Basically new integration tests can be added in the middle here, and removing integration tests can remove from the middle as well. So changing the number of tests can cause CI/CD failures until integration tests are again added or removed.

I think the reason the new tests stopped working is because integration tests were added in FINERACT-2455: WCP - Product Configuration. The next 2 builds failed.

<img width="1383" height="311" alt="Screenshot 2026-03-03 at 3 40 23 PM" src="https://github.com/user-attachments/assets/3ad73681-b23d-4cf7-8d74-04d39235ca2a" />

It then worked for a while due to FINERACT-2421: Fix flaky savings account test. But only for PRs approved before 12am Asia/Kolkata, when the date mismatch wouldn't occur. When the time window for a date mismatch arose, that was the reason PRs were failing.

<img width="1373" height="1144" alt="Screenshot 2026-03-03 at 3 40 18 PM" src="https://github.com/user-attachments/assets/8199bb23-c45d-48aa-b7f9-b2912e308c61" />

Finally, the reason it started working again even without a change was because an integration test was added in FINERACT-2418: Attach Loan originator details to events. This shifted the FeignClientHelper out of the shard with SavingsAccountExternalIdTest. 

<img width="1311" height="280" alt="Screenshot 2026-03-03 at 3 39 54 PM" src="https://github.com/user-attachments/assets/0c04f542-26ac-4e48-841a-70ae67352f02" />

Locally testing wouldn't reproduce this issue because local tests don't have sharding.

This all corresponds exactly to when the build failures started and when they stopped. 

## Changes

Changed the hardcoded UTC to getLocalDateOfTenant() which defaults to Asia/Kolkata. This matches the default tenant timezone used in CI/CD.

## Results

Tests pass with changes:
<img width="1651" height="460" alt="Screenshot 2026-03-02 at 7 11 49 PM" src="https://github.com/user-attachments/assets/ac30cd8f-c79f-44e4-a36e-428fed352997" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
