### PR TITLE
FINERACT-2588: Include transactionId in payCharge response for Savings Account

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -1431,6 +1431,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 .withClientId(savingsAccountCharge.savingsAccount().clientId()) //
                 .withGroupId(savingsAccountCharge.savingsAccount().groupId()) //
                 .withSavingsId(savingsAccountCharge.savingsAccount().getId()) //
+                .withTransactionId(chargeTransaction.getId().toString()) //
                 .build();
 
     }

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
@@ -21,21 +21,34 @@ package org.apache.fineract.portfolio.savings.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.staff.domain.StaffRepositoryWrapper;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.apache.fineract.portfolio.account.domain.StandingInstructionRepository;
@@ -51,6 +64,7 @@ import org.apache.fineract.portfolio.savings.domain.DepositAccountOnHoldTransact
 import org.apache.fineract.portfolio.savings.domain.GSIMRepositoy;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountAssembler;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountCharge;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
@@ -58,27 +72,79 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRep
 import org.apache.fineract.useradministration.domain.AppUserRepositoryWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
 
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private SavingsAccountDataValidator fromApiJsonDeserializer;
+    @Mock
+    private SavingsAccountRepositoryWrapper savingAccountRepositoryWrapper;
+    @Mock
+    private StaffRepositoryWrapper staffRepository;
+    @Mock
+    private SavingsAccountTransactionRepository savingsAccountTransactionRepository;
+    @Mock
+    private SavingsAccountAssembler savingAccountAssembler;
+    @Mock
+    private SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator;
+    @Mock
+    private SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
+    @Mock
+    private PaymentDetailWritePlatformService paymentDetailWritePlatformService;
+    @Mock
+    private JournalEntryWritePlatformService journalEntryWritePlatformService;
+    @Mock
+    private SavingsAccountDomainService savingsAccountDomainService;
+    @Mock
+    private NoteRepository noteRepository;
+    @Mock
+    private AccountTransfersReadPlatformService accountTransfersReadPlatformService;
+    @Mock
+    private AccountAssociationsReadPlatformService accountAssociationsReadPlatformService;
+    @Mock
+    private ChargeRepositoryWrapper chargeRepository;
+    @Mock
+    private SavingsAccountChargeRepositoryWrapper savingsAccountChargeRepository;
+    @Mock
+    private HolidayRepositoryWrapper holidayRepository;
+    @Mock
+    private WorkingDaysRepositoryWrapper workingDaysRepository;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository;
+    @Mock
+    private EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService;
+    @Mock
+    private AppUserRepositoryWrapper appuserRepository;
+    @Mock
+    private StandingInstructionRepository standingInstructionRepository;
+    @Mock
+    private BusinessEventNotifierService businessEventNotifierService;
+    @Mock
+    private GSIMRepositoy gsimRepository;
+    @Mock
+    private SavingsAccountInterestPostingService savingsAccountInterestPostingService;
+    @Mock
+    private ErrorHandler errorHandler;
+
+    @InjectMocks
     private SavingsAccountWritePlatformServiceJpaRepositoryImpl service;
+
     private Method validateTransactionsForTransfer;
 
     @BeforeEach
     void setUp() throws Exception {
-        service = new SavingsAccountWritePlatformServiceJpaRepositoryImpl(mock(PlatformSecurityContext.class),
-                mock(SavingsAccountDataValidator.class), mock(SavingsAccountRepositoryWrapper.class), mock(StaffRepositoryWrapper.class),
-                mock(SavingsAccountTransactionRepository.class), mock(SavingsAccountAssembler.class),
-                mock(SavingsAccountTransactionDataValidator.class), mock(SavingsAccountChargeDataValidator.class),
-                mock(PaymentDetailWritePlatformService.class), mock(JournalEntryWritePlatformService.class),
-                mock(SavingsAccountDomainService.class), mock(NoteRepository.class), mock(AccountTransfersReadPlatformService.class),
-                mock(AccountAssociationsReadPlatformService.class), mock(ChargeRepositoryWrapper.class),
-                mock(SavingsAccountChargeRepositoryWrapper.class), mock(HolidayRepositoryWrapper.class),
-                mock(WorkingDaysRepositoryWrapper.class), mock(ConfigurationDomainService.class),
-                mock(DepositAccountOnHoldTransactionRepository.class), mock(EntityDatatableChecksWritePlatformService.class),
-                mock(AppUserRepositoryWrapper.class), mock(StandingInstructionRepository.class), mock(BusinessEventNotifierService.class),
-                mock(GSIMRepositoy.class), mock(SavingsAccountInterestPostingService.class), mock(ErrorHandler.class));
-
         validateTransactionsForTransfer = SavingsAccountWritePlatformServiceJpaRepositoryImpl.class
                 .getDeclaredMethod("validateTransactionsForTransfer", SavingsAccount.class, LocalDate.class);
         validateTransactionsForTransfer.setAccessible(true);
@@ -157,5 +223,60 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         when(savingsAccount.getTransactions()).thenReturn(List.of(transaction));
 
         assertThatNoException().isThrownBy(() -> validateTransactionsForTransfer.invoke(service, savingsAccount, transferDate));
+    }
+
+    @Test
+    void payCharge_shouldReturnTransactionIdInResult() {
+        // Given
+        final Long savingsAccountId = 1L;
+        final Long chargeId = 2L;
+        final Long expectedTransactionId = 42L;
+        final LocalDate transactionDate = LocalDate.of(2024, 3, 15);
+
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, transactionDate)));
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.json()).thenReturn("{}");
+        when(command.extractLocale()).thenReturn(java.util.Locale.ENGLISH);
+        when(command.dateFormat()).thenReturn("dd MMMM yyyy");
+        when(command.bigDecimalValueOfParameterNamed("amount")).thenReturn(BigDecimal.TEN);
+        when(command.localDateValueOfParameterNamed("dueAsOfDate")).thenReturn(transactionDate);
+        when(command.stringValueOfParameterNamed("note")).thenReturn(null);
+
+        SavingsAccount savingsAccount = mock(SavingsAccount.class);
+        when(savingsAccount.getId()).thenReturn(savingsAccountId);
+        when(savingsAccount.officeId()).thenReturn(1L);
+        when(savingsAccount.clientId()).thenReturn(1L);
+        when(savingsAccount.groupId()).thenReturn(1L);
+        when(savingsAccount.findExistingTransactionIds()).thenReturn(new HashSet<>());
+        when(savingsAccount.findExistingReversedTransactionIds()).thenReturn(new HashSet<>());
+        when(savingsAccount.getOnHoldFunds()).thenReturn(BigDecimal.ZERO);
+        when(savingsAccount.isBeforeLastPostingPeriod(any(LocalDate.class), anyBoolean())).thenReturn(false);
+        MonetaryCurrency currency = mock(MonetaryCurrency.class);
+        when(currency.getCode()).thenReturn("USD");
+        when(savingsAccount.getCurrency()).thenReturn(currency);
+        when(savingsAccount.deriveAccountingBridgeData(any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(new HashMap<>());
+
+        SavingsAccountCharge savingsAccountCharge = mock(SavingsAccountCharge.class);
+        when(savingsAccountCharge.getId()).thenReturn(chargeId);
+        when(savingsAccountCharge.savingsAccount()).thenReturn(savingsAccount);
+
+        SavingsAccountTransaction chargeTransaction = mock(SavingsAccountTransaction.class);
+        when(chargeTransaction.getId()).thenReturn(expectedTransactionId);
+
+        when(savingsAccountChargeRepository.findOneWithNotFoundDetection(chargeId, savingsAccountId)).thenReturn(savingsAccountCharge);
+        when(configurationDomainService.allowTransactionsOnHolidayEnabled()).thenReturn(true);
+        when(configurationDomainService.allowTransactionsOnNonWorkingDayEnabled()).thenReturn(true);
+        when(configurationDomainService.isSavingsInterestPostingAtCurrentPeriodEnd()).thenReturn(false);
+        when(configurationDomainService.retrieveFinancialYearBeginningMonth()).thenReturn(1);
+        when(savingsAccountTransactionRepository.findBySavingsAccountIdAndLessThanDateOfAndReversedIsFalse(anyLong(), any(LocalDate.class),
+                any())).thenReturn(Collections.emptyList());
+        when(savingsAccount.payCharge(any(), any(), any(), any(), anyBoolean(), any())).thenReturn(chargeTransaction);
+
+        // When
+        CommandProcessingResult result = service.payCharge(savingsAccountId, chargeId, command);
+
+        // Then
+        assertThat(result.getTransactionId()).isEqualTo(expectedTransactionId.toString());
     }
 }


### PR DESCRIPTION
Include the `transactionId` in the response from the `payCharge` endpoint for Savings Account Charges, so API consumers can reference the resulting charge payment transaction without making a separate lookup.

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).