### PR TITLE
FINERACT-2583: Batch entity lookups in holiday office selection, provisioning criteria, and collateral assembly

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/service/HolidayWritePlatformServiceJpaRepositoryImpl.java
@@ -27,6 +27,8 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -44,7 +46,9 @@ import org.apache.fineract.organisation.holiday.domain.Holiday;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
 import org.apache.fineract.organisation.holiday.exception.HolidayDateException;
 import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.office.domain.OfficeRepository;
 import org.apache.fineract.organisation.office.domain.OfficeRepositoryWrapper;
+import org.apache.fineract.organisation.office.exception.OfficeNotFoundException;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.apache.fineract.organisation.workingdays.service.WorkingDaysUtil;
@@ -61,6 +65,7 @@ public class HolidayWritePlatformServiceJpaRepositoryImpl implements HolidayWrit
     private final WorkingDaysRepositoryWrapper daysRepositoryWrapper;
     private final PlatformSecurityContext context;
     private final OfficeRepositoryWrapper officeRepositoryWrapper;
+    private final OfficeRepository officeRepository;
     private final FromJsonHelper fromApiJsonHelper;
 
     @Transactional
@@ -162,11 +167,21 @@ public class HolidayWritePlatformServiceJpaRepositoryImpl implements HolidayWrit
                 && topLevelJsonElement.get(HolidayApiConstants.officesParamName).isJsonArray()) {
 
             final JsonArray array = topLevelJsonElement.get(HolidayApiConstants.officesParamName).getAsJsonArray();
+            Set<Long> officeIds = new HashSet<>(array.size());
+            for (int i = 0; i < array.size(); i++) {
+                officeIds.add(
+                        this.fromApiJsonHelper.extractLongNamed(HolidayApiConstants.officeIdParamName, array.get(i).getAsJsonObject()));
+            }
+            Map<Long, Office> officeMap = this.officeRepository.findAllById(officeIds).stream()
+                    .collect(Collectors.toMap(Office::getId, Function.identity()));
             offices = new HashSet<>(array.size());
             for (int i = 0; i < array.size(); i++) {
-                final JsonObject officeElement = array.get(i).getAsJsonObject();
-                final Long officeId = this.fromApiJsonHelper.extractLongNamed(HolidayApiConstants.officeIdParamName, officeElement);
-                final Office office = this.officeRepositoryWrapper.findOneWithNotFoundDetection(officeId);
+                final Long officeId = this.fromApiJsonHelper.extractLongNamed(HolidayApiConstants.officeIdParamName,
+                        array.get(i).getAsJsonObject());
+                final Office office = officeMap.get(officeId);
+                if (office == null) {
+                    throw new OfficeNotFoundException(officeId);
+                }
                 offices.add(office);
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/starter/OrganisationHolidayConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/starter/OrganisationHolidayConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.fineract.organisation.holiday.service.HolidayReadPlatformServi
 import org.apache.fineract.organisation.holiday.service.HolidayReadPlatformServiceImpl;
 import org.apache.fineract.organisation.holiday.service.HolidayWritePlatformService;
 import org.apache.fineract.organisation.holiday.service.HolidayWritePlatformServiceJpaRepositoryImpl;
+import org.apache.fineract.organisation.office.domain.OfficeRepository;
 import org.apache.fineract.organisation.office.domain.OfficeRepositoryWrapper;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -46,8 +47,8 @@ public class OrganisationHolidayConfiguration {
     @ConditionalOnMissingBean(HolidayWritePlatformService.class)
     public HolidayWritePlatformService holidayWritePlatformService(HolidayDataValidator fromApiJsonDeserializer,
             HolidayRepositoryWrapper holidayRepository, PlatformSecurityContext context, OfficeRepositoryWrapper officeRepositoryWrapper,
-            FromJsonHelper fromApiJsonHelper, WorkingDaysRepositoryWrapper daysRepositoryWrapper) {
+            OfficeRepository officeRepository, FromJsonHelper fromApiJsonHelper, WorkingDaysRepositoryWrapper daysRepositoryWrapper) {
         return new HolidayWritePlatformServiceJpaRepositoryImpl(fromApiJsonDeserializer, holidayRepository, daysRepositoryWrapper, context,
-                officeRepositoryWrapper, fromApiJsonHelper);
+                officeRepositoryWrapper, officeRepository, fromApiJsonHelper);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaAssembler.java
@@ -26,7 +26,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.accounting.glaccount.domain.GLAccount;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountRepository;
@@ -57,9 +60,14 @@ public class ProvisioningCriteriaAssembler {
         if (fromApiJsonHelper.parameterExists(ProvisioningCriteriaConstants.JSON_LOANPRODUCTS_PARAM, jsonElement)) {
             JsonArray jsonloanProducts = this.fromApiJsonHelper.extractJsonArrayNamed(ProvisioningCriteriaConstants.JSON_LOANPRODUCTS_PARAM,
                     jsonElement);
+            List<Long> productIds = new ArrayList<>(jsonloanProducts.size());
             for (JsonElement element : jsonloanProducts) {
-                Long productId = this.fromApiJsonHelper.extractLongNamed("id", element.getAsJsonObject());
-                loanProducts.add(loanProductRepository.findById(productId).orElse(null));
+                productIds.add(this.fromApiJsonHelper.extractLongNamed("id", element.getAsJsonObject()));
+            }
+            Map<Long, LoanProduct> productMap = loanProductRepository.findAllById(productIds).stream()
+                    .collect(Collectors.toMap(LoanProduct::getId, Function.identity()));
+            for (Long productId : productIds) {
+                loanProducts.add(productMap.getOrDefault(productId, null));
             }
         } else {
             loanProducts = loanProductRepository.findAll();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/service/CollateralAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/service/CollateralAssembler.java
@@ -24,10 +24,15 @@ import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
+import org.apache.fineract.infrastructure.codes.domain.CodeValueRepository;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrapper;
+import org.apache.fineract.infrastructure.codes.exception.CodeValueNotFoundException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.portfolio.collateral.domain.LoanCollateral;
 import org.apache.fineract.portfolio.collateral.domain.LoanCollateralRepository;
@@ -38,6 +43,7 @@ public class CollateralAssembler {
 
     private final FromJsonHelper fromApiJsonHelper;
     private final CodeValueRepositoryWrapper codeValueRepository;
+    private final CodeValueRepository codeValueRepositoryDirect;
     private final LoanCollateralRepository loanCollateralRepository;
 
     public Set<LoanCollateral> fromParsedJson(final JsonElement element) {
@@ -50,13 +56,22 @@ public class CollateralAssembler {
             if (topLevelJsonElement.has("collateral") && topLevelJsonElement.get("collateral").isJsonArray()) {
                 final JsonArray array = topLevelJsonElement.get("collateral").getAsJsonArray();
                 final Locale locale = this.fromApiJsonHelper.extractLocaleParameter(topLevelJsonElement);
+                Set<Long> collateralTypeIds = new HashSet<>();
+                for (int i = 0; i < array.size(); i++) {
+                    collateralTypeIds.add(this.fromApiJsonHelper.extractLongNamed("type", array.get(i).getAsJsonObject()));
+                }
+                Map<Long, CodeValue> codeValueMap = this.codeValueRepositoryDirect.findAllById(collateralTypeIds).stream()
+                        .collect(Collectors.toMap(CodeValue::getId, Function.identity()));
                 for (int i = 0; i < array.size(); i++) {
 
                     final JsonObject collateralItemElement = array.get(i).getAsJsonObject();
 
                     final Long id = this.fromApiJsonHelper.extractLongNamed("id", collateralItemElement);
                     final Long collateralTypeId = this.fromApiJsonHelper.extractLongNamed("type", collateralItemElement);
-                    final CodeValue collateralType = this.codeValueRepository.findOneWithNotFoundDetection(collateralTypeId);
+                    final CodeValue collateralType = codeValueMap.get(collateralTypeId);
+                    if (collateralType == null) {
+                        throw new CodeValueNotFoundException(collateralTypeId);
+                    }
                     final String description = this.fromApiJsonHelper.extractStringNamed("description", collateralItemElement);
                     final BigDecimal value = this.fromApiJsonHelper.extractBigDecimalNamed("value", collateralItemElement, locale);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/starter/CollateralConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateral/starter/CollateralConfiguration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.collateral.starter;
 
+import org.apache.fineract.infrastructure.codes.domain.CodeValueRepository;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrapper;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
@@ -40,8 +41,8 @@ public class CollateralConfiguration {
     @Bean
     @ConditionalOnMissingBean(CollateralAssembler.class)
     public CollateralAssembler collateralAssembler(FromJsonHelper fromApiJsonHelper, CodeValueRepositoryWrapper codeValueRepository,
-            LoanCollateralRepository loanCollateralRepository) {
-        return new CollateralAssembler(fromApiJsonHelper, codeValueRepository, loanCollateralRepository);
+            CodeValueRepository codeValueRepositoryDirect, LoanCollateralRepository loanCollateralRepository) {
+        return new CollateralAssembler(fromApiJsonHelper, codeValueRepository, codeValueRepositoryDirect, loanCollateralRepository);
     }
 
     @Bean


### PR DESCRIPTION
## Description

JIRA: https://issues.apache.org/jira/browse/FINERACT-2583

Three methods were executing per-iteration repository queries where all IDs were known before the loop:

**HolidayWritePlatformServiceJpaRepositoryImpl.getSelectedOffices()**
- `officeRepositoryWrapper.findOneWithNotFoundDetection(officeId)` was called on every iteration
- Fix: collect IDs -> bulk `officeRepository.findAllById()` -> map lookup
- `OfficeRepository` injected directly (same pattern as FINERACT-2579)

**ProvisioningCriteriaAssembler.parseLoanProducts()**
- `loanProductRepository.findById(productId).orElse(null)` was called on every product
- Fix: collect IDs -> bulk `findAllById()` -> `map.getOrDefault(id, null)`
- Preserves null-tolerant behavior of original (orElse(null))

**CollateralAssembler.fromParsedJson()**
- `codeValueRepository.findOneWithNotFoundDetection(collateralTypeId)` was called on every item
- Fix: collect IDs -> bulk fetch -> map lookup
- Throws `CodeValueNotFoundException` for missing IDs to replicate original behavior

Same class of redundancy as FINERACT-2579. No logic changes.