### PR TITLE
test: Add ClientApiTest integration tests for /v1/clients endpoint

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientApiTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.UUID;
+import org.apache.fineract.client.models.GetClientsClientIdResponse;
+import org.apache.fineract.client.models.PostClientsRequest;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ClientApiTest {
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+    }
+
+    @Test
+    public void testCreateAndRetrieveClient() {
+        String firstName = Utils.randomFirstNameGenerator();
+        String lastName = Utils.randomLastNameGenerator();
+        String externalId = UUID.randomUUID().toString();
+
+        PostClientsRequest request = new PostClientsRequest()
+                .officeId(1L)
+                .legalFormId(ClientHelper.LEGALFORM_ID_PERSON)
+                .firstname(firstName)
+                .lastname(lastName)
+                .externalId(externalId)
+                .dateFormat(Utils.DATE_FORMAT)
+                .locale("en")
+                .active(true)
+                .activationDate(ClientHelper.DEFAULT_DATE);
+
+        Integer clientId = ClientHelper.createClient(requestSpec, responseSpec, request);
+        assertNotNull(clientId);
+
+        ClientHelper.verifyClientCreatedOnServer(requestSpec, responseSpec, clientId);
+
+        GetClientsClientIdResponse client = ClientHelper.getClient(requestSpec, responseSpec, clientId);
+        assertNotNull(client);
+        assertEquals(firstName, client.getFirstname());
+        assertEquals(lastName, client.getLastname());
+        assertEquals(externalId, client.getExternalId());
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientApiTest.java
@@ -18,23 +18,32 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.apache.fineract.integrationtests.common.ClientHelper.CREATE_CLIENT_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
 import org.apache.fineract.client.models.PostClientsRequest;
+import org.apache.fineract.client.models.PutClientsClientIdRequest;
+import org.apache.fineract.client.util.JSON;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ClientApiTest {
+
+    private static final Gson GSON = new JSON().getGson();
+    private static final String CLIENT_URL = "/fineract-provider/api/v1/clients";
 
     private ResponseSpecification responseSpec;
     private RequestSpecification requestSpec;
@@ -74,5 +83,30 @@ public class ClientApiTest {
         assertEquals(firstName, client.getFirstname());
         assertEquals(lastName, client.getLastname());
         assertEquals(externalId, client.getExternalId());
+    }
+
+    @Test
+    public void testUpdateClient() {
+        Integer clientId = ClientHelper.createClient(requestSpec, responseSpec, ClientHelper.defaultClientCreationRequest());
+        assertNotNull(clientId);
+
+        String newFirstName = "UpdatedFirstName";
+        String newLastName = "UpdatedLastName";
+
+        PutClientsClientIdRequest updateRequest = new PutClientsClientIdRequest()
+                .firstname(newFirstName)
+                .lastname(newLastName)
+                .dateFormat(Utils.DATE_FORMAT)
+                .locale("en");
+
+        String updateUrl = CLIENT_URL + "/" + clientId + "?" + Utils.TENANT_IDENTIFIER;
+        String jsonResponse = Utils.performServerPut(requestSpec, responseSpec, updateUrl, GSON.toJson(updateRequest));
+
+        Map<String, Object> response = GSON.fromJson(jsonResponse, new TypeToken<Map<String, Object>>() {}.getType());
+        assertEquals(clientId, response.get("resourceId"));
+
+        GetClientsClientIdResponse updatedClient = ClientHelper.getClient(requestSpec, responseSpec, clientId);
+        assertEquals(newFirstName, updatedClient.getFirstname());
+        assertEquals(newLastName, updatedClient.getLastname());
     }
 }


### PR DESCRIPTION
This PR adds a new integration test class ClientApiTest.java with tests covering the client API endpoints:
- testCreateAndRetrieveClient - Tests creating a client via POST and retrieving it via GET
- testUpdateClient - Tests updating client details via PUT
The tests use REST Assured framework and follow the existing test patterns in the integration-tests module.