### PR TITLE
FINERACT-2556: Prevent no-op updates for approved amount modification

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApprovedAmountWritePlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApprovedAmountWritePlatformServiceImpl.java
@@ -27,6 +27,7 @@ import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanApprovedAmountChangedBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.portfolio.common.service.Validator;
 import org.apache.fineract.portfolio.loanaccount.api.LoanApiConstants;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanApprovedAmountHistory;
@@ -38,6 +39,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class LoanApprovedAmountWritePlatformServiceImpl implements LoanApprovedAmountWritePlatformService {
+
+    private static final String ERROR_CODE_MUST_BE_DIFFERENT_FROM_CURRENT_APPROVED_AMOUNT = "must.be.different.from.current.approved.amount";
 
     private final LoanAssembler loanAssembler;
     private final LoanApprovedAmountValidator loanApprovedAmountValidator;
@@ -57,6 +60,8 @@ public class LoanApprovedAmountWritePlatformServiceImpl implements LoanApprovedA
         changes.put("oldApprovedAmount", loan.getApprovedPrincipal());
 
         BigDecimal newApprovedAmount = command.bigDecimalValueOfParameterNamed(LoanApiConstants.amountParameterName);
+
+        validateNewApprovedAmountDiffersFromCurrent(loan, newApprovedAmount);
 
         LoanApprovedAmountHistory loanApprovedAmountHistory = new LoanApprovedAmountHistory(loan.getId(), newApprovedAmount,
                 loan.getApprovedPrincipal());
@@ -114,5 +119,13 @@ public class LoanApprovedAmountWritePlatformServiceImpl implements LoanApprovedA
                 .withGroupId(loan.getGroupId()) //
                 .with(changes) //
                 .build();
+    }
+
+    private static void validateNewApprovedAmountDiffersFromCurrent(final Loan loan, final BigDecimal newApprovedAmount) {
+        if (newApprovedAmount.compareTo(loan.getApprovedPrincipal()) == 0) {
+            Validator.validateOrThrowDomainViolation("loan.approved.amount",
+                    baseDataValidator -> baseDataValidator.reset().parameter(LoanApiConstants.amountParameterName).value(newApprovedAmount)
+                            .failWithCode(ERROR_CODE_MUST_BE_DIFFERENT_FROM_CURRENT_APPROVED_AMOUNT));
+        }
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanModifyApprovedAmountTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanModifyApprovedAmountTest.java
@@ -128,6 +128,30 @@ public class LoanModifyApprovedAmountTest extends BaseLoanIntegrationTest {
     }
 
     @Test
+    public void testShouldFailWhenApprovedAmountIsSame() {
+
+        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive());
+
+        runAt("1 January 2024", () -> {
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
+                    1000.0, 10.0, 4, null);
+
+            disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
+
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            BigDecimal sameApprovedAmount = loanDetails.getApprovedPrincipal();
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> modifyLoanApprovedAmount(loanId, sameApprovedAmount));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage()
+                    .contains("validation.msg.loan.approved.amount.amount.must.be.different.from.current.approved.amount"));
+        });
+    }
+
+    @Test
     public void testModifyLoanApprovedAmountTooHigh() {
         BigDecimal twoThousand = BigDecimal.valueOf(2000.0);
 


### PR DESCRIPTION
## Description

This PR implements FINERACT-2556.

Currently, updating the approved amount with the same value still triggers unnecessary history entries and business events.

Such no-op updates:
- create unnecessary history entries
- trigger business events
- cause redundant database writes

This change adds validation to ensure that the approved amount is different from the current value, preventing no-op updates.

Also includes integration test coverage for this scenario.

This can be considered a small improvement to ensure only meaningful updates are processed.

## JIRA: https://issues.apache.org/jira/browse/FINERACT-2556


