### PR TITLE
FINERACT-2542: Fix typos in GLClosures and AccountingRule Swagger descriptions

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/closure/api/GLClosuresApiResource.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/closure/api/GLClosuresApiResource.java
@@ -63,7 +63,7 @@ import org.springframework.stereotype.Component;
         closingDate
         The date for which the accounting closure is defined
         officeId
-        The identifer of the branch for which accounting has been closed
+        The identifier of the branch for which accounting has been closed
         comments
         Description associated with an Accounting closure
         """)

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/rule/api/AccountingRuleApiResource.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/rule/api/AccountingRuleApiResource.java
@@ -71,7 +71,7 @@ import org.springframework.stereotype.Component;
 @Tag(name = "Accounting Rules", description = """
         It is typical scenario in MFI's that non accountants pass journal entries on a regular basis. For Ex: A branch office might deposit their entire cash at hand to their Bank account at the end of a working day. The branch office users might not understand enough of accounting to figure out which account needs to get credited and which account needs to be debited to represent this transaction.
 
-        Enter accounting rules, an abstraction on top of manual Journal entires for enabling simpler data entry. An accounting rule can define any of the following abstractions
+        Enter accounting rules, an abstraction on top of manual journal entries for enabling simpler data entry. An accounting rule can define any of the following abstractions
 
         A Simple journal entry where both the credit and debit account have been preselected
         A Simple journal entry where either credit or debit accounts have been limited to a pre-selected list of accounts (Ex: Debit account should be one of "Bank of America" of "JP Morgan" and credit account should be "Cash")


### PR DESCRIPTION
## Description

Identified and corrected spelling errors in the Swagger-generated API documentation:
- `GLClosuresApiResource.java`: Changed "identifer" to "identifier".
- `AccountingRuleApiResource.java`: Changed "Journal entires" to "journal entries".

Associated Jira Ticket: https://issues.apache.org/jira/browse/FINERACT-2542

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made. *(N/A - Documentation typo fix only)*
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).