### PR TITLE
FINERACT-2540: Add unit tests for IpAddressUtils

### DIFF
--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/IpAddressUtilsTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/IpAddressUtilsTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class IpAddressUtilsTest {
+
+    @AfterEach
+    void clearContext() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    // Proper isolation helper
+    private void withRequest(HttpServletRequest request, Runnable testLogic) {
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        try {
+            RequestContextHolder.setRequestAttributes(attributes);
+            testLogic.run();
+        } finally {
+            RequestContextHolder.resetRequestAttributes(); // critical cleanup
+        }
+    }
+
+    @Test
+    void getClientIpReturnsEmptyWhenNoRequestContext() {
+        RequestContextHolder.resetRequestAttributes();
+
+        String result = IpAddressUtils.getClientIp();
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void getClientIpReturnsEmptyWhenIpAttributeMissing() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute("IP")).thenReturn(null);
+
+        withRequest(request, () -> {
+            String result = IpAddressUtils.getClientIp();
+            assertEquals("", result);
+        });
+    }
+
+    @Test
+    void getClientIpReturnsIpWhenAttributePresent() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute("IP")).thenReturn("192.168.1.1");
+
+        withRequest(request, () -> {
+            String result = IpAddressUtils.getClientIp();
+            assertEquals("192.168.1.1", result);
+        });
+    }
+
+    @Test
+    void getClientIpConvertsNonStringAttributeUsingToString() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute("IP")).thenReturn(12345);
+
+        withRequest(request, () -> {
+            String result = IpAddressUtils.getClientIp();
+            assertEquals("12345", result);
+        });
+    }
+}


### PR DESCRIPTION
## Description

## Description

This PR adds unit tests for the `IpAddressUtils` utility class.

The tests verify the behavior of the `getClientIp()` method under different request context scenarios, including:

- When no request context is available
- When a request context exists but the IP attribute is missing
- When a valid IP attribute is present
- When the IP attribute is a non-string object and must be converted using `toString()`

These tests improve reliability and increase test coverage for request-related utilities used across the platform.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2540


## Testing

Executed locally:

-   ./gradlew spotlessApply
-   ./gradlew :fineract-core:test

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
