### PR TITLE
FINERACT-2505: Fix bulk import output template download using wrong e…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResource.java
@@ -102,13 +102,16 @@ public class BulkImportApiResource {
     @Path("downloadOutputTemplate")
     @Produces("application/vnd.ms-excel")
     public Response getOutputTemplate(@QueryParam("importDocumentId") final Long importDocumentId) {
-        // TODO: can we avoid 2 calls by introducing a new function? clean code more important now
-        final var docs = documentReadPlatformService.retrieveAllDocuments("IMPORT", importDocumentId);
-
-        final var docData = docs.stream().findFirst();
-
-        final var d = docData.orElseThrow(() -> new DocumentNotFoundException("IMPORT", importDocumentId, -1L));
-        final var content = documentReadPlatformService.retrieveDocumentContent(d.getParentEntityType(), d.getParentEntityId(), d.getId());
+        final var importData = bulkImportWorkbookService.getImport(importDocumentId);
+        if (importData == null) {
+            throw new DocumentNotFoundException("IMPORT", importDocumentId, -1L);
+        }
+        final var doc = documentReadPlatformService.retrieveDocument(importData.getDocumentId());
+        if (doc == null) {
+            throw new DocumentNotFoundException("IMPORT", importDocumentId, importData.getDocumentId());
+        }
+        final var content = documentReadPlatformService.retrieveDocumentContent(doc.getParentEntityType(), doc.getParentEntityId(),
+                doc.getId());
         final var streamResponseData = StreamResponseUtil.StreamResponseData.builder().type(content.getContentType())
                 .fileName(content.getFileName()).stream(content.getStream()).dispositionType(DISPOSITION_TYPE_ATTACHMENT).build();
 

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResourceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/api/BulkImportApiResourceTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.bulkimport.api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import org.apache.fineract.infrastructure.bulkimport.data.ImportData;
+import org.apache.fineract.infrastructure.bulkimport.service.BulkImportWorkbookService;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.documentmanagement.data.DocumentContent;
+import org.apache.fineract.infrastructure.documentmanagement.data.DocumentData;
+import org.apache.fineract.infrastructure.documentmanagement.exception.DocumentNotFoundException;
+import org.apache.fineract.infrastructure.documentmanagement.service.DocumentReadPlatformService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BulkImportApiResourceTest {
+
+    @Mock
+    private BulkImportWorkbookService bulkImportWorkbookService;
+
+    @Mock
+    private DocumentReadPlatformService documentReadPlatformService;
+
+    @Mock
+    private DefaultToApiJsonSerializer bulkImportSerializer;
+
+    @Mock
+    private ApiRequestParameterHelper apiRequestParameterHelper;
+
+    @InjectMocks
+    private BulkImportApiResource underTest;
+
+    @Test
+    void getOutputTemplate_success() {
+        Long importDocumentId = 2L;
+        Long documentId = 10L;
+
+        ImportData importData = ImportData.instance(importDocumentId, documentId, null, null, false, "file.xls", 1L, 1, 0, 0);
+
+        DocumentData documentData = DocumentData.builder().id(documentId).parentEntityType("IMPORT").parentEntityId(1L).fileName("file.xls")
+                .build();
+
+        DocumentContent documentContent = DocumentContent.builder().fileName("file.xls").contentType("application/vnd.ms-excel")
+                .stream(new ByteArrayInputStream(new byte[] { 1, 2, 3 })).build();
+
+        when(bulkImportWorkbookService.getImport(importDocumentId)).thenReturn(importData);
+        when(documentReadPlatformService.retrieveDocument(documentId)).thenReturn(documentData);
+        when(documentReadPlatformService.retrieveDocumentContent("IMPORT", 1L, documentId)).thenReturn(documentContent);
+
+        underTest.getOutputTemplate(importDocumentId);
+
+        verify(bulkImportWorkbookService).getImport(importDocumentId);
+        verify(documentReadPlatformService).retrieveDocument(documentId);
+        verify(documentReadPlatformService).retrieveDocumentContent("IMPORT", 1L, documentId);
+    }
+
+    @Test
+    void getOutputTemplate_importNotFound_throwsDocumentNotFoundException() {
+        Long importDocumentId = 99L;
+        when(bulkImportWorkbookService.getImport(importDocumentId)).thenReturn(null);
+
+        assertThatThrownBy(() -> underTest.getOutputTemplate(importDocumentId)).isInstanceOf(DocumentNotFoundException.class);
+
+        verifyNoInteractions(documentReadPlatformService);
+    }
+
+    @Test
+    void getOutputTemplate_documentNotFound_throwsDocumentNotFoundException() {
+        Long importDocumentId = 2L;
+        Long documentId = 10L;
+
+        ImportData importData = ImportData.instance(importDocumentId, documentId, null, null, false, "file.xls", 1L, 1, 0, 0);
+
+        when(bulkImportWorkbookService.getImport(importDocumentId)).thenReturn(importData);
+        when(documentReadPlatformService.retrieveDocument(documentId)).thenReturn(null);
+
+        assertThatThrownBy(() -> underTest.getOutputTemplate(importDocumentId)).isInstanceOf(DocumentNotFoundException.class);
+
+        verify(documentReadPlatformService).retrieveDocument(documentId);
+    }
+
+    @Test
+    void getOutputTemplate_usesDocumentIdFromImportData_notImportDocumentId() {
+        Long importDocumentId = 5L;
+        Long documentId = 10L;
+
+        ImportData importData = ImportData.instance(importDocumentId, documentId, null, null, false, "file.xls", 1L, 1, 0, 0);
+
+        DocumentData documentData = DocumentData.builder().id(documentId).parentEntityType("IMPORT").parentEntityId(1L).fileName("file.xls")
+                .build();
+
+        DocumentContent documentContent = DocumentContent.builder().fileName("file.xls").contentType("application/vnd.ms-excel")
+                .stream(new ByteArrayInputStream(new byte[0])).build();
+
+        when(bulkImportWorkbookService.getImport(importDocumentId)).thenReturn(importData);
+        when(documentReadPlatformService.retrieveDocument(documentId)).thenReturn(documentData);
+        when(documentReadPlatformService.retrieveDocumentContent("IMPORT", 1L, documentId)).thenReturn(documentContent);
+
+        underTest.getOutputTemplate(importDocumentId);
+
+        verify(documentReadPlatformService).retrieveDocument(documentId);
+        verify(documentReadPlatformService).retrieveDocumentContent("IMPORT", 1L, documentId);
+    }
+}


### PR DESCRIPTION
## Description

Fixed getOutputTemplate in BulkImportApiResource which was returning 404 because it searched for the document by importDocumentId instead of the actual document_id stored in m_import_document.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
