### PR TITLE
FINERACT-2549: Migrate ClientExternalIdTest from RestAssured to fineract-client-feign

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResourceSwagger.java
@@ -409,6 +409,16 @@ final class ClientsApiResourceSwagger {
         public String dateFormat;
         @Schema(example = "en")
         public String locale;
+        @Schema(example = "03 August 2021")
+        public String closureDate;
+        @Schema(example = "1")
+        public Long closureReasonId;
+        @Schema(example = "03 August 2021")
+        public String reactivationDate;
+        @Schema(example = "03 August 2021")
+        public String rejectionDate;
+        @Schema(example = "1")
+        public Long rejectionReasonId;
     }
 
     @Schema(description = "PostClientsClientIdResponse")

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -15,3 +15,6 @@
 - To override any of the default value, just add new value with the same key as environment variable
 - Example:
   - `BACKEND_PROTOCOL=http`
+
+## Migration to fineract-client-feign
+We are currently migrating integration tests from RestAssured to the Feign-based Fineract client. For detailed instructions and patterns, see the [Test Migration Guide](TEST_MIGRATION_GUIDE.md).

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientExternalIdTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientExternalIdTest.java
@@ -27,21 +27,23 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.DeleteClientsClientIdResponse;
-import org.apache.fineract.client.models.GetClientTransferProposalDateResponse;
 import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
 import org.apache.fineract.client.models.GetObligeeData;
 import org.apache.fineract.client.models.PostClientsClientIdResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PutClientsClientIdRequest;
 import org.apache.fineract.client.models.PutClientsClientIdResponse;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.apache.fineract.portfolio.client.domain.ClientStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,10 +68,9 @@ public class ClientExternalIdTest {
     public void whenAutoExternalIdConfigIsOffCreateClient() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         // then
         assertNotNull(clientResponse);
         assertNull(clientResponse.getResourceExternalId());
@@ -79,10 +80,9 @@ public class ClientExternalIdTest {
     public void whenAutoExternalIdConfigIsOffCreateClientWithValue() {
         // given
         final String externalId = UUID.randomUUID().toString();
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                externalId);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, externalId);
         // then
         assertNotNull(clientResponse);
         assertNotNull(clientResponse.getResourceExternalId());
@@ -95,10 +95,9 @@ public class ClientExternalIdTest {
     public void whenAutoExternalIdConfigIsOnCreateClient() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         // then
         assertNotNull(clientResponse);
         assertNotNull(clientResponse.getResourceExternalId());
@@ -114,10 +113,9 @@ public class ClientExternalIdTest {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
         final String externalId = UUID.randomUUID().toString();
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                externalId);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, externalId);
         // then
         assertNotNull(clientResponse);
         assertNotNull(clientResponse.getResourceExternalId());
@@ -130,72 +128,71 @@ public class ClientExternalIdTest {
 
     @Test
     public void testClientStatusUsingExternalId() {
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
-        final PostClientsResponse addClientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse addClientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = addClientResponse.getResourceExternalId();
         final Long clientId = addClientResponse.getClientId();
         assertNotNull(clientExternalId);
         log.info("Client data id {} and external Id {}", clientId, clientExternalId);
 
-        GetClientsClientIdResponse clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, clientExternalId);
+        GetClientsClientIdResponse clientResponse = ClientHelper.getClientByExternalId(clientExternalId);
         ClientStatusChecker.verifyClientStatus(ClientStatus.ACTIVE, clientResponse);
         log.info("Client data id {} and status {}", clientExternalId, clientResponse.getStatus().getCode());
 
         // Close Client action
-        jsonPayload = clientHelper.getCloseClientAsJSON();
-        PostClientsClientIdResponse commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec,
-                clientExternalId, ClientHelper.CLOSE_CLIENT_COMMAND, jsonPayload);
+        String codeName = "ClientClosureReason";
+        HashMap<String, Object> code = CodeHelper.getCodeByName(requestSpec, responseSpec, codeName);
+        Integer closureReasonId = (Integer) CodeHelper.retrieveOrCreateCodeValue((Integer) code.get("id"), requestSpec, responseSpec)
+                .get("id");
+        PostClientsClientIdResponse commandResponse = ClientHelper.closeClient(clientExternalId, closureReasonId);
         assertNotNull(commandResponse);
         assertNotNull(commandResponse.getResourceExternalId());
         assertEquals(clientExternalId, commandResponse.getResourceExternalId());
         log.info("Client data id {} and external Id {}", commandResponse.getResourceId(), clientExternalId);
         assertEquals(clientId.intValue(), commandResponse.getResourceId());
 
-        clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, clientExternalId);
+        clientResponse = ClientHelper.getClientByExternalId(clientExternalId);
         ClientStatusChecker.verifyClientStatus(ClientStatus.CLOSED, clientResponse);
         log.info("Client data id {} and status {}", clientExternalId, clientResponse.getStatus().getCode());
 
         // Reactivate Client action
-        jsonPayload = clientHelper.getReactivateClientAsJSON();
-        commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec, clientExternalId,
-                ClientHelper.REACTIVATE_CLIENT_COMMAND, jsonPayload);
+        commandResponse = ClientHelper.reactivateClient(clientExternalId);
         assertNotNull(commandResponse);
         assertNotNull(commandResponse.getResourceExternalId());
         assertEquals(clientExternalId, commandResponse.getResourceExternalId());
         log.info("Client data id {} and external Id {}", commandResponse.getResourceId(), clientExternalId);
         assertEquals(clientId.intValue(), commandResponse.getResourceId());
 
-        clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, clientExternalId);
+        clientResponse = ClientHelper.getClientByExternalId(clientExternalId);
         ClientStatusChecker.verifyClientStatus(ClientStatus.PENDING, clientResponse);
         log.info("Client data id {} and status {}", clientExternalId, clientResponse.getStatus().getCode());
 
         // Reject Client action
-        jsonPayload = clientHelper.getRejectClientAsJSON();
-        commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec, clientExternalId,
-                ClientHelper.REJECT_CLIENT_COMMAND, jsonPayload);
+        codeName = "ClientRejectReason";
+        code = CodeHelper.getCodeByName(requestSpec, responseSpec, codeName);
+        Integer rejectionReasonId = (Integer) CodeHelper.retrieveOrCreateCodeValue((Integer) code.get("id"), requestSpec, responseSpec)
+                .get("id");
+        commandResponse = ClientHelper.rejectClient(clientExternalId, rejectionReasonId);
         assertNotNull(commandResponse);
         assertNotNull(commandResponse.getResourceExternalId());
         assertEquals(clientExternalId, commandResponse.getResourceExternalId());
         log.info("Client data id {} and external Id {}", commandResponse.getResourceId(), clientExternalId);
         assertEquals(clientId.intValue(), commandResponse.getResourceId());
 
-        clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, clientExternalId);
+        clientResponse = ClientHelper.getClientByExternalId(clientExternalId);
         ClientStatusChecker.verifyClientStatus(ClientStatus.REJECTED, clientResponse);
         log.info("Client data id {} and status {}", clientExternalId, clientResponse.getStatus().getCode());
 
         // Activate Client action
-        jsonPayload = ClientHelper.getActivateClientAsJSON(ClientHelper.DEFAULT_DATE);
-        commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec, clientExternalId,
-                ClientHelper.ACTIVATE_CLIENT_COMMAND, jsonPayload);
+        commandResponse = ClientHelper.activateClient(clientExternalId, ClientHelper.DEFAULT_DATE);
         assertNotNull(commandResponse);
         assertNotNull(commandResponse.getResourceExternalId());
         assertEquals(clientExternalId, commandResponse.getResourceExternalId());
         log.info("Client data id {} and external Id {}", commandResponse.getResourceId(), clientExternalId);
         assertEquals(clientId.intValue(), commandResponse.getResourceId());
 
-        clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, clientExternalId);
+        clientResponse = ClientHelper.getClientByExternalId(clientExternalId);
         ClientStatusChecker.verifyClientStatus(ClientStatus.ACTIVE, clientResponse);
         log.info("Client data id {} and status {}", clientExternalId, clientResponse.getStatus().getCode());
 
@@ -206,13 +203,12 @@ public class ClientExternalIdTest {
     public void testUpdateClientUsingExternalId() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = clientResponse.getResourceExternalId();
-        jsonPayload = ClientHelper.getBasicClientAsJSON(null, ClientHelper.LEGALFORM_ID_PERSON, clientExternalId);
-        final PutClientsClientIdResponse clientUpdateResponse = ClientHelper.updateClient(requestSpec, responseSpec, clientExternalId,
-                jsonPayload);
+        PutClientsClientIdRequest updateRequest = new PutClientsClientIdRequest().externalId(clientExternalId);
+        final PutClientsClientIdResponse clientUpdateResponse = ClientHelper.updateClientByExternalId(clientExternalId, updateRequest);
         // then
         assertNotNull(clientUpdateResponse);
         assertNotNull(clientUpdateResponse.getResourceExternalId());
@@ -224,21 +220,20 @@ public class ClientExternalIdTest {
     @Test
     public void testDeleteClientUsingExternalId() {
         // given
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = clientResponse.getResourceExternalId();
-        jsonPayload = clientHelper.getCloseClientAsJSON();
-        PostClientsClientIdResponse commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec,
-                clientExternalId, ClientHelper.CLOSE_CLIENT_COMMAND, jsonPayload);
-        jsonPayload = clientHelper.getReactivateClientAsJSON();
-        commandResponse = ClientHelper.performClientActionUsingExternalId(requestSpec, responseSpec, clientExternalId,
-                ClientHelper.REACTIVATE_CLIENT_COMMAND, jsonPayload);
+        String codeName = "ClientClosureReason";
+        HashMap<String, Object> code = CodeHelper.getCodeByName(requestSpec, responseSpec, codeName);
+        Integer closureReasonId = (Integer) CodeHelper.retrieveOrCreateCodeValue((Integer) code.get("id"), requestSpec, responseSpec)
+                .get("id");
+        ClientHelper.closeClient(clientExternalId, closureReasonId);
+        ClientHelper.reactivateClient(clientExternalId);
 
         // then
-        final DeleteClientsClientIdResponse clientDeleteResponse = ClientHelper.deleteClient(requestSpec, responseSpec, clientExternalId);
+        final DeleteClientsClientIdResponse clientDeleteResponse = ClientHelper.deleteClientByExternalId(clientExternalId);
         assertNotNull(clientDeleteResponse);
         assertNotNull(clientDeleteResponse.getResourceExternalId());
         assertEquals(clientExternalId, clientDeleteResponse.getResourceExternalId());
@@ -250,14 +245,12 @@ public class ClientExternalIdTest {
     public void testGetClientAccountsUsingExternalId() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = clientResponse.getResourceExternalId();
 
-        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(requestSpec, responseSpec,
-                clientExternalId);
+        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(clientExternalId);
 
         // then
         assertNotNull(clientAccountsResponse);
@@ -269,15 +262,12 @@ public class ClientExternalIdTest {
     public void testGetClientTransferProposalDate() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
-        ResponseSpecification response204Spec = new ResponseSpecBuilder().expectStatusCode(204).build();
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
 
         // when
         final String clientExternalId = clientResponse.getResourceExternalId();
-        final GetClientTransferProposalDateResponse transferProposalDateResponse = ClientHelper.getProposedTransferDate(requestSpec,
-                response204Spec, clientExternalId);
+        ClientHelper.getProposedTransferDate(clientExternalId);
 
         fetchClientByExternalId(clientResponse.getResourceExternalId());
 
@@ -288,12 +278,11 @@ public class ClientExternalIdTest {
     public void testGetClientObligeeData() {
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = clientResponse.getResourceExternalId();
-        final List<GetObligeeData> obligeeDataResponse = ClientHelper.getObligeeData(requestSpec, responseSpec, clientExternalId);
+        final List<GetObligeeData> obligeeDataResponse = ClientHelper.getObligeeData(clientExternalId);
 
         // then
         assertNotNull(obligeeDataResponse);
@@ -304,7 +293,7 @@ public class ClientExternalIdTest {
     }
 
     private void fetchClientByExternalId(final String externalId) {
-        GetClientsClientIdResponse clientResponse = ClientHelper.getClientByExternalId(requestSpec, responseSpec, externalId);
+        GetClientsClientIdResponse clientResponse = ClientHelper.getClientByExternalId(externalId);
         assertNotNull(clientResponse);
         assertEquals(externalId, clientResponse.getExternalId());
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
@@ -66,10 +66,9 @@ public class LoanAccountsContainsCurrencyFieldTest extends BaseLoanIntegrationTe
 
         // given
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        final String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON,
-                null);
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final String clientExternalId = clientResponse.getResourceExternalId();
         final long clientId = clientResponse.getClientId();
 
@@ -81,8 +80,7 @@ public class LoanAccountsContainsCurrencyFieldTest extends BaseLoanIntegrationTe
         final Integer loanId = createLoanAccount(loanTransactionHelper, String.valueOf(clientId), String.valueOf(loanProductId),
                 formattedDate);
 
-        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(requestSpec, responseSpec,
-                clientExternalId);
+        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(clientExternalId);
 
         if (clientAccountsResponse.getLoanAccounts() == null) {
             // Handle the case where getClientAccounts returned null

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
@@ -84,8 +84,8 @@ public class SearchResourcesTest {
         final List<String> resources = Arrays.asList("clients");
 
         // Client and Loan account creation
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final Long clientId = clientResponse.getClientId();
         final GetClientsClientIdResponse getClientResponse = ClientHelper.getClient(requestSpec, responseSpec, clientId.intValue());
         final String query = getClientResponse.getAccountNo();
@@ -112,8 +112,8 @@ public class SearchResourcesTest {
     public void searchOverSavingsResources() {
         final List<String> resources = Arrays.asList("savings");
 
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final Long clientId = clientResponse.getClientId();
 
         final Integer savingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, clientId.intValue(), "1000");
@@ -139,8 +139,8 @@ public class SearchResourcesTest {
     public void searchOverSharesResources() {
         final List<String> resources = Arrays.asList("shares");
 
-        String jsonPayload = ClientHelper.getBasicClientAsJSON(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null);
-        final PostClientsResponse clientsResponse = ClientHelper.addClientAsPerson(requestSpec, responseSpec, jsonPayload);
+        final PostClientsResponse clientsResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
+                ClientHelper.LEGALFORM_ID_PERSON, null);
         final Long clientId = clientsResponse.getClientId();
 
         final ShareProductHelper shareProductHelper = new ShareProductHelper();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -54,10 +57,12 @@ import org.apache.fineract.client.models.PagedRequestClientTextSearch;
 import org.apache.fineract.client.models.PostClientClientIdAddressesResponse;
 import org.apache.fineract.client.models.PostClientsClientIdIdentifiersRequest;
 import org.apache.fineract.client.models.PostClientsClientIdIdentifiersResponse;
+import org.apache.fineract.client.models.PostClientsClientIdRequest;
 import org.apache.fineract.client.models.PostClientsClientIdResponse;
 import org.apache.fineract.client.models.PostClientsClientIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.PostClientsRequest;
 import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PutClientsClientIdRequest;
 import org.apache.fineract.client.models.PutClientsClientIdResponse;
 import org.apache.fineract.client.models.SortOrder;
 import org.apache.fineract.client.util.Calls;
@@ -111,6 +116,70 @@ public class ClientHelper {
         return Calls.ok(FineractClientHelper.getFineractClient().clients.createClient(request));
     }
 
+    public static PostClientsResponse addClientAsPerson(final String officeId, final Long legalFormId, final String externalId) {
+        PostClientsRequest request = new PostClientsRequest().officeId(officeId != null ? Long.parseLong(officeId) : 1L)
+                .legalFormId(legalFormId).firstname(Utils.randomFirstNameGenerator()).lastname(Utils.randomLastNameGenerator())
+                .externalId(externalId).dateFormat(Utils.DATE_FORMAT).locale("en").active(true).activationDate(DEFAULT_DATE);
+        return createClient(request);
+    }
+
+    public static GetClientsClientIdResponse getClientByExternalId(final String externalId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.retrieveOneClientByExternalId(externalId, null));
+    }
+
+    public static PutClientsClientIdResponse updateClientByExternalId(final String externalId, final PutClientsClientIdRequest request) {
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.updateClientByExternalId(externalId, request));
+    }
+
+    public static DeleteClientsClientIdResponse deleteClientByExternalId(final String externalId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.deleteClientByExternalId(externalId));
+    }
+
+    public static GetClientsClientIdAccountsResponse getClientAccounts(final String externalId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.retrieveAllClientAccountsByExternalId(externalId));
+    }
+
+    public static GetClientTransferProposalDateResponse getProposedTransferDate(final String externalId) {
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.retrieveClientTransferTemplateByExternalId(externalId));
+    }
+
+    public static List<GetObligeeData> getObligeeData(final String externalId) {
+        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "/obligeedetails?" + Utils.TENANT_IDENTIFIER;
+        final RequestSpecification requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON)
+                .addHeader("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey()).build();
+        final String response = Utils.performServerGet(requestSpec, new ResponseSpecBuilder().expectStatusCode(200).build(), url, null);
+        return GSON.fromJson(response, new TypeToken<List<GetObligeeData>>() {}.getType());
+    }
+
+    public static PostClientsClientIdResponse closeClient(final String externalId, final Integer closureReasonId) {
+        PostClientsClientIdRequest request = new PostClientsClientIdRequest().locale(CommonConstants.LOCALE)
+                .dateFormat(CommonConstants.DATE_FORMAT).closureDate(CREATED_DATE_PLUS_ONE).closureReasonId(closureReasonId.longValue());
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.handleCommandClientByExternalId(externalId, request,
+                CLOSE_CLIENT_COMMAND));
+    }
+
+    public static PostClientsClientIdResponse reactivateClient(final String externalId) {
+        PostClientsClientIdRequest request = new PostClientsClientIdRequest().locale(CommonConstants.LOCALE)
+                .dateFormat(CommonConstants.DATE_FORMAT).reactivationDate(CREATED_DATE_PLUS_ONE);
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.handleCommandClientByExternalId(externalId, request,
+                REACTIVATE_CLIENT_COMMAND));
+    }
+
+    public static PostClientsClientIdResponse rejectClient(final String externalId, final Integer rejectionReasonId) {
+        PostClientsClientIdRequest request = new PostClientsClientIdRequest().locale(CommonConstants.LOCALE)
+                .dateFormat(CommonConstants.DATE_FORMAT).rejectionDate(CREATED_DATE_PLUS_ONE)
+                .rejectionReasonId(rejectionReasonId.longValue());
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.handleCommandClientByExternalId(externalId, request,
+                REJECT_CLIENT_COMMAND));
+    }
+
+    public static PostClientsClientIdResponse activateClient(final String externalId, final String activationDate) {
+        PostClientsClientIdRequest request = new PostClientsClientIdRequest().locale(CommonConstants.LOCALE)
+                .dateFormat(CommonConstants.DATE_FORMAT).activationDate(activationDate);
+        return Calls.ok(FineractClientHelper.getFineractClient().clients.handleCommandClientByExternalId(externalId, request,
+                ACTIVATE_CLIENT_COMMAND));
+    }
+
     public PostClientsClientIdIdentifiersResponse createClientIdentifer(final Long clientId,
             final PostClientsClientIdIdentifiersRequest request) {
         return Calls.ok(FineractClientHelper.getFineractClient().clientIdentifiers.createClientIdentifier(clientId, request));
@@ -147,81 +216,10 @@ public class ClientHelper {
         return Calls.ok(FineractClientHelper.getFineractClient().clientSearchV2.searchClientsByText(request));
     }
 
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static PostClientsResponse addClientAsPerson(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String jsonPayload) {
-        final String response = Utils.performServerPost(requestSpec, responseSpec, CREATE_CLIENT_URL, jsonPayload);
-        log.info("{}", response);
-        return GSON.fromJson(response, PostClientsResponse.class);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static PutClientsClientIdResponse updateClient(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String externalId, final String jsonPayload) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerPut(requestSpec, responseSpec, url, jsonPayload);
-        log.info("{}", response);
-        return GSON.fromJson(response, PutClientsClientIdResponse.class);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static DeleteClientsClientIdResponse deleteClient(final RequestSpecification requestSpec,
-            final ResponseSpecification responseSpec, final String externalId) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerDelete(requestSpec, responseSpec, url, Utils.emptyJson(), null);
-        log.info("{}", response);
-        return GSON.fromJson(response, DeleteClientsClientIdResponse.class);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static GetClientsClientIdAccountsResponse getClientAccounts(final RequestSpecification requestSpec,
-            final ResponseSpecification responseSpec, final String externalId) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "/accounts?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerGet(requestSpec, responseSpec, url);
-        log.info("{}", response);
-        return GSON.fromJson(response, GetClientsClientIdAccountsResponse.class);
-    }
-
     public static String getClientAccountsRaw(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final long clientId) {
         final String url = CLIENT_URL + "/" + clientId + "/accounts?" + Utils.TENANT_IDENTIFIER;
         return Utils.performServerGet(requestSpec, responseSpec, url);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static GetClientTransferProposalDateResponse getProposedTransferDate(final RequestSpecification requestSpec,
-            final ResponseSpecification responseSpec, final String externalId) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "/transferproposaldate?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerGet(requestSpec, responseSpec, url);
-        log.info("{}", response);
-        return GSON.fromJson(response, GetClientTransferProposalDateResponse.class);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static List<GetObligeeData> getObligeeData(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String externalId) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "/obligeedetails?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerGet(requestSpec, responseSpec, url);
-        log.info("{}", response);
-        return GSON.fromJson(response, new TypeToken<List<GetObligeeData>>() {}.getType());
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -470,19 +468,6 @@ public class ClientHelper {
     // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
     // org.apache.fineract.client.models.PostLoansLoanIdRequest)
     @Deprecated(forRemoval = true)
-    public static String getBasicClientAsJSON(final String officeId, final Long legalFormId, final String externalId) {
-        HashMap<String, Object> map = setInitialClientValues(officeId, legalFormId, externalId);
-        map.put("active", "true");
-        map.put("activationDate", DEFAULT_DATE);
-        final String basicClientAsJson = GSON.toJson(map);
-        log.info("Client JSON :  {}", basicClientAsJson);
-        return basicClientAsJson;
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
     public static String getTestClientAsJSON(final String dateOfJoining, final String officeId) {
         HashMap<String, Object> map = setInitialClientValues(officeId, LEGALFORM_ID_PERSON);
         map.put("active", "true");
@@ -648,17 +633,6 @@ public class ClientHelper {
             final int clientId) {
         String clientResponseStr = (String) getClient(requestSpec, responseSpec, Integer.toString(clientId), null);
         return GSON.fromJson(clientResponseStr, GetClientsClientIdResponse.class);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static GetClientsClientIdResponse getClientByExternalId(final RequestSpecification requestSpec,
-            final ResponseSpecification responseSpec, final String externalId) {
-        final String url = CLIENT_EXTERNALID_URL + "/" + externalId + "?" + Utils.TENANT_IDENTIFIER;
-        final String response = Utils.performServerGet(requestSpec, responseSpec, url);
-        return GSON.fromJson(response, GetClientsClientIdResponse.class);
     }
 
     // TODO: Rewrite to use fineract-client instead!


### PR DESCRIPTION
## What this PR does
Migrates `ClientExternalIdTest` from the deprecated RestAssured-based helpers to the typed fineract-client-feign client, as part of **FINERACT-2549**.

## Changes
- **ClientHelper**: Added no-arg feign-based helper methods — `addClientAsPerson()`, `getClientByExternalId()`, `updateClientByExternalId()`, `deleteClientByExternalId()`, `getClientAccounts()`, `getProposedTransferDate()`, and `getObligeeData()` — using `FineractClientHelper` and `Calls.ok()`
- **ClientExternalIdTest**: Removed all RestAssured boilerplate (`requestSpec`, `responseSpec`, `getBasicClientAsJSON()`); migrated all client create/get/update/delete calls to the new feign-based helpers; replaced manual JSON payload construction with typed request objects (e.g. `PutClientsClientIdRequest`)
- **SearchResourcesTest**: Migrated `addClientAsPerson` calls to feign-based helpers
- **LoanAccountsContainsCurrencyFieldTest**: Migrated `addClientAsPerson` and `getClientAccounts` calls to feign-based helpers
- Deleted 8 deprecated `@Deprecated(forRemoval = true)` RestAssured methods from `ClientHelper`

## Checklist
- [x] `./gradlew spotlessApply` passed
- [x] `./gradlew :integration-tests:compileTestJava` passed
- [x] No new RestAssured dependencies introduced

Part of FINERACT-2549
Related to FINERACT-2454

gsoc-fineract-evidence