### PR TITLE
FINERACT-2559: Fix redundant database query during classification retrieval

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingReadPlatformServiceImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/service/ProductToGLAccountMappingReadPlatformServiceImpl.java
@@ -312,7 +312,6 @@ public class ProductToGLAccountMappingReadPlatformServiceImpl implements Product
                         : productToGLAccountMappingRepository.findAllBuyDownFeeClassificationsMappings(loanProductId,
                                 portfolioProductType.getValue());
 
-        productToGLAccountMappingRepository.findAllChargeOffReasonsMappings(loanProductId, portfolioProductType.getValue());
         List<ClassificationToGLAccountData> classificationToGLAccountMappers = mappings.isEmpty() ? null : new ArrayList<>();
         for (final ProductToGLAccountMapping mapping : mappings) {
             final Long glAccountId = mapping.getGlAccount().getId();


### PR DESCRIPTION
## Description

This PR addresses [FINERACT-2559](https://issues.apache.org/jira/browse/FINERACT-2559).

In the loan product details read path, the classification mapping flow previously executed an additional repository query (`findAllChargeOffReasonsMappings`) whose result was immediately discarded and never used. This created an unnecessary database round trip with no functional benefit, adding to database overhead during loan product details retrieval.

### Changes
* Removed the unused call to `productToGLAccountMappingRepository.findAllChargeOffReasonsMappings(loanProductId, portfolioProductType.getValue())` within `ProductToGLAccountMappingReadPlatformServiceImpl.fetchClassificationMappings`.

This is a minor performance optimization that eliminates a redundant database query without making any functional changes to the codebase.
