### PR TITLE
FINERACT-2530: Fix 500 error on GET /provisioningentries/{id} when no loan products exist

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesReadPlatformServiceImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesReadPlatformServiceImpl.java
@@ -195,7 +195,7 @@ public class ProvisioningEntriesReadPlatformServiceImpl implements ProvisioningE
                  entry.id, journal_entry_created, createdby_id, created_date, created.username as createduser,
                 lastmodifiedby_id, modified.username as modifieduser, lastmodified_date, SUM(reserved.reseve_amount) as totalreserved
                 from m_provisioning_history entry
-                JOIN m_loanproduct_provisioning_entry reserved on entry.id = reserved.history_id
+                LEFT JOIN m_loanproduct_provisioning_entry reserved on entry.id = reserved.history_id
                 left JOIN m_appuser created ON created.id = entry.createdby_id
                 left JOIN m_appuser modified ON modified.id = entry.lastmodifiedby_id\s""";
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ProvisioningIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ProvisioningIntegrationTest.java
@@ -26,12 +26,20 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
+import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import org.apache.fineract.client.models.ProvisionEntryRequest;
+import org.apache.fineract.client.models.ProvisioningEntryData;
+import org.apache.fineract.client.util.Calls;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
@@ -149,6 +157,45 @@ public class ProvisioningIntegrationTest {
         Assertions.assertTrue((Boolean) entry.get("journalEntry"));
         Map provisioningEntry = transactionHelper.retrieveProvisioningEntries(provisioningEntryId);
         Assertions.assertTrue(((ArrayList) provisioningEntry.get("pageItems")).size() > 0);
+    }
+
+    @Test
+    public void testGetProvisioningEntryWithNoActiveLoansShouldReturn200() {
+        // FINERACT-2530: GET /provisioningentries/{id} threw EmptyResultDataAccessException (HTTP 500)
+        // when no rows existed in m_loanproduct_provisioning_entry for the given history ID.
+        ProvisioningTransactionHelper transactionHelper = new ProvisioningTransactionHelper(requestSpec, responseSpec);
+
+        // Create a loan product but do NOT disburse any loans so m_loanproduct_provisioning_entry stays empty
+        final Integer loanProductID = createLoanProduct(false, NONE);
+        Assertions.assertNotNull(loanProductID);
+        ArrayList<Integer> loanProducts = new ArrayList<>();
+        loanProducts.add(loanProductID);
+
+        ArrayList categories = transactionHelper.retrieveAllProvisioningCategories();
+        Assertions.assertTrue(categories.size() > 0);
+        Account liability = accountHelper.createLiabilityAccount();
+        Account expense = accountHelper.createExpenseAccount();
+        Map requestCriteria = ProvisioningHelper.createProvisioingCriteriaJson(loanProducts, categories, liability, expense);
+        Integer criteriaId = transactionHelper.createProvisioningCriteria(new Gson().toJson(requestCriteria));
+        Assertions.assertNotNull(criteriaId);
+
+        // Create provisioning entry using fineract-client — no active loans so m_loanproduct_provisioning_entry is empty
+        DateFormat simple = new SimpleDateFormat("dd MMMM yyyy", Locale.US);
+        String date = simple.format(Date.from(Utils.getLocalDateOfTenant().atStartOfDay(Utils.getZoneIdOfTenant()).toInstant()));
+        Long entryId = Calls.ok(FineractClientHelper.getFineractClient().provisioningEntries
+                .createProvisioningEntries(new ProvisionEntryRequest()
+                        .date(date).locale("en").dateFormat("dd MMMM yyyy").createjournalentries("false")))
+                .getResourceId();
+        Assertions.assertNotNull(entryId);
+
+        // Before fix: INNER JOIN -> 0 rows -> EmptyResultDataAccessException -> HTTP 500
+        // After fix: LEFT JOIN -> 1 row with totalReserved=NULL -> HTTP 200
+        ProvisioningEntryData entry = Calls.ok(FineractClientHelper.getFineractClient().provisioningEntries
+                .retrieveProvisioningEntry(entryId));
+        Assertions.assertNotNull(entry);
+        Assertions.assertNotNull(entry.getId());
+
+        transactionHelper.deleteProvisioningCriteria(criteriaId);
     }
 
     private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {


### PR DESCRIPTION

Change INNER JOIN to LEFT JOIN in PROVISIONING_ENTRY_SUM_RESERVED_SCHEMA so that provisioning entries with no associated loan product rows still return a valid result instead of throwing EmptyResultDataAccessException.

[FINERACT-2530](https://issues.apache.org/jira/browse/FINERACT-2530)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
