### PR TITLE
FINERACT-2533: Add E2E test scenarios for SavingsAccount insufficient balance withdrawal

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/saving/SavingsAccountStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/saving/SavingsAccountStepDef.java
@@ -19,8 +19,11 @@
 package org.apache.fineract.test.stepdef.saving;
 
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
 import java.math.BigDecimal;
 import java.util.Map;
 import org.apache.fineract.client.feign.FineractFeignClient;
@@ -31,7 +34,11 @@ import org.apache.fineract.client.models.PostSavingsAccountsAccountIdRequest;
 import org.apache.fineract.client.models.PostSavingsAccountsAccountIdResponse;
 import org.apache.fineract.client.models.PostSavingsAccountsRequest;
 import org.apache.fineract.client.models.PostSavingsAccountsResponse;
+import org.apache.fineract.client.models.PostSavingsProductsRequest;
+import org.apache.fineract.client.models.PostSavingsProductsResponse;
 import org.apache.fineract.test.factory.SavingsAccountRequestFactory;
+import org.apache.fineract.test.factory.SavingsProductRequestFactory;
+import org.apache.fineract.test.helper.ErrorResponse;
 import org.apache.fineract.test.stepdef.AbstractStepDef;
 import org.apache.fineract.test.support.TestContextKey;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,13 +48,24 @@ public class SavingsAccountStepDef extends AbstractStepDef {
     @Autowired
     private FineractFeignClient fineractClient;
 
+    @And("Admin creates a EUR savings product")
+    public void createEurSavingsProduct() {
+        PostSavingsProductsRequest savingsProductRequest = SavingsProductRequestFactory.defaultSavingsProductRequest();
+        PostSavingsProductsResponse savingsProductResponse = ok(
+                () -> fineractClient.savingsProduct().createSavingsProduct(savingsProductRequest));
+        testContext().set(TestContextKey.DEFAULT_SAVINGS_PRODUCT_CREATE_RESPONSE_EUR, savingsProductResponse);
+    }
+
     @And("Client creates a new EUR savings account with {string} submitted on date")
     public void createSavingsAccountEUR(String submittedOnDate) {
         PostClientsResponse clientResponse = testContext().get(TestContextKey.CLIENT_CREATE_RESPONSE);
         long clientId = clientResponse.getClientId();
 
+        PostSavingsProductsResponse savingsProductResponse = testContext().get(TestContextKey.DEFAULT_SAVINGS_PRODUCT_CREATE_RESPONSE_EUR);
+        long productId = savingsProductResponse.getResourceId();
+
         PostSavingsAccountsRequest createSavingsAccountRequest = SavingsAccountRequestFactory.defaultEURSavingsAccountRequest()
-                .clientId(clientId).submittedOnDate(submittedOnDate);
+                .clientId(clientId).productId(productId).submittedOnDate(submittedOnDate);
 
         PostSavingsAccountsResponse createSavingsAccountResponse = ok(
                 () -> fineractClient.savingsAccount().submitSavingsApplication(createSavingsAccountRequest));
@@ -169,5 +187,44 @@ public class SavingsAccountStepDef extends AbstractStepDef {
         PostSavingsAccountTransactionsResponse withdrawalResponse = ok(() -> fineractClient.savingsAccountTransactions()
                 .createSavingsAccountTransaction(savingsAccountID, withdrawRequest, Map.of("command", "withdrawal")));
         testContext().set(TestContextKey.USD_SAVINGS_ACCOUNT_WITHDRAW_RESPONSE, withdrawalResponse);
+    }
+
+    @And("Client tries to withdraw {double} {string} from savings account on {string} date and expects an error")
+    public void withdrawWithInsufficientBalance(double withdrawAmount, String currency, String transactionDate) {
+
+        String contextKey = currency.equalsIgnoreCase("EUR") ? TestContextKey.EUR_SAVINGS_ACCOUNT_CREATE_RESPONSE
+                : TestContextKey.USD_SAVINGS_ACCOUNT_CREATE_RESPONSE;
+
+        PostSavingsAccountsResponse savingsAccountResponse = testContext().get(contextKey);
+        long savingsAccountID = savingsAccountResponse.getSavingsId();
+
+        PostSavingsAccountTransactionsRequest withdrawRequest = SavingsAccountRequestFactory.defaultWithdrawRequest()
+                .transactionDate(transactionDate).transactionAmount(BigDecimal.valueOf(withdrawAmount));
+
+        try {
+            ok(() -> fineractClient.savingsAccountTransactions().createSavingsAccountTransaction(savingsAccountID, withdrawRequest,
+                    "withdrawal"));
+
+            fail("Expected withdrawal to fail due to insufficient funds, but it succeeded.");
+
+        } catch (org.apache.fineract.client.feign.util.CallFailedRuntimeException e) {
+            ErrorResponse errorResponse = ErrorResponse.fromFeignException((org.apache.fineract.client.feign.FeignException) e.getCause());
+            testContext().set(TestContextKey.ERROR_RESPONSE, errorResponse);
+        }
+    }
+
+    @Then("The savings account withdrawal error response has an HTTP status of {int}")
+    public void verifySavingsWithdrawalHttpStatus(int expectedStatus) {
+        ErrorResponse errorResponse = testContext().get(TestContextKey.ERROR_RESPONSE);
+        assertThat(errorResponse).isNotNull();
+        assertThat(errorResponse.getHttpStatusCode()).isEqualTo(expectedStatus);
+    }
+
+    @And("The savings account withdrawal developer message contains {string}")
+    public void verifySavingsWithdrawalErrorMessage(String expectedMessage) {
+        ErrorResponse errorResponse = testContext().get(TestContextKey.ERROR_RESPONSE);
+        assertThat(errorResponse).isNotNull();
+        String developerMessage = errorResponse.getErrors().get(0).getDeveloperMessage();
+        assertThat(developerMessage).contains(expectedMessage);
     }
 }

--- a/fineract-e2e-tests-runner/src/test/resources/features/SavingsAccount.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/SavingsAccount.feature
@@ -1,36 +1,49 @@
 @SavingsAccount
-  Feature: SavingsAccount
+Feature: SavingsAccount
 
 #    TODO unskip and check when PS-1088 is done
-    @Skip @TestRailId:C2438
-    Scenario: As a user I would like to Deposit to my savings account
-      When Admin sets the business date to "1 June 2022"
-      When Admin creates a client with random data
-      And Client creates a new EUR savings account with "1 June 2022" submitted on date
-      And Approve EUR savings account on "1 June 2022" date
-      And Activate EUR savings account on "1 June 2022" date
-      And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
+  @Skip @TestRailId:C2438
+  Scenario: As a user I would like to Deposit to my savings account
+    When Admin sets the business date to "1 June 2022"
+    When Admin creates a client with random data
+    And Client creates a new EUR savings account with "1 June 2022" submitted on date
+    And Approve EUR savings account on "1 June 2022" date
+    And Activate EUR savings account on "1 June 2022" date
+    And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
 
-    @Skip @TestRailId:C2439
-    Scenario: As a user I would like to Withdraw from my savings account
-      When Admin sets the business date to "1 June 2022"
-      When Admin creates a client with random data
-      And Client creates a new EUR savings account with "1 June 2022" submitted on date
-      And Approve EUR savings account on "1 June 2022" date
-      And Activate EUR savings account on "1 June 2022" date
-      And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
-      And Client successfully withdraw 1000 EUR from the savings account on "1 June 2022" date
+  @Skip @TestRailId:C2439
+  Scenario: As a user I would like to Withdraw from my savings account
+    When Admin sets the business date to "1 June 2022"
+    When Admin creates a client with random data
+    And Client creates a new EUR savings account with "1 June 2022" submitted on date
+    And Approve EUR savings account on "1 June 2022" date
+    And Activate EUR savings account on "1 June 2022" date
+    And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
+    And Client successfully withdraw 1000 EUR from the savings account on "1 June 2022" date
 
-    @Skip @TestRailId:C2440
-    Scenario: As a user I would like to create an EUR and USD Savings accounts and make deposit and withdraw events
-      When Admin sets the business date to "1 June 2022"
-      When Admin creates a client with random data
-      And Client creates a new EUR savings account with "1 June 2022" submitted on date
-      And Approve EUR savings account on "1 June 2022" date
-      And Activate EUR savings account on "1 June 2022" date
-      And Client creates a new USD savings account with "1 June 2022" submitted on date
-      And Approve USD savings account on "1 June 2022" date
-      And Activate USD savings account on "1 June 2022" date
-      And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
-      And Client successfully withdraw 1000 EUR from the savings account on "1 June 2022" date
-      And Client successfully deposits 1000 USD to the savings account on "1 June 2022" date
+  @Skip @TestRailId:C2440
+  Scenario: As a user I would like to create an EUR and USD Savings accounts and make deposit and withdraw events
+    When Admin sets the business date to "1 June 2022"
+    When Admin creates a client with random data
+    And Client creates a new EUR savings account with "1 June 2022" submitted on date
+    And Approve EUR savings account on "1 June 2022" date
+    And Activate EUR savings account on "1 June 2022" date
+    And Client creates a new USD savings account with "1 June 2022" submitted on date
+    And Approve USD savings account on "1 June 2022" date
+    And Activate USD savings account on "1 June 2022" date
+    And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
+    And Client successfully withdraw 1000 EUR from the savings account on "1 June 2022" date
+    And Client successfully deposits 1000 USD to the savings account on "1 June 2022" date
+
+  @TestRailId:C2441
+  Scenario: As a user I would like to verify that withdrawal fails when balance is insufficient
+    When Admin sets the business date to "1 June 2022"
+    And Admin creates a client with random data
+    And Admin creates a EUR savings product
+    And Client creates a new EUR savings account with "1 June 2022" submitted on date
+    And Approve EUR savings account on "1 June 2022" date
+    And Activate EUR savings account on "1 June 2022" date
+    And Client successfully deposits 500 EUR to the savings account on "1 June 2022" date
+    And Client tries to withdraw 1000 "EUR" from savings account on "1 June 2022" date and expects an error
+    Then The savings account withdrawal error response has an HTTP status of 403
+    And The savings account withdrawal developer message contains "Insufficient account balance."


### PR DESCRIPTION
## Description

## Summary

This PR adds E2E test scenarios for SavingsAccount as suggested by @adamsaghy 
in #5623.

## Changes

### SavingsAccount.feature
- Added Scenario C2441: Withdrawal fails when account has insufficient balance

### SavingsAccountStepDef.java  
- Added step: `Client tries to withdraw {double} {string} from savings account on {string} date and expects an error`
- Added step: `The savings account withdrawal error response has an HTTP status of {int}`
- Added step: `The savings account withdrawal developer message contains {string}`

## Test Design Decisions

- Used `try/catch FeignException` pattern consistent with existing codebase
- Added `Assertions.fail()` inside try block to prevent false positives
- Dynamic currency via ternary operator — avoids hardcoding EUR/USD
- HTTP 403 confirmed from `AbstractPlatformDomainRuleException`
- Error code `insufficient.account.balance` confirmed from `InsufficientAccountBalanceException.java`

## Closes
Supersedes #5623