### PR TITLE
Fix LocalDateValidator by using the return value of parse()

### DIFF
--- a/fineract-validation/src/main/java/org/apache/fineract/validation/constraints/LocalDateValidator.java
+++ b/fineract-validation/src/main/java/org/apache/fineract/validation/constraints/LocalDateValidator.java
@@ -78,6 +78,6 @@ public class LocalDateValidator implements ConstraintValidator<LocalDate, Object
                 .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0).parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
                 .toFormatter(Locale.forLanguageTag(locale)).withResolverStyle(ResolverStyle.STRICT);
 
-        parse(date, formatter);
+        var parsedDate = (date, formatter);
     }
 }


### PR DESCRIPTION
Sonar rule java:S2201 flagged that the return value of parse() was ignored. Assigned the parsed result to a variable to ensure proper validation behavior and improve reliability.


This pull request fixes a SonarCloud issue (java:S2201) in LocalDateValidator.
The parse() method was being called without using its return value, which reduces
reliability and may hide parsing errors. The parsed result is now assigned to a
variable to comply with the rule and ensure proper validation behavior.

No functional changes were introduced. Only a small reliability improvement.
