### PR TITLE
FINERACT-1152: Loan Rescheduling End Date Validation Fix

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResourceSwagger.java
@@ -200,6 +200,10 @@ final class RescheduleLoansApiResourceSwagger {
         public Long rescheduleReasonId;
         @Schema(example = "20 September 2011")
         public String submittedOnDate;
+        @Schema(example = "20 September 2011")
+        public String endDate;
+        @Schema(example = "100.00")
+        public BigDecimal emi;
     }
 
     @Schema(description = "PostUpdateRescheduleLoansRequest")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImpl.java
@@ -102,6 +102,8 @@ public class LoanRescheduleRequestDataValidatorImpl implements LoanRescheduleReq
             DataValidatorBuilder dataValidatorBuilder) {
         final LocalDate endDate = fromJsonHelper.extractLocalDateNamed(RescheduleLoansApiConstants.endDateParamName, jsonElement);
         final BigDecimal emi = fromJsonHelper.extractBigDecimalWithLocaleNamed(RescheduleLoansApiConstants.emiParamName, jsonElement);
+        final Integer extraTerms = fromJsonHelper.extractIntegerWithLocaleNamed(RescheduleLoansApiConstants.extraTermsParamName,
+                jsonElement);
         if (emi != null || endDate != null) {
             dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName).value(endDate).notNull();
             dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.emiParamName).value(emi).notNull().positiveAmount();
