### PR TITLE
FINERACT-2543: Fix SBOM generation errors and issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -917,6 +917,7 @@ cyclonedxBom {
 
 tasks.withType(org.cyclonedx.gradle.CyclonedxDirectTask).configureEach {
     includeMetadataResolution.set(false)
+    skipConfigs.set(['.*eclipse.*', '.*swt.*'])
 }
 
 tasks.register('printSourceSetInformation') {


### PR DESCRIPTION
## JIRA

https://issues.apache.org/jira/browse/FINERACT-2543

## Problem

SBOM generation fails with the following error:

'dependencies.dependency.artifactId' for 
org.eclipse.platform:org.eclipse.swt.${osgi.platform}:jar 
does not match a valid id pattern.

This occurs because org.eclipse.swt uses a platform-specific 
artifact ID containing ${osgi.platform} — a Maven property 
that the CycloneDX plugin cannot resolve when building the 
effective POM.

## Fix

Added skipConfigs to exclude eclipse and swt related 
configurations from SBOM metadata resolution in the 
CyclonedxDirectTask configuration in build.gradle.

## Changes

- **build.gradle**: Added `skipConfigs.set(['.*eclipse.*', 
  '.*swt.*'])` to the `CyclonedxDirectTask` configuration 
  to skip unresolvable eclipse/swt dependencies during 
  SBOM generation.

## Testing

Run the following to verify the fix:
gradlew.bat cyclonedxBom

The task should now complete without the 
IllegalStateException for org.eclipse.swt.