### PR TITLE
FINERACT-2585: Standardize String Locale usage in Command Infrastructure and Build Services

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/fineract/gradle/service/GpgService.groovy
+++ b/buildSrc/src/main/groovy/org/apache/fineract/gradle/service/GpgService.groovy
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory
 import java.security.GeneralSecurityException
 import java.security.MessageDigest
 import java.security.Security
+import java.util.Locale
 
 class GpgService {
     private static final Logger log = LoggerFactory.getLogger(GpgService.class)
@@ -64,7 +65,7 @@ class GpgService {
                             def k = iterator.next();
 
                             if (k.isEncryptionKey()) {
-                                def keyName = Long.toHexString(k.keyID).toUpperCase()
+                                def keyName = Long.toHexString(k.keyID).toUpperCase(java.util.Locale.ROOT)
 
                                 if(config.keyName.substring(config.keyName.length()-keyName.length()) == keyName) {
                                     publicKey = k;

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
@@ -22,6 +22,7 @@ import static org.apache.fineract.commands.domain.CommandProcessingResultType.UN
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.util.Locale;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.batch.exception.ErrorInfo;
@@ -82,7 +83,7 @@ public class CommandSourceService {
             return commandSourceRepository.saveAndFlush(initialCommandSource);
         } catch (JpaSystemException jse) {
             final String message = (jse.getRootCause() != null) ? jse.getRootCause().getMessage() : null;
-            if (message != null && message.toUpperCase().contains("UNIQUE_PORTFOLIO_COMMAND_SOURCE")) {
+            if (message != null && message.toUpperCase(Locale.ROOT).contains("UNIQUE_PORTFOLIO_COMMAND_SOURCE")) {
                 throw new IdempotentCommandProcessUnderProcessingException(wrapper, idempotencyKey, jse);
             }
             throw jse;

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -249,6 +249,7 @@ import static org.apache.fineract.useradministration.service.AppUserConstants.RE
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.infrastructure.accountnumberformat.service.AccountNumberFormatConstants;
@@ -2822,7 +2823,7 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder updateDepositAmountForRecurringDepositAccount(final Long accountId) {
-        this.actionName = DepositsApiConstants.UPDATE_DEPOSIT_AMOUNT.toUpperCase();
+        this.actionName = DepositsApiConstants.UPDATE_DEPOSIT_AMOUNT.toUpperCase(Locale.ROOT);
         this.entityName = ENTITY_RECURRINGDEPOSITACCOUNT;
         this.entityId = accountId;
         this.savingsId = accountId;
@@ -2955,14 +2956,14 @@ public class CommandWrapperBuilder {
 
     public CommandWrapperBuilder createAccountNumberFormat() {
         this.actionName = ACTION_CREATE;
-        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase();
+        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase(Locale.ROOT);
         this.href = AccountNumberFormatConstants.resourceRelativeURL;
         return this;
     }
 
     public CommandWrapperBuilder updateAccountNumberFormat(final Long accountNumberFormatId) {
         this.actionName = ACTION_UPDATE;
-        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase();
+        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase(Locale.ROOT);
         this.entityId = accountNumberFormatId;
         this.href = AccountNumberFormatConstants.resourceRelativeURL + "/" + accountNumberFormatId;
         return this;
@@ -2970,7 +2971,7 @@ public class CommandWrapperBuilder {
 
     public CommandWrapperBuilder deleteAccountNumberFormat(final Long accountNumberFormatId) {
         this.actionName = ACTION_DELETE;
-        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase();
+        this.entityName = AccountNumberFormatConstants.ENTITY_NAME.toUpperCase(Locale.ROOT);
         this.entityId = accountNumberFormatId;
         this.href = "AccountNumberFormatConstants.resourceRelativeURL" + "/" + accountNumberFormatId;
         this.json = "{}";
@@ -3286,10 +3287,10 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder createProduct(String productType) {
-        this.entityName = productType.toUpperCase() + "PRODUCT"; // To Support
-                                                                 // different
-                                                                 // type of
-                                                                 // products
+        this.entityName = productType.toUpperCase(Locale.ROOT) + "PRODUCT"; // To Support
+        // different
+        // type of
+        // products
         this.actionName = ACTION_CREATE;
         this.entityId = null;
         this.href = "/products/" + productType;
@@ -3297,7 +3298,7 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder updateProduct(String productType, final Long productId) {
-        this.entityName = productType.toUpperCase() + "PRODUCT";
+        this.entityName = productType.toUpperCase(Locale.ROOT) + "PRODUCT";
         this.actionName = ACTION_UPDATE;
         this.entityId = productId;
         this.href = "/products/" + productType + "/" + productId;
@@ -3305,10 +3306,10 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder createAccount(String accountType) {
-        this.entityName = accountType.toUpperCase() + "ACCOUNT"; // To Support
-                                                                 // different
-                                                                 // type of
-                                                                 // Accounts
+        this.entityName = accountType.toUpperCase(Locale.ROOT) + "ACCOUNT"; // To Support
+        // different
+        // type of
+        // Accounts
         this.actionName = ACTION_CREATE;
         this.entityId = null;
         this.href = "/accounts/" + accountType;
@@ -3316,7 +3317,7 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder updateAccount(String accountType, final Long accountId) {
-        this.entityName = accountType.toUpperCase() + "ACCOUNT";
+        this.entityName = accountType.toUpperCase(Locale.ROOT) + "ACCOUNT";
         this.actionName = ACTION_UPDATE;
         this.entityId = accountId;
         this.href = "/accounts/" + accountType + "/" + accountId;
@@ -3324,8 +3325,8 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder createProductCommand(String productType, String command, final Long productId) {
-        this.entityName = productType.toUpperCase() + "PRODUCT";
-        this.actionName = ACTION_CREATE + "_" + command.toUpperCase();
+        this.entityName = productType.toUpperCase(Locale.ROOT) + "PRODUCT";
+        this.actionName = ACTION_CREATE + "_" + command.toUpperCase(Locale.ROOT);
         this.entityId = productId;
         this.href = "/products/" + productType + "/" + productId + "?command=" + command;
         return this;
@@ -3356,8 +3357,8 @@ public class CommandWrapperBuilder {
     }
 
     public CommandWrapperBuilder createAccountCommand(String accountType, final Long accountId, String command) {
-        this.entityName = accountType.toUpperCase() + "ACCOUNT";
-        this.actionName = command.toUpperCase();
+        this.entityName = accountType.toUpperCase(Locale.ROOT) + "ACCOUNT";
+        this.actionName = command.toUpperCase(Locale.ROOT);
         this.entityId = accountId;
         this.href = "/accounts/" + accountType + "/" + accountId + "?command=" + command;
         return this;


### PR DESCRIPTION
## Description
This PR standardizes locale-dependent string case conversions across core command processing and build services. By replacing default .toUpperCase() calls with .toUpperCase(Locale.ROOT), we ensure consistent behavior across different deployment environments and prevent functional failures in locales with unique casing rules (e.g., the "Turkish I" issue).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