@@ -109,9 +111,15 @@ public class LoanRescheduleRequestDataValidatorImpl implements LoanRescheduleReq
             if (endDate != null) {
                 LoanRepaymentScheduleInstallment endInstallment = loan.fetchLoanRepaymentScheduleInstallmentByDueDate(endDate);
 
-                if (endInstallment == null) {
+                if (endInstallment == null && (extraTerms == null || extraTerms == 0)) {
                     dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName)
                             .failWithCode("repayment.schedule.installment.does.not.exist", "Repayment schedule installment does not exist");
+                } else if (endInstallment == null && extraTerms != null && extraTerms > 0) {
+                    LocalDate lastDueDate = loan.getLastLoanRepaymentScheduleInstallment().getDueDate();
+                    if (!DateUtils.isAfter(endDate, lastDueDate)) {
+                        dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName).failWithCode(
+                                "repayment.schedule.installment.does.not.exist", "Repayment schedule installment does not exist");
+                    }
                 }
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -249,17 +249,19 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
             final boolean isSpecificToInstallment, BigDecimal decimalValue, LocalDate dueDate, LocalDate endDate, BigDecimal emi) {
 
         if (rescheduleFromDate != null && endDate != null && emi != null) {
-            LoanTermVariations parent = null;
             final Integer termType = LoanTermVariationType.EMI_AMOUNT.getValue();
-            List<LoanRepaymentScheduleInstallment> installments = loan.getRepaymentScheduleInstallments();
-            for (LoanRepaymentScheduleInstallment installment : installments) {
-                if (!DateUtils.isBefore(installment.getDueDate(), rescheduleFromDate)
-                        && !DateUtils.isAfter(installment.getDueDate(), endDate)) {
-                    createLoanTermVariations(loanRescheduleRequest, termType, loan, installment.getDueDate(), installment.getDueDate(),
-                            loanRescheduleRequestToTermVariationMappings, isActive, true, emi, parent);
-                }
-                if (DateUtils.isAfter(installment.getDueDate(), endDate)) {
-                    break;
+
+            LoanTermVariations parent = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate,
+                    rescheduleFromDate, loanRescheduleRequestToTermVariationMappings, isActive, false, emi, null);
+
+            LoanRepaymentScheduleInstallment revertInstallment = loan.getRepaymentScheduleInstallments().stream()
+                    .filter(i -> DateUtils.isAfter(i.getDueDate(), endDate)).findFirst().orElse(null);
+            if (revertInstallment != null) {
+                BigDecimal originalEmi = loan.retriveLastEmiAmount();
+                if (originalEmi != null) {
+                    createLoanTermVariations(loanRescheduleRequest, termType, loan, revertInstallment.getDueDate(),
+                            revertInstallment.getDueDate(), loanRescheduleRequestToTermVariationMappings, isActive, false, originalEmi,
+                            parent);
                 }
             }
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
@@ -410,6 +410,33 @@ public class LoanRescheduleRequestTest extends BaseLoanIntegrationTest {
         });
     }
 
+    @Test
+    public void testCreateLoanRescheduleChangeEMIWithExtraTerms() {
+        PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        Long commonLoanProductId = createLoanProductPeriodicWithInterest();
+
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+        runAt("01 March 2024", () -> {
+            Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), commonLoanProductId, BigDecimal.valueOf(4000),
+                    "1 March 2023", "1 March 2024");
+            loanIdRef.set(loanId);
+            loanTransactionHelper.approveLoan("1 March 2024", loanId.intValue());
+
+            loanTransactionHelper.disburseLoan("1 March 2024", loanId.intValue(), "4000", null);
+
+            PostCreateRescheduleLoansResponse rescheduleLoansResponse = loanRescheduleRequestHelper
+                    .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanIdRef.get()).dateFormat(DATETIME_PATTERN)
+                            .locale("en").submittedOnDate("1 March 2024").rescheduleReasonId(1L).rescheduleFromDate("1 April 2024")
+                            .emi(BigDecimal.valueOf(500)).endDate("1 May 2024").extraTerms(2));
+
+            GetLoanRescheduleRequestResponse getLoanRescheduleRequestResponse = Assertions.assertDoesNotThrow(
+                    () -> loanRescheduleRequestHelper.readLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(), null));
+            Assertions.assertNotNull(getLoanRescheduleRequestResponse);
+
+            approveLoanReschedule(rescheduleLoansResponse.getResourceId(), "1 March 2024");
+        });
+    }
+
     private Integer createProgressiveLoanProduct() {
         AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation("NEXT_INSTALLMENT");
         final String loanProductJSON = new LoanProductTestBuilder().withNumberOfRepayments(numberOfRepayments)


### PR DESCRIPTION
## Description

Resolves FINERACT-1152.

The core issue here was that you couldn't extend a loan's tenure (`extraTerms`) and change its EMI at the same time because the validation threw an error if the new `endDate` didn't already exist in the schedule. 

**What I changed:**
1. **Relaxed End Date Validation:** Tweaked [LoanRescheduleRequestDataValidatorImpl](cci:2://file:///home/deathgun/fineract/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImpl.java:52:0-408:1) so that if `extraTerms > 0`, we allow the `endDate` to fall on a future, projected installment date.
2. **Blanket EMI Variations:** The old logic tried to map new EMIs to specific existing installments using a loop. I rewrote [LoanRescheduleRequestWritePlatformServiceImpl](cci:2://file:///home/deathgun/fineract/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java:92:0-574:1) to use a blanket term variation instead (`isSpecificToInstallment=false`). Now, the schedule generator will naturally apply the new EMI across all future installments, including the newly requested ones.
3. **Fineract-Client & Tests:** To properly test this, I realized the Swagger API docs were missing the `emi` and `endDate` fields for rescheduling requests. I added them in, regenerated the `fineract-client` SDK, and then wrote a modern integration test ([testCreateLoanRescheduleChangeEMIWithExtraTerms](cci:1://file:///home/deathgun/fineract/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java:412:4-437:5)) bypassing the legacy RestAssured models to prove the fix works perfectly!

## Checklist

- [x] Write the commit message as per our guidelines
- [x] Acknowledge that we will not review PRs that are not passing the build
- [x] Create/update unit or integration tests
- [x] Follow our coding conventions
- [x] Add required Swagger annotation and update API documentation
- [x] This PR must not be a "code dump"
