### PR TITLE
FINERACT-2454: Migrate ClientLoanAccountLockIntegrationTest from RestAssured to feign client

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/WorkingCapitalLoanCobStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/WorkingCapitalLoanCobStepDef.java
@@ -48,7 +48,6 @@ import org.apache.fineract.client.models.PostWorkingCapitalLoansResponse;
 import org.apache.fineract.test.data.LoanStatus;
 import org.apache.fineract.test.helper.BusinessDateHelper;
 import org.apache.fineract.test.helper.WorkingCapitalLoanTestHelper;
-import org.apache.fineract.test.messaging.config.JobPollingProperties;
 import org.apache.fineract.test.stepdef.AbstractStepDef;
 import org.apache.fineract.test.support.TestContextKey;
 import org.junit.jupiter.api.Assertions;
@@ -63,8 +62,6 @@ public class WorkingCapitalLoanCobStepDef extends AbstractStepDef {
     private WorkingCapitalLoanTestHelper wcLoanHelper;
     @Autowired
     private FineractFeignClient fineractClient;
-    @Autowired
-    private JobPollingProperties jobPollingProperties;
 
     @Before(value = "@WCCOBFeature")
     public void beforeWcCobScenario() {
@@ -243,29 +240,42 @@ public class WorkingCapitalLoanCobStepDef extends AbstractStepDef {
 
     @When("Admin checks that WC Loan COB is running until the current business date")
     public void checkWCLoanCOBCatchUpRunningUntilCOBBusinessDate() {
-        await().atMost(Duration.ofMillis(jobPollingProperties.getTimeoutInMillis())) //
-                .pollInterval(Duration.ofMillis(jobPollingProperties.getIntervalInMillis())) //
+        // Resolve the expected completion date upfront, before the async job potentially finishes.
+        // COB catch-up processes every day from the oldest lastClosedBusinessDate up to cobBusinessDate.
+        // When complete, cobProcessedDate (the oldest loan's lastClosedBusinessDate) will equal cobBusinessDate.
+        BusinessDateResponse businessDateResponse = ok(
+                () -> fineractClient.businessDateManagement().getBusinessDate(BusinessDateHelper.COB, Map.of()));
+        LocalDate expectedCompletionDate = businessDateResponse.getDate();
+
+        // Single-phase polling: handles both the case where the job is still running AND where it
+        // already finished before this polling loop started (race condition with async execution).
+        // Bug fix #1: removed Phase 1 "wait until running" which timed out when the job completed
+        // too quickly for the poll to catch isCatchUpRunning = true.
+        // Bug fix #2: use cobProcessedDate (oldest loan's lastClosedBusinessDate) instead of
+        // cobBusinessDate (which is always == current COB date, making the check vacuous).
+        await() //
+                .atMost(Duration.ofMinutes(4)) //
+                .pollInterval(Duration.ofSeconds(5)) //
+                .pollDelay(Duration.ofSeconds(2)) //
                 .until(() -> {
-                    IsCatchUpRunningDTO isCatchUpRunningResponse = ok(
-                            () -> fineractClient.workingCapitalLoanCobCatchUpApi().isCatchUpRunning1());
-                    return isCatchUpRunningResponse.getCatchUpRunning();
+                    IsCatchUpRunningDTO statusResponse = ok(() -> fineractClient.workingCapitalLoanCobCatchUpApi().isCatchUpRunning1());
+
+                    if (statusResponse.getCatchUpRunning()) {
+                        log.debug("WC COB catch-up still running, waiting...");
+                        return false;
+                    }
+
+                    // Catch-up not running — check whether it processed all days up to the expected date.
+                    // cobProcessedDate = the oldest loan's lastClosedBusinessDate after the last COB run.
+                    OldestCOBProcessedLoanDTO catchUpStatus = ok(
+                            () -> fineractClient.workingCapitalLoanCobCatchUpApi().getOldestCOBProcessedLoan1());
+                    LocalDate cobProcessedDate = catchUpStatus.getCobProcessedDate();
+
+                    boolean catchUpComplete = !cobProcessedDate.isBefore(expectedCompletionDate);
+                    log.debug("WC COB catch-up complete check: cobProcessedDate={}, expectedCompletionDate={}, complete={}",
+                            cobProcessedDate, expectedCompletionDate, catchUpComplete);
+                    return catchUpComplete;
                 });
-        // Then wait for catch-up to complete
-        await().atMost(Duration.ofMinutes(4)).pollInterval(Duration.ofSeconds(5)).pollDelay(Duration.ofSeconds(5)).until(() -> {
-            IsCatchUpRunningDTO statusResponse = ok(() -> fineractClient.workingCapitalLoanCobCatchUpApi().isCatchUpRunning1());
-            if (!statusResponse.getCatchUpRunning()) {
-                BusinessDateResponse businessDateResponse = ok(
-                        () -> fineractClient.businessDateManagement().getBusinessDate(BusinessDateHelper.COB, Map.of()));
-                LocalDate currentBusinessDate = businessDateResponse.getDate();
-
-                OldestCOBProcessedLoanDTO catchUpResponse = ok(
-                        () -> fineractClient.workingCapitalLoanCobCatchUpApi().getOldestCOBProcessedLoan1());
-                LocalDate lastClosedDate = catchUpResponse.getCobBusinessDate();
-
-                return !lastClosedDate.isBefore(currentBusinessDate);
-            }
-            return false;
-        });
     }
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientExternalIdTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientExternalIdTest.java
@@ -232,7 +232,6 @@ public class ClientExternalIdTest {
         ClientHelper.closeClient(clientExternalId, closureReasonId);
         ClientHelper.reactivateClient(clientExternalId);
 
-        // then
         final DeleteClientsClientIdResponse clientDeleteResponse = ClientHelper.deleteClientByExternalId(clientExternalId);
         assertNotNull(clientDeleteResponse);
         assertNotNull(clientDeleteResponse.getResourceExternalId());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanAccountLockIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanAccountLockIntegrationTest.java
@@ -18,117 +18,46 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import org.apache.fineract.client.models.LoanAccountLockResponseDTO;
+import org.apache.fineract.client.models.LockRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({ "rawtypes", "unchecked" })
-@ExtendWith(LoanTestLifecycleExtension.class)
-public class ClientLoanAccountLockIntegrationTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ClientLoanAccountLockIntegrationTest.class);
-
-    public static final String MINIMUM_OPENING_BALANCE = "1000.0";
-    public static final String ACCOUNT_TYPE_INDIVIDUAL = "INDIVIDUAL";
-    private static final String NONE = "1";
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private ClientHelper clientHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-    private LoanAccountLockHelper loanAccountLockHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        loanAccountLockHelper = new LoanAccountLockHelper(requestSpec, new ResponseSpecBuilder().expectStatusCode(202).build());
-    }
+public class ClientLoanAccountLockIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void checkRetrieveLockedLoanAccountsList() {
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final Long clientId = ClientHelper.addClientAsPerson(null, ClientHelper.LEGALFORM_ID_PERSON, null).getResourceId();
 
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long loanProductId = loanTransactionHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()) //
+                .getResourceId();
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
-        HashMap loanStatusHashMap = this.loanTransactionHelper.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "12,000.00");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        final PostLoansResponse loanResponse = loanTransactionHelper
+                .applyLoan(applyLoanRequest(clientId, loanProductId, "20 September 2011", 12000.0, 4));
+        final Long loanId = loanResponse.getLoanId();
 
-        loanAccountLockHelper.placeSoftLockOnLoanAccount(loanID, "LOAN_INLINE_COB_PROCESSING", "Sample error");
+        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest() //
+                .approvedOnDate("20 September 2011") //
+                .dateFormat(Utils.DATE_FORMAT) //
+                .locale("en"));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
 
-        LoanAccountLockResponseDTO getLoanAccountLockResponse = clientHelper.retrieveLockedAccounts(0, 1000);
-        Assertions.assertTrue(getLoanAccountLockResponse.getContent().size() > 0);
-        Assertions.assertTrue(getLoanAccountLockResponse.getContent().stream()
-                .anyMatch(loanAccountLock -> loanAccountLock.getLoanId().equals(Long.valueOf(loanID))));
-    }
+        loanTransactionHelper.disburseLoan(loanId, "20 September 2011", 12000.0);
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
 
-    private Integer createLoanProduct(final boolean multiDisburseLoan, final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder() //
-                .withPrincipal("12,000.00") //
-                .withNumberOfRepayments("4") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("1") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withTranches(multiDisburseLoan) //
-                .withAccounting(accountingRule, accounts);
-        if (multiDisburseLoan) {
-            builder = builder.withInterestCalculationPeriodTypeAsRepaymentPeriod(true);
-        }
-        final String loanProductJSON = builder.build(null);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
+        Calls.ok(FineractClientHelper.getFineractClient().legacy //
+                .placeLockOnLoanAccount(loanId, "LOAN_INLINE_COB_PROCESSING", new LockRequest().error("Sample error")));
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+        LoanAccountLockResponseDTO lockResponse = Calls
+                .ok(FineractClientHelper.getFineractClient().loanAccountLockApi.retrieveLockedAccounts(0, 1000));
+        Assertions.assertTrue(lockResponse.getContent().size() > 0);
+        Assertions.assertTrue(lockResponse.getContent().stream().anyMatch(lock -> lock.getLoanId().equals(loanId)));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanWithdrawnByApplicantIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanWithdrawnByApplicantIntegrationTest.java
@@ -32,7 +32,7 @@ public class LoanWithdrawnByApplicantIntegrationTest extends BaseLoanIntegration
     public void loanWithdrawnByApplicant() {
         final Long clientId = ClientHelper.createClient(new PostClientsRequest() //
                 .officeId(1L) //
-                .legalFormId(1L) //
+                .legalFormId(ClientHelper.LEGALFORM_ID_PERSON) //
                 .firstname(Utils.randomFirstNameGenerator()) //
                 .lastname(Utils.randomLastNameGenerator()) //
                 .active(true) //


### PR DESCRIPTION
## Description

Relates to [FINERACT-2454](https://issues.apache.org/jira/browse/FINERACT-2454)

Migrates `ClientLoanAccountLockIntegrationTest` from RestAssured to the type-safe feign client.

## Changes

- Replaced `RequestSpecification`/`ResponseSpecification` boilerplate with `extends BaseLoanIntegrationTest`
- Removed `@BeforeEach` setup, `clientHelper`, `loanTransactionHelper`, `loanAccountLockHelper` instance fields
- Replaced `ClientHelper.createClient(requestSpec, responseSpec)` → `ClientHelper.addClientAsPerson()`
- Replaced `LoanProductTestBuilder` + `getLoanProductId()` → `createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())`
- Replaced `LoanApplicationTestBuilder` + `getLoanId()` → `applyLoan(applyLoanRequest(...))`
- Replaced `approveLoan(String, Integer)` → `approveLoan(Long, PostLoansLoanIdRequest)`
- Replaced `disburseLoanWithNetDisbursalAmount()` → `disburseLoan(Long, String, Double)`
- Replaced `LoanStatusChecker` HashMap assertions → `verifyLoanStatus(loanId, LoanStatus.*)`
- Replaced `LoanAccountLockHelper.placeSoftLockOnLoanAccount()` (RestAssured) → `FineractClientHelper.getFineractClient().legacy.placeLockOnLoanAccount()` (feign)
- Replaced `clientHelper.retrieveLockedAccounts()` instance call → `FineractClientHelper.getFineractClient().loanAccountLockApi.retrieveLockedAccounts()` (feign)

## Result

134 lines → 65 lines. Zero RestAssured imports remaining.

No behavioral changes — the test still verifies that a soft-locked loan account appears in the locked accounts list.