### PR TITLE
FINERACT-2582: Move constant repository lookups outside loops in email campaign and notification services

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/jobs/updateemailoutboundwithcampaignmessage/UpdateEmailOutboundWithCampaignMessageTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/jobs/updateemailoutboundwithcampaignmessage/UpdateEmailOutboundWithCampaignMessageTasklet.java
@@ -90,10 +90,10 @@ public class UpdateEmailOutboundWithCampaignMessageTasklet implements Tasklet {
             List<HashMap<String, Object>> runReportObject = emailCampaignWritePlatformService
                     .getRunReportByServiceImpl(campaignParams.get("reportName"), queryParamForRunReport);
             if (runReportObject != null) {
+                EmailCampaign emailCampaign = emailCampaignRepository.findById(campaignId).orElse(null);
                 for (HashMap<String, Object> entry : runReportObject) {
                     String message = compileEmailTemplate(messageTemplate, campaignName, entry);
                     Integer clientId = (Integer) entry.get("id");
-                    EmailCampaign emailCampaign = emailCampaignRepository.findById(campaignId).orElse(null);
                     Client client = clientRepositoryWrapper.findOneWithNotFoundDetection(clientId.longValue());
                     String emailAddress = client.emailAddress();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationWritePlatformServiceImpl.java
@@ -61,11 +61,11 @@ public class NotificationWritePlatformServiceImpl implements NotificationWritePl
 
     private List<Long> insertIntoNotificationMapper(Collection<Long> userIds, Long generatedNotificationId) {
         List<Long> mappedIds = new ArrayList<>();
+        Notification notification = this.notificationGeneratorReadRepositoryWrapper.findById(generatedNotificationId);
         for (Long userId : userIds) {
             AppUser appUser = this.appUserRepository.findById(userId).orElseThrow();
-            NotificationMapper notificationMapper = new NotificationMapper()
-                    .setNotification(this.notificationGeneratorReadRepositoryWrapper.findById(generatedNotificationId)).setUserId(appUser)
-                    .setRead(false).setCreatedAt(DateUtils.getLocalDateTimeOfSystem());
+            NotificationMapper notificationMapper = new NotificationMapper().setNotification(notification).setUserId(appUser).setRead(false)
+                    .setCreatedAt(DateUtils.getLocalDateTimeOfSystem());
             this.notificationMapperWritePlatformService.create(notificationMapper);
             mappedIds.add(notificationMapper.getId());
         }


### PR DESCRIPTION
## Description

JIRA: https://issues.apache.org/jira/browse/FINERACT-2582

Two methods were performing identical repository lookups inside loops 
where the argument never changes across iterations, causing N redundant 
DB round-trips per invocation.

- `UpdateEmailOutboundWithCampaignMessageTasklet.insertDirectCampaignIntoEmailOutboundTable()`: 
  `emailCampaignRepository.findById(campaignId)` hoisted above the loop — `campaignId` is constant per invocation.

- `NotificationWritePlatformServiceImpl.insertIntoNotificationMapper()`: 
  `notificationGeneratorReadRepositoryWrapper.findById(generatedNotificationId)` hoisted above the loop — `generatedNotificationId` is constant per invocation.

No logic change — both lookups still happen, just once instead of N times.

Same class of redundancy as FINERACT-2561.