### PR TITLE
Fix Gradle deprecated property assignment warnings in build files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ buildscript {
         npmRepository = 'https://npm.pkg.github.com'
     }
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url = 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -243,13 +243,13 @@ allprojects  {
             trimTrailingWhitespace()
         }
 
-        lineEndings 'UNIX'
+        lineEndings = 'UNIX'
     }
 
     // Configuration for Gradle license plug-in
     // https://github.com/hierynomus/license-gradle-plugin
     license {
-        header rootProject.file("$rootDir/APACHE_LICENSETEXT.md")
+        header = rootProject.file("$rootDir/APACHE_LICENSETEXT.md")
         excludes([
             "**/gradlew*",
             "**/git.properties",
@@ -266,7 +266,7 @@ allprojects  {
             "**/avro/**/*.java",
             "**/org/apache/fineract/client/**/*.java"
         ])
-        strictCheck true
+        strictCheck = true
     }
 
     licenseReport {
@@ -535,7 +535,7 @@ configure(project.fineractJavaProjects) {
             }
         }
 
-        lineEndings 'UNIX'
+        lineEndings = 'UNIX'
     }
 
     // If we are running Gradle within Eclipse to enhance classes,
@@ -722,7 +722,7 @@ configure(project.fineractJavaProjects) {
     }
 
     testlogger {
-        logLevel 'quiet'
+        logLevel = 'quiet'
     }
 
     // Configuration for spotbugs plugin
@@ -842,9 +842,9 @@ configure(project.fineractPublishProjects) {
     publishing {
         publications {
             mavenJava(MavenPublication) {
-                groupId 'org.apache.fineract'
-                artifactId project.name
-                version "${project.version}-SNAPSHOT"
+                groupId = 'org.apache.fineract'
+                artifactId = project.name
+                version = "${project.version}-SNAPSHOT"
 
                 from components.java
 
@@ -881,11 +881,11 @@ configure(project.fineractPublishProjects) {
             def stagingUrl = 'https://repository.apache.org/content/repositories/snapshots'
 
             maven {
-                name 'apache'
-                url hasProperty('fineract.release.version') ? releaseUrl : stagingUrl
+                name = 'apache'
+                url = hasProperty('fineract.release.version') ? releaseUrl : stagingUrl
                 credentials {
-                    username "${findProperty('fineract.config.username')}"
-                    password "${findProperty('fineract.config.password')}"
+                    username = "${findProperty('fineract.config.username')}"
+                    password = "${findProperty('fineract.config.password')}"
                 }
             }
         }
@@ -903,7 +903,7 @@ configure(project.fineractPublishProjects) {
 apply plugin: 'org.cyclonedx.bom'
 
 cyclonedxBom {
-    projectType = "application"
+    projectType = 'APPLICATION'
     includeBomSerialNumber = true
     includeLicenseText = true
 }

--- a/fineract-doc/build.gradle
+++ b/fineract-doc/build.gradle
@@ -95,12 +95,12 @@ task copyDiagrams(type: Copy) {
 asciidoctor {
     languages 'en'
 
-    baseDir 'src/docs'
-    sourceDir 'src/docs'
+    baseDir = 'src/docs'
+    sourceDir = 'src/docs'
     sources {
         include('index.adoc')
     }
-    outputDir 'build/docs/html'
+    outputDir = 'build/docs/html'
 
     logging.captureStandardError LogLevel.INFO
 
@@ -112,12 +112,12 @@ asciidoctor {
 asciidoctorPdf {
     languages 'en'
 
-    baseDir 'src/docs'
-    sourceDir 'src/docs'
+    baseDir = 'src/docs'
+    sourceDir = 'src/docs'
     sources {
         include('index.adoc')
     }
-    outputDir 'build/docs/pdf'
+    outputDir = 'build/docs/pdf'
 
     logging.captureStandardError LogLevel.INFO
 

--- a/fineract-war/build.gradle
+++ b/fineract-war/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 }
 
 tasks.withType(Tar) {
-    compression Compression.GZIP
+    compression = Compression.GZIP
     archiveExtension = 'tar.gz'
     
     // Enable caching for all tar tasks
@@ -185,5 +185,5 @@ tasks.named('srcDistTar') {
 }
 
 // Disable zip distributions as they're not needed
-binaryDistZip.enabled false
-srcDistZip.enabled false
+binaryDistZip.enabled = false
+srcDistZip.enabled = false

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 }
 
 cargo {
-    containerId "tomcat10x"
+    containerId = "tomcat10x"
 
     // looks like Cargo doesn't detect the WAR file automatically in the multi-module setup
     deployable {

--- a/oauth2-tests/build.gradle
+++ b/oauth2-tests/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 cargo {
-    containerId "tomcat10x"
+    containerId = "tomcat10x"
 
     // looks like Cargo doesn't detect the WAR file automatically in the multi-module setup
     deployable {


### PR DESCRIPTION
## Summary
Fixed Gradle deprecated property assignment syntax warnings
in multiple build.gradle files across the project.

## Changes
- build.gradle: Fixed propName value → propName = value syntax
- fineract-doc/build.gradle: Fixed same syntax warnings
- fineract-war/build.gradle: Fixed compression, enabled properties
- integration-tests/build.gradle: Fixed containerId property
- oauth2-tests/build.gradle: Fixed containerId property

## Testing
Command: gradlew.bat compileJava --warning-mode all
Result: BUILD SUCCESSFUL - warnings resolved