### PR TITLE
FINERACT-2565: Batch API support for disburseToSavings, paySavingsAccountCharge, createAccountTransfer

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/batch/command/CommandStrategyProvider.java
+++ b/fineract-core/src/main/java/org/apache/fineract/batch/command/CommandStrategyProvider.java
@@ -151,6 +151,9 @@ public class CommandStrategyProvider {
                 .method(POST).build(), "savingsAccountAdjustTransactionCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/savingsaccounts\\/" + NUMBER_REGEX + "\\/charges").method(POST).build(),
                 "createSavingsAccountChargeCommandStrategy");
+        commandStrategies.put(CommandContext
+                .resource("v1\\/savingsaccounts\\/" + NUMBER_REGEX + "\\/charges\\/" + NUMBER_REGEX + MANDATORY_COMMAND_PARAM_REGEX)
+                .method(POST).build(), "paySavingsAccountChargeCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/loans\\/" + NUMBER_REGEX + "\\/charges").method(POST).build(),
                 "createChargeCommandStrategy");
         commandStrategies.put(
@@ -190,6 +193,8 @@ public class CommandStrategyProvider {
                 "approveLoanCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/loans\\/" + NUMBER_REGEX + "\\?command=disburse").method(POST).build(),
                 "disburseLoanCommandStrategy");
+        commandStrategies.put(CommandContext.resource("v1\\/loans\\/" + NUMBER_REGEX + "\\?command=disburseToSavings").method(POST).build(),
+                "disburseToSavingsCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/loans\\/external-id\\/" + UUID_PARAM_REGEX + MANDATORY_COMMAND_PARAM_REGEX)
                 .method(POST).build(), "loanStateTransistionsByExternalIdCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/rescheduleloans").method(POST).build(),
@@ -252,6 +257,8 @@ public class CommandStrategyProvider {
         commandStrategies.put(CommandContext
                 .resource("v1\\/loans\\/external-id\\/" + UUID_PARAM_REGEX + "\\/interest-pauses\\/" + NUMBER_REGEX).method(PUT).build(),
                 "updateLoanInterestPauseByExternalIdCommandStrategy");
+        commandStrategies.put(CommandContext.resource("v1\\/accounttransfers").method(POST).build(),
+                "createAccountTransferCommandStrategy");
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/CreateAccountTransferCommandStrategy.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/CreateAccountTransferCommandStrategy.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import jakarta.ws.rs.core.UriInfo;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.batch.command.CommandStrategy;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.service.CommandWrapperBuilder;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * Batch command strategy for creating account transfers via {@code POST v1/accounttransfers}.
+ *
+ * The {@link org.apache.fineract.portfolio.account.api.AccountTransfersApiResource#create} method accepts a typed DTO
+ * and immediately re-serializes it to JSON before passing it to the command pipeline. This strategy bypasses that
+ * round-trip and passes the raw request body directly to {@link PortfolioCommandSourceWritePlatformService}, which is
+ * functionally equivalent.
+ */
+@Component
+@RequiredArgsConstructor
+public class CreateAccountTransferCommandStrategy implements CommandStrategy {
+
+    private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    private final DefaultToApiJsonSerializer<CommandProcessingResult> toApiJsonSerializer;
+
+    @Override
+    public BatchResponse execute(final BatchRequest request, @SuppressWarnings("unused") final UriInfo uriInfo) {
+        final BatchResponse response = new BatchResponse();
+        response.setRequestId(request.getRequestId());
+        response.setHeaders(request.getHeaders());
+
+        final CommandWrapper commandRequest = new CommandWrapperBuilder().createAccountTransfer().withJson(request.getBody()).build();
+
+        final CommandProcessingResult result = commandsSourceWritePlatformService.logCommandSource(commandRequest);
+
+        response.setStatusCode(HttpStatus.SC_OK);
+        response.setBody(toApiJsonSerializer.serialize(result));
+
+        return response;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/DisburseToSavingsCommandStrategy.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/DisburseToSavingsCommandStrategy.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.apache.fineract.batch.command.CommandStrategyUtils.relativeUrlWithoutVersion;
+
+import com.google.common.base.Splitter;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.batch.command.CommandStrategy;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.portfolio.loanaccount.api.LoansApiResource;
+import org.apache.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implements {@link org.apache.fineract.batch.command.CommandStrategy} to handle disbursement of a loan directly to a
+ * linked savings account via the {@code disburseToSavings} command. It passes the contents of the body from the
+ * BatchRequest to {@link org.apache.fineract.portfolio.loanaccount.api.LoansApiResource} and gets back the response.
+ *
+ * @see org.apache.fineract.batch.command.CommandStrategy
+ * @see org.apache.fineract.batch.domain.BatchRequest
+ * @see org.apache.fineract.batch.domain.BatchResponse
+ */
+@Component
+@RequiredArgsConstructor
+public class DisburseToSavingsCommandStrategy implements CommandStrategy {
+
+    private final LoansApiResource loansApiResource;
+
+    @Override
+    public BatchResponse execute(final BatchRequest request, @SuppressWarnings("unused") UriInfo uriInfo) {
+
+        final BatchResponse response = new BatchResponse();
+        final String responseBody;
+
+        response.setRequestId(request.getRequestId());
+        response.setHeaders(request.getHeaders());
+
+        final List<String> pathParameters = Splitter.on('/').splitToList(relativeUrlWithoutVersion(request));
+        final Long loanId = Long.parseLong(pathParameters.get(1).substring(0, pathParameters.get(1).indexOf("?")));
+
+        responseBody = loansApiResource.stateTransitions(loanId, "disburseToSavings", request.getBody());
+
+        response.setStatusCode(HttpStatus.SC_OK);
+        response.setBody(responseBody);
+
+        return response;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/PaySavingsAccountChargeCommandStrategy.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/PaySavingsAccountChargeCommandStrategy.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.apache.fineract.batch.command.CommandStrategyUtils.relativeUrlWithoutVersion;
+
+import com.google.common.base.Splitter;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.batch.command.CommandStrategy;
+import org.apache.fineract.batch.command.CommandStrategyUtils;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.portfolio.savings.api.SavingsAccountChargesApiResource;
+import org.apache.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implements {@link CommandStrategy} to pay (or waive) a savings account charge via the Batch API. It passes the
+ * contents of the body from the BatchRequest to {@link SavingsAccountChargesApiResource} and gets back the response.
+ *
+ * <p>
+ * Handles URLs of the form: {@code POST
+ * savingsaccounts/{savingsAccountId}/charges/{savingsAccountChargeId}?command=paycharge}
+ * </p>
+ *
+ * @see CommandStrategy
+ * @see BatchRequest
+ * @see BatchResponse
+ */
+@Component
+@RequiredArgsConstructor
+public class PaySavingsAccountChargeCommandStrategy implements CommandStrategy {
+
+    private final SavingsAccountChargesApiResource savingsAccountChargesApiResource;
+
+    @Override
+    public BatchResponse execute(final BatchRequest request, @SuppressWarnings("unused") final UriInfo uriInfo) {
+        final BatchResponse response = new BatchResponse();
+
+        response.setRequestId(request.getRequestId());
+        response.setHeaders(request.getHeaders());
+
+        final String relativeUrl = relativeUrlWithoutVersion(request);
+
+        // URL: savingsaccounts/{savingsAccountId}/charges/{savingsAccountChargeId}?command=paycharge
+        final List<String> pathParameters = Splitter.on('/').splitToList(relativeUrl);
+
+        if (pathParameters.size() < 4) {
+            response.setStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
+            response.setBody(
+                    "Resource with method " + request.getMethod() + " and relativeUrl " + request.getRelativeUrl() + " doesn't exist");
+            return response;
+        }
+
+        final Long savingsAccountId = Long.parseLong(pathParameters.get(1));
+
+        // The charge id may have the query string appended: "47?command=paycharge"
+        final String chargeIdSegment = pathParameters.get(3);
+        final Long savingsAccountChargeId;
+        final String command;
+
+        if (chargeIdSegment.contains("?")) {
+            savingsAccountChargeId = Long.parseLong(chargeIdSegment.substring(0, chargeIdSegment.indexOf("?")));
+            final Map<String, String> queryParameters = CommandStrategyUtils.getQueryParameters(relativeUrl);
+            command = queryParameters.get("command");
+        } else {
+            response.setStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
+            response.setBody(
+                    "Resource with method " + request.getMethod() + " and relativeUrl " + request.getRelativeUrl() + " doesn't exist");
+            return response;
+        }
+
+        final String responseBody = savingsAccountChargesApiResource.payOrWaiveSavingsAccountCharge(savingsAccountId,
+                savingsAccountChargeId, command, request.getBody());
+
+        response.setStatusCode(HttpStatus.SC_OK);
+        response.setBody(responseBody);
+
+        return response;
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/CommandStrategyProviderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/CommandStrategyProviderTest.java
@@ -35,6 +35,7 @@ import org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy;
 import org.apache.fineract.batch.command.internal.ApproveLoanRescheduleCommandStrategy;
 import org.apache.fineract.batch.command.internal.CollectChargesByLoanExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.CollectChargesCommandStrategy;
+import org.apache.fineract.batch.command.internal.CreateAccountTransferCommandStrategy;
 import org.apache.fineract.batch.command.internal.CreateChargeByLoanExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.CreateChargeCommandStrategy;
 import org.apache.fineract.batch.command.internal.CreateClientCommandStrategy;
@@ -44,6 +45,7 @@ import org.apache.fineract.batch.command.internal.CreateSavingsAccountChargeComm
 import org.apache.fineract.batch.command.internal.CreateTransactionByLoanExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy;
 import org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy;
+import org.apache.fineract.batch.command.internal.DisburseToSavingsCommandStrategy;
 import org.apache.fineract.batch.command.internal.GetChargeByChargeExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.GetChargeByIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy;
@@ -57,6 +59,7 @@ import org.apache.fineract.batch.command.internal.GetReagePreviewByLoanExternalI
 import org.apache.fineract.batch.command.internal.GetReagePreviewByLoanIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.LoanStateTransistionsByExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.ModifyLoanApplicationCommandStrategy;
+import org.apache.fineract.batch.command.internal.PaySavingsAccountChargeCommandStrategy;
 import org.apache.fineract.batch.command.internal.UnknownCommandStrategy;
 import org.apache.fineract.batch.command.internal.UpdateClientCommandStrategy;
 import org.apache.fineract.batch.command.internal.UpdateDatatableEntryOneToManyCommandStrategy;
@@ -94,6 +97,10 @@ public class CommandStrategyProviderTest {
                 Arguments.of("savingsaccounts", HttpMethod.POST, "applySavingsCommandStrategy", mock(ApplySavingsCommandStrategy.class)),
                 Arguments.of("savingsaccounts/123/charges", HttpMethod.POST, "createSavingsAccountChargeCommandStrategy",
                         mock(CreateSavingsAccountChargeCommandStrategy.class)),
+                Arguments.of("savingsaccounts/123/charges/47?command=paycharge", HttpMethod.POST, "paySavingsAccountChargeCommandStrategy",
+                        mock(PaySavingsAccountChargeCommandStrategy.class)),
+                Arguments.of("savingsaccounts/123/charges/47?command=waive", HttpMethod.POST, "paySavingsAccountChargeCommandStrategy",
+                        mock(PaySavingsAccountChargeCommandStrategy.class)),
                 Arguments.of("loans/123/charges", HttpMethod.POST, "createChargeCommandStrategy", mock(CreateChargeCommandStrategy.class)),
                 Arguments.of("loans/external-id/8dfad438-2319-48ce-8520-10a62801e9a1/charges", HttpMethod.POST,
                         "createChargeByLoanExternalIdCommandStrategy", mock(CreateChargeByLoanExternalIdCommandStrategy.class)),
@@ -165,6 +172,8 @@ public class CommandStrategyProviderTest {
                         mock(ApproveLoanCommandStrategy.class)),
                 Arguments.of("loans/123?command=disburse", HttpMethod.POST, "disburseLoanCommandStrategy",
                         mock(DisburseLoanCommandStrategy.class)),
+                Arguments.of("loans/123?command=disburseToSavings", HttpMethod.POST, "disburseToSavingsCommandStrategy",
+                        mock(DisburseToSavingsCommandStrategy.class)),
                 Arguments.of("loans/external-id/8dfad438-2319-48ce-8520-10a62801e9a1?command=approve", HttpMethod.POST,
                         "loanStateTransistionsByExternalIdCommandStrategy", mock(LoanStateTransistionsByExternalIdCommandStrategy.class)),
                 Arguments.of("loans/external-id/8dfad438-2319-48ce-8520-10a62801e9a1?command=disburse", HttpMethod.POST,
@@ -232,7 +241,9 @@ public class CommandStrategyProviderTest {
                 Arguments.of(
                         "loans/external-id/8dfad438-2319-48ce-8520-10a62801e9a1/transactions/reage-preview?frequency-number=2&frequencyType=long-string",
                         HttpMethod.GET, "getReagePreviewByLoanExternalIdCommandStrategy",
-                        mock(GetReagePreviewByLoanExternalIdCommandStrategy.class)));
+                        mock(GetReagePreviewByLoanExternalIdCommandStrategy.class)),
+                Arguments.of("accounttransfers", HttpMethod.POST, "createAccountTransferCommandStrategy",
+                        mock(CreateAccountTransferCommandStrategy.class)));
     }
 
     /**

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/CreateAccountTransferCommandStrategyTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/CreateAccountTransferCommandStrategyTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Test class for {@link CreateAccountTransferCommandStrategy}.
+ */
+public class CreateAccountTransferCommandStrategyTest {
+
+    /**
+     * Test {@link CreateAccountTransferCommandStrategy#execute} happy path scenario.
+     */
+    @Test
+    public void testExecuteSuccessScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final BatchRequest request = getBatchRequest();
+        final CommandProcessingResult processingResult = CommandProcessingResult.resourceResult(42L, null);
+        final String serializedResponse = "{\"resourceId\":42}";
+
+        given(testContext.commandsSourceWritePlatformService.logCommandSource(any(CommandWrapper.class))).willReturn(processingResult);
+        given(testContext.toApiJsonSerializer.serialize(processingResult)).willReturn(serializedResponse);
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(request.getRequestId(), response.getRequestId());
+        assertEquals(request.getHeaders(), response.getHeaders());
+        assertEquals(serializedResponse, response.getBody());
+
+        final ArgumentCaptor<CommandWrapper> commandCaptor = ArgumentCaptor.forClass(CommandWrapper.class);
+        verify(testContext.commandsSourceWritePlatformService).logCommandSource(commandCaptor.capture());
+        assertEquals(request.getBody(), commandCaptor.getValue().getJson());
+        verify(testContext.toApiJsonSerializer).serialize(processingResult);
+    }
+
+    /**
+     * Creates and returns a batch request for {@code POST accounttransfers}.
+     */
+    private BatchRequest getBatchRequest() {
+        final BatchRequest br = new BatchRequest();
+        br.setRequestId(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        br.setRelativeUrl("accounttransfers");
+        br.setMethod(HttpMethod.POST);
+        br.setBody("{\"fromOfficeId\":1,\"fromClientId\":2,\"fromAccountType\":2,\"fromAccountId\":3,"
+                + "\"toOfficeId\":1,\"toClientId\":4,\"toAccountType\":2,\"toAccountId\":5,"
+                + "\"transferAmount\":100,\"transferDate\":\"01 March 2026\"," + "\"locale\":\"en\",\"dateFormat\":\"dd MMMM yyyy\"}");
+        return br;
+    }
+
+    /**
+     * Private test context class used since testng runs in parallel to avoid state between tests.
+     */
+    private static class TestContext {
+
+        @Mock
+        private UriInfo uriInfo;
+
+        @Mock
+        private PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+
+        @Mock
+        private DefaultToApiJsonSerializer<CommandProcessingResult> toApiJsonSerializer;
+
+        private final CreateAccountTransferCommandStrategy subjectToTest;
+
+        TestContext() {
+            MockitoAnnotations.openMocks(this);
+            subjectToTest = new CreateAccountTransferCommandStrategy(commandsSourceWritePlatformService, toApiJsonSerializer);
+        }
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/DisburseToSavingsCommandStrategyTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/DisburseToSavingsCommandStrategyTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.portfolio.loanaccount.api.LoansApiResource;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Test class for {@link DisburseToSavingsCommandStrategy}.
+ */
+public class DisburseToSavingsCommandStrategyTest {
+
+    /**
+     * Test {@link DisburseToSavingsCommandStrategy#execute} happy path scenario.
+     */
+    @Test
+    public void testExecuteSuccessScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final BatchRequest request = getBatchRequest(loanId);
+        final String responseBody = "{\"loanId\":" + loanId + ",\"resourceId\":16,\"changes\":{}}";
+
+        given(testContext.loansApiResource.stateTransitions(eq(loanId), eq("disburseToSavings"), eq(request.getBody())))
+                .willReturn(responseBody);
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(request.getRequestId(), response.getRequestId());
+        assertEquals(request.getHeaders(), response.getHeaders());
+        assertEquals(responseBody, response.getBody());
+        verify(testContext.loansApiResource).stateTransitions(eq(loanId), eq("disburseToSavings"), eq(request.getBody()));
+    }
+
+    /**
+     * Test {@link DisburseToSavingsCommandStrategy#execute} with a versioned relative URL (v1/ prefix).
+     */
+    @Test
+    public void testExecuteWithVersionedUrlSuccessScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final Long loanId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final BatchRequest request = getBatchRequest(loanId);
+        request.setRelativeUrl("v1/loans/" + loanId + "?command=disburseToSavings");
+        final String responseBody = "{\"loanId\":" + loanId + ",\"resourceId\":17,\"changes\":{}}";
+
+        given(testContext.loansApiResource.stateTransitions(eq(loanId), eq("disburseToSavings"), eq(request.getBody())))
+                .willReturn(responseBody);
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(responseBody, response.getBody());
+        verify(testContext.loansApiResource).stateTransitions(eq(loanId), eq("disburseToSavings"), eq(request.getBody()));
+    }
+
+    /**
+     * Creates and returns a batch request for the given loan id.
+     */
+    private BatchRequest getBatchRequest(final Long loanId) {
+        final BatchRequest br = new BatchRequest();
+        br.setRequestId(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        br.setRelativeUrl(String.format("loans/%s?command=disburseToSavings", loanId));
+        br.setMethod(HttpMethod.POST);
+        br.setReference(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        br.setBody("{\"actualDisbursementDate\":\"01 March 2026\",\"locale\":\"en\",\"dateFormat\":\"dd MMMM yyyy\"}");
+        return br;
+    }
+
+    /**
+     * Private test context class used since testng runs in parallel to avoid state between tests.
+     */
+    private static class TestContext {
+
+        @Mock
+        private UriInfo uriInfo;
+
+        @Mock
+        private LoansApiResource loansApiResource;
+
+        private final DisburseToSavingsCommandStrategy subjectToTest;
+
+        TestContext() {
+            MockitoAnnotations.openMocks(this);
+            subjectToTest = new DisburseToSavingsCommandStrategy(loansApiResource);
+        }
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/PaySavingsAccountChargeCommandStrategyTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/internal/PaySavingsAccountChargeCommandStrategyTest.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.portfolio.savings.api.SavingsAccountChargesApiResource;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Test class for {@link PaySavingsAccountChargeCommandStrategy}.
+ */
+public class PaySavingsAccountChargeCommandStrategyTest {
+
+    /**
+     * Test {@link PaySavingsAccountChargeCommandStrategy#execute} happy path scenario with paycharge command.
+     */
+    @Test
+    public void testExecuteWithPayChargeCommandSuccessScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final Long savingsAccountId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final Long savingsAccountChargeId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final String command = "paycharge";
+        final BatchRequest request = getBatchRequest(savingsAccountId, savingsAccountChargeId, command);
+        final String responseBody = "{\"savingsId\":51,\"resourceId\":47,\"changes\":{}}";
+
+        given(testContext.savingsAccountChargesApiResource.payOrWaiveSavingsAccountCharge(eq(savingsAccountId), eq(savingsAccountChargeId),
+                eq(command), eq(request.getBody()))).willReturn(responseBody);
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(request.getRequestId(), response.getRequestId());
+        assertEquals(request.getHeaders(), response.getHeaders());
+        assertEquals(responseBody, response.getBody());
+        verify(testContext.savingsAccountChargesApiResource).payOrWaiveSavingsAccountCharge(eq(savingsAccountId),
+                eq(savingsAccountChargeId), eq(command), eq(request.getBody()));
+    }
+
+    /**
+     * Test {@link PaySavingsAccountChargeCommandStrategy#execute} with waive command.
+     */
+    @Test
+    public void testExecuteWithWaiveCommandSuccessScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final Long savingsAccountId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final Long savingsAccountChargeId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final String command = "waive";
+        final BatchRequest request = getBatchRequest(savingsAccountId, savingsAccountChargeId, command);
+        final String responseBody = "{\"savingsId\":51,\"resourceId\":47,\"changes\":{}}";
+
+        given(testContext.savingsAccountChargesApiResource.payOrWaiveSavingsAccountCharge(eq(savingsAccountId), eq(savingsAccountChargeId),
+                eq(command), eq(request.getBody()))).willReturn(responseBody);
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        verify(testContext.savingsAccountChargesApiResource).payOrWaiveSavingsAccountCharge(eq(savingsAccountId),
+                eq(savingsAccountChargeId), eq(command), eq(request.getBody()));
+    }
+
+    /**
+     * Test {@link PaySavingsAccountChargeCommandStrategy#execute} error scenario when no command is present.
+     */
+    @Test
+    public void testExecuteWithoutCommandErrorScenario() {
+        // given
+        final TestContext testContext = new TestContext();
+
+        final Long savingsAccountId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final Long savingsAccountChargeId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+
+        // URL without ?command=... — should return 501
+        final BatchRequest request = new BatchRequest();
+        request.setRequestId(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        request.setRelativeUrl(String.format("savingsaccounts/%s/charges/%s", savingsAccountId, savingsAccountChargeId));
+        request.setMethod(HttpMethod.POST);
+        request.setBody("{\"transactionDate\":\"2026-03-16\",\"amount\":100}");
+
+        // when
+        final BatchResponse response = testContext.subjectToTest.execute(request, testContext.uriInfo);
+
+        // then
+        assertEquals(HttpStatus.SC_NOT_IMPLEMENTED, response.getStatusCode());
+        assertEquals(request.getRequestId(), response.getRequestId());
+        verifyNoInteractions(testContext.savingsAccountChargesApiResource);
+    }
+
+    /**
+     * Creates and returns a request for the given savings account, charge, and command.
+     */
+    private BatchRequest getBatchRequest(final Long savingsAccountId, final Long savingsAccountChargeId, final String command) {
+        final BatchRequest br = new BatchRequest();
+        br.setRequestId(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        br.setRelativeUrl(String.format("savingsaccounts/%s/charges/%s?command=%s", savingsAccountId, savingsAccountChargeId, command));
+        br.setMethod(HttpMethod.POST);
+        br.setReference(Long.valueOf(RandomStringUtils.randomNumeric(5)));
+        br.setBody("{\"transactionDate\":\"2026-03-16\",\"amount\":100,\"locale\":\"en\",\"dateFormat\":\"yyyy-MM-dd\"}");
+        return br;
+    }
+
+    /**
+     * Private test context class used since testng runs in parallel to avoid state between tests.
+     */
+    private static class TestContext {
+
+        @Mock
+        private UriInfo uriInfo;
+
+        @Mock
+        private SavingsAccountChargesApiResource savingsAccountChargesApiResource;
+
+        private final PaySavingsAccountChargeCommandStrategy subjectToTest;
+
+        TestContext() {
+            MockitoAnnotations.openMocks(this);
+            subjectToTest = new PaySavingsAccountChargeCommandStrategy(savingsAccountChargesApiResource);
+        }
+    }
+}


### PR DESCRIPTION
Add support for the following operations to the Fineract Batch API:
- Disburse a loan to a linked savings account (`POST loans/{loanId}?command=disburseToSavings`)
- Pay or waive a savings account charge (`POST savingsaccounts/{savingsAccountId}/charges/{savingsAccountChargeId}?command=paycharge` and `?command=waive`)
- Create an account transfer (`POST accounttransfers`)

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).