### PR TITLE
Fix FEB_29_PERIOD_ONLY strategy for cross-year repayment periods

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -1280,12 +1280,15 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     }
 
     private boolean isPeriodContainsFeb29(final LocalDate repaymentPeriodFromDate, final LocalDate repaymentPeriodDueDate) {
-        if (repaymentPeriodFromDate.isLeapYear()) {
-            final LocalDate leapDay = LocalDate.of(repaymentPeriodFromDate.getYear(), 2, 29);
-            return DateUtils.isDateInRangeFromExclusiveToInclusive(leapDay, repaymentPeriodFromDate, repaymentPeriodDueDate);
-        } else {
-            return false;
+        for (int year = repaymentPeriodFromDate.getYear(); year <= repaymentPeriodDueDate.getYear(); year++) {
+            if (Year.isLeap(year)) {
+                final LocalDate leapDay = LocalDate.of(year, 2, 29);
+                if (DateUtils.isDateInRangeFromExclusiveToInclusive(leapDay, repaymentPeriodFromDate, repaymentPeriodDueDate)) {
+                    return true;
+                }
+            }
         }
+        return false;
     }
 
     private Integer numberOfDaysFeb29PeriodOnly(final LocalDate repaymentPeriodFromDate, final LocalDate repaymentPeriodDueDate) {

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -3174,6 +3174,60 @@ class ProgressiveEMICalculatorTest {
             checkPeriod(interestSchedule, 5, 867.65, 10.03, 857.62, 0.00, false);
         }
 
+        /**
+         * Cross-year edge case: quarterly repayment period spans from non-leap year (2023) into leap year (2024) and
+         * contains Feb 29. With FEB_29_PERIOD_ONLY strategy, this period should use 366 days (same as FULL_LEAP_YEAR)
+         * because Feb 29 falls within the period.
+         */
+        @Test
+        public void test_feb29_period_only_cross_year_quarterly_period_containing_feb29() {
+            final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(
+                    periodData(LocalDate.of(2023, 9, 1), LocalDate.of(2023, 12, 1)),
+                    periodData(LocalDate.of(2023, 12, 1), LocalDate.of(2024, 3, 1)),
+                    periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 1)),
+                    periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 9, 1)));
+
+            final BigDecimal interestRate = BigDecimal.valueOf(12.0);
+            final Integer installmentAmountInMultiplesOf = null;
+
+            // Schedule with FEB_29_PERIOD_ONLY
+            Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(interestRate);
+            Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.ACTUAL.getValue());
+            Mockito.when(loanProductRelatedDetail.getDaysInYearCustomStrategy())
+                    .thenReturn(DaysInYearCustomStrategyType.FEB_29_PERIOD_ONLY);
+            Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.ACTUAL.getValue());
+            Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+            Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(3);
+            Mockito.when(loanProductRelatedDetail.getCurrencyData()).thenReturn(currency);
+            Mockito.when(loanProductRelatedDetail.isAllowFullTermForTranche()).thenReturn(false);
+
+            final ProgressiveLoanInterestScheduleModel feb29Schedule = emiCalculator.generatePeriodInterestScheduleModel(
+                    expectedRepaymentPeriods, loanProductRelatedDetail, installmentAmountInMultiplesOf, mc);
+            emiCalculator.addDisbursement(feb29Schedule, LocalDate.of(2023, 9, 1), toMoney(10000.0));
+
+            // Schedule with FULL_LEAP_YEAR
+            Mockito.when(loanProductRelatedDetail.getDaysInYearCustomStrategy())
+                    .thenReturn(DaysInYearCustomStrategyType.FULL_LEAP_YEAR);
+
+            final ProgressiveLoanInterestScheduleModel fullLeapSchedule = emiCalculator.generatePeriodInterestScheduleModel(
+                    expectedRepaymentPeriods, loanProductRelatedDetail, installmentAmountInMultiplesOf, mc);
+            emiCalculator.addDisbursement(fullLeapSchedule, LocalDate.of(2023, 9, 1), toMoney(10000.0));
+
+            // Period 1 (Dec 1, 2023 → Mar 1, 2024) contains Feb 29, 2024.
+            // Both strategies should use 366 days for this period, so interest should match.
+            final RepaymentPeriod feb29Period1 = feb29Schedule.repaymentPeriods().get(1);
+            final RepaymentPeriod fullLeapPeriod1 = fullLeapSchedule.repaymentPeriods().get(1);
+            Assertions.assertEquals(toDouble(fullLeapPeriod1.getDueInterest()), toDouble(feb29Period1.getDueInterest()),
+                    "Cross-year period containing Feb 29 should use 366 days for both strategies");
+
+            // Period 2 (Mar 1, 2024 → Jun 1, 2024) does NOT contain Feb 29.
+            // FEB_29_PERIOD_ONLY should use 365 days, FULL_LEAP_YEAR should use 366 days.
+            final RepaymentPeriod feb29Period2 = feb29Schedule.repaymentPeriods().get(2);
+            final RepaymentPeriod fullLeapPeriod2 = fullLeapSchedule.repaymentPeriods().get(2);
+            Assertions.assertNotEquals(toDouble(fullLeapPeriod2.getDueInterest()), toDouble(feb29Period2.getDueInterest()),
+                    "Period without Feb 29 should differ between strategies (365 vs 366 days)");
+        }
+
         @Test
         public void test_leap_year_only_actual_no_effect_on_360_loan() {
             final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = List.of(


### PR DESCRIPTION
## Description

- Fix `isPeriodContainsFeb29` in `ProgressiveEMICalculator` to correctly detect Feb 29 when a repayment period spans from a non-leap year into a leap year (e.g., Dec 1, 2023 → Mar 1, 2024)
  - The previous implementation only checked the `repaymentPeriodFromDate`'s year for leap year, causing it to return `false` when the from-date was in a non-leap year — even if Feb 29 of the next (leap) year
  fell within the period
  - This caused two downstream issues for `FEB_29_PERIOD_ONLY` strategy:
    - `numberOfDaysFeb29PeriodOnly` returned 365 instead of 366
    - `partialPeriodCalculationNeeded` was `false`, skipping the year-splitting interest calculation
  - Add unit test for quarterly repayment cross-year scenario validating the fix

  ## Summary

  - Fix `isPeriodContainsFeb29` in `ProgressiveEMICalculator` to correctly detect Feb 29 when a repayment period spans from a non-leap year into a leap year (e.g., Dec 1, 2023 → Mar 1, 2024)
  - The previous implementation only checked the `repaymentPeriodFromDate`'s year for leap year, causing it to return `false` when the from-date was in a non-leap year — even if Feb 29 of the next (leap) year
  fell within the period
  - This caused two downstream issues for `FEB_29_PERIOD_ONLY` strategy:
    - `numberOfDaysFeb29PeriodOnly` returned 365 instead of 366
    - `partialPeriodCalculationNeeded` was `false`, skipping the year-splitting interest calculation
  - Add unit test for quarterly repayment cross-year scenario validating the fix

  ## Impact

  Affects **progressive loan** interest calculations using:
  - `DaysInYearType.ACTUAL` + `DaysInYearCustomStrategyType.FEB_29_PERIOD_ONLY`
  - Non-monthly repayment frequencies (bi-monthly, quarterly, etc.) where a single repayment period crosses from a non-leap year into a leap year past February 29

  Monthly repayments are **not affected** since a single month cannot span from one year past Feb 29 of the next year.

  ## Changes

  | File | Change |
  |------|--------|
  | `ProgressiveEMICalculator.java` | Iterate all years the period spans to check for Feb 29 in each leap year, instead of only checking the from-date's year |
  | `ProgressiveEMICalculatorTest.java` | Add `test_feb29_period_only_cross_year_quarterly_period_containing_feb29` verifying cross-year FEB_29_PERIOD_ONLY matches FULL_LEAP_YEAR when Feb 29 is in the period |


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
