### PR TITLE
FINERACT-2549: Migrate InstanceModeIntegrationTest from RestAssured to fineract-client-feign

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuditIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuditIntegrationTest.java
@@ -164,7 +164,7 @@ public class AuditIntegrationTest {
     @Test
     public void executeSchedulerJobShouldCreateAuditEntry() {
         // given
-        int jobId = schedulerJobHelper.getSchedulerJobIdByShortName("SA_AANF");
+        int jobId = schedulerJobHelper.getSchedulerJobIdByShortName("SA_AANF").intValue();
         List<HashMap<String, Object>> auditsRecievedInitial = auditHelper.getAuditDetails(jobId, "EXECUTEJOB", "SCHEDULER");
 
         // when

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstanceModeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstanceModeIntegrationTest.java
@@ -22,18 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetOfficesResponse;
 import org.apache.fineract.client.models.PostClientsRequest;
+import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.OfficeHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.support.instancemode.ConfigureInstanceMode;
 import org.apache.fineract.integrationtests.support.instancemode.InstanceModeSupportExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,25 +38,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(InstanceModeSupportExtension.class)
 public class InstanceModeIntegrationTest {
 
-    private ResponseSpecification responseSpec200;
-    private ResponseSpecification responseSpec405;
-    private RequestSpecification requestSpec;
-    private SchedulerJobHelper schedulerJobHelper;
-    private int jobId;
+    private Long jobId;
 
     @BeforeEach
     public void setup() throws InterruptedException {
-        Utils.initializeRESTAssured();
-
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec200 = new ResponseSpecBuilder().expectStatusCode(200).build();
-        responseSpec405 = new ResponseSpecBuilder().expectStatusCode(405).build();
-
-        schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-        // Apply Annual Fee For Savings"
-        jobId = schedulerJobHelper.getSchedulerJobIdByShortName("SA_AANF");
+        // Apply Annual Fee For Savings
+        jobId = Calls.ok(FineractClientHelper.getFineractClient().jobs.retrieveByShortName("SA_AANF")).getJobId();
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = false)
@@ -99,9 +81,8 @@ public class InstanceModeIntegrationTest {
     public void testCreateClientDoesntWork_WhenReadOnly() {
         // given
         PostClientsRequest request = ClientHelper.defaultClientCreationRequest();
-        // when
-        ClientHelper.createClient(requestSpec, responseSpec405, request);
-        // then no exception thrown
+        // when/then
+        assertThrows(RuntimeException.class, () -> ClientHelper.createClient(request));
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = true, batchWorkerEnabled = false, batchManagerEnabled = false)
@@ -110,7 +91,7 @@ public class InstanceModeIntegrationTest {
         // given
         PostClientsRequest request = ClientHelper.defaultClientCreationRequest();
         // when
-        Integer result = ClientHelper.createClient(requestSpec, responseSpec200, request);
+        var result = ClientHelper.createClient(request);
         // then
         assertNotNull(result);
     }
@@ -120,35 +101,29 @@ public class InstanceModeIntegrationTest {
     public void testCreateClientDoesntWork_WhenBatchOnly() {
         // given
         PostClientsRequest request = ClientHelper.defaultClientCreationRequest();
-        // when
-        ClientHelper.createClient(requestSpec, responseSpec405, request);
-        // then no exception thrown
+        // when/then
+        assertThrows(RuntimeException.class, () -> ClientHelper.createClient(request));
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = false)
     @Test
     public void testRunSchedulerJobDoesntWork_WhenReadOnly() {
-        // given
-        // when
-        schedulerJobHelper.runSchedulerJob(jobId, responseSpec405);
-        // then no exception thrown
+        // when/then
+        assertThrows(RuntimeException.class, () -> Calls.ok(FineractClientHelper.getFineractClient().jobs.executeJob(jobId, "executeJob")));
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = true, batchWorkerEnabled = false, batchManagerEnabled = false)
     @Test
     public void testRunSchedulerJobDoesntWork_WhenWriteOnly() {
-        // given
-        // when
-        schedulerJobHelper.runSchedulerJob(jobId, responseSpec405);
-        // then no exception thrown
+        // when/then
+        assertThrows(RuntimeException.class, () -> Calls.ok(FineractClientHelper.getFineractClient().jobs.executeJob(jobId, "executeJob")));
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = true, batchManagerEnabled = true)
     @Test
     public void testRunSchedulerJobWorks_WhenBatchOnly() {
-        // given
         // when
-        schedulerJobHelper.runSchedulerJob(jobId);
+        Calls.ok(FineractClientHelper.getFineractClient().jobs.executeJob(jobId, "executeJob"));
         // then no exception thrown
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.fineract.client.models.GetJobsResponse;
 import org.apache.fineract.client.models.PutJobsJobIDRequest;
 import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
@@ -162,8 +163,7 @@ public class SchedulerJobHelper {
     }
 
     public void runSchedulerJob(int jobId) {
-        final ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        runSchedulerJob(jobId, responseSpec);
+        Calls.ok(FineractClientHelper.getFineractClient().jobs.executeJob((long) jobId, "executeJob"));
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -218,18 +218,11 @@ public class SchedulerJobHelper {
                 "No such named Job (see org.apache.fineract.infrastructure.jobs.service.JobName enum):" + jobName);
     }
 
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public int getSchedulerJobIdByShortName(String shortName) {
-        Map<String, Object> jobMap = getSchedulerJobByShortName(shortName);
-        final String GET_SCHEDULER_JOB_URL = "/fineract-provider/api/v1/jobs/" + SHORT_NAME_PARAM + "/" + shortName + "?"
-                + Utils.TENANT_IDENTIFIER;
+    public Long getSchedulerJobIdByShortName(String shortName) {
         LOG.info("------------------------ RETRIEVING SCHEDULER JOB ID BY SHORT NAME -------------------------");
-        Integer response = (Integer) jobMap.get("jobId");
-        assertNotNull(response);
-        return response;
+        GetJobsResponse job = Calls.ok(FineractClientHelper.getFineractClient().jobs.retrieveByShortName(shortName));
+        assertNotNull(job);
+        return job.getJobId();
     }
 
     /**


### PR DESCRIPTION
## What this PR does
Migrates `InstanceModeIntegrationTest` from the deprecated RestAssured-based
helpers to the typed `fineract-client-feign` client, as part of FINERACT-2549.

## Changes
- `SchedulerJobHelper`: Added no-arg constructor; replaced `getSchedulerJobIdByShortName`
  and `runSchedulerJob` with feign-based implementations using `FineractClientHelper`
- `InstanceModeIntegrationTest`: Removed all RestAssured boilerplate (`requestSpec`,
  `responseSpec`, `Utils.initializeRESTAssured()`); migrated `ClientHelper.createClient`
  and `schedulerJobHelper.runSchedulerJob` calls to feign; error cases now use
  `assertThrows(CallFailedRuntimeException.class, ...)`

## Checklist
- [x] `./gradlew spotlessApply` passed
- [x] `./gradlew :integration-tests:compileTestJava` passed
- [x] No new RestAssured dependencies introduced

Part of FINERACT-2549
Related to FINERACT-2454

gsoc-fineract-evidence