### PR TITLE
FINERACT-1152: Use projected schedule to validate EMI end date in loan reschedule

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResourceSwagger.java
@@ -194,6 +194,10 @@ final class RescheduleLoansApiResourceSwagger {
         public BigDecimal newInterestRate;
         @Schema(example = "20 September 2011")
         public String rescheduleFromDate;
+        @Schema(example = "20 September 2011")
+        public String endDate;
+        @Schema(example = "100.0")
+        public BigDecimal emi;
         @Schema(example = "comment")
         public String rescheduleReasonComment;
         @Schema(example = "1")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImpl.java
@@ -98,7 +98,7 @@ public class LoanRescheduleRequestDataValidatorImpl implements LoanRescheduleReq
         }
     }
 
-    public static void validateEMIAndEndDate(FromJsonHelper fromJsonHelper, Loan loan, JsonElement jsonElement,
+    public static void validateEMIAndEndDate(FromJsonHelper fromJsonHelper, JsonElement jsonElement, LocalDate rescheduleFromDate,
             DataValidatorBuilder dataValidatorBuilder) {
         final LocalDate endDate = fromJsonHelper.extractLocalDateNamed(RescheduleLoansApiConstants.endDateParamName, jsonElement);
         final BigDecimal emi = fromJsonHelper.extractBigDecimalWithLocaleNamed(RescheduleLoansApiConstants.emiParamName, jsonElement);
@@ -106,13 +106,9 @@ public class LoanRescheduleRequestDataValidatorImpl implements LoanRescheduleReq
             dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName).value(endDate).notNull();
             dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.emiParamName).value(emi).notNull().positiveAmount();
 
-            if (endDate != null) {
-                LoanRepaymentScheduleInstallment endInstallment = loan.fetchLoanRepaymentScheduleInstallmentByDueDate(endDate);
-
-                if (endInstallment == null) {
-                    dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName)
-                            .failWithCode("repayment.schedule.installment.does.not.exist", "Repayment schedule installment does not exist");
-                }
+            if (endDate != null && DateUtils.isBefore(endDate, rescheduleFromDate)) {
+                dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName)
+                        .failWithCode("end.date.before.reschedule.from.date", "End date cannot be before the reschedule from date");
             }
         }
     }
@@ -272,7 +268,7 @@ public class LoanRescheduleRequestDataValidatorImpl implements LoanRescheduleReq
             validateRescheduleReasonId(fromJsonHelper, jsonElement, dataValidatorBuilder);
             validateRescheduleReasonComment(fromJsonHelper, jsonElement, dataValidatorBuilder);
             validateAndRetrieveAdjustedDate(fromJsonHelper, jsonElement, rescheduleFromDate, dataValidatorBuilder);
-            validateEMIAndEndDate(fromJsonHelper, loan, jsonElement, dataValidatorBuilder);
+            validateEMIAndEndDate(fromJsonHelper, jsonElement, rescheduleFromDate, dataValidatorBuilder);
             validateIsThereAnyIncomingChange(fromJsonHelper, jsonElement, dataValidatorBuilder);
             validateMultiDisburseLoan(loan, dataValidatorBuilder);
 

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImplTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/data/LoanRescheduleRequestDataValidatorImplTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.rescheduleloan.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansApiConstants;
+import org.junit.jupiter.api.Test;
+
+class LoanRescheduleRequestDataValidatorImplTest {
+
+    @Test
+    void validateEMIAndEndDateShouldFailWhenEndDateBeforeRescheduleFromDate() {
+        FromJsonHelper fromJsonHelper = mock(FromJsonHelper.class);
+        JsonElement jsonElement = mock(JsonElement.class);
+        LocalDate rescheduleFromDate = LocalDate.of(2026, 3, 10);
+        LocalDate endDate = LocalDate.of(2026, 3, 9);
+
+        when(fromJsonHelper.extractLocalDateNamed(RescheduleLoansApiConstants.endDateParamName, jsonElement)).thenReturn(endDate);
+        when(fromJsonHelper.extractBigDecimalWithLocaleNamed(RescheduleLoansApiConstants.emiParamName, jsonElement))
+                .thenReturn(BigDecimal.valueOf(100));
+
+        List<ApiParameterError> errors = new ArrayList<>();
+        DataValidatorBuilder dataValidatorBuilder = new DataValidatorBuilder(errors).resource("loanreschedule");
+
+        LoanRescheduleRequestDataValidatorImpl.validateEMIAndEndDate(fromJsonHelper, jsonElement, rescheduleFromDate, dataValidatorBuilder);
+
+        assertEquals(1, errors.size());
+        assertEquals(RescheduleLoansApiConstants.endDateParamName, errors.getFirst().getParameterName());
+        assertTrue(errors.getFirst().getUserMessageGlobalisationCode().contains("end.date.before.reschedule.from.date"));
+    }
+
+    @Test
+    void validateEMIAndEndDateShouldAllowNonInstallmentEndDate() {
+        FromJsonHelper fromJsonHelper = mock(FromJsonHelper.class);
+        JsonElement jsonElement = mock(JsonElement.class);
+        LocalDate rescheduleFromDate = LocalDate.of(2026, 3, 10);
+        LocalDate endDate = LocalDate.of(2026, 4, 13);
+
+        when(fromJsonHelper.extractLocalDateNamed(RescheduleLoansApiConstants.endDateParamName, jsonElement)).thenReturn(endDate);
+        when(fromJsonHelper.extractBigDecimalWithLocaleNamed(RescheduleLoansApiConstants.emiParamName, jsonElement))
+                .thenReturn(BigDecimal.valueOf(100));
+
+        List<ApiParameterError> errors = new ArrayList<>();
+        DataValidatorBuilder dataValidatorBuilder = new DataValidatorBuilder(errors).resource("loanreschedule");
+
+        LoanRescheduleRequestDataValidatorImpl.validateEMIAndEndDate(fromJsonHelper, jsonElement, rescheduleFromDate, dataValidatorBuilder);
+
+        assertTrue(errors.isEmpty());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
@@ -68,6 +69,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepayme
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepaymentScheduleHistoryRepository;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGenerator;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGeneratorFactory;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.service.LoanScheduleHistoryWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.mapper.LoanTermVariationsMapper;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansApiConstants;
@@ -253,34 +255,22 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
             List<LoanRescheduleRequestToTermVariationMapping> loanRescheduleRequestToTermVariationMappings, final Boolean isActive,
             final boolean isSpecificToInstallment, BigDecimal decimalValue, LocalDate dueDate, LocalDate endDate, BigDecimal emi) {
 
-        if (rescheduleFromDate != null && endDate != null && emi != null) {
-            LoanTermVariations parent = null;
-            final Integer termType = LoanTermVariationType.EMI_AMOUNT.getValue();
-            List<LoanRepaymentScheduleInstallment> installments = loan.getRepaymentScheduleInstallments();
-            for (LoanRepaymentScheduleInstallment installment : installments) {
-                if (!DateUtils.isBefore(installment.getDueDate(), rescheduleFromDate)
-                        && !DateUtils.isAfter(installment.getDueDate(), endDate)) {
-                    createLoanTermVariations(loanRescheduleRequest, termType, loan, installment.getDueDate(), installment.getDueDate(),
-                            loanRescheduleRequestToTermVariationMappings, isActive, true, emi, parent);
-                }
-                if (DateUtils.isAfter(installment.getDueDate(), endDate)) {
-                    break;
-                }
-            }
-        }
+        List<LoanTermVariations> pendingRescheduleVariations = new ArrayList<>();
 
         if (rescheduleFromDate != null && adjustedDueDate != null) {
             LoanTermVariations parent = null;
             final Integer termType = LoanTermVariationType.DUE_DATE.getValue();
-            createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate, adjustedDueDate,
-                    loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, decimalValue, parent);
+            LoanTermVariations loanTermVariation = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate,
+                    adjustedDueDate, loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, decimalValue, parent);
+            pendingRescheduleVariations.add(loanTermVariation);
         }
 
         if (rescheduleFromDate != null && interestRate != null) {
             LoanTermVariations parent = null;
             final Integer termType = LoanTermVariationType.INTEREST_RATE_FROM_INSTALLMENT.getValue();
-            createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate, dueDate,
-                    loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, interestRate, parent);
+            LoanTermVariations loanTermVariation = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate,
+                    dueDate, loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, interestRate, parent);
+            pendingRescheduleVariations.add(loanTermVariation);
         }
 
         if (rescheduleFromDate != null && graceOnPrincipal != null) {
@@ -289,30 +279,109 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
             parent = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate, dueDate,
                     loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, BigDecimal.valueOf(graceOnPrincipal),
                     parent);
+            pendingRescheduleVariations.add(parent);
 
             BigDecimal extraTermsBasedOnGracePeriods = BigDecimal.valueOf(graceOnPrincipal);
-            createLoanTermVariations(loanRescheduleRequest, LoanTermVariationType.EXTEND_REPAYMENT_PERIOD.getValue(), loan,
-                    rescheduleFromDate, dueDate, loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment,
-                    extraTermsBasedOnGracePeriods, parent);
+            LoanTermVariations extraTermsVariation = createLoanTermVariations(loanRescheduleRequest,
+                    LoanTermVariationType.EXTEND_REPAYMENT_PERIOD.getValue(), loan, rescheduleFromDate, dueDate,
+                    loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, extraTermsBasedOnGracePeriods, parent);
+            pendingRescheduleVariations.add(extraTermsVariation);
 
         }
 
         if (rescheduleFromDate != null && graceOnInterest != null) {
             LoanTermVariations parent = null;
             final Integer termType = LoanTermVariationType.GRACE_ON_INTEREST.getValue();
-            createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate, dueDate,
-                    loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, BigDecimal.valueOf(graceOnInterest),
-                    parent);
+            LoanTermVariations loanTermVariation = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate,
+                    dueDate, loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment,
+                    BigDecimal.valueOf(graceOnInterest), parent);
+            pendingRescheduleVariations.add(loanTermVariation);
         }
 
         if (rescheduleFromDate != null && extraTerms != null) {
             LoanTermVariations parent = null;
             final Integer termType = LoanTermVariationType.EXTEND_REPAYMENT_PERIOD.getValue();
-            createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate, dueDate,
-                    loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment, BigDecimal.valueOf(extraTerms),
-                    parent);
+            LoanTermVariations loanTermVariation = createLoanTermVariations(loanRescheduleRequest, termType, loan, rescheduleFromDate,
+                    dueDate, loanRescheduleRequestToTermVariationMappings, isActive, isSpecificToInstallment,
+                    BigDecimal.valueOf(extraTerms), parent);
+            pendingRescheduleVariations.add(loanTermVariation);
+        }
+
+        if (rescheduleFromDate != null && endDate != null && emi != null) {
+            LoanTermVariations parent = null;
+            final Integer termType = LoanTermVariationType.EMI_AMOUNT.getValue();
+            int emiVariationsCreated = 0;
+            List<LocalDate> projectedInstallmentDueDates = getProjectedInstallmentDueDates(loan, rescheduleFromDate,
+                    pendingRescheduleVariations);
+            for (LocalDate installmentDueDate : projectedInstallmentDueDates) {
+                if (!DateUtils.isBefore(installmentDueDate, rescheduleFromDate) && !DateUtils.isAfter(installmentDueDate, endDate)) {
+                    createLoanTermVariations(loanRescheduleRequest, termType, loan, installmentDueDate, installmentDueDate,
+                            loanRescheduleRequestToTermVariationMappings, isActive, true, emi, parent);
+                    emiVariationsCreated++;
+                }
+                if (DateUtils.isAfter(installmentDueDate, endDate)) {
+                    break;
+                }
+            }
+            if (emiVariationsCreated == 0) {
+                List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+                final DataValidatorBuilder dataValidatorBuilder = new DataValidatorBuilder(dataValidationErrors)
+                        .resource(RescheduleLoansApiConstants.ENTITY_NAME);
+                dataValidatorBuilder.reset().parameter(RescheduleLoansApiConstants.endDateParamName).failWithCode(
+                        "end.date.before.next.installment", "End date must be on or after the next projected installment date");
+                throw new PlatformApiDataValidationException(dataValidationErrors);
+            }
         }
         loanRescheduleRequest.updateLoanRescheduleRequestToTermVariationMappings(loanRescheduleRequestToTermVariationMappings);
+    }
+
+    private List<LocalDate> getProjectedInstallmentDueDates(final Loan loan, final LocalDate rescheduleFromDate,
+            final List<LoanTermVariations> pendingRescheduleVariations) {
+        ScheduleGeneratorDTO scheduleGeneratorDTO = this.loanUtilService.buildScheduleGeneratorDTO(loan, rescheduleFromDate);
+        final LoanApplicationTerms loanApplicationTerms = loanTermVariationsMapper.constructLoanApplicationTerms(scheduleGeneratorDTO,
+                loan);
+        List<LoanTermVariationsData> projectedVariations = buildProjectedLoanTermVariations(loanApplicationTerms,
+                pendingRescheduleVariations);
+        loanApplicationTerms.getLoanTermVariations().setExceptionData(projectedVariations);
+
+        final MathContext mathContext = MoneyHelper.getMathContext();
+        final LoanRepaymentScheduleTransactionProcessor loanRepaymentScheduleTransactionProcessor = this.loanRepaymentScheduleTransactionProcessorFactory
+                .determineProcessor(loan.transactionProcessingStrategy());
+        final LoanScheduleGenerator loanScheduleGenerator = this.loanScheduleFactory.create(loanApplicationTerms.getLoanScheduleType(),
+                loanApplicationTerms.getInterestMethod());
+        final LoanScheduleDTO projectedLoanSchedule = loanScheduleGenerator.rescheduleNextInstallments(mathContext, loanApplicationTerms,
+                loan, loanApplicationTerms.getHolidayDetailDTO(), loanRepaymentScheduleTransactionProcessor, rescheduleFromDate);
+
+        Set<LocalDate> dueDates = new TreeSet<>();
+        if (projectedLoanSchedule.getInstallments() != null) {
+            for (LoanRepaymentScheduleInstallment installment : projectedLoanSchedule.getInstallments()) {
+                dueDates.add(installment.getDueDate());
+            }
+        } else {
+            for (LoanScheduleModelPeriod period : projectedLoanSchedule.getLoanScheduleModel().getPeriods()) {
+                if (period.isRepaymentPeriod() || period.isDownPaymentPeriod()) {
+                    dueDates.add(period.periodDueDate());
+                }
+            }
+        }
+        return new ArrayList<>(dueDates);
+    }
+
+    private List<LoanTermVariationsData> buildProjectedLoanTermVariations(final LoanApplicationTerms loanApplicationTerms,
+            final List<LoanTermVariations> pendingRescheduleVariations) {
+        final List<LoanTermVariationsData> projectedVariations = new ArrayList<>();
+
+        projectedVariations.addAll(loanApplicationTerms.getLoanTermVariations().getExceptionData());
+        projectedVariations.addAll(loanApplicationTerms.getLoanTermVariations().getDueDateVariation());
+        projectedVariations.addAll(loanApplicationTerms.getLoanTermVariations().getInterestRateChanges());
+        projectedVariations.addAll(loanApplicationTerms.getLoanTermVariations().getInterestRateFromInstallment());
+        projectedVariations.addAll(loanApplicationTerms.getLoanTermVariations().getInterestPauseVariations());
+
+        for (LoanTermVariations pendingVariation : pendingRescheduleVariations) {
+            projectedVariations.add(pendingVariation.toData());
+        }
+
+        return projectedVariations;
     }
 
     private LoanTermVariations createLoanTermVariations(LoanRescheduleRequest loanRescheduleRequest, final Integer termType,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanRescheduleRequestTest.java
@@ -30,13 +30,18 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.fineract.client.models.AdvancedPaymentData;
 import org.apache.fineract.client.models.GetLoanRescheduleRequestResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.LoanTermVariationsData;
 import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
@@ -407,6 +412,56 @@ public class LoanRescheduleRequestTest extends BaseLoanIntegrationTest {
             GetLoanRescheduleRequestResponse getLoanRescheduleRequestResponse = Assertions.assertDoesNotThrow(
                     () -> loanRescheduleRequestHelper.readLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(), null));
             Assertions.assertNotNull(getLoanRescheduleRequestResponse);
+        });
+    }
+
+    @Test
+    public void testCreateLoanRescheduleChangeEMIWithExtraTermsUsesFutureScheduleForEndDate() {
+        PostClientsResponse client = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        Long commonLoanProductId = createLoanProductPeriodicWithInterest();
+
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+        runAt("01 March 2024", () -> {
+            Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), commonLoanProductId, BigDecimal.valueOf(4000),
+                    "1 March 2024", "1 March 2024");
+            loanIdRef.set(loanId);
+            loanTransactionHelper.approveLoan("1 March 2024", loanId.intValue());
+            loanTransactionHelper.disburseLoan("1 March 2024", loanId.intValue(), "4000", null);
+
+            String requestJSON = new LoanRescheduleRequestTestBuilder().updateGraceOnPrincipal(null).updateGraceOnInterest(null)
+                    .updateExtraTerms("2").updateEMI("500").updateEmiChangeEndDate("01 September 2024")
+                    .updateRescheduleFromDate("01 April 2024").updateSubmittedOnDate("01 March 2024").build(loanId.toString());
+
+            Integer rescheduleRequestId = loanRescheduleRequestHelper.createLoanRescheduleRequest(requestJSON);
+            Assertions.assertNotNull(rescheduleRequestId);
+
+            GetLoanRescheduleRequestResponse createResponse = loanRescheduleRequestHelper
+                    .readLoanRescheduleRequest(rescheduleRequestId.longValue(), null);
+            Assertions.assertNotNull(createResponse);
+            Assertions.assertNotNull(createResponse.getLoanTermVariationsData());
+
+            Set<LocalDate> emiTermVariationDates = createResponse.getLoanTermVariationsData().stream()
+                    .filter(variation -> variation.getTermType() != null && variation.getTermType().getId() != null
+                            && variation.getTermType().getId() == 1L)
+                    .map(LoanTermVariationsData::getTermVariationApplicableFrom).collect(Collectors.toCollection(TreeSet::new));
+
+            Set<LocalDate> expectedEMIVariationDates = Set.of(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1),
+                    LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1));
+            assertEquals(expectedEMIVariationDates, emiTermVariationDates,
+                    "EMI term variations should include installment dates created by extra terms");
+
+            approveLoanReschedule(rescheduleRequestId.longValue(), "01 March 2024");
+
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanIdRef.get().intValue());
+
+            Set<LocalDate> repaymentDueDates = loanDetails.getRepaymentSchedule().getPeriods().stream()
+                    .filter(period -> period.getPeriod() != null && period.getPeriod() > 0).map(period -> period.getDueDate())
+                    .collect(Collectors.toCollection(TreeSet::new));
+
+            assertTrue(repaymentDueDates.containsAll(expectedEMIVariationDates),
+                    "Repayment schedule should include all projected installment dates up to the EMI end date");
+            assertEquals(LocalDate.of(2024, 9, 1), ((TreeSet<LocalDate>) repaymentDueDates).last(),
+                    "Repayment schedule should end on the EMI change end date when extra terms are applied");
         });
     }
 


### PR DESCRIPTION
## Description

This PR fixes [FINERACT-1152](https://issues.apache.org/jira/browse/FINERACT-1152); loan reschedule validation and term-variation generation for EMI changes with `endDate` when other reschedule changes (for example `extraTerms`) are submitted together.

Previously, EMI/end-date validation effectively depended on the current installment schedule, which could reject valid requests where the end date only exists in the projected post-reschedule schedule.

## Changes
- Updates EMI/end-date validation to enforce:
  - both fields are required together
  - `emi` must be positive
  - `endDate` must not be before `rescheduleFromDate`
- Builds projected installment due dates using pending reschedule variations, then creates EMI term variations using those projected dates up to `endDate`
- Returns a validation error when `endDate` is before the next projected installment date
- Adds/updates tests:
  - unit tests for validator behavior
  - integration test covering EMI + extra terms using projected future schedule
- Updates Swagger request model with `endDate` and `emi` fields for create-reschedule request payload examples

I would like to mention #5619 since it helped me to have a better overall view of the problem and the potential fix. Hope this goes well. Pls let me know if anything should be changed.

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).