### PR TITLE
FINERACT-2520: Add integration test for disbursement charges to total repayment expected in progressive loan schedule

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ProgressiveLoanDisbursementChargeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ProgressiveLoanDisbursementChargeTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import java.math.BigDecimal;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ProgressiveLoanDisbursementChargeTest extends BaseLoanIntegrationTest {
+
+    @Test
+    public void testProgressiveLoanDisbursementChargeIsIncludedInTotalRepaymentExpected() {
+        runAt("01 June 2024", () -> {
+            // 1. Create a client
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+
+            // 2. Create a percentage-based disbursement charge (10% of amount) in EUR
+            String chargePayload = ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "10");
+            chargePayload = chargePayload.replace("\"currencyCode\":\"USD\"", "\"currencyCode\":\"EUR\"");
+            Integer chargeId = ChargesHelper.createCharges(requestSpec, responseSpec, chargePayload);
+
+            // 3. Create a progressive loan product
+            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive());
+
+            // 4. Apply for a loan with 1000 EUR principal
+            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "01 June 2024", 1000.0, 10.0, 4, null));
+            Long loanId = postLoansResponse.getLoanId();
+
+            // 5. Add the disbursement charge to the loan account before approval
+            String addChargePayload = LoanTransactionHelper.getDisbursementChargesForLoanAsJSON(chargeId.toString(), "10");
+            loanTransactionHelper.addChargeForLoan(loanId.intValue(), addChargePayload, responseSpec);
+
+            // 6. Approve the loan
+            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1000.0, "01 June 2024"));
+
+            // 7. Disburse the loan
+            disburseLoan(loanId, BigDecimal.valueOf(1000.0), "01 June 2024");
+
+            // 8. Retrieve the loan details
+            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+
+            // 9. Verify the disbursement charge is calculated correctly (10% of 1000 = 100 EUR)
+            // It should be completely due at disbursement (period 0)
+            Double expectedFeeAmount = 100.0;
+            Double totalFeeChargesCharged = Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getTotalFeeChargesCharged());
+            Assertions.assertEquals(expectedFeeAmount, totalFeeChargesCharged,
+                    "Total fee charges charged should match the disbursement fee.");
+
+            // 10. Verify that total repayment expected includes the disbursement fee without double counting
+            Double totalPrincipalExpected = Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getTotalPrincipalExpected());
+            Double totalInterestCharged = Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getTotalInterestCharged());
+            Double expectedTotalRepayment = totalPrincipalExpected + totalInterestCharged + expectedFeeAmount;
+
+            Double actualTotalRepaymentExpected = Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getTotalRepaymentExpected());
+            Assertions.assertEquals(expectedTotalRepayment, actualTotalRepaymentExpected,
+                    "Total repayment expected is missing or double-counting the disbursement fee.");
+
+            // 11. Check the disbursement period (period 0)
+            Double feeChargesDueAtDisbursement = Utils
+                    .getDoubleValue(loanDetails.getRepaymentSchedule().getPeriods().get(0).getFeeChargesDue());
+            Assertions.assertEquals(expectedFeeAmount, feeChargesDueAtDisbursement, "Disbursement period (0) should have the fee due.");
+        });
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes FINERACT-2520 where disbursement charges were missing from the total repayment expected in the progressive loan schedule.

**Changes**

Updated ProgressiveLoanScheduleGenerator.java to explicitly add chargesDueAtTimeOfDisbursement to the scheduleParams.totalRepaymentExpected after the main repayment loop.

**Impact**
Ensures the final schedule model correctly reflects all initial charges, matching the logic used in cumulative loan models.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
