### PR TITLE
FINERACT-2538: Fix locale-sensitive string operations in EnumValueVal…

### DIFF
--- a/fineract-validation/src/main/java/org/apache/fineract/validation/constraints/EnumValueValidator.java
+++ b/fineract-validation/src/main/java/org/apache/fineract/validation/constraints/EnumValueValidator.java
@@ -21,6 +21,7 @@ package org.apache.fineract.validation.constraints;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,12 +31,19 @@ public class EnumValueValidator implements ConstraintValidator<EnumValue, String
 
     @Override
     public void initialize(EnumValue annotation) {
-        acceptedValues = Arrays.stream(annotation.enumClass().getEnumConstants()).map(e -> e.name().toLowerCase())
+        acceptedValues = Arrays.stream(annotation.enumClass().getEnumConstants()).map(e -> e.name().toLowerCase(Locale.US))
                 .collect(Collectors.toSet());
     }
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        return value != null && acceptedValues.contains(value.toLowerCase());
+        if (value == null || !acceptedValues.contains(value.toLowerCase(Locale.US))) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(
+                    String.format(Locale.US, "Value '%s' is not valid. Accepted values are: %s", value, acceptedValues))
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Description

  Summary                                                                                                                                                                           
                                                                                                                                                                                    
  - Added explicit Locale.US to all toLowerCase() calls in EnumValueValidator to avoid locale-dependent behaviour.                                                                  
  - Fixed the String.format(String, Object...) compiler warning by specifying Locale.US as the first argument.
  - Improved the constraint violation message to include the rejected value and the full list of accepted enum values, replacing the generic annotation-level message.              
                                                                                                                                                                                    
  Motivation                                                                                                                                                                        
                                                                                                                                                                                    
  Calling String.toLowerCase() and String.format() without an explicit Locale produces compiler warnings and can yield inconsistent results on systems with a non-English default   
  locale (e.g. Turkish, where I lowercases to ı rather than i). Since enum constant names are always ASCII, Locale.US is the correct and safe choice here.
                                                                                                                                                                                    
  Changes                                                   

 EnumValueValidator.java
 - Added Locale.US to toLowerCase() calls
 - Added String.format(Locale.US, ...) for the constraint violation message
 - Added import java.util.Locale
 
                                                                                                                                                                                    
  Test plan                                                                                                                                                                         
                                                                                                                                                                                    
  - Existing unit/integration tests pass.                                                                                                                                           
  - Manually verify that an invalid enum value returns a descriptive message listing the accepted values.
  - Verify no new compiler warnings are raised by static analysis.   