### PR TITLE
FINERACT-2437: Decrease compilation warnings

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/exception/LoanChargeNotFoundException.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/exception/LoanChargeNotFoundException.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.portfolio.charge.exception;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.AbstractPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
@@ -49,6 +49,6 @@ public class LoanChargeNotFoundException extends AbstractPlatformResourceNotFoun
 
     public LoanChargeNotFoundException(ExternalId externalId) {
         super("error.msg.loanCharge.external.id.invalid", "Loan Charge with external identifier "
-                + ObjectUtils.defaultIfNull(externalId, ExternalId.empty()).getValue() + " does not exist", externalId);
+                + Objects.requireNonNullElse(externalId, ExternalId.empty()).getValue() + " does not exist", externalId);
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonQuery.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/api/JsonQuery.java
@@ -25,7 +25,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Map;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.security.domain.BasicPasswordEncodablePlatformUser;
@@ -240,7 +240,7 @@ public final class JsonQuery {
      */
     public boolean booleanPrimitiveValueOfParameterNamed(final String parameterName) {
         final Boolean value = this.fromApiJsonHelper.extractBooleanNamed(parameterName, this.parsedQuery);
-        return ObjectUtils.defaultIfNull(value, Boolean.FALSE);
+        return Objects.requireNonNullElse(value, Boolean.FALSE);
     }
 
     public boolean isChangeInArrayParameterNamed(final String parameterName, final String[] existingValue) {

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/PaginationHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/PaginationHelper.java
@@ -19,7 +19,7 @@
 package org.apache.fineract.infrastructure.core.service;
 
 import java.util.List;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +62,6 @@ public class PaginationHelper {
         String sqlCountRows = sqlGenerator.countLastExecutedQueryResult(sql);
         Integer totalFilteredRecords = jdbcTemplate.queryForObject(sqlCountRows, Integer.class);
 
-        return new Page<>(items, ObjectUtils.defaultIfNull(totalFilteredRecords, 0));
+        return new Page<>(items, Objects.requireNonNullElse(totalFilteredRecords, 0));
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetailAssembler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetailAssembler.java
@@ -22,7 +22,8 @@ import com.google.gson.JsonObject;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.portfolio.paymentdetail.PaymentDetailConstants;
 import org.apache.fineract.portfolio.paymenttype.domain.PaymentType;
-import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepositoryWrapper;
+import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepository;
+import org.apache.fineract.portfolio.paymenttype.exception.PaymentTypeNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,12 +31,12 @@ import org.springframework.stereotype.Service;
 public class PaymentDetailAssembler {
 
     private final FromJsonHelper fromApiJsonHelper;
-    private final PaymentTypeRepositoryWrapper repositoryWrapper;
+    private final PaymentTypeRepository paymentTypeRepository;
 
     @Autowired
-    public PaymentDetailAssembler(final FromJsonHelper fromApiJsonHelper, final PaymentTypeRepositoryWrapper repositoryWrapper) {
+    public PaymentDetailAssembler(final FromJsonHelper fromApiJsonHelper, final PaymentTypeRepository paymentTypeRepository) {
         this.fromApiJsonHelper = fromApiJsonHelper;
-        this.repositoryWrapper = repositoryWrapper;
+        this.paymentTypeRepository = paymentTypeRepository;
     }
 
     public PaymentDetail fetchPaymentDetail(final JsonObject json) {
@@ -44,7 +45,8 @@ public class PaymentDetailAssembler {
             return null;
         }
 
-        final PaymentType paymentType = this.repositoryWrapper.findOneWithNotFoundDetection(paymentTypeId);
+        final PaymentType paymentType = this.paymentTypeRepository.findById(paymentTypeId)
+                .orElseThrow(() -> new PaymentTypeNotFoundException(paymentTypeId));
 
         final String accountNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.accountNumberParamName, json);
         final String checkNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.checkNumberParamName, json);

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/service/PaymentDetailWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/service/PaymentDetailWritePlatformServiceJpaRepositoryImpl.java
@@ -25,7 +25,8 @@ import org.apache.fineract.portfolio.paymentdetail.PaymentDetailConstants;
 import org.apache.fineract.portfolio.paymentdetail.domain.PaymentDetail;
 import org.apache.fineract.portfolio.paymentdetail.domain.PaymentDetailRepository;
 import org.apache.fineract.portfolio.paymenttype.domain.PaymentType;
-import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepositoryWrapper;
+import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepository;
+import org.apache.fineract.portfolio.paymenttype.exception.PaymentTypeNotFoundException;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class PaymentDetailWritePlatformServiceJpaRepositoryImpl implements Payme
 
     private final PaymentDetailRepository paymentDetailRepository;
     // private final CodeValueRepositoryWrapper codeValueRepositoryWrapper;
-    private final PaymentTypeRepositoryWrapper paymentTyperepositoryWrapper;
+    private final PaymentTypeRepository paymentTypeRepository;
 
     @Override
     public PaymentDetail createPaymentDetail(final JsonCommand command, final Map<String, Object> changes) {
@@ -42,7 +43,8 @@ public class PaymentDetailWritePlatformServiceJpaRepositoryImpl implements Payme
             return null;
         }
 
-        final PaymentType paymentType = this.paymentTyperepositoryWrapper.findOneWithNotFoundDetection(paymentTypeId);
+        final PaymentType paymentType = this.paymentTypeRepository.findById(paymentTypeId)
+                .orElseThrow(() -> new PaymentTypeNotFoundException(paymentTypeId));
         final PaymentDetail paymentDetail = PaymentDetail.generatePaymentDetail(paymentType, command, changes);
         return paymentDetail;
 

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/starter/PaymentDetailConfiguration.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/paymentdetail/starter/PaymentDetailConfiguration.java
@@ -21,7 +21,7 @@ package org.apache.fineract.portfolio.paymentdetail.starter;
 import org.apache.fineract.portfolio.paymentdetail.domain.PaymentDetailRepository;
 import org.apache.fineract.portfolio.paymentdetail.service.PaymentDetailWritePlatformService;
 import org.apache.fineract.portfolio.paymentdetail.service.PaymentDetailWritePlatformServiceJpaRepositoryImpl;
-import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepositoryWrapper;
+import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +32,7 @@ public class PaymentDetailConfiguration {
     @Bean
     @ConditionalOnMissingBean(PaymentDetailWritePlatformService.class)
     PaymentDetailWritePlatformService paymentDetailWritePlatformService(PaymentDetailRepository paymentDetailRepository,
-            PaymentTypeRepositoryWrapper paymentTyperepositoryWrapper) {
-        return new PaymentDetailWritePlatformServiceJpaRepositoryImpl(paymentDetailRepository, paymentTyperepositoryWrapper);
+            PaymentTypeRepository paymentTypeRepository) {
+        return new PaymentDetailWritePlatformServiceJpaRepositoryImpl(paymentDetailRepository, paymentTypeRepository);
     }
 }

--- a/fineract-document/src/main/java/org/apache/fineract/infrastructure/contentstore/util/DefaultContentPathRandomizer.java
+++ b/fineract-document/src/main/java/org/apache/fineract/infrastructure/contentstore/util/DefaultContentPathRandomizer.java
@@ -34,6 +34,6 @@ public class DefaultContentPathRandomizer implements ContentPathRandomizer {
     @Override
     public String randomize() {
         // TODO: make length configurable
-        return RandomStringUtils.secureStrong().randomAlphabetic(16);
+        return RandomStringUtils.secureStrong().nextAlphabetic(16);
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/exception/LoanNotFoundException.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/exception/LoanNotFoundException.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.exception;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
 
@@ -40,14 +40,12 @@ public class LoanNotFoundException extends AbstractPlatformResourceNotFoundExcep
     }
 
     public LoanNotFoundException(ExternalId externalId) {
-        super("error.msg.loan.external.id.invalid",
-                "Loan with external identifier " + ObjectUtils.defaultIfNull(externalId, ExternalId.empty()).getValue() + " does not exist",
-                externalId);
+        super("error.msg.loan.external.id.invalid", "Loan with external identifier "
+                + Objects.requireNonNullElse(externalId, ExternalId.empty()).getValue() + " does not exist", externalId);
     }
 
     public LoanNotFoundException(ExternalId externalId, Exception e) {
-        super("error.msg.loan.external.id.invalid",
-                "Loan with external identifier " + ObjectUtils.defaultIfNull(externalId, ExternalId.empty()).getValue() + " does not exist",
-                externalId, e);
+        super("error.msg.loan.external.id.invalid", "Loan with external identifier "
+                + Objects.requireNonNullElse(externalId, ExternalId.empty()).getValue() + " does not exist", externalId, e);
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/exception/LoanTransactionNotFoundException.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/exception/LoanTransactionNotFoundException.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.exception;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -47,13 +47,13 @@ public class LoanTransactionNotFoundException extends AbstractPlatformResourceNo
 
     public LoanTransactionNotFoundException(ExternalId transactionExternalId) {
         super("error.msg.loan.transaction.external.id.invalid", "Transaction with external identifier "
-                + ObjectUtils.defaultIfNull(transactionExternalId, ExternalId.empty()).getValue() + " does not exist",
+                + Objects.requireNonNullElse(transactionExternalId, ExternalId.empty()).getValue() + " does not exist",
                 transactionExternalId);
     }
 
     public LoanTransactionNotFoundException(ExternalId transactionExternalId, EmptyResultDataAccessException e) {
         super("error.msg.loan.transaction.external.id.invalid", "Transaction with external identifier "
-                + ObjectUtils.defaultIfNull(transactionExternalId, ExternalId.empty()).getValue() + " does not exist",
+                + Objects.requireNonNullElse(transactionExternalId, ExternalId.empty()).getValue() + " does not exist",
                 transactionExternalId, e);
     }
 }

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -65,7 +65,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
@@ -1963,17 +1962,17 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
 
     private void addToTransactionMapping(LoanTransactionToRepaymentScheduleMapping loanTransactionToRepaymentScheduleMapping,
             Money principalPortion, Money interestPortion, Money feePortion, Money penaltyPortion) {
-        BigDecimal aggregatedPenalty = ObjectUtils
-                .defaultIfNull(loanTransactionToRepaymentScheduleMapping.getPenaltyChargesPortion(), BigDecimal.ZERO)
+        BigDecimal aggregatedPenalty = Objects
+                .requireNonNullElse(loanTransactionToRepaymentScheduleMapping.getPenaltyChargesPortion(), BigDecimal.ZERO)
                 .add(penaltyPortion.getAmount());
-        BigDecimal aggregatedFee = ObjectUtils
-                .defaultIfNull(loanTransactionToRepaymentScheduleMapping.getFeeChargesPortion(), BigDecimal.ZERO)
+        BigDecimal aggregatedFee = Objects
+                .requireNonNullElse(loanTransactionToRepaymentScheduleMapping.getFeeChargesPortion(), BigDecimal.ZERO)
                 .add(feePortion.getAmount());
-        BigDecimal aggregatedInterest = ObjectUtils
-                .defaultIfNull(loanTransactionToRepaymentScheduleMapping.getInterestPortion(), BigDecimal.ZERO)
+        BigDecimal aggregatedInterest = Objects
+                .requireNonNullElse(loanTransactionToRepaymentScheduleMapping.getInterestPortion(), BigDecimal.ZERO)
                 .add(interestPortion.getAmount());
-        BigDecimal aggregatedPrincipal = ObjectUtils
-                .defaultIfNull(loanTransactionToRepaymentScheduleMapping.getPrincipalPortion(), BigDecimal.ZERO)
+        BigDecimal aggregatedPrincipal = Objects
+                .requireNonNullElse(loanTransactionToRepaymentScheduleMapping.getPrincipalPortion(), BigDecimal.ZERO)
                 .add(principalPortion.getAmount());
         loanTransactionToRepaymentScheduleMapping.setComponents(aggregatedPrincipal, aggregatedInterest, aggregatedFee, aggregatedPenalty);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableWriteServiceImpl.java
@@ -64,11 +64,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.fineract.infrastructure.codes.service.CodeReadPlatformService;
@@ -924,7 +924,7 @@ public class DatatableWriteServiceImpl implements DatatableWriteService {
         } catch (final EmptyResultDataAccessException e) {
             log.warn("Error occurred.", e);
         }
-        return ObjectUtils.defaultIfNull(codeId, 0);
+        return Objects.requireNonNullElse(codeId, 0);
     }
 
     /**

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleHistoryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/service/LoanScheduleHistoryReadPlatformServiceImpl.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
@@ -59,12 +59,11 @@ public class LoanScheduleHistoryReadPlatformServiceImpl implements LoanScheduleH
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public Integer fetchCurrentVersionNumber(Long loanId) {
         final String sql = "select MAX(lrs.version) from m_loan_repayment_schedule_history lrs where lrs.loan_id = ?";
-        Integer max = this.jdbcTemplate.queryForObject(sql, new Object[] { loanId }, Integer.class);
-        return ObjectUtils.defaultIfNull(max, 0);
+        Integer max = this.jdbcTemplate.queryForObject(sql, Integer.class, loanId);
+        return Objects.requireNonNullElse(max, 0);
     }
 
     @Override

--- a/fineract-security/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResourceSwagger.java
+++ b/fineract-security/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResourceSwagger.java
@@ -39,9 +39,9 @@ public final class AuthenticationApiResourceSwagger {
 
         }
 
-        @Schema(required = true, example = "mifos")
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "mifos")
         public String username;
-        @Schema(required = true, example = "password")
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "password")
         public String password;
     }
 

--- a/fineract-security/src/main/java/org/apache/fineract/infrastructure/security/data/PlatformRequestLog.java
+++ b/fineract-security/src/main/java/org/apache/fineract/infrastructure/security/data/PlatformRequestLog.java
@@ -53,7 +53,7 @@ public final class PlatformRequestLog {
         parameters.remove("password");
         parameters.remove("_");
 
-        return new PlatformRequestLog().setStartTime(task.getStartTime()).setTotalTime(task.getTime()).setMethod(request.getMethod())
-                .setUrl(requestUrl).setParameters(parameters);
+        return new PlatformRequestLog().setStartTime(task.getStartInstant().toEpochMilli()).setTotalTime(task.getTime())
+                .setMethod(request.getMethod()).setUrl(requestUrl).setParameters(parameters);
     }
 }


### PR DESCRIPTION
Replace deprecated method calls with their modern equivalents across several modules:

- **`ObjectUtils.defaultIfNull`** (deprecated in Commons Lang 3.15) → `Objects.requireNonNullElse` in 8 files across fineract-charge, fineract-core, fineract-loan, fineract-provider, and fineract-progressive-loan
- **`RandomStringUtils.randomAlphabetic`** (static call on instance) → `nextAlphabetic` in `DefaultContentPathRandomizer`
- **`StopWatch.getStartTime`** (deprecated in Commons Lang 3.12) → `getStartInstant().toEpochMilli()` in `PlatformRequestLog`
- **`@Schema(required = true)`** (deprecated in Swagger 2.2) → `@Schema(requiredMode = Schema.RequiredMode.REQUIRED)` in `AuthenticationApiResourceSwagger`
- **`PaymentTypeRepositoryWrapper`** (marked `@Deprecated(forRemoval = true)`) → replaced with direct `PaymentTypeRepository` usage in `PaymentDetailAssembler`, `PaymentDetailWritePlatformServiceJpaRepositoryImpl`, and `PaymentDetailConfiguration`

No behavioural changes.

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
