### PR TITLE
FINERACT-2529: pass externalId instead of null resolvedClientId in Cl…

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/exception/ClientNotFoundException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/exception/ClientNotFoundException.java
@@ -32,7 +32,7 @@ public class ClientNotFoundException extends AbstractPlatformResourceNotFoundExc
     }
 
     public ClientNotFoundException(final ExternalId externalId) {
-        super("error.msg.client.id.invalid", "Client with identifier " + externalId + " does not exist", externalId);
+        super("error.msg.client.id.invalid", "Client with identifier " + externalId.getValue() + " does not exist", externalId.getValue());
     }
 
     public ClientNotFoundException() {

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BatchApiStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BatchApiStepDef.java
@@ -115,7 +115,7 @@ public class BatchApiStepDef extends AbstractStepDef {
     private static final Long CHARGE_ID_NFS_FEE = ChargeProductType.LOAN_NSF_FEE.value;
     private static final String ERROR_DEVELOPER_MESSAGE = "The requested resource is not available.";
     private static final Integer ERROR_HTTP_404 = 404;
-    private static final String ERROR_DEVELOPER_MESSAGE_CLIENT = "Client with identifier null does not exist";
+    private static final String ERROR_DEVELOPER_MESSAGE_CLIENT = "Client with identifier {externalId} does not exist";
     private static final String ERROR_DEVELOPER_MESSAGE_LOAN_EXTERNAL = "Loan with external identifier {externalId} does not exist";
     private static final String PWD_USER_WITH_ROLE = "1234567890Aa!";
 
@@ -921,7 +921,7 @@ public class BatchApiStepDef extends AbstractStepDef {
 
         String developerMessageExpected = ERROR_DEVELOPER_MESSAGE;
         Integer httpStatusCodeExpected = ERROR_HTTP_404;
-        String errorsDeveloperMessageExpected = ERROR_DEVELOPER_MESSAGE_CLIENT;
+        String errorsDeveloperMessageExpected = ERROR_DEVELOPER_MESSAGE_CLIENT.replace("{externalId}", clientExternalId);
 
         assertThat(developerMessageActual).as(ErrorMessageHelper.wrongErrorMessage(developerMessageActual, developerMessageExpected))
                 .isEqualTo(developerMessageExpected);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
@@ -460,7 +460,7 @@ public class ClientsApiResource {
             clientExternalId.throwExceptionIfEmpty();
             resolvedClientId = clientReadPlatformService.retrieveClientIdByExternalId(clientExternalId);
             if (resolvedClientId == null) {
-                throw new ClientNotFoundException(resolvedClientId);
+                throw new ClientNotFoundException(clientExternalId);
             }
         }
         return resolvedClientId;


### PR DESCRIPTION
## Problem
In `ClientApiResource.java`, the `getResolvedClientId` method throws a `ClientNotFoundException` using `resolvedClientId` variable. However, this block of code only executes when `resolvedClientId` is null, resulting in an unhelpful error message: "Client with identifier null does not exist."

## Fix
Passed the `externalId` string to the exception instead of `resolvedClientId`, so the error message accurately reflects which external identifier failed to resolve.