### PR TITLE
FINERACT-2561: Move organisation currency validation outside loop in saveAllDebitOrCreditEntries

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryWritePlatformServiceJpaRepositoryImpl.java
@@ -647,6 +647,10 @@ public class JournalEntryWritePlatformServiceJpaRepositoryImpl implements Journa
             final SingleDebitOrCreditEntryCommand[] singleDebitOrCreditEntryCommands, final String transactionId,
             final JournalEntryType type, final String referenceNumber, final ExternalAssetOwner externalAssetOwner) {
         final boolean manualEntry = true;
+
+        /** Validate current code is appropriate **/
+        this.organisationCurrencyRepository.findOneWithNotFoundDetection(currencyCode);
+
         for (final SingleDebitOrCreditEntryCommand singleDebitOrCreditEntryCommand : singleDebitOrCreditEntryCommands) {
             final GLAccount glAccount = this.glAccountRepository.findById(singleDebitOrCreditEntryCommand.getGlAccountId())
                     .orElseThrow(() -> new GLAccountNotFoundException(singleDebitOrCreditEntryCommand.getGlAccountId()));
@@ -657,9 +661,6 @@ public class JournalEntryWritePlatformServiceJpaRepositoryImpl implements Journa
             if (!StringUtils.isBlank(singleDebitOrCreditEntryCommand.getComments())) {
                 comments = singleDebitOrCreditEntryCommand.getComments();
             }
-
-            /** Validate current code is appropriate **/
-            this.organisationCurrencyRepository.findOneWithNotFoundDetection(currencyCode);
 
             final JournalEntry glJournalEntry = JournalEntry.createNew(office, paymentDetail, glAccount, currencyCode, transactionId,
                     manualEntry, transactionDate, type, singleDebitOrCreditEntryCommand.getAmount(), comments, null, null, referenceNumber,


### PR DESCRIPTION
## Description

JIRA: https://issues.apache.org/jira/browse/FINERACT-2561

The `saveAllDebitOrCreditEntries()` method was executing the same 
organisation currency validation query inside the per-entry loop, causing 
redundant identical database round-trips on every debit/credit line of a 
manual journal entry request.

Since `currencyCode` does not change within a single request, the validation 
only needs to run once per method invocation — not once per loop iteration.

This fix moves `organisationCurrencyRepository.findOneWithNotFoundDetection(currencyCode)` 
to before the loop, consistent with the pattern already used in the same class 
inside `saveAllDebitOrCreditOpeningBalanceEntries()`.

No logic change — validation still happens, just once instead of N times.