### PR TITLE
FINERACT-2454: Migrate LoanWithdrawnByApplicantIntegrationTest from RestAssured to feign client

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanWithdrawnByApplicantIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanWithdrawnByApplicantIntegrationTest.java
@@ -18,85 +18,44 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import org.apache.fineract.client.models.PostClientsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@SuppressWarnings("rawtypes")
-@ExtendWith(LoanTestLifecycleExtension.class)
-public class LoanWithdrawnByApplicantIntegrationTest {
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-    }
+public class LoanWithdrawnByApplicantIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void loanWithdrawnByApplicant() {
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final Integer loanProductID = this.loanTransactionHelper.getLoanProductId(new LoanProductTestBuilder().build(null));
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long clientId = ClientHelper.createClient(new PostClientsRequest() //
+                .officeId(1L) //
+                .legalFormId(1L) //
+                .firstname(Utils.randomFirstNameGenerator()) //
+                .lastname(Utils.randomLastNameGenerator()) //
+                .active(true) //
+                .activationDate("01 January 2012") //
+                .dateFormat(Utils.DATE_FORMAT) //
+                .locale("en")) //
+                .getResourceId();
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        final Long loanProductId = loanTransactionHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()) //
+                .getResourceId();
 
-        this.loanTransactionHelper.withdrawLoanApplicationByClient("03 April 2012", loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, loanID);
-        LoanStatusChecker.verifyLoanAccountIsNotActive(loanStatusHashMap);
+        final PostLoansResponse loanResponse = loanTransactionHelper
+                .applyLoan(applyLoanRequest(clientId, loanProductId, "04 April 2012", 5000.0, 5));
+        final Long loanId = loanResponse.getLoanId();
 
-    }
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
 
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
+        loanTransactionHelper.withdrawnByApplicantLoan(loanId, //
+                new PostLoansLoanIdRequest() //
+                        .withdrawnOnDate("05 April 2012") //
+                        .dateFormat(Utils.DATE_FORMAT) //
+                        .locale("en"));
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<String, String>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID) {
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-        final String loanApplication = new LoanApplicationTestBuilder().withPrincipal("5000").withLoanTermFrequency("5")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("5").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withExpectedDisbursementDate("04 April 2012")
-                .withCollaterals(collaterals).withSubmittedOnDate("02 April 2012")
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return this.loanTransactionHelper.getLoanId(loanApplication);
+        verifyLoanStatus(loanId, LoanStatus.WITHDRAWN_BY_CLIENT);
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -20,8 +20,8 @@ package org.apache.fineract.integrationtests.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -2972,6 +2972,10 @@ public class LoanTransactionHelper {
         return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "reject"));
     }
 
+    public PostLoansLoanIdResponse withdrawnByApplicantLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "withdrawnByApplicant"));
+    }
+
     public PostLoansLoanIdResponse withdrawnByApplicantLoan(String loanExternalId, PostLoansLoanIdRequest request) {
         return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request,
                 "withdrawnByApplicant"));


### PR DESCRIPTION
## Description

Closes/relates to [FINERACT-2454](https://issues.apache.org/jira/browse/FINERACT-2454)

Migrates `LoanWithdrawnByApplicantIntegrationTest` from RestAssured to the type-safe feign client, as part of the ongoing test migration effort.

## Changes

- Replaced `RequestSpecification`/`ResponseSpecification` boilerplate with `extends BaseLoanIntegrationTest`
- Removed `@BeforeEach` setup — lifecycle managed by `BaseLoanIntegrationTest`
- Replaced `ClientHelper.createClient(requestSpec, responseSpec, ...)` → `ClientHelper.createClient(PostClientsRequest)`
- Replaced `LoanProductTestBuilder` → `createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()`
- Replaced `LoanApplicationTestBuilder` + `CollateralManagementHelper` (no feign equivalent) → `applyLoan(applyLoanRequest(...))`
- Replaced `LoanStatusChecker` HashMap-based assertions → `verifyLoanStatus(loanId, LoanStatus.*)`
- Replaced `withdrawLoanApplicationByClient()` → `withdrawnByApplicantLoan(externalId, PostLoansLoanIdRequest)`

## Result

102 lines → 60 lines. Zero RestAssured imports remaining.

No behavioral changes — the test still verifies that a pending loan application can be withdrawn by the applicant and transitions to `WITHDRAWN_BY_CLIENT` status.