### PR TITLE
FINERACT-2571: Migrate charge creation helper to feign client

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/NotificationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/NotificationHelper.java
@@ -26,6 +26,7 @@ import io.restassured.specification.ResponseSpecification;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetNotificationsResponse;
+import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.client.util.JSON;
 
 @Slf4j
@@ -42,10 +43,10 @@ public final class NotificationHelper {
     @Deprecated(forRemoval = true)
     public static GetNotificationsResponse getNotifications(final RequestSpecification requestSpec,
             final ResponseSpecification responseSpec) {
-        final String GET_NOTIFICATIONS_URL = NOTIFICATION_API_URL;
+
         log.info("-----------------------------GET NOTIFICATIONS-----------------------------------");
-        String response = Utils.performServerGet(requestSpec, responseSpec, GET_NOTIFICATIONS_URL);
-        return GSON.fromJson(response, GetNotificationsResponse.class);
+
+        return Calls.ok(() -> FineractClientHelper.getFineractClient().notifications().getAllNotifications(null, 1, 0, null, null));
     }
 
     // TODO: Rewrite to use fineract-client instead!

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
@@ -599,7 +599,9 @@ public final class ChargesHelper {
     @Deprecated(forRemoval = true)
     public static Integer createCharges(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String request) {
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_CHARGES_URL, request, "resourceId");
+        ChargeRequest chargeRequest = GSON.fromJson(request, ChargeRequest.class);
+        PostChargesResponse response = Calls.ok(FineractClientHelper.getFineractClient().charges.createCharge(chargeRequest));
+        return response.getResourceId().intValue();
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -608,8 +610,10 @@ public final class ChargesHelper {
     @Deprecated(forRemoval = true)
     public static PostChargesResponse createLoanCharge(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
             final String payload) {
-        final String response = Utils.performServerPost(requestSpec, responseSpec, CREATE_CHARGES_URL, payload, null);
-        return GSON.fromJson(response, PostChargesResponse.class);
+
+        ChargeRequest chargeRequest = GSON.fromJson(payload, ChargeRequest.class);
+
+        return Calls.ok(FineractClientHelper.getFineractClient().charges().createCharge(chargeRequest));
     }
 
     // TODO: Rewrite to use fineract-client instead!


### PR DESCRIPTION
This change migrates a deprecated helper method in `ChargesHelper` from RestAssured (`Utils.performServerPost`) to the feign client approach using `FineractClientHelper`.

This aligns with the ongoing effort to modernize integration tests and reduce direct HTTP usage.

Only a single method is migrated in this PR to keep the change minimal and review-friendly.
