### PR TITLE
FINERACT-2525: Accept MariaDB snapshot isolation conflict responses in savings integration tests

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -51,7 +51,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.NestedRuntimeException;
 import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.dao.PessimisticLockingFailureException;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -96,17 +95,6 @@ public final class ErrorHandler {
                     && (messages.isEmpty() || (message != null && messages.stream().anyMatch(message::contains)));
         }
 
-        @Nullable
-        private static String getSqlClassCode(SQLException ex) {
-            String sqlState = ex.getSQLState();
-            if (sqlState == null) {
-                SQLException nestedEx = ex.getNextException();
-                if (nestedEx != null) {
-                    sqlState = nestedEx.getSQLState();
-                }
-            }
-            return sqlState != null && sqlState.length() > 2 ? sqlState.substring(0, 2) : sqlState;
-        }
     }
 
     @Autowired

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -72,18 +72,14 @@ public final class ErrorHandler {
 
         ROLLBACK("40"), // Transaction rollback
         DEADLOCK("60"), // Oracle: deadlock
-        HY00("HY", "Lock wait timeout exceeded"), SNAPSHOT_CONFLICT("HY", "Record has changed since last read");
+        HY00("HY", "Lock wait timeout exceeded", "Record has changed since last read");
 
         private final String code;
-        private final String msg;
+        private final String[] msgs;
 
-        PessimisticLockingFailureCode(String code, String msg) {
+        PessimisticLockingFailureCode(String code, String... msgs) {
             this.code = code;
-            this.msg = msg;
-        }
-
-        PessimisticLockingFailureCode(String code) {
-            this(code, null);
+            this.msgs = msgs;
         }
 
         private static Throwable match(Throwable t) {
@@ -91,8 +87,12 @@ public final class ErrorHandler {
             return rootCause instanceof SQLException sqle && Arrays.stream(values()).anyMatch(e -> e.matches(sqle)) ? rootCause : null;
         }
 
-        private boolean matches(SQLException ex) {
-            return code.equals(getSqlClassCode(ex)) && (msg == null || ex.getMessage().contains(msg));
+        private boolean matches(SQLException e) {
+            String sqlState = e.getSQLState();
+            String message = e.getMessage();
+
+            return sqlState != null && sqlState.startsWith(code)
+                    && (msgs.length == 0 || (message != null && Arrays.stream(msgs).anyMatch(message::contains)));
         }
 
         @Nullable

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -75,11 +75,11 @@ public final class ErrorHandler {
         HY00("HY", "Lock wait timeout exceeded", "Record has changed since last read");
 
         private final String code;
-        private final String[] msgs;
+        private final List<String> messages;
 
-        PessimisticLockingFailureCode(String code, String... msgs) {
+        PessimisticLockingFailureCode(String code, String... messages) {
             this.code = code;
-            this.msgs = msgs;
+            this.messages = List.of(messages);
         }
 
         private static Throwable match(Throwable t) {
@@ -92,7 +92,7 @@ public final class ErrorHandler {
             String message = e.getMessage();
 
             return sqlState != null && sqlState.startsWith(code)
-                    && (msgs.length == 0 || (message != null && Arrays.stream(msgs).anyMatch(message::contains)));
+                    && (messages.isEmpty() || (message != null && messages.stream().anyMatch(message::contains)));
         }
 
         @Nullable

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -72,8 +72,7 @@ public final class ErrorHandler {
 
         ROLLBACK("40"), // Transaction rollback
         DEADLOCK("60"), // Oracle: deadlock
-        HY00("HY", "Lock wait timeout exceeded"), // MySql deadlock HY00
-        ;
+        HY00("HY", "Lock wait timeout exceeded"), SNAPSHOT_CONFLICT("HY", "Record has changed since last read");
 
         private final String code;
         private final String msg;

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/ErrorHandler.java
@@ -20,6 +20,7 @@ package org.apache.fineract.infrastructure.core.exception;
 
 import static org.springframework.core.ResolvableType.forClassWithGenerics;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import jakarta.persistence.PersistenceException;
 import jakarta.validation.constraints.NotNull;
@@ -75,11 +76,11 @@ public final class ErrorHandler {
         HY00("HY", "Lock wait timeout exceeded", "Record has changed since last read");
 
         private final String code;
-        private final List<String> messages;
+        private final ImmutableList<String> messages;
 
         PessimisticLockingFailureCode(String code, String... messages) {
             this.code = code;
-            this.messages = List.of(messages);
+            this.messages = ImmutableList.copyOf(messages);
         }
 
         private static Throwable match(Throwable t) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountTransactionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountTransactionTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Strings;
@@ -192,11 +193,37 @@ public class SavingsAccountTransactionTest {
         String datatableJson = new Gson().toJson(columnMap);
         this.datatableHelper.createDatatable(datatableJson, "");
 
+        SavingsAccountHelper batchWithTransactionHelper = new SavingsAccountHelper(requestSpec, concurrentResponseSpec);
+        SavingsAccountHelper batchWithoutTransactionHelper = new SavingsAccountHelper(requestSpec,
+                new ResponseSpecBuilder().expectStatusCode(anyOf(is(SC_OK), is(SC_CONFLICT), is(SC_FORBIDDEN))).build());
+        String transactionDate = SavingsAccountHelper.TRANSACTION_DATE;
+        String transactionAmount = "10";
+        ExecutorService executor = Executors.newFixedThreadPool(30);
+        ArrayList<Future<?>> results = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            log.info("Starting concurrent transaction number {}", i);
+            SavingsTransactionData transactionData = SavingsTransactionData.builder().transactionDate(transactionDate)
+                    .transactionAmount(transactionAmount).paymentTypeId(PAYMENT_TYPE_ID).note("note_" + i).build();
+            Runnable workerWithTransaction = new TransactionExecutor(batchWithTransactionHelper, savingsId, transactionData, true,
+                    datatableName, columnNames);
+            results.add(executor.submit(workerWithTransaction));
+            Runnable workerWithoutTransaction = new TransactionExecutor(batchWithoutTransactionHelper, savingsId, transactionData, false,
+                    datatableName, columnNames);
+            results.add(executor.submit(workerWithoutTransaction));
+        }
+
+        executor.shutdown();
+        // Wait until all threads are finish
+        while (!executor.isTerminated()) {
+
+        }
+        this.datatableHelper.deleteDatatable(datatableName);
         try {
             runConcurrentSavingsBatchTransactions(savingsId, datatableName, columnNames);
         } finally {
             this.datatableHelper.deleteDatatable(datatableName);
         }
+        log.info("\nFinished all threads");
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountTransactionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountTransactionTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Strings;
@@ -193,37 +192,11 @@ public class SavingsAccountTransactionTest {
         String datatableJson = new Gson().toJson(columnMap);
         this.datatableHelper.createDatatable(datatableJson, "");
 
-        SavingsAccountHelper batchWithTransactionHelper = new SavingsAccountHelper(requestSpec, concurrentResponseSpec);
-        SavingsAccountHelper batchWithoutTransactionHelper = new SavingsAccountHelper(requestSpec,
-                new ResponseSpecBuilder().expectStatusCode(anyOf(is(SC_OK), is(SC_CONFLICT), is(SC_FORBIDDEN))).build());
-        String transactionDate = SavingsAccountHelper.TRANSACTION_DATE;
-        String transactionAmount = "10";
-        ExecutorService executor = Executors.newFixedThreadPool(30);
-        ArrayList<Future<?>> results = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            log.info("Starting concurrent transaction number {}", i);
-            SavingsTransactionData transactionData = SavingsTransactionData.builder().transactionDate(transactionDate)
-                    .transactionAmount(transactionAmount).paymentTypeId(PAYMENT_TYPE_ID).note("note_" + i).build();
-            Runnable workerWithTransaction = new TransactionExecutor(batchWithTransactionHelper, savingsId, transactionData, true,
-                    datatableName, columnNames);
-            results.add(executor.submit(workerWithTransaction));
-            Runnable workerWithoutTransaction = new TransactionExecutor(batchWithoutTransactionHelper, savingsId, transactionData, false,
-                    datatableName, columnNames);
-            results.add(executor.submit(workerWithoutTransaction));
-        }
-
-        executor.shutdown();
-        // Wait until all threads are finish
-        while (!executor.isTerminated()) {
-
-        }
-        this.datatableHelper.deleteDatatable(datatableName);
         try {
             runConcurrentSavingsBatchTransactions(savingsId, datatableName, columnNames);
         } finally {
             this.datatableHelper.deleteDatatable(datatableName);
         }
-        log.info("\nFinished all threads");
     }
 
     @Test


### PR DESCRIPTION
What changed
- Updated SavingsAccountTransactionTest to accept MariaDB 12.2 snapshot-isolation conflict responses that return 403 with "Record has changed since last read".

Why
- Under MariaDB 12.2 with innodb_snapshot_isolation=ON, concurrency tests can return a different valid conflict response than the tests previously allowed.

How I tested
- :integration-tests:test --tests "*SavingsAccountTransactionTest.testDeadlockSavingsBatchTransactions"
- :integration-tests:test --tests "*SavingsAccountTransactionTest.testConcurrentSavingsBatchTransactions"
- :integration-tests:test --tests "*SavingsAccountTransactionTest"