### PR TITLE
FINERACT-2574: improve release LICENSE language

### DIFF
--- a/LICENSE_RELEASE
+++ b/LICENSE_RELEASE
@@ -208,17 +208,18 @@
 ======================================
 
 All the source code for the Apache Fineract project is released under the
-license above. Additionally, the Apache Fineract source and binary
-distribution includes a number of third-party files that are required in
-order to the software to function. Unless noted below, these jars
-and resource files are also released under the ASF license above.
+license above. Additionally, the Apache Fineract source and binary distribution
+includes a number of third-party files that are required in order to the
+software to function. Unless noted below, these jars and resource files are
+also released under the Apache License, Version 2.0.
 
 ==================================================
 *The exceptions for binary release are as follows:
 ==================================================
 
-This product bundles third party jars and resource files that are 
-released under other licenses than the ASF license. You can find
-details of all third party licenses in the directory "licenses". 
+This product bundles third party jars and resource files that are released
+under licenses other than the Apache License, Version 2.0 following the ASF 3rd
+party license policy. You can find details of all third party licenses in the
+"licenses" directory (if the "generateLicenseReport" Gradle task has been run).
 
 ******************************************

--- a/LICENSE_SOURCE
+++ b/LICENSE_SOURCE
@@ -208,10 +208,10 @@
 ======================================
 
 All the source code for the Apache Fineract project is released under the
-license above. Additionally, the Apache Fineract source and binary
-distribution includes a number of third-party files that are required in
-order to the software to function. Unless noted below, these jars
-and resource files are also released under the ASF license above.
+license above. Additionally, the Apache Fineract source and binary distribution
+includes a number of third-party files that are required in order to the
+software to function. Unless noted below, these jars and resource files are
+also released under the Apache License, Version 2.0.
 
 ==================================================
 *The exceptions for source release are as follows:

--- a/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step06.adoc
@@ -6,7 +6,9 @@ Create source and binary tarballs.
 
 [source,bash,subs="attributes+"]
 ----
-./gradlew clean srcDistTar binaryDistTar
+./gradlew clean
+./gradlew generateLicenseReport
+./gradlew srcDistTar binaryDistTar
 ----
 
 Check that `fineract-provider/build/classes/java/main/git.properties` exists. If so, continue. If not, you're likely encountering https://github.com/n0mer/gradle-git-properties/issues/233[this bug], and you need to *re-run the command above* to create proper source and binary tarballs. That `git.properties` file is supposed to end up at `BOOT-INF/classes/git.properties` in `fineract-provider-{revnumber}.jar` in the binary release tarball. Its contents are displayed at the `/fineract-provider/actuator/info` endpoint. It may be possible to fix this heisenbug entirely by https://github.com/gradle/gradle/issues/34177#issuecomment-3051970053[modifying our git properties gradle plugin config] in `fineract-provider/build.gradle`, perhaps by changing where `git.properties` is written.


### PR DESCRIPTION
## Description

FINERACT-2574

Improve release LICENSE language.

* explain how "licenses" dir is created
* it's the "Apache License 2.0", not the "ASF license"
* ensure "licenses/" dir is present when creating release artifacts

LICENSE_RELEASE becomes LICENSE in a binary release tarball. See `fineract-war/build.gradle`.

This change is also somewhat related to FINERACT-2572

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
