### PR TITLE
FINERACT-2436: Fix PostgreSQL compatibility for client and loan trends reports

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -245,4 +245,5 @@
     <include file="parts/0224_add_allow_cash_and_non_cash_accrual_config.xml" relativeToChangelogFile="true" />
     <include file="parts/0225_add_originator_external_ids_to_aggregation_summary.xml" relativeToChangelogFile="true" />
     <include file="parts/0226_trial_balance_summary_fix_originator_join_conditions.xml" relativeToChangelogFile="true" />
+    <include file="parts/0227_postgresql_client_and_loan_trends_reports.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0227_postgresql_client_and_loan_trends_reports.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0227_postgresql_client_and_loan_trends_reports.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="postgresql-client-trends-by-week" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql" value="SELECT COUNT(cl.id) AS count, EXTRACT(WEEK FROM cl.activation_date) AS Weeks
+            FROM m_office o LEFT JOIN m_client cl on o.id = cl.office_id
+            WHERE o.hierarchy like concat((select ino.hierarchy from m_office ino where ino.id = ${officeId}),'%' )
+                AND (cl.activation_date BETWEEN (CURRENT_DATE - INTERVAL '12 weeks') AND CURRENT_DATE)
+            GROUP BY EXTRACT(WEEK FROM cl.activation_date)"/>
+            <where>report_name = 'ClientTrendsByWeek'</where>
+        </update>
+    </changeSet>
+
+    <changeSet author="fineract" id="postgresql-client-trends-by-month" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql" value="SELECT COUNT(cl.id) AS count, TRIM(TO_CHAR(cl.activation_date, 'Month')) AS Months
+            FROM m_office o LEFT JOIN m_client cl ON o.id = cl.office_id
+            WHERE o.hierarchy LIKE CONCAT((SELECT ino.hierarchy FROM m_office ino WHERE ino.id = ${officeId}), '%')
+                AND (cl.activation_date BETWEEN (CURRENT_DATE - INTERVAL '12 months') AND CURRENT_DATE)
+            GROUP BY TRIM(TO_CHAR(cl.activation_date, 'Month')), EXTRACT(MONTH FROM cl.activation_date)
+            ORDER BY EXTRACT(MONTH FROM cl.activation_date) ASC"/>
+            <where>report_name = 'ClientTrendsByMonth'</where>
+        </update>
+    </changeSet>
+
+    <changeSet author="fineract" id="postgresql-loan-trends-by-week" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql" value="SELECT COUNT(ln.id) AS lcount, EXTRACT(WEEK FROM ln.disbursedon_date) AS Weeks
+            FROM m_office o
+                LEFT JOIN m_client cl on o.id = cl.office_id
+                LEFT JOIN m_loan ln on cl.id = ln.client_id
+            WHERE o.hierarchy like concat((select ino.hierarchy from m_office ino where ino.id = ${officeId}),'%' )
+                AND (ln.disbursedon_date BETWEEN (CURRENT_DATE - INTERVAL '12 weeks') AND CURRENT_DATE)
+            GROUP BY EXTRACT(WEEK FROM ln.disbursedon_date)"/>
+            <where>report_name = 'LoanTrendsByWeek'</where>
+        </update>
+    </changeSet>
+
+    <changeSet author="fineract" id="postgresql-loan-trends-by-month" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql" value="SELECT COUNT(ln.id) AS lcount, TRIM(TO_CHAR(ln.disbursedon_date, 'Month')) AS Months
+            FROM m_office o
+                LEFT JOIN m_client cl on o.id = cl.office_id
+                LEFT JOIN m_loan ln on cl.id = ln.client_id
+            WHERE o.hierarchy like concat((select ino.hierarchy from m_office ino where ino.id = ${officeId}),'%' )
+                AND (ln.disbursedon_date BETWEEN (CURRENT_DATE - INTERVAL '12 months') AND CURRENT_DATE)
+            GROUP BY TRIM(TO_CHAR(ln.disbursedon_date, 'Month')), EXTRACT(MONTH FROM ln.disbursedon_date)
+            ORDER BY EXTRACT(MONTH FROM ln.disbursedon_date) ASC"/>
+            <where>report_name = 'LoanTrendsByMonth'</where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientAndLoanTrendsPostgresTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientAndLoanTrendsPostgresTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.apache.fineract.client.models.RunReportsResponse;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import retrofit2.Response;
+
+public class ClientAndLoanTrendsPostgresTest extends IntegrationTest {
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+    }
+
+    @Test
+    void testClientTrendsByWeekReportRunsSuccessfully() {
+        Response<RunReportsResponse> response = okR(
+                fineractClient().reportsRun.runReportGetData("ClientTrendsByWeek", Map.of("R_officeId", "1")));
+        assertEquals(200, response.code());
+    }
+
+    @Test
+    void testClientTrendsByMonthReportRunsSuccessfully() {
+        Response<RunReportsResponse> response = okR(
+                fineractClient().reportsRun.runReportGetData("ClientTrendsByMonth", Map.of("R_officeId", "1")));
+        assertEquals(200, response.code());
+    }
+
+    @Test
+    void testLoanTrendsByWeekReportRunsSuccessfully() {
+        Response<RunReportsResponse> response = okR(
+                fineractClient().reportsRun.runReportGetData("LoanTrendsByWeek", Map.of("R_officeId", "1")));
+        assertEquals(200, response.code());
+    }
+
+    @Test
+    void testLoanTrendsByMonthReportRunsSuccessfully() {
+        Response<RunReportsResponse> response = okR(
+                fineractClient().reportsRun.runReportGetData("LoanTrendsByMonth", Map.of("R_officeId", "1")));
+        assertEquals(200, response.code());
+    }
+
+}


### PR DESCRIPTION
## Description

The ClientTrendsByWeek, ClientTrendsByMonth, LoanTrendsByWeek, and LoanTrendsByMonth
reports were using MySQL-specific functions (WEEK(), MONTHNAME()) that don't exist in
PostgreSQL, causing a BadSqlGrammarException when running on a PostgreSQL database.

This replaces those functions with ISO-standard equivalents — EXTRACT(WEEK FROM ...) 
and TO_CHAR(..., 'Month') — which work correctly on both MySQL and PostgreSQL.

Picks up from #5477 (closed as abandoned), extends the fix to cover all 4 affected
reports and adds an integration test for each.

Jira : https://issues.apache.org/jira/browse/FINERACT-2436