### PR TITLE
FINERACT-2511: Validate dateFormat parameter to return HTTP 400 instead of 500

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilder.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonArray;
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1087,6 +1088,36 @@ public class DataValidatorBuilder {
                     value, scale);
             this.dataValidationErrors.add(error);
             return this;
+        }
+        return this;
+    }
+
+    /**
+     * Validates that the value is a valid {@link DateTimeFormatter} pattern.
+     *
+     * <p>
+     * If the value is a non-blank string, this method attempts to create a {@link DateTimeFormatter} using
+     * {@link DateTimeFormatter#ofPattern(String)}. If the pattern is invalid, a validation error is added.
+     * </p>
+     *
+     * @return this {@code DataValidatorBuilder} for method chaining
+     */
+    public DataValidatorBuilder validDateTimeFormatPattern() {
+        if (this.value == null && this.ignoreNullValue) {
+            return this;
+        }
+
+        if (this.value != null && this.value instanceof String pattern && !StringUtils.isBlank(pattern)) {
+            try {
+                DateTimeFormatter.ofPattern(pattern);
+            } catch (final IllegalArgumentException e) {
+                String validationErrorCode = "validation.msg." + this.resource + "." + this.parameter + ".invalid.dateFormat.pattern";
+                String defaultEnglishMessage = "The parameter `" + this.parameter + "` has an invalid date/time pattern: `" + pattern
+                        + "`.";
+                final ApiParameterError error = ApiParameterError.parameterError(validationErrorCode, defaultEnglishMessage, this.parameter,
+                        pattern);
+                this.dataValidationErrors.add(error);
+            }
         }
         return this;
     }

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilderDateFormatTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/data/DataValidatorBuilderDateFormatTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DataValidatorBuilderDateFormatTest {
+
+    private static final String RESOURCE = "test";
+    private static final String PARAMETER = "dateFormat";
+
+    @ParameterizedTest
+    @ValueSource(strings = { "dd MMMM yyyy", "yyyy-MM-dd", "dd/MM/yyyy", "MM/dd/yyyy", "dd-MM-yyyy HH:mm:ss" })
+    void validDateTimeFormatPatternShouldAcceptValidPatterns(final String pattern) {
+        final List<ApiParameterError> errors = new ArrayList<>();
+        new DataValidatorBuilder(errors).resource(RESOURCE).parameter(PARAMETER).value(pattern).validDateTimeFormatPattern();
+        assertThat(errors).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "02 February 2026", "not-a-pattern", "P!@#$", "{{invalid}}" })
+    void validDateTimeFormatPatternShouldRejectInvalidPatterns(final String pattern) {
+        final List<ApiParameterError> errors = new ArrayList<>();
+        new DataValidatorBuilder(errors).resource(RESOURCE).parameter(PARAMETER).value(pattern).validDateTimeFormatPattern();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getParameterName()).isEqualTo(PARAMETER);
+        assertThat(errors.get(0).getDeveloperMessage()).contains("invalid date/time pattern");
+    }
+
+    @Test
+    void validDateTimeFormatPatternShouldAcceptNullValueWhenIgnoreNullEnabled() {
+        final List<ApiParameterError> errors = new ArrayList<>();
+        new DataValidatorBuilder(errors).resource(RESOURCE).parameter(PARAMETER).value(null).ignoreIfNull().validDateTimeFormatPattern();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void validDateTimeFormatPatternShouldNotFailOnNullValue() {
+        final List<ApiParameterError> errors = new ArrayList<>();
+        // value is null but ignoreIfNull is NOT set — should still not throw NPE
+        new DataValidatorBuilder(errors).resource(RESOURCE).parameter(PARAMETER).value(null).validDateTimeFormatPattern();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void validDateTimeFormatPatternShouldNotFailOnBlankValue() {
+        final List<ApiParameterError> errors = new ArrayList<>();
+        new DataValidatorBuilder(errors).resource(RESOURCE).parameter(PARAMETER).value("   ").validDateTimeFormatPattern();
+        assertThat(errors).isEmpty();
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
@@ -212,6 +212,12 @@ public final class ClientDataValidator {
                     .integerGreaterThanZero();
         }
 
+        if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.dateFormatParamName, element)) {
+            final String dateFormat = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.dateFormatParamName, element);
+            baseDataValidator.reset().parameter(ClientApiConstants.dateFormatParamName).value(dateFormat).notBlank()
+                    .validDateTimeFormatPattern();
+        }
+
         final Integer legalFormId = this.fromApiJsonHelper.extractIntegerSansLocaleNamed(ClientApiConstants.legalFormIdParamName, element);
         baseDataValidator.reset().parameter(ClientApiConstants.legalFormIdParamName).value(legalFormId).notNull().inMinMaxRange(1, 2);
 
@@ -499,6 +505,12 @@ public final class ClientDataValidator {
             final LocalDate dateOfBirth = this.fromApiJsonHelper.extractLocalDateNamed(ClientApiConstants.dateOfBirthParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.dateOfBirthParamName).value(dateOfBirth).notNull()
                     .validateDateBefore(DateUtils.getBusinessLocalDate()).validateDateBefore(submittedDate);
+        }
+
+        if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.dateFormatParamName, element)) {
+            final String dateFormat = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.dateFormatParamName, element);
+            baseDataValidator.reset().parameter(ClientApiConstants.dateFormatParamName).value(dateFormat).notBlank()
+                    .validDateTimeFormatPattern();
         }
 
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.legalFormIdParamName, element)) {


### PR DESCRIPTION
## Description

Fixes [FINERACT-2511](https://issues.apache.org/jira/browse/FINERACT-2511): Invalid `dateFormat` on client create returns HTTP 500 instead of 400 Bad Request.

### Root Cause

When an invalid `dateFormat` value (e.g., `02 February 2026` instead of a valid pattern like `dd MMMM yyyy`) is provided in `POST /fineract-provider/api/v1/clients`, `ClientDataValidator.validateForCreate()` does not validate this parameter. The invalid value reaches `DateTimeFormatter.ofPattern(command.dateFormat())` in `ClientWritePlatformServiceJpaRepositoryImpl.createClient()`, which throws `IllegalArgumentException`. This uncaught exception surfaces as HTTP 500.

### Changes

1. **`DataValidatorBuilder.java`** - Added a reusable `validDateTimeFormatPattern()` method that validates date/time format pattern strings by attempting `DateTimeFormatter.ofPattern()` and catching `IllegalArgumentException`. This method follows the existing fluent API pattern and can be reused by other validators across the codebase.

2. **`ClientDataValidator.java`** - Added `dateFormat` validation in both `validateForCreate()` and `validateForUpdate()` using the new `validDateTimeFormatPattern()` method. Invalid patterns are now caught during validation and returned as HTTP 400 with a clear error message.

3. **`DataValidatorBuilderDateFormatTest.java`** [NEW] - 12 parameterized unit tests covering:
   - Valid patterns (`dd MMMM yyyy`, `yyyy-MM-dd`, `dd/MM/yyyy`, `MM/dd/yyyy`, `dd-MM-yyyy HH:mm:ss`)
   - Invalid patterns (`02 February 2026`, `not-a-pattern`, `P!@#$`, `{{invalid}}`)
   - Null value handling (with and without `ignoreIfNull`)
   - Blank value handling

### Testing

- All 12 unit tests pass (0 failures, 0 errors)
- `fineract-core:compileJava` BUILD SUCCESSFUL
- Code formatted via `spotlessJavaApply`