### PR TITLE
FINERACT-2533: Remove @Skip tags from savings account E2E scenarios

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/factory/SavingsProductRequestFactory.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/factory/SavingsProductRequestFactory.java
@@ -20,13 +20,13 @@ package org.apache.fineract.test.factory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.apache.fineract.client.models.PostSavingsCharges;
 import org.apache.fineract.client.models.PostSavingsProductsRequest;
 
 public final class SavingsProductRequestFactory {
 
     public static final String DEFAULT_SAVINGS_PRODUCT_NAME = "CEUR";
-
     public static final String DEFAULT_SAVINGS_PRODUCT_SHORT_NAME = "CEU";
     public static final String DEFAULT_SAVINGS_PRODUCT_DESCRIPTION = "";
     public static final String DEFAULT_SAVINGS_PRODUCT_CURRENCY_CODE = "EUR";
@@ -43,10 +43,11 @@ public final class SavingsProductRequestFactory {
     private SavingsProductRequestFactory() {}
 
     public static PostSavingsProductsRequest defaultSavingsProductRequest() {
+        String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, 4).toUpperCase();
         List<PostSavingsCharges> charges = new ArrayList<>();
 
-        return new PostSavingsProductsRequest().name(DEFAULT_SAVINGS_PRODUCT_NAME)//
-                .shortName(DEFAULT_SAVINGS_PRODUCT_SHORT_NAME)//
+        return new PostSavingsProductsRequest().name(DEFAULT_SAVINGS_PRODUCT_NAME + "-" + uniqueId)//
+                .shortName(uniqueId)//
                 .description(DEFAULT_SAVINGS_PRODUCT_DESCRIPTION)//
                 .currencyCode(DEFAULT_SAVINGS_PRODUCT_CURRENCY_CODE)//
                 .digitsAfterDecimal(DEFAULT_SAVINGS_PRODUCT_DIGITS_AFTER_DECIMAL)//

--- a/fineract-e2e-tests-runner/src/test/resources/features/SavingsAccount.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/SavingsAccount.feature
@@ -1,30 +1,32 @@
 @SavingsAccount
 Feature: SavingsAccount
 
-#    TODO unskip and check when PS-1088 is done
-  @Skip @TestRailId:C2438
+  @TestRailId:C2438
   Scenario: As a user I would like to Deposit to my savings account
     When Admin sets the business date to "1 June 2022"
     When Admin creates a client with random data
+    And Admin creates a EUR savings product
     And Client creates a new EUR savings account with "1 June 2022" submitted on date
     And Approve EUR savings account on "1 June 2022" date
     And Activate EUR savings account on "1 June 2022" date
     And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
 
-  @Skip @TestRailId:C2439
+  @TestRailId:C2439
   Scenario: As a user I would like to Withdraw from my savings account
     When Admin sets the business date to "1 June 2022"
     When Admin creates a client with random data
+    And Admin creates a EUR savings product
     And Client creates a new EUR savings account with "1 June 2022" submitted on date
     And Approve EUR savings account on "1 June 2022" date
     And Activate EUR savings account on "1 June 2022" date
     And Client successfully deposits 1000 EUR to the savings account on "1 June 2022" date
     And Client successfully withdraw 1000 EUR from the savings account on "1 June 2022" date
 
-  @Skip @TestRailId:C2440
+  @TestRailId:C2440
   Scenario: As a user I would like to create an EUR and USD Savings accounts and make deposit and withdraw events
     When Admin sets the business date to "1 June 2022"
     When Admin creates a client with random data
+    And Admin creates a EUR savings product
     And Client creates a new EUR savings account with "1 June 2022" submitted on date
     And Approve EUR savings account on "1 June 2022" date
     And Activate EUR savings account on "1 June 2022" date


### PR DESCRIPTION
Removes @Skip annotations from scenarios C2438, C2439, and C2440 in SavingsAccount.feature.

These scenarios were skipped because SavingsAccountRequestFactory hardcoded
EUR_SAVING_PRODUCT_ID = 1L which did not exist in the E2E environment.

PR #5646 fixed the root cause by dynamically creating the EUR savings product via
SavingsProductRequestFactory.defaultSavingsProductRequest() and storing its ID in
TestContextKey.DEFAULT_SAVINGS_PRODUCT_CREATE_RESPONSE_EUR.

The "And Admin creates a EUR savings product" step is now added to C2438, C2439,
and C2440 (already present in C2441 from PR #5646), making the skip reason obsolete.

Closes FINERACT-2533