### PR TITLE
FINERACT-2575: replace archived Avro Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ plugins {
     id 'com.github.andygoossens.modernizer' version '1.10.0' apply false
     id 'com.github.spotbugs' version '6.0.26' apply false
     id 'se.thinkcode.cucumber-runner' version '0.0.11' apply false
-    id "com.github.davidmc24.gradle.plugin.avro-base" version "1.9.1" apply false
+    id "eu.eventloopsoftware.avro-gradle-plugin" version "0.1.2" apply false
     id 'org.openapi.generator' version '7.8.0' apply false
     id 'com.gradleup.shadow' version '9.3.2' apply false
     id 'me.champeau.jmh' version '0.7.1' apply false

--- a/fineract-avro-schemas/build.gradle
+++ b/fineract-avro-schemas/build.gradle
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import com.github.davidmc24.gradle.plugin.avro.GenerateAvroJavaTask
-
 // TODO: @vidakovic we should publish this lib to Maven Central; do in separate PR
 description = 'Fineract Avro Schemas'
 
-apply plugin: 'com.github.davidmc24.gradle.plugin.avro-base'
+apply plugin: 'eu.eventloopsoftware.avro-gradle-plugin'
 
 apply from: 'dependencies.gradle'
 
@@ -41,7 +39,7 @@ abstract class PreprocessAvroSchemasTask extends DefaultTask {
         def template = getBigDecimalTemplate().get().asFile.getText("UTF-8")
         def input = getInputDir().get().asFile
         def output = getOutputDir().get().asFile
-        
+
         input.eachFileRecurse { file ->
             if (file.isFile()) {
                 def relativePath = input.toPath().relativize(file.toPath())
@@ -59,10 +57,11 @@ tasks.register('preprocessAvroSchemas', PreprocessAvroSchemasTask) {
     outputDir = file("$buildDir/generated/avro/src/main/avro")
 }
 
-task buildJavaSdk(type: GenerateAvroJavaTask) {
-    source("$buildDir/generated/avro/src/main/avro")
-    outputDir = file("$buildDir/generated/java/src/main/java")
+avro {
+    sourceDirectory = "$buildDir/generated/avro/src/main/avro"
+    outputDirectory = "$buildDir/generated/java/src/main/java"
     templateDirectory = "$projectDir/src/main/resources/avro-generator-templates/"
+    enableDecimalLogicalType = true
 }
 
 spotless {
@@ -73,7 +72,13 @@ spotless {
     }
 }
 
-buildJavaSdk.dependsOn(preprocessAvroSchemas, spotlessJsonApply)
+tasks.named('avroGenerateJavaClasses') {
+    dependsOn tasks.named('preprocessAvroSchemas'), tasks.named('spotlessJsonApply')
+}
+
+def buildJavaSdk = tasks.register('buildJavaSdk') {
+    dependsOn tasks.named('avroGenerateJavaClasses')
+}
 
 sourceSets {
     main {


### PR DESCRIPTION
Replaces the archived Avro Gradle plugin with `eu.eventloopsoftware.avro-gradle-plugin` in `fineract-avro-schemas`.
The migration keeps the current generation flow unchanged:

- Preserves schema preprocessing for bigdecimal
- Keeps the custom Avro templates
- Keeps the existing buildJavaSdk task contract for downstream modules

I also restored `enableDecimalLogicalType = true` so decimal fields continue to be generated as `BigDecimal` instead of `ByteBuffer`.