### PR TITLE
FINERACT-1556: treat template runreports as parameter metadata

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResource.java
@@ -136,6 +136,11 @@ public class RunreportsApiResource {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.putAll(uriInfo.getQueryParameters());
 
+        final boolean template = ApiParameterHelper.template(queryParams);
+        if (template && queryParams.getFirst(ReportParameters.getParameterType()) == null) {
+            queryParams.putSingle(ReportParameters.getParameterType(), Boolean.TRUE.toString());
+        }
+
         final boolean parameterTypeValue = ApiParameterHelper.parameterType(queryParams);
 
         checkUserPermissionForReport(reportName, parameterTypeValue);

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResourceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResourceTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.fineract.infrastructure.dataqueries.service.ReadReportingService;
+import org.apache.fineract.infrastructure.report.provider.ReportingProcessServiceProvider;
+import org.apache.fineract.infrastructure.report.service.ReportingProcessService;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RunreportsApiResourceTest {
+
+    @Mock
+    private PlatformSecurityContext platformSecurityContext;
+
+    @Mock
+    private ReadReportingService readReportingService;
+
+    @Mock
+    private ReportingProcessServiceProvider reportingProcessServiceProvider;
+
+    @Mock
+    private ReportingProcessService reportingProcessService;
+
+    @Mock
+    private UriInfo uriInfo;
+
+    @InjectMocks
+    private RunreportsApiResource runreportsApiResource;
+
+    @Test
+    void templateQueryParamIsTreatedAsParameterTypeRequest() {
+        // given
+        String reportName = "Active Loans - Details";
+        MultivaluedStringMap params = new MultivaluedStringMap();
+        params.putSingle("template", "true");
+        given(uriInfo.getQueryParameters()).willReturn(params);
+
+        // Reporting process service wiring
+        given(readReportingService.getReportType(reportName, false, true)).willReturn("Table");
+        given(reportingProcessServiceProvider.findReportingProcessService("Table")).willReturn(reportingProcessService);
+        given(reportingProcessService.processRequest(any(), any())).willReturn(Response.ok().build());
+
+        // when
+        Response response = runreportsApiResource.runReport(reportName, uriInfo, false);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        // and the downstream services receive parameterType propagated from template
+        ArgumentCaptor<jakarta.ws.rs.core.MultivaluedMap<String, String>> captor = ArgumentCaptor.forClass(jakarta.ws.rs.core.MultivaluedMap.class);
+        verify(reportingProcessService).processRequest(any(), captor.capture());
+        assertThat(captor.getValue().getFirst("parameterType")).isEqualTo("true");
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where calling the Stretchy Reports endpoint with `template=true` still attempted to execute the underlying SQL query.

Stretchy report queries often contain placeholders such as `${officeId}{}` or `${currencyId}{}` which are meant to be replaced with request parameters. When `template=true` is used, the expected behavior is to return report parameter metadata without executing the SQL query.

However, the existing implementation did not properly handle the `template` flag. As a result, the SQL query was executed with unresolved placeholders, which caused PostgreSQL to throw errors such as:

org.postgresql.util.PSQLException: ERROR: syntax error at or near "$"

This PR resolves the issue by ensuring that when `template=true` is present in the request and `parameterType` is not explicitly provided, the system automatically treats the request as a parameter metadata request by setting `parameterType=true`.

This prevents SQL execution and returns the required report parameter metadata as intended.

Fixes: FINERACT-1556


## Changes Made

- Updated `RunreportsApiResource.processReportRequest` to ensure that `template=true` implies `parameterType=true` when `parameterType` is not explicitly provided.
- Prevented execution of report SQL queries when the request is meant to fetch parameter metadata.
- Added regression tests to validate correct propagation of the `template` flag.


## Files Modified

- fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResource.java
- fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/api/RunreportsApiResourceTest.java


## Testing

Added unit tests to verify that requests with `template=true` correctly propagate as `parameterType=true`.

Commands used:

./gradlew :fineract-provider:test --tests org.apache.fineract.infrastructure.dataqueries.api.RunreportsApiResourceTest

./gradlew :fineract-provider:test

Result:

All tests passed successfully.


## How to Verify

Call the following API:

GET /fineract-provider/api/v1/runreports/Active%20Loans%20-%20Details?template=true

Expected behavior:

- The API returns report parameter metadata
- The SQL query is not executed
- No PostgreSQL `$` placeholder errors occur


## Checklist

- [x] Write the commit message as per our guidelines
- [x] Ensure the build passes successfully
- [x] Create/update unit tests verifying the changes
- [x] Follow Apache Fineract coding conventions
- [ ] Add Swagger annotation / API documentation update (not required as no API contract change)
- [x] PR is focused and not a code dump

