### PR TITLE
FINERACT-2560: Fix NullPointerException in calcInterestTransactionWaivedAmount

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImpl.java
@@ -529,7 +529,7 @@ public class LoanAccrualsProcessingServiceImpl implements LoanAccrualsProcessing
         Predicate<LoanTransaction> transactionPredicate = t -> !t.isReversed() && t.isInterestWaiver()
                 && !DateUtils.isAfter(t.getTransactionDate(), tillDate);
         return installment.getLoanTransactionToRepaymentScheduleMappings().stream()
-                .filter(tm -> transactionPredicate.test(tm.getLoanTransaction()))
+                .filter(tm -> tm.getLoanTransaction() != null && transactionPredicate.test(tm.getLoanTransaction()))
                 .map(LoanTransactionToRepaymentScheduleMapping::getInterestPortion).reduce(BigDecimal.ZERO, MathUtil::add);
     }
 
@@ -639,7 +639,7 @@ public class LoanAccrualsProcessingServiceImpl implements LoanAccrualsProcessing
             @NonNull final LocalDate tillDate) {
         return loanChargePaidBy.stream().filter(pb -> {
             final LoanTransaction t = pb.getLoanTransaction();
-            return !t.isReversed() && t.isWaiveCharge() && !DateUtils.isAfter(t.getTransactionDate(), tillDate);
+            return t != null && !t.isReversed() && t.isWaiveCharge() && !DateUtils.isAfter(t.getTransactionDate(), tillDate);
         }).map(LoanChargePaidBy::getAmount).reduce(BigDecimal.ZERO, MathUtil::add);
     }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanAccrualsProcessingServiceImplTest.java
@@ -18,22 +18,36 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanChargePaidBy;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionToRepaymentScheduleMapping;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -43,6 +57,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -71,6 +86,15 @@ public class LoanAccrualsProcessingServiceImplTest {
         when(loan.isClosed()).thenReturn(false);
         when(loan.getStatus()).thenReturn(loanStatus);
         when(loanStatus.isOverpaid()).thenReturn(false);
+
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "Test Tenant", "America/Mexico_City", null));
+        MoneyHelper.initializeTenantRoundingMode("test", 6);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+        MoneyHelper.clearCache();
     }
 
     @ParameterizedTest
@@ -93,6 +117,54 @@ public class LoanAccrualsProcessingServiceImplTest {
         verifyNoInteractions(journalEntryWritePlatformService);
         verify(businessEventNotifierService, never()).notifyPostBusinessEvent(any());
         verify(loan, never()).addLoanTransaction(any());
+    }
+
+    @Test
+    void calcInterestTransactionWaivedAmount_ShouldSkipMappingsWithoutTransaction() {
+        // Given
+        LocalDate tillDate = LocalDate.now(ZoneId.systemDefault());
+        LoanRepaymentScheduleInstallment installment = mock(LoanRepaymentScheduleInstallment.class);
+        LoanTransactionToRepaymentScheduleMapping nullTransactionMapping = mock(LoanTransactionToRepaymentScheduleMapping.class);
+        LoanTransactionToRepaymentScheduleMapping interestWaiverMapping = mock(LoanTransactionToRepaymentScheduleMapping.class);
+        LoanTransaction interestWaiverTransaction = mock(LoanTransaction.class);
+
+        when(nullTransactionMapping.getLoanTransaction()).thenReturn(null);
+        when(interestWaiverMapping.getLoanTransaction()).thenReturn(interestWaiverTransaction);
+        when(interestWaiverMapping.getInterestPortion()).thenReturn(new BigDecimal("12.34"));
+        when(interestWaiverTransaction.isReversed()).thenReturn(false);
+        when(interestWaiverTransaction.isInterestWaiver()).thenReturn(true);
+        when(interestWaiverTransaction.getTransactionDate()).thenReturn(tillDate);
+        when(installment.getLoanTransactionToRepaymentScheduleMappings()).thenReturn(Set.of(nullTransactionMapping, interestWaiverMapping));
+
+        // When
+        BigDecimal result = ReflectionTestUtils.invokeMethod(accrualsProcessingService, "calcInterestTransactionWaivedAmount", installment,
+                tillDate);
+
+        // Then
+        assertThat(result).isEqualByComparingTo("12.34");
+    }
+
+    @Test
+    void calcChargeWaivedAmount_ShouldSkipMappingsWithoutTransaction() {
+        // Given
+        LocalDate tillDate = LocalDate.now(ZoneId.systemDefault());
+        LoanChargePaidBy nullTransactionPaidBy = mock(LoanChargePaidBy.class);
+        LoanChargePaidBy chargeWaiverPaidBy = mock(LoanChargePaidBy.class);
+        LoanTransaction chargeWaiverTransaction = mock(LoanTransaction.class);
+
+        when(nullTransactionPaidBy.getLoanTransaction()).thenReturn(null);
+        when(chargeWaiverPaidBy.getLoanTransaction()).thenReturn(chargeWaiverTransaction);
+        when(chargeWaiverPaidBy.getAmount()).thenReturn(new BigDecimal("12.34"));
+        when(chargeWaiverTransaction.isReversed()).thenReturn(false);
+        when(chargeWaiverTransaction.isWaiveCharge()).thenReturn(true);
+        when(chargeWaiverTransaction.getTransactionDate()).thenReturn(tillDate);
+
+        // When
+        BigDecimal result = ReflectionTestUtils.invokeMethod(accrualsProcessingService, "calcChargeWaivedAmount",
+                List.of(nullTransactionPaidBy, chargeWaiverPaidBy), tillDate);
+
+        // Then
+        assertThat(result).isEqualByComparingTo("12.34");
     }
 
     private static Stream<Arguments> loanStatusTestCases() {


### PR DESCRIPTION
This PR fixes [FINERACT-2560](https://issues.apache.org/jira/projects/FINERACT/issues/FINERACT-2560) and adds a test to verify the fix.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [X] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [X] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [X] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
