### PR TITLE
FINERACT-2259: Manage external IDs: Savings (transactions)

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionData.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.domain.LocalDateInterval;
 import org.apache.fineract.infrastructure.core.jersey.serializer.legacy.JsonLocalDateArrayFormat;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
@@ -61,6 +62,7 @@ public class SavingsAccountTransactionData implements Serializable {
 
     private final Long accountId;
     private final String accountNo;
+    private final ExternalId externalId;
     private final LocalDate date;
     private final CurrencyData currency;
     private final PaymentDetailData paymentDetailData;
@@ -111,12 +113,13 @@ public class SavingsAccountTransactionData implements Serializable {
     private Long accountDebit;
 
     protected SavingsAccountTransactionData(final Long id, final SavingsAccountTransactionEnumData transactionType,
-            final PaymentDetailData paymentDetailData, final Long savingsId, final String savingsAccountNo, final LocalDate transactionDate,
-            final CurrencyData currency, final BigDecimal amount, final BigDecimal outstandingChargeAmount, final BigDecimal runningBalance,
-            final boolean reversed, final AccountTransferData transfer, final Collection<PaymentTypeData> paymentTypeOptions,
-            final LocalDate submittedOnDate, final boolean interestedPostedAsOn, final String submittedByUsername, final String note,
-            final Boolean isReversal, final Long originalTransactionId, boolean isManualTransaction, final Boolean lienTransaction,
-            final Long releaseTransactionId, final String reasonForBlock, final Boolean isOverdraft) {
+            final PaymentDetailData paymentDetailData, final Long savingsId, final String savingsAccountNo, final ExternalId externalId,
+            final LocalDate transactionDate, final CurrencyData currency, final BigDecimal amount, final BigDecimal outstandingChargeAmount,
+            final BigDecimal runningBalance, final boolean reversed, final AccountTransferData transfer,
+            final Collection<PaymentTypeData> paymentTypeOptions, final LocalDate submittedOnDate, final boolean interestedPostedAsOn,
+            final String submittedByUsername, final String note, final Boolean isReversal, final Long originalTransactionId,
+            boolean isManualTransaction, final Boolean lienTransaction, final Long releaseTransactionId, final String reasonForBlock,
+            final Boolean isOverdraft) {
         this.id = id;
         this.transactionType = transactionType;
         TransactionEntryType entryType = null;
@@ -129,6 +132,7 @@ public class SavingsAccountTransactionData implements Serializable {
         // duplicated fields
         this.accountId = savingsId;
         this.accountNo = savingsAccountNo;
+        this.externalId = externalId;
         this.date = transactionDate;
         this.amount = amount;
 
@@ -154,14 +158,37 @@ public class SavingsAccountTransactionData implements Serializable {
     }
 
     private static SavingsAccountTransactionData createData(final Long id, final SavingsAccountTransactionEnumData transactionType,
+            final PaymentDetailData paymentDetailData, final Long accountId, final String accountNo, final ExternalId externalId,
+            final LocalDate date, final CurrencyData currency, final BigDecimal amount, final BigDecimal outstandingChargeAmount,
+            final BigDecimal runningBalance, final boolean reversed, final AccountTransferData transfer,
+            final Collection<PaymentTypeData> paymentTypeOptions, final LocalDate submittedOnDate, final boolean interestedPostedAsOn,
+            final String submittedByUsername, final String note, final Boolean lienTransaction) {
+        return new SavingsAccountTransactionData(id, transactionType, paymentDetailData, accountId, accountNo, externalId, date, currency,
+                amount, outstandingChargeAmount, runningBalance, reversed, transfer, paymentTypeOptions, submittedOnDate,
+                interestedPostedAsOn, submittedByUsername, note, null, null, false, lienTransaction, null, null, false);
+    }
+
+    private static SavingsAccountTransactionData createData(final Long id, final SavingsAccountTransactionEnumData transactionType,
             final PaymentDetailData paymentDetailData, final Long accountId, final String accountNo, final LocalDate date,
             final CurrencyData currency, final BigDecimal amount, final BigDecimal outstandingChargeAmount, final BigDecimal runningBalance,
             final boolean reversed, final AccountTransferData transfer, final Collection<PaymentTypeData> paymentTypeOptions,
             final LocalDate submittedOnDate, final boolean interestedPostedAsOn, final String submittedByUsername, final String note,
             final Boolean lienTransaction) {
-        return new SavingsAccountTransactionData(id, transactionType, paymentDetailData, accountId, accountNo, date, currency, amount,
+        return createData(id, transactionType, paymentDetailData, accountId, accountNo, ExternalId.empty(), date, currency, amount,
                 outstandingChargeAmount, runningBalance, reversed, transfer, paymentTypeOptions, submittedOnDate, interestedPostedAsOn,
-                submittedByUsername, note, null, null, false, lienTransaction, null, null, false);
+                submittedByUsername, note, lienTransaction);
+    }
+
+    public static SavingsAccountTransactionData create(final Long id, final SavingsAccountTransactionEnumData transactionType,
+            final PaymentDetailData paymentDetailData, final Long savingsId, final String savingsAccountNo, final ExternalId externalId,
+            final LocalDate date, final CurrencyData currency, final BigDecimal amount, final BigDecimal outstandingChargeAmount,
+            final BigDecimal runningBalance, final boolean reversed, final AccountTransferData transfer, final LocalDate submittedOnDate,
+            final boolean interestedPostedAsOn, final String submittedByUsername, final String note, final Boolean isReversal,
+            final Long originalTransactionId, final Boolean lienTransaction, final Long releaseTransactionId, final String reasonForBlock) {
+        return new SavingsAccountTransactionData(id, transactionType, paymentDetailData, savingsId, savingsAccountNo, externalId, date,
+                currency, amount, outstandingChargeAmount, runningBalance, reversed, transfer, null, submittedOnDate, interestedPostedAsOn,
+                submittedByUsername, note, isReversal, originalTransactionId, false, lienTransaction, releaseTransactionId, reasonForBlock,
+                false);
     }
 
     public static SavingsAccountTransactionData create(final Long id, final SavingsAccountTransactionEnumData transactionType,
@@ -170,10 +197,9 @@ public class SavingsAccountTransactionData implements Serializable {
             final boolean reversed, final AccountTransferData transfer, final LocalDate submittedOnDate, final boolean interestedPostedAsOn,
             final String submittedByUsername, final String note, final Boolean isReversal, final Long originalTransactionId,
             final Boolean lienTransaction, final Long releaseTransactionId, final String reasonForBlock) {
-        return new SavingsAccountTransactionData(id, transactionType, paymentDetailData, savingsId, savingsAccountNo, date, currency,
-                amount, outstandingChargeAmount, runningBalance, reversed, transfer, null, submittedOnDate, interestedPostedAsOn,
-                submittedByUsername, note, isReversal, originalTransactionId, false, lienTransaction, releaseTransactionId, reasonForBlock,
-                false);
+        return create(id, transactionType, paymentDetailData, savingsId, savingsAccountNo, ExternalId.empty(), date, currency, amount,
+                outstandingChargeAmount, runningBalance, reversed, transfer, submittedOnDate, interestedPostedAsOn, submittedByUsername,
+                note, isReversal, originalTransactionId, lienTransaction, releaseTransactionId, reasonForBlock);
     }
 
     public static SavingsAccountTransactionData create(final Long id, final SavingsAccountTransactionEnumData transactionType,
@@ -210,13 +236,14 @@ public class SavingsAccountTransactionData implements Serializable {
         final SavingsAccountTransactionEnumData transactionType = SavingsEnumerations
                 .transactionType(SavingsAccountTransactionType.WITHDRAWAL.getValue());
         return createData(savingsAccountTransactionData.getId(), transactionType, savingsAccountTransactionData.getPaymentDetailData(),
-                savingsAccountTransactionData.getAccountId(), savingsAccountTransactionData.getAccountNo(), currentDate,
-                savingsAccountTransactionData.getCurrency(), savingsAccountTransactionData.getAmount(),
-                savingsAccountTransactionData.getOutstandingChargeAmount(), savingsAccountTransactionData.getRunningBalance(),
-                savingsAccountTransactionData.isReversed(), savingsAccountTransactionData.getTransfer(),
-                savingsAccountTransactionData.getPaymentTypeOptions(), savingsAccountTransactionData.getSubmittedOnDate(),
-                savingsAccountTransactionData.isInterestedPostedAsOn(), savingsAccountTransactionData.getSubmittedByUsername(),
-                savingsAccountTransactionData.getNote(), savingsAccountTransactionData.getLienTransaction());
+                savingsAccountTransactionData.getAccountId(), savingsAccountTransactionData.getAccountNo(),
+                savingsAccountTransactionData.getExternalId(), currentDate, savingsAccountTransactionData.getCurrency(),
+                savingsAccountTransactionData.getAmount(), savingsAccountTransactionData.getOutstandingChargeAmount(),
+                savingsAccountTransactionData.getRunningBalance(), savingsAccountTransactionData.isReversed(),
+                savingsAccountTransactionData.getTransfer(), savingsAccountTransactionData.getPaymentTypeOptions(),
+                savingsAccountTransactionData.getSubmittedOnDate(), savingsAccountTransactionData.isInterestedPostedAsOn(),
+                savingsAccountTransactionData.getSubmittedByUsername(), savingsAccountTransactionData.getNote(),
+                savingsAccountTransactionData.getLienTransaction());
     }
 
     public static SavingsAccountTransactionData template(final Long savingsId, final String savingsAccountNo,
@@ -229,22 +256,23 @@ public class SavingsAccountTransactionData implements Serializable {
             final Collection<PaymentTypeData> paymentTypeOptions) {
         return createData(savingsAccountTransactionData.getId(), savingsAccountTransactionData.getTransactionType(),
                 savingsAccountTransactionData.getPaymentDetailData(), savingsAccountTransactionData.getAccountId(),
-                savingsAccountTransactionData.getAccountNo(), savingsAccountTransactionData.getDate(),
-                savingsAccountTransactionData.getCurrency(), savingsAccountTransactionData.getAmount(),
-                savingsAccountTransactionData.getOutstandingChargeAmount(), savingsAccountTransactionData.getRunningBalance(),
-                savingsAccountTransactionData.isReversed(), savingsAccountTransactionData.getTransfer(), paymentTypeOptions,
-                savingsAccountTransactionData.getSubmittedOnDate(), savingsAccountTransactionData.isInterestedPostedAsOn(),
-                savingsAccountTransactionData.getSubmittedByUsername(), savingsAccountTransactionData.getNote(),
-                savingsAccountTransactionData.getLienTransaction());
+                savingsAccountTransactionData.getAccountNo(), savingsAccountTransactionData.getExternalId(),
+                savingsAccountTransactionData.getDate(), savingsAccountTransactionData.getCurrency(),
+                savingsAccountTransactionData.getAmount(), savingsAccountTransactionData.getOutstandingChargeAmount(),
+                savingsAccountTransactionData.getRunningBalance(), savingsAccountTransactionData.isReversed(),
+                savingsAccountTransactionData.getTransfer(), paymentTypeOptions, savingsAccountTransactionData.getSubmittedOnDate(),
+                savingsAccountTransactionData.isInterestedPostedAsOn(), savingsAccountTransactionData.getSubmittedByUsername(),
+                savingsAccountTransactionData.getNote(), savingsAccountTransactionData.getLienTransaction());
     }
 
     private static SavingsAccountTransactionData createImport(final SavingsAccountTransactionEnumData transactionType,
-            final PaymentDetailData paymentDetailData, final Long savingsAccountId, final String accountNumber,
+            final PaymentDetailData paymentDetailData, final Long savingsAccountId, final String accountNumber, final ExternalId externalId,
             final LocalDate transactionDate, final BigDecimal transactionAmount, final boolean reversed, final LocalDate submittedOnDate,
             boolean isManualTransaction, final Boolean lienTransaction, final Boolean isOverdraft) {
         SavingsAccountTransactionData data = new SavingsAccountTransactionData(null, transactionType, paymentDetailData, savingsAccountId,
-                accountNumber, transactionDate, null, transactionAmount, null, null, reversed, null, null, submittedOnDate, false, null,
-                null, null, null, isManualTransaction, lienTransaction, null, null, isOverdraft);
+                accountNumber, externalId == null ? ExternalId.empty() : externalId, transactionDate, null, transactionAmount, null, null,
+                reversed, null, null, submittedOnDate, false, null, null, null, null, isManualTransaction, lienTransaction, null, null,
+                isOverdraft);
         // duplicated import fields
         data.savingsAccountId = savingsAccountId;
         data.accountNumber = accountNumber;
@@ -253,11 +281,19 @@ public class SavingsAccountTransactionData implements Serializable {
         return data;
     }
 
+    private static SavingsAccountTransactionData createImport(final SavingsAccountTransactionEnumData transactionType,
+            final PaymentDetailData paymentDetailData, final Long savingsAccountId, final String accountNumber,
+            final LocalDate transactionDate, final BigDecimal transactionAmount, final boolean reversed, final LocalDate submittedOnDate,
+            boolean isManualTransaction, final Boolean lienTransaction, final Boolean isOverdraft) {
+        return createImport(transactionType, paymentDetailData, savingsAccountId, accountNumber, ExternalId.empty(), transactionDate,
+                transactionAmount, reversed, submittedOnDate, isManualTransaction, lienTransaction, isOverdraft);
+    }
+
     public static SavingsAccountTransactionData copyTransaction(SavingsAccountTransactionData accountTransaction) {
         return createImport(accountTransaction.getTransactionType(), accountTransaction.getPaymentDetailData(),
-                accountTransaction.getSavingsAccountId(), null, accountTransaction.getTransactionDate(), accountTransaction.getAmount(),
-                accountTransaction.isReversed(), accountTransaction.getSubmittedOnDate(), accountTransaction.isManualTransaction(),
-                accountTransaction.getLienTransaction(), false);
+                accountTransaction.getSavingsAccountId(), null, accountTransaction.getExternalId(), accountTransaction.getTransactionDate(),
+                accountTransaction.getAmount(), accountTransaction.isReversed(), accountTransaction.getSubmittedOnDate(),
+                accountTransaction.isManualTransaction(), accountTransaction.getLienTransaction(), false);
     }
 
     public static SavingsAccountTransactionData importInstance(BigDecimal transactionAmount, LocalDate transactionDate, Long paymentTypeId,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResource.java
@@ -48,10 +48,12 @@ import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
 import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.UnrecognizedQueryParamException;
 import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
 import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.serialization.JsonParserHelper;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.PagedLocalRequest;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.paymenttype.data.PaymentTypeData;
@@ -59,6 +61,8 @@ import org.apache.fineract.portfolio.paymenttype.service.PaymentTypeReadService;
 import org.apache.fineract.portfolio.savings.DepositAccountType;
 import org.apache.fineract.portfolio.savings.SavingsApiConstants;
 import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionData;
+import org.apache.fineract.portfolio.savings.exception.SavingsAccountNotFoundException;
+import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
 import org.apache.fineract.portfolio.savings.service.search.SavingsAccountTransactionSearchService;
 import org.apache.fineract.portfolio.search.data.AdvancedQueryRequest;
@@ -67,7 +71,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
-@Path("/v1/savingsaccounts/{savingsId}/transactions")
+@Path("/v1/savingsaccounts")
 @Component
 @Tag(name = "Savings Account Transactions", description = "")
 @RequiredArgsConstructor
@@ -82,19 +86,31 @@ public class SavingsAccountTransactionsApiResource {
     private final SavingsAccountTransactionSearchService transactionsSearchService;
 
     @GET
-    @Path("template")
+    @Path("{savingsId}/transactions/template")
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Retrieve a savings account transaction template", operationId = "retrieveTemplateSavingsAccountTransaction")
     public String retrieveTemplate(@PathParam("savingsId") final Long savingsId,
             // @QueryParam("command") final String commandParam,
             @Context final UriInfo uriInfo) {
+        return retrieveTemplate(savingsId, null, uriInfo);
+    }
 
+    @GET
+    @Path("external-id/{savingsExternalId}/transactions/template")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Retrieve a savings account transaction template", operationId = "retrieveTemplateSavingsAccountTransactionBySavingsExternalId")
+    public String retrieveTemplate(@PathParam("savingsExternalId") final String savingsExternalId, @Context final UriInfo uriInfo) {
+        return retrieveTemplate(null, savingsExternalId, uriInfo);
+    }
+
+    private String retrieveTemplate(final Long savingsId, final String savingsExternalIdStr, final UriInfo uriInfo) {
         this.context.authenticatedUser().validateHasReadPermission(SavingsApiConstants.SAVINGS_ACCOUNT_RESOURCE_NAME);
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
 
         // FIXME - KW - for now just send back generic default information for
         // both deposit/withdrawal templates
-        SavingsAccountTransactionData savingsAccount = this.savingsAccountReadPlatformService.retrieveDepositTransactionTemplate(savingsId,
-                DepositAccountType.SAVINGS_DEPOSIT);
+        SavingsAccountTransactionData savingsAccount = this.savingsAccountReadPlatformService
+                .retrieveDepositTransactionTemplate(resolvedSavingsId, DepositAccountType.SAVINGS_DEPOSIT);
         final Collection<PaymentTypeData> paymentTypeOptions = this.paymentTypeReadPlatformService.retrieveAllPaymentTypes();
         savingsAccount = SavingsAccountTransactionData.templateOnTop(savingsAccount, paymentTypeOptions);
 
@@ -104,15 +120,32 @@ public class SavingsAccountTransactionsApiResource {
     }
 
     @GET
-    @Path("{transactionId}")
+    @Path("{savingsId}/transactions/{transactionId}")
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Retrieve a savings account transaction", operationId = "retrieveOneSavingsAccountTransaction")
     public String retrieveOne(@PathParam("savingsId") final Long savingsId, @PathParam("transactionId") final Long transactionId,
             @Context final UriInfo uriInfo) {
+        return retrieveOne(savingsId, null, transactionId, null, uriInfo);
+    }
 
+    @GET
+    @Path("external-id/{savingsExternalId}/transactions/{transactionId}")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Retrieve a savings account transaction", operationId = "retrieveOneSavingsAccountTransactionBySavingsExternalId")
+    public String retrieveOne(@PathParam("savingsExternalId") final String savingsExternalId,
+            @PathParam("transactionId") final Long transactionId, @Context final UriInfo uriInfo) {
+        return retrieveOne(null, savingsExternalId, transactionId, null, uriInfo);
+    }
+
+    private String retrieveOne(final Long savingsId, final String savingsExternalIdStr, final Long transactionId,
+            final String transactionExternalIdStr, final UriInfo uriInfo) {
         this.context.authenticatedUser().validateHasReadPermission(SavingsApiConstants.SAVINGS_ACCOUNT_RESOURCE_NAME);
-        SavingsAccountTransactionData transactionData = this.savingsAccountReadPlatformService.retrieveSavingsTransaction(savingsId,
-                transactionId, DepositAccountType.SAVINGS_DEPOSIT);
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
+        final Long resolvedTransactionId = getResolvedSavingsTransactionId(resolvedSavingsId, transactionId,
+                ExternalIdFactory.produce(transactionExternalIdStr));
+
+        SavingsAccountTransactionData transactionData = this.savingsAccountReadPlatformService.retrieveSavingsTransaction(resolvedSavingsId,
+                resolvedTransactionId, DepositAccountType.SAVINGS_DEPOSIT);
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
         if (settings.isTemplate()) {
             final Collection<PaymentTypeData> paymentTypeOptions = this.paymentTypeReadPlatformService.retrieveAllPaymentTypes();
@@ -124,9 +157,27 @@ public class SavingsAccountTransactionsApiResource {
     }
 
     @GET
-    @Path("search")
+    @Path("{savingsId}/transactions/external-id/{transactionExternalId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Search Savings Account Transactions")
+    @Operation(summary = "Retrieve a savings account transaction by external ID", operationId = "retrieveOneSavingsAccountTransactionByExternalId")
+    public String retrieveOne(@PathParam("savingsId") final Long savingsId,
+            @PathParam("transactionExternalId") final String transactionExternalId, @Context final UriInfo uriInfo) {
+        return retrieveOne(savingsId, null, null, transactionExternalId, uriInfo);
+    }
+
+    @GET
+    @Path("external-id/{savingsExternalId}/transactions/external-id/{transactionExternalId}")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Retrieve a savings account transaction by external ID", operationId = "retrieveOneSavingsAccountTransactionBySavingsAndTransactionExternalId")
+    public String retrieveOne(@PathParam("savingsExternalId") final String savingsExternalId,
+            @PathParam("transactionExternalId") final String transactionExternalId, @Context final UriInfo uriInfo) {
+        return retrieveOne(null, savingsExternalId, null, transactionExternalId, uriInfo);
+    }
+
+    @GET
+    @Path("{savingsId}/transactions/search")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Search Savings Account Transactions", operationId = "searchSavingsAccountTransactions")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.SavingsAccountTransactionsSearchResponse.class)))
     public String searchTransactions(@PathParam("savingsId") @Parameter(description = "savings account id") final Long savingsId,
             @QueryParam("fromDate") @Parameter(description = "minimum value date (inclusive)", example = "2023-08-08") final String fromDate,
@@ -144,29 +195,85 @@ public class SavingsAccountTransactionsApiResource {
             @QueryParam("sortOrder") @Parameter(description = "sort direction") final Sort.Direction sortOrder,
             @QueryParam("locale") @Parameter(description = "locale") final String localeString,
             @QueryParam("dateFormat") @Parameter(description = "date format", example = "yyyy-MM-dd") String dateFormat) {
+
+        return searchTransactions(savingsId, null, fromDate, toDate, fromSubmittedDate, toSubmittedDate, fromAmount, toAmount, types,
+                credit, debit, offset, limit, orderBy, sortOrder, localeString, dateFormat);
+    }
+
+    @GET
+    @Path("external-id/{savingsExternalId}/transactions/search")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Search Savings Account Transactions", operationId = "searchSavingsAccountTransactionsBySavingsExternalId")
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.SavingsAccountTransactionsSearchResponse.class)))
+    public String searchTransactions(
+            @PathParam("savingsExternalId") @Parameter(description = "savings account external ID") final String savingsExternalId,
+            @QueryParam("fromDate") @Parameter(description = "minimum value date (inclusive)", example = "2023-08-08") final String fromDate,
+            @QueryParam("toDate") @Parameter(description = "maximum value date (inclusive)", example = "2023-08-15") final String toDate,
+            @QueryParam("fromSubmittedDate") @Parameter(description = "minimum booking date (inclusive)", example = "2023-08-08") final String fromSubmittedDate,
+            @QueryParam("toSubmittedDate") @Parameter(description = "maximum booking date (inclusive)", example = "2023-08-15") final String toSubmittedDate,
+            @QueryParam("fromAmount") @Parameter(description = "minimum transaction amount (inclusive)", example = "1000") final BigDecimal fromAmount,
+            @QueryParam("toAmount") @Parameter(description = "maximum transaction amount (inclusive)", example = "50000000") final BigDecimal toAmount,
+            @QueryParam("types") @Parameter(description = "transaction types", example = "1,2,4,20,21") final String types,
+            @QueryParam("credit") @Parameter(description = "credit") final Boolean credit,
+            @QueryParam("debit") @Parameter(description = "debit") final Boolean debit,
+            @QueryParam("offset") @Parameter(description = "offset") final Integer offset,
+            @QueryParam("limit") @Parameter(description = "limit") final Integer limit,
+            @QueryParam("orderBy") @Parameter(description = "sort properties", example = "createdDate,transactionDate,id") final String orderBy,
+            @QueryParam("sortOrder") @Parameter(description = "sort direction") final Sort.Direction sortOrder,
+            @QueryParam("locale") @Parameter(description = "locale") final String localeString,
+            @QueryParam("dateFormat") @Parameter(description = "date format", example = "yyyy-MM-dd") final String dateFormat) {
+        return searchTransactions(null, savingsExternalId, fromDate, toDate, fromSubmittedDate, toSubmittedDate, fromAmount, toAmount,
+                types, credit, debit, offset, limit, orderBy, sortOrder, localeString, dateFormat);
+    }
+
+    private String searchTransactions(final Long savingsId, final String savingsExternalIdStr, final String fromDate, final String toDate,
+            final String fromSubmittedDate, final String toSubmittedDate, final BigDecimal fromAmount, final BigDecimal toAmount,
+            final String types, final Boolean credit, final Boolean debit, final Integer offset, final Integer limit, final String orderBy,
+            final Sort.Direction sortOrder, final String localeString, final String dateFormat) {
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
         final Locale locale = localeString == null ? null : JsonParserHelper.localeFromString(localeString);
-        TransactionSearchRequest searchParameters = new TransactionSearchRequest().accountId(savingsId)
+        TransactionSearchRequest searchParameters = new TransactionSearchRequest().accountId(resolvedSavingsId)
                 .fromDate(fromDate, dateFormat, locale).toDate(toDate, dateFormat, locale)
                 .fromSubmittedDate(fromSubmittedDate, dateFormat, locale).toSubmittedDate(toSubmittedDate, dateFormat, locale)
                 .fromAmount(fromAmount).toAmount(toAmount).types(types).credit(credit).debit(debit)
                 .pageable(offset, limit, orderBy, sortOrder);
-        Page<SavingsAccountTransactionData> transactionsData = transactionsSearchService.searchTransactions(savingsId, searchParameters);
+        Page<SavingsAccountTransactionData> transactionsData = transactionsSearchService.searchTransactions(resolvedSavingsId,
+                searchParameters);
         return toApiJsonSerializer.serialize(transactionsData);
     }
 
     @POST
-    @Path("query")
+    @Path("{savingsId}/transactions/query")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Advanced search Savings Account Transactions", operationId = "advancedQuerySavingsAccountTransactions")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = List.class)))
     public String advancedQuery(@PathParam("savingsId") @Parameter(description = "savingsId") final Long savingsId,
             PagedLocalRequest<AdvancedQueryRequest> queryRequest, @Context final UriInfo uriInfo) {
-        final Page<JsonObject> result = transactionsSearchService.queryAdvanced(savingsId, queryRequest);
+        return advancedQuery(savingsId, null, queryRequest, uriInfo);
+    }
+
+    @POST
+    @Path("external-id/{savingsExternalId}/transactions/query")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Advanced search Savings Account Transactions", operationId = "advancedQuerySavingsAccountTransactionsBySavingsExternalId")
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = List.class)))
+    public String advancedQuery(
+            @PathParam("savingsExternalId") @Parameter(description = "savings account external ID") final String savingsExternalId,
+            PagedLocalRequest<AdvancedQueryRequest> queryRequest, @Context final UriInfo uriInfo) {
+        return advancedQuery(null, savingsExternalId, queryRequest, uriInfo);
+    }
+
+    private String advancedQuery(final Long savingsId, final String savingsExternalIdStr,
+            final PagedLocalRequest<AdvancedQueryRequest> queryRequest, final UriInfo uriInfo) {
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
+        final Page<JsonObject> result = transactionsSearchService.queryAdvanced(resolvedSavingsId, queryRequest);
         return this.toApiJsonSerializer.serialize(result);
     }
 
     @POST
+    @Path("{savingsId}/transactions")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Create a savings account transaction", operationId = "createSavingsAccountTransaction")
@@ -174,15 +281,33 @@ public class SavingsAccountTransactionsApiResource {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountTransactionsResponse.class)))
     public String transaction(@PathParam("savingsId") final Long savingsId, @QueryParam("command") final String commandParam,
             final String apiRequestBodyAsJson) {
+        return transaction(savingsId, null, commandParam, apiRequestBodyAsJson);
+    }
+
+    @POST
+    @Path("external-id/{savingsExternalId}/transactions")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Create a savings account transaction", operationId = "createSavingsAccountTransactionBySavingsExternalId")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountTransactionsRequest.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountTransactionsResponse.class)))
+    public String transaction(@PathParam("savingsExternalId") final String savingsExternalId,
+            @QueryParam("command") final String commandParam, final String apiRequestBodyAsJson) {
+        return transaction(null, savingsExternalId, commandParam, apiRequestBodyAsJson);
+    }
+
+    private String transaction(final Long savingsId, final String savingsExternalIdStr, final String commandParam,
+            final String apiRequestBodyAsJson) {
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
         final CommandWrapperBuilder builder = new CommandWrapperBuilder().withJson(apiRequestBodyAsJson);
 
         final CommandWrapper commandRequest = switch (StringUtils.trimToEmpty(commandParam)) {
-            case "deposit" -> builder.savingsAccountDeposit(savingsId).build();
-            case "gsimDeposit" -> builder.gsimSavingsAccountDeposit(savingsId).build();
-            case "withdrawal" -> builder.savingsAccountWithdrawal(savingsId).build();
-            case "force-withdrawal" -> builder.savingsAccountForceWithdrawal(savingsId).build();
-            case "postInterestAsOn" -> builder.savingsAccountInterestPosting(savingsId).build();
-            case SavingsApiConstants.COMMAND_HOLD_AMOUNT -> builder.holdAmount(savingsId).build();
+            case "deposit" -> builder.savingsAccountDeposit(resolvedSavingsId).build();
+            case "gsimDeposit" -> builder.gsimSavingsAccountDeposit(resolvedSavingsId).build();
+            case "withdrawal" -> builder.savingsAccountWithdrawal(resolvedSavingsId).build();
+            case "force-withdrawal" -> builder.savingsAccountForceWithdrawal(resolvedSavingsId).build();
+            case "postInterestAsOn" -> builder.savingsAccountInterestPosting(resolvedSavingsId).build();
+            case SavingsApiConstants.COMMAND_HOLD_AMOUNT -> builder.holdAmount(resolvedSavingsId).build();
             default -> throw new UnrecognizedQueryParamException("command", commandParam, "deposit", "withdrawal", "force-withdrawal",
                     SavingsApiConstants.COMMAND_HOLD_AMOUNT);
         };
@@ -192,7 +317,7 @@ public class SavingsAccountTransactionsApiResource {
     }
 
     @POST
-    @Path("{transactionId}")
+    @Path("{savingsId}/transactions/{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Undo/Reverse/Modify/Release Amount transaction API", operationId = "adjustSavingsAccountTransaction", description = "Undo/Reverse/Modify/Release Amount transaction API\n\n"
@@ -202,7 +327,30 @@ public class SavingsAccountTransactionsApiResource {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class))))
     public String adjustTransaction(@PathParam("savingsId") final Long savingsId, @PathParam("transactionId") final Long transactionId,
             @QueryParam("command") final String commandParam, final String apiRequestBodyAsJson) {
+        return adjustTransaction(savingsId, null, transactionId, null, commandParam, apiRequestBodyAsJson);
+    }
 
+    @POST
+    @Path("external-id/{savingsExternalId}/transactions/{transactionId}")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Undo/Reverse/Modify/Release Amount transaction API", operationId = "adjustSavingsAccountTransactionBySavingsExternalId", description = "Undo/Reverse/Modify/Release Amount transaction API\n\n"
+            + "Example Requests:\n" + "\n" + "\n"
+            + "savingsaccounts/external-id/{savingsExternalId}/transactions/{transactionId}?command=reverse\n" + "\n"
+            + "Accepted command = undo, reverse, modify, releaseAmount")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class))))
+    public String adjustTransaction(@PathParam("savingsExternalId") final String savingsExternalId,
+            @PathParam("transactionId") final Long transactionId, @QueryParam("command") final String commandParam,
+            final String apiRequestBodyAsJson) {
+        return adjustTransaction(null, savingsExternalId, transactionId, null, commandParam, apiRequestBodyAsJson);
+    }
+
+    private String adjustTransaction(final Long savingsId, final String savingsExternalIdStr, final Long transactionId,
+            final String transactionExternalIdStr, final String commandParam, final String apiRequestBodyAsJson) {
+        final Long resolvedSavingsId = getResolvedSavingsId(savingsId, ExternalIdFactory.produce(savingsExternalIdStr));
+        final Long resolvedTransactionId = getResolvedSavingsTransactionId(resolvedSavingsId, transactionId,
+                ExternalIdFactory.produce(transactionExternalIdStr));
         String jsonApiRequest = apiRequestBodyAsJson;
         if (StringUtils.isBlank(jsonApiRequest)) {
             jsonApiRequest = "{}";
@@ -211,12 +359,13 @@ public class SavingsAccountTransactionsApiResource {
         final CommandWrapperBuilder builder = new CommandWrapperBuilder().withJson(jsonApiRequest);
 
         final CommandWrapper commandRequest = switch (StringUtils.trimToEmpty(commandParam)) {
-            case SavingsApiConstants.COMMAND_UNDO_TRANSACTION -> builder.undoSavingsAccountTransaction(savingsId, transactionId).build();
+            case SavingsApiConstants.COMMAND_UNDO_TRANSACTION ->
+                builder.undoSavingsAccountTransaction(resolvedSavingsId, resolvedTransactionId).build();
             case SavingsApiConstants.COMMAND_REVERSE_TRANSACTION ->
-                builder.reverseSavingsAccountTransaction(savingsId, transactionId).build();
+                builder.reverseSavingsAccountTransaction(resolvedSavingsId, resolvedTransactionId).build();
             case SavingsApiConstants.COMMAND_ADJUST_TRANSACTION ->
-                builder.adjustSavingsAccountTransaction(savingsId, transactionId).build();
-            case SavingsApiConstants.COMMAND_RELEASE_AMOUNT -> builder.releaseAmount(savingsId, transactionId).build();
+                builder.adjustSavingsAccountTransaction(resolvedSavingsId, resolvedTransactionId).build();
+            case SavingsApiConstants.COMMAND_RELEASE_AMOUNT -> builder.releaseAmount(resolvedSavingsId, resolvedTransactionId).build();
             default -> throw new UnrecognizedQueryParamException("command", commandParam, SavingsApiConstants.COMMAND_UNDO_TRANSACTION,
                     SavingsApiConstants.COMMAND_ADJUST_TRANSACTION, SavingsApiConstants.COMMAND_RELEASE_AMOUNT,
                     SavingsApiConstants.COMMAND_REVERSE_TRANSACTION);
@@ -224,5 +373,62 @@ public class SavingsAccountTransactionsApiResource {
 
         final CommandProcessingResult result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
         return this.toApiJsonSerializer.serialize(result);
+    }
+
+    @POST
+    @Path("{savingsId}/transactions/external-id/{transactionExternalId}")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Undo/Reverse/Modify/Release Amount transaction API by external ID", operationId = "adjustSavingsAccountTransactionByExternalId", description = "Undo/Reverse/Modify/Release Amount transaction API by external ID\n\n"
+            + "Example Requests:\n" + "\n" + "\n"
+            + "savingsaccounts/{savingsId}/transactions/external-id/{transactionExternalId}?command=reverse\n" + "\n"
+            + "Accepted command = undo, reverse, modify, releaseAmount")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class))))
+    public String adjustTransaction(@PathParam("savingsId") final Long savingsId,
+            @PathParam("transactionExternalId") final String transactionExternalId, @QueryParam("command") final String commandParam,
+            final String apiRequestBodyAsJson) {
+        return adjustTransaction(savingsId, null, null, transactionExternalId, commandParam, apiRequestBodyAsJson);
+    }
+
+    @POST
+    @Path("external-id/{savingsExternalId}/transactions/external-id/{transactionExternalId}")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Undo/Reverse/Modify/Release Amount transaction API by external ID", operationId = "adjustSavingsAccountTransactionBySavingsAndTransactionExternalId", description = "Undo/Reverse/Modify/Release Amount transaction API by external ID\n\n"
+            + "Example Requests:\n" + "\n" + "\n"
+            + "savingsaccounts/external-id/{savingsExternalId}/transactions/external-id/{transactionExternalId}?command=reverse\n" + "\n"
+            + "Accepted command = undo, reverse, modify, releaseAmount")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SavingsAccountTransactionsApiResourceSwagger.PostSavingsAccountBulkReversalTransactionsRequest.class))))
+    public String adjustTransaction(@PathParam("savingsExternalId") final String savingsExternalId,
+            @PathParam("transactionExternalId") final String transactionExternalId, @QueryParam("command") final String commandParam,
+            final String apiRequestBodyAsJson) {
+        return adjustTransaction(null, savingsExternalId, null, transactionExternalId, commandParam, apiRequestBodyAsJson);
+    }
+
+    private Long getResolvedSavingsId(final Long savingsId, final ExternalId savingsExternalId) {
+        Long resolvedSavingsId = savingsId;
+        if (resolvedSavingsId == null) {
+            savingsExternalId.throwExceptionIfEmpty();
+            resolvedSavingsId = this.savingsAccountReadPlatformService.retrieveAccountIdByExternalId(savingsExternalId);
+            if (resolvedSavingsId == null) {
+                throw new SavingsAccountNotFoundException(savingsExternalId.getValue());
+            }
+        }
+        return resolvedSavingsId;
+    }
+
+    private Long getResolvedSavingsTransactionId(final Long resolvedSavingsId, final Long transactionId,
+            final ExternalId externalTransactionId) {
+        Long resolvedTransactionId = transactionId;
+        if (resolvedTransactionId == null) {
+            externalTransactionId.throwExceptionIfEmpty();
+            resolvedTransactionId = this.savingsAccountReadPlatformService.retrieveSavingsTransactionIdByExternalId(externalTransactionId);
+            if (resolvedTransactionId == null) {
+                throw new SavingsAccountTransactionNotFoundException(resolvedSavingsId, externalTransactionId);
+            }
+        }
+        return resolvedTransactionId;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResourceSwagger.java
@@ -154,6 +154,8 @@ final class SavingsAccountTransactionsApiResourceSwagger {
             public Long accountId;
             @Schema(example = "000000001")
             public String accountNo;
+            @Schema(example = "5dd80a7c-ccba-4446-b378-01eb6f53e871")
+            public String externalId;
             @Schema(example = "[2023, 05, 01]")
             public LocalDate date;
             public GetTransactionsCurrency currency;
@@ -202,6 +204,10 @@ final class SavingsAccountTransactionsApiResourceSwagger {
         public String locale;
         @Schema(example = "dd MMMM yyyy")
         public String dateFormat;
+        @Schema(example = "5dd80a7c-ccba-4446-b378-01eb6f53e871")
+        public String externalId;
+        @Schema(example = "true")
+        public Boolean isPostInterestAsOn;
         @Schema(example = "true")
         public String lienAllowed;
         @Schema(example = "String")
@@ -230,6 +236,8 @@ final class SavingsAccountTransactionsApiResourceSwagger {
 
         private PostSavingsAccountBulkReversalTransactionsRequest() {}
 
+        @Schema(example = "5dd80a7c-ccba-4446-b378-01eb6f53e871")
+        public String externalId;
         @Schema(example = "true")
         public String isBulk;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
@@ -67,17 +67,24 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SavingsAccountTransactionDataValidator {
 
+    private static final String IS_BULK_PARAM_NAME = "isBulk";
     private static final String IS_POST_INTEREST_AS_ON_PARAM_NAME = "isPostInterestAsOn";
+    private static final String POST_INTEREST_MANUAL_OR_AUTOMATIC_PARAM_NAME = "postInterestManualOrAutomatic";
     private final FromJsonHelper fromApiJsonHelper;
     private static final Set<String> SAVINGS_ACCOUNT_HOLD_AMOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(transactionDateParamName, SavingsApiConstants.dateFormatParamName, SavingsApiConstants.localeParamName,
                     transactionAmountParamName, externalIdParamName, lienAllowedParamName, SavingsApiConstants.reasonForBlockParamName));
-    private static final Set<String> SAVINGS_ACCOUNT_RELEASE_AMOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(externalIdParamName));
+    private static final Set<String> SAVINGS_ACCOUNT_RELEASE_AMOUNT_REQUEST_DATA_PARAMETERS = createReleaseAmountRequestDataParameters();
     private static final Set<String> SAVINGS_ACCOUNT_POST_INTEREST_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(SavingsApiConstants.dateFormatParamName, SavingsApiConstants.localeParamName, transactionDateParamName,
-                    externalIdParamName, IS_POST_INTEREST_AS_ON_PARAM_NAME));
+                    externalIdParamName, IS_POST_INTEREST_AS_ON_PARAM_NAME, POST_INTEREST_MANUAL_OR_AUTOMATIC_PARAM_NAME));
     private final ConfigurationDomainService configurationDomainService;
+
+    private static Set<String> createReleaseAmountRequestDataParameters() {
+        final Set<String> requestDataParameters = new HashSet<>(SavingsAccountConstant.SAVINGS_ACCOUNT_TRANSACTION_REQUEST_DATA_PARAMETERS);
+        requestDataParameters.add(IS_BULK_PARAM_NAME);
+        return requestDataParameters;
+    }
 
     public void validateTransactionWithPivotDate(final LocalDate transactionDate, final SavingsAccount savingsAccount) {
         final boolean backdatedTxnsAllowedTill = this.configurationDomainService.retrievePivotDateConfig();
@@ -371,6 +378,12 @@ public class SavingsAccountTransactionDataValidator {
             final Boolean isPostInterestAsOn = this.fromApiJsonHelper.extractBooleanNamed(IS_POST_INTEREST_AS_ON_PARAM_NAME, element);
             baseDataValidator.reset().parameter(IS_POST_INTEREST_AS_ON_PARAM_NAME).value(isPostInterestAsOn).isOneOfTheseValues(true,
                     false);
+        }
+        if (this.fromApiJsonHelper.parameterExists(POST_INTEREST_MANUAL_OR_AUTOMATIC_PARAM_NAME, element)) {
+            final Boolean postInterestManualOrAutomatic = this.fromApiJsonHelper
+                    .extractBooleanNamed(POST_INTEREST_MANUAL_OR_AUTOMATIC_PARAM_NAME, element);
+            baseDataValidator.reset().parameter(POST_INTEREST_MANUAL_OR_AUTOMATIC_PARAM_NAME).value(postInterestManualOrAutomatic)
+                    .isOneOfTheseValues(true, false);
         }
 
         throwExceptionIfValidationWarningsExist(dataValidationErrors);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
@@ -23,6 +23,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.activate
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.bankNumberParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.checkNumberParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.closedOnDateParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.externalIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.lienAllowedParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.paymentTypeIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.receiptNumberParamName;
@@ -66,10 +67,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SavingsAccountTransactionDataValidator {
 
+    private static final String IS_POST_INTEREST_AS_ON_PARAM_NAME = "isPostInterestAsOn";
     private final FromJsonHelper fromApiJsonHelper;
     private static final Set<String> SAVINGS_ACCOUNT_HOLD_AMOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(transactionDateParamName, SavingsApiConstants.dateFormatParamName, SavingsApiConstants.localeParamName,
-                    transactionAmountParamName, lienAllowedParamName, SavingsApiConstants.reasonForBlockParamName));
+                    transactionAmountParamName, externalIdParamName, lienAllowedParamName, SavingsApiConstants.reasonForBlockParamName));
+    private static final Set<String> SAVINGS_ACCOUNT_RELEASE_AMOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(
+            Arrays.asList(externalIdParamName));
+    private static final Set<String> SAVINGS_ACCOUNT_POST_INTEREST_REQUEST_DATA_PARAMETERS = new HashSet<>(
+            Arrays.asList(SavingsApiConstants.dateFormatParamName, SavingsApiConstants.localeParamName, transactionDateParamName,
+                    externalIdParamName, IS_POST_INTEREST_AS_ON_PARAM_NAME));
     private final ConfigurationDomainService configurationDomainService;
 
     public void validateTransactionWithPivotDate(final LocalDate transactionDate, final SavingsAccount savingsAccount) {
@@ -111,6 +118,9 @@ public class SavingsAccountTransactionDataValidator {
 
         final BigDecimal transactionAmount = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(transactionAmountParamName, element);
         baseDataValidator.reset().parameter(transactionAmountParamName).value(transactionAmount).notNull().positiveAmount();
+
+        final String externalId = this.fromApiJsonHelper.extractStringNamed(externalIdParamName, element);
+        baseDataValidator.reset().parameter(externalIdParamName).value(externalId).ignoreIfNull().notExceedingLengthOf(100);
 
         final Integer paymentType = this.fromApiJsonHelper.extractIntegerWithLocaleNamed(paymentTypeIdParamName, element);
         baseDataValidator.reset().parameter(paymentTypeIdParamName).value(paymentType).notNull();
@@ -224,6 +234,8 @@ public class SavingsAccountTransactionDataValidator {
 
         final BigDecimal amount = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(transactionAmountParamName, element);
         baseDataValidator.reset().parameter(transactionAmountParamName).value(amount).notNull().positiveAmount();
+        final String externalId = this.fromApiJsonHelper.extractStringNamed(externalIdParamName, element);
+        baseDataValidator.reset().parameter(externalIdParamName).value(externalId).ignoreIfNull().notExceedingLengthOf(100);
         final LocalDate transactionDate = this.fromApiJsonHelper.extractLocalDateNamed(transactionDateParamName, element);
 
         final String reasonForBlock = this.fromApiJsonHelper.extractStringNamed(SavingsApiConstants.reasonForBlockParamName, element);
@@ -316,6 +328,52 @@ public class SavingsAccountTransactionDataValidator {
         LocalDate transactionDate = DateUtils.getBusinessLocalDate();
         SavingsAccountTransaction transaction = SavingsAccountTransaction.releaseAmount(holdTransaction, transactionDate);
         return transaction;
+    }
+
+    public void validateReleaseAmount(final JsonCommand command) {
+        final String json = command.json();
+        if (StringUtils.isBlank(json)) {
+            throw new InvalidJsonException();
+        }
+
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, SAVINGS_ACCOUNT_RELEASE_AMOUNT_REQUEST_DATA_PARAMETERS);
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
+                .resource(SavingsApiConstants.SAVINGS_ACCOUNT_TRANSACTION_RESOURCE_NAME);
+
+        final JsonElement element = command.parsedJson();
+        final String externalId = this.fromApiJsonHelper.extractStringNamed(externalIdParamName, element);
+        baseDataValidator.reset().parameter(externalIdParamName).value(externalId).ignoreIfNull().notExceedingLengthOf(100);
+
+        throwExceptionIfValidationWarningsExist(dataValidationErrors);
+    }
+
+    public void validatePostInterest(final JsonCommand command) {
+        final String json = command.json();
+        if (StringUtils.isBlank(json)) {
+            throw new InvalidJsonException();
+        }
+
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, SAVINGS_ACCOUNT_POST_INTEREST_REQUEST_DATA_PARAMETERS);
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
+                .resource(SavingsApiConstants.SAVINGS_ACCOUNT_TRANSACTION_RESOURCE_NAME);
+
+        final JsonElement element = command.parsedJson();
+        final String externalId = this.fromApiJsonHelper.extractStringNamed(externalIdParamName, element);
+        baseDataValidator.reset().parameter(externalIdParamName).value(externalId).ignoreIfNull().notExceedingLengthOf(100);
+
+        if (this.fromApiJsonHelper.parameterExists(IS_POST_INTEREST_AS_ON_PARAM_NAME, element)) {
+            final Boolean isPostInterestAsOn = this.fromApiJsonHelper.extractBooleanNamed(IS_POST_INTEREST_AS_ON_PARAM_NAME, element);
+            baseDataValidator.reset().parameter(IS_POST_INTEREST_AS_ON_PARAM_NAME).value(isPostInterestAsOn).isOneOfTheseValues(true,
+                    false);
+        }
+
+        throwExceptionIfValidationWarningsExist(dataValidationErrors);
     }
 
     private void throwExceptionIfValidationWarningsExist(final List<ApiParameterError> dataValidationErrors) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/ReleaseAmountSavingsAccountCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/ReleaseAmountSavingsAccountCommandHandler.java
@@ -42,7 +42,7 @@ public class ReleaseAmountSavingsAccountCommandHandler implements NewCommandSour
     @Override
     public CommandProcessingResult processCommand(JsonCommand command) {
         final Long transactionId = Long.valueOf(command.getTransactionId());
-        return this.writePlatformService.releaseAmount(command.getSavingsId(), transactionId);
+        return this.writePlatformService.releaseAmount(command.getSavingsId(), transactionId, command);
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
 import org.apache.fineract.infrastructure.core.service.SearchParameters;
@@ -72,7 +73,9 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargesPaidByD
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountStatusType;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountSubStatusEnum;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountNotFoundException;
+import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.data.TaxDetailsData;
 import org.apache.fineract.portfolio.tax.data.TaxGroupData;
@@ -104,14 +107,17 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
     private final SavingsAccountAssembler savingAccountAssembler;
 
     private final SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper;
+    private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
 
     public SavingsAccountReadPlatformServiceImpl(final PlatformSecurityContext context, final JdbcTemplate jdbcTemplate,
             final SavingsAccountAssembler savingAccountAssembler, PaginationHelper paginationHelper, ColumnValidator columnValidator,
-            DatabaseSpecificSQLGenerator sqlGenerator, SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper) {
+            DatabaseSpecificSQLGenerator sqlGenerator, SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper,
+            SavingsAccountTransactionRepository savingsAccountTransactionRepository) {
         this.context = context;
         this.jdbcTemplate = jdbcTemplate;
         this.sqlGenerator = sqlGenerator;
         this.savingsAccountRepositoryWrapper = savingsAccountRepositoryWrapper;
+        this.savingsAccountTransactionRepository = savingsAccountTransactionRepository;
         this.transactionTemplateMapper = new SavingsAccountTransactionTemplateMapper();
         this.transactionsMapper = new SavingsAccountTransactionsMapper();
         this.savingsAccountTransactionsForBatchMapper = new SavingsAccountTransactionsForBatchMapper();
@@ -1052,8 +1058,12 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
         final String sql = "select " + this.transactionsMapper.schema() + " where sa.id = ? and sa.deposit_type_enum = ? and tr.id= ?";
 
-        return this.jdbcTemplate.queryForObject(sql, this.transactionsMapper, // NOSONAR
-                new Object[] { savingsId, depositAccountType.getValue(), transactionId });
+        try {
+            return this.jdbcTemplate.queryForObject(sql, this.transactionsMapper, // NOSONAR
+                    new Object[] { savingsId, depositAccountType.getValue(), transactionId });
+        } catch (final EmptyResultDataAccessException e) {
+            throw new SavingsAccountTransactionNotFoundException(savingsId, transactionId, e);
+        }
     }
 
     private static final class SavingsAccountTransactionsForBatchMapper implements RowMapper<SavingsAccountTransactionData> {
@@ -1101,7 +1111,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
         protected static String buildSelect() {
             return "tr.id as transactionId, tr.transaction_type_enum as transactionType, "
-                    + "tr.transaction_date as transactionDate, tr.amount as transactionAmount, "
+                    + "tr.transaction_date as transactionDate, tr.external_id as externalId, tr.amount as transactionAmount, "
                     + "tr.release_id_of_hold_amount as releaseTransactionId, tr.reason_for_block as reasonForBlock, "
                     + "tr.submitted_on_date as submittedOnDate, au.username as submittedByUsername, nt.note as transactionNote, "
                     + "tr.running_balance_derived as runningBalance, tr.is_reversed as reversed, "
@@ -1149,6 +1159,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
             final LocalDate date = JdbcSupport.getLocalDate(rs, "transactionDate");
             final LocalDate submittedOnDate = JdbcSupport.getLocalDate(rs, "submittedOnDate");
+            final ExternalId externalId = ExternalIdFactory.produce(rs.getString("externalId"));
             final BigDecimal amount = JdbcSupport.getBigDecimalDefaultToZeroIfNull(rs, "transactionAmount");
             final Long releaseTransactionId = rs.getLong("releaseTransactionId");
             final String reasonForBlock = rs.getString("reasonForBlock");
@@ -1210,8 +1221,8 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
             }
             final String submittedByUsername = rs.getString("submittedByUsername");
             final String note = rs.getString("transactionNote");
-            return SavingsAccountTransactionData.create(id, transactionType, paymentDetailData, savingsId, accountNo, date, currency,
-                    amount, outstandingChargeAmount, runningBalance, reversed, transfer, submittedOnDate, postInterestAsOn,
+            return SavingsAccountTransactionData.create(id, transactionType, paymentDetailData, savingsId, accountNo, externalId, date,
+                    currency, amount, outstandingChargeAmount, runningBalance, reversed, transfer, submittedOnDate, postInterestAsOn,
                     submittedByUsername, note, isReversal, originalTransactionId, lienTransaction, releaseTransactionId, reasonForBlock);
         }
     }
@@ -1403,6 +1414,11 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
         } catch (EmptyResultDataAccessException e) {
             return new ArrayList<>();
         }
+    }
+
+    @Override
+    public Long retrieveSavingsTransactionIdByExternalId(final ExternalId externalId) {
+        return savingsAccountTransactionRepository.findIdByExternalId(externalId);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -57,12 +57,14 @@ import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.exception.PlatformServiceUnavailableException;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.MathUtil;
 import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
 import org.apache.fineract.infrastructure.dataqueries.data.StatusEnum;
@@ -164,6 +166,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private final BusinessEventNotifierService businessEventNotifierService;
     private final GSIMRepositoy gsimRepository;
     private final SavingsAccountInterestPostingService savingsAccountInterestPostingService;
+    private final ExternalIdFactory externalIdFactory;
     private final ErrorHandler errorHandler;
 
     @Transactional
@@ -296,6 +299,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
         final LocalDate transactionDate = command.localDateValueOfParameterNamed("transactionDate");
         final BigDecimal transactionAmount = command.bigDecimalValueOfParameterNamed("transactionAmount");
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
 
         this.savingsAccountTransactionDataValidator.validateTransactionWithPivotDate(transactionDate, account);
 
@@ -305,6 +309,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         boolean isRegularTransaction = true;
         final SavingsAccountTransaction deposit = this.savingsAccountDomainService.handleDeposit(account, fmt, transactionDate,
                 transactionAmount, paymentDetail, isAccountTransfer, isRegularTransaction, backdatedTxnsAllowedTill);
+        deposit.updateExternalId(externalId);
+        this.savingsAccountTransactionRepository.save(deposit);
 
         if (isGsim && (deposit.getId() != null)) {
 
@@ -353,6 +359,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
         final LocalDate transactionDate = command.localDateValueOfParameterNamed("transactionDate");
         final BigDecimal transactionAmount = command.bigDecimalValueOfParameterNamed("transactionAmount");
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
 
         final Locale locale = command.extractLocale();
         final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat()).withLocale(locale);
@@ -380,6 +387,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 isRegularTransaction, isApplyWithdrawFee, isInterestTransfer, isWithdrawBalance);
         final SavingsAccountTransaction withdrawal = this.savingsAccountDomainService.handleWithdrawal(account, fmt, transactionDate,
                 transactionAmount, paymentDetail, transactionBooleanValues, backdatedTxnsAllowedTill);
+        withdrawal.updateExternalId(externalId);
+        this.savingsAccountTransactionRepository.save(withdrawal);
 
         if (isGsim && (withdrawal.getId() != null)) {
             GroupSavingsIndividualMonitoring gsim = gsimRepository.findById(account.getGsim().getId()).orElseThrow();
@@ -415,6 +424,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
         final LocalDate transactionDate = command.localDateValueOfParameterNamed("transactionDate");
         final BigDecimal transactionAmount = command.bigDecimalValueOfParameterNamed("transactionAmount");
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
 
         final Locale locale = command.extractLocale();
         final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat()).withLocale(locale);
@@ -443,6 +453,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 isRegularTransaction, isApplyWithdrawFee, isInterestTransfer, isWithdrawBalance, isForceWithdrawal);
         final SavingsAccountTransaction withdrawal = this.savingsAccountDomainService.handleWithdrawal(account, fmt, transactionDate,
                 transactionAmount, paymentDetail, transactionBooleanValues, backdatedTxnsAllowedTill);
+        withdrawal.updateExternalId(externalId);
+        this.savingsAccountTransactionRepository.save(withdrawal);
 
         if (isGsim && (withdrawal.getId() != null)) {
             GroupSavingsIndividualMonitoring gsim = gsimRepository.findById(account.getGsim().getId()).orElseThrow();
@@ -530,8 +542,10 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     @Transactional
     public CommandProcessingResult postInterest(final JsonCommand command) {
         Long savingsId = command.getSavingsId();
+        this.savingsAccountTransactionDataValidator.validatePostInterest(command);
         final boolean postInterestAs = command.booleanPrimitiveValueOfParameterNamed("isPostInterestAsOn");
         final LocalDate transactionDate = command.localDateValueOfParameterNamed("transactionDate");
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
 
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
         final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);
@@ -564,7 +578,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 throw new PostInterestAsOnDateException(PostInterestAsOnExceptionType.FUTURE_DATE);
             }
         }
-        postInterest(account, postInterestAs, transactionDate, backdatedTxnsAllowedTill);
+        postInterest(account, postInterestAs, transactionDate, backdatedTxnsAllowedTill, externalId);
 
         businessEventNotifierService.notifyPostBusinessEvent(new SavingsPostInterestBusinessEvent(account));
         return new CommandProcessingResultBuilder() //
@@ -580,6 +594,11 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     @Override
     public void postInterest(final SavingsAccount account, final boolean postInterestAs, final LocalDate transactionDate,
             final boolean backdatedTxnsAllowedTill) {
+        postInterest(account, postInterestAs, transactionDate, backdatedTxnsAllowedTill, ExternalId.empty());
+    }
+
+    private void postInterest(final SavingsAccount account, final boolean postInterestAs, final LocalDate transactionDate,
+            final boolean backdatedTxnsAllowedTill, final ExternalId externalId) {
         final boolean isSavingsInterestPostingAtCurrentPeriodEnd = this.configurationDomainService
                 .isSavingsInterestPostingAtCurrentPeriodEnd();
         final Integer financialYearBeginningMonth = this.configurationDomainService.retrieveFinancialYearBeginningMonth();
@@ -605,6 +624,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
             boolean postReversals = false;
             account.postInterest(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
                     postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+            updateManualInterestPostingExternalId(account, externalId, transactionDate, backdatedTxnsAllowedTill);
 
             if (!backdatedTxnsAllowedTill) {
                 List<SavingsAccountTransaction> transactions = account.getTransactions();
@@ -622,6 +642,28 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
             this.savingAccountRepositoryWrapper.saveAndFlush(account);
 
             postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds, backdatedTxnsAllowedTill);
+        }
+    }
+
+    private void updateManualInterestPostingExternalId(final SavingsAccount account, final ExternalId externalId,
+            final LocalDate transactionDate, final boolean backdatedTxnsAllowedTill) {
+        if (externalId.isEmpty()) {
+            return;
+        }
+        final List<SavingsAccountTransaction> transactions = backdatedTxnsAllowedTill
+                ? account.getSavingsAccountTransactionsWithPivotConfig()
+                : account.getTransactions();
+        SavingsAccountTransaction transactionToUpdate = null;
+        for (SavingsAccountTransaction accountTransaction : transactions) {
+            if (accountTransaction.getId() == null && accountTransaction.isInterestPosting() && accountTransaction.isManualTransaction()) {
+                transactionToUpdate = accountTransaction;
+                if (transactionDate != null && transactionDate.equals(accountTransaction.getTransactionDate())) {
+                    break;
+                }
+            }
+        }
+        if (transactionToUpdate != null) {
+            transactionToUpdate.updateExternalId(externalId);
         }
     }
 
@@ -863,6 +905,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat()).withLocale(locale);
         final LocalDate transactionDate = command.localDateValueOfParameterNamed(SavingsApiConstants.transactionDateParamName);
         final BigDecimal transactionAmount = command.bigDecimalValueOfParameterNamed(SavingsApiConstants.transactionAmountParamName);
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
         final Map<String, Object> changes = new LinkedHashMap<>();
         final PaymentDetail paymentDetail = this.paymentDetailWritePlatformService.createAndPersistPaymentDetail(command, changes);
 
@@ -887,6 +930,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         } else {
             transaction = account.withdraw(transactionDTO, true, false, relaxingDaysConfigForPivotDate, refNo.toString());
         }
+        transaction.updateExternalId(externalId);
         final Long newtransactionId = saveTransactionToGenerateTransactionId(transaction);
         final LocalDate postInterestOnDate = null;
         boolean postReversals = false;
@@ -1827,6 +1871,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
         final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);
         final LocalDate transactionDate = command.localDateValueOfParameterNamed(transactionDateParamName);
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
         final boolean lienAllowed = command.booleanPrimitiveValueOfParameterNamed(lienAllowedParamName);
 
         checkClientOrGroupActive(account);
@@ -1843,6 +1888,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         this.savingsAccountTransactionDataValidator.validateHoldAndAssembleForm(command.json(), account, submittedBy,
                 backdatedTxnsAllowedTill);
         SavingsAccountTransaction transaction = this.savingsAccountDomainService.handleHold(account, amount, transactionDate, lienAllowed);
+        transaction.updateExternalId(externalId);
         account.holdAmount(amount);
         transaction.setRunningBalance(runningBalance);
 
@@ -1872,15 +1918,21 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
     @Transactional
     @Override
-    public CommandProcessingResult releaseAmount(final Long savingsId, final Long savingsTransactionId) {
+    public CommandProcessingResult releaseAmount(final Long savingsId, final Long savingsTransactionId, final JsonCommand command) {
         context.authenticatedUser();
+        this.savingsAccountTransactionDataValidator.validateReleaseAmount(command);
         SavingsAccountTransaction holdTransaction = this.savingsAccountTransactionRepository
                 .findOneByIdAndSavingsAccountId(savingsTransactionId, savingsId);
+        if (holdTransaction == null) {
+            throw new SavingsAccountTransactionNotFoundException(savingsId, savingsTransactionId);
+        }
 
         holdTransaction.updateReason(null);
 
         final SavingsAccountTransaction transaction = this.savingsAccountTransactionDataValidator
                 .validateReleaseAmountAndAssembleForm(holdTransaction);
+        final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
+        transaction.updateExternalId(externalId);
 
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
         final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -543,7 +543,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     public CommandProcessingResult postInterest(final JsonCommand command) {
         Long savingsId = command.getSavingsId();
         this.savingsAccountTransactionDataValidator.validatePostInterest(command);
-        final boolean postInterestAs = command.booleanPrimitiveValueOfParameterNamed("isPostInterestAsOn");
+        final boolean postInterestAs = command.booleanPrimitiveValueOfParameterNamed("isPostInterestAsOn")
+                || command.booleanPrimitiveValueOfParameterNamed("postInterestManualOrAutomatic");
         final LocalDate transactionDate = command.localDateValueOfParameterNamed("transactionDate");
         final ExternalId externalId = this.externalIdFactory.createFromCommand(command, SavingsApiConstants.externalIdParamName);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDoma
 import org.apache.fineract.infrastructure.core.data.PaginationParametersDataValidator;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.dataqueries.data.DataTableValidator;
@@ -338,9 +339,10 @@ public class SavingsConfiguration {
     @ConditionalOnMissingBean(SavingsAccountReadPlatformService.class)
     public SavingsAccountReadPlatformService savingsAccountReadPlatformService(PlatformSecurityContext context, JdbcTemplate jdbcTemplate,
             SavingsAccountAssembler savingAccountAssembler, PaginationHelper paginationHelper, DatabaseSpecificSQLGenerator sqlGenerator,
-            SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper, ColumnValidator columnValidator) {
+            SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper, ColumnValidator columnValidator,
+            SavingsAccountTransactionRepository savingsAccountTransactionRepository) {
         return new SavingsAccountReadPlatformServiceImpl(context, jdbcTemplate, savingAccountAssembler, paginationHelper, columnValidator,
-                sqlGenerator, savingsAccountRepositoryWrapper);
+                sqlGenerator, savingsAccountRepositoryWrapper, savingsAccountTransactionRepository);
     }
 
     @Bean
@@ -373,7 +375,7 @@ public class SavingsConfiguration {
             EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService, AppUserRepositoryWrapper appuserRepository,
             StandingInstructionRepository standingInstructionRepository, BusinessEventNotifierService businessEventNotifierService,
             GSIMRepositoy gsimRepository, SavingsAccountInterestPostingService savingsAccountInterestPostingService,
-            ErrorHandler errorHandler) {
+            ExternalIdFactory externalIdFactory, ErrorHandler errorHandler) {
         return new SavingsAccountWritePlatformServiceJpaRepositoryImpl(context, fromApiJsonDeserializer, savingAccountRepositoryWrapper,
                 staffRepository, savingsAccountTransactionRepository, savingAccountAssembler, savingsAccountTransactionDataValidator,
                 savingsAccountChargeDataValidator, paymentDetailWritePlatformService, journalEntryWritePlatformService,
@@ -381,7 +383,7 @@ public class SavingsConfiguration {
                 chargeRepository, savingsAccountChargeRepository, holidayRepository, workingDaysRepository, configurationDomainService,
                 depositAccountOnHoldTransactionRepository, entityDatatableChecksWritePlatformService, appuserRepository,
                 standingInstructionRepository, businessEventNotifierService, gsimRepository, savingsAccountInterestPostingService,
-                errorHandler);
+                externalIdFactory, errorHandler);
     }
 
     @Bean

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResourceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/api/SavingsAccountTransactionsApiResourceTest.java
@@ -1,0 +1,302 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.PagedLocalRequest;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.paymenttype.data.PaymentTypeData;
+import org.apache.fineract.portfolio.paymenttype.service.PaymentTypeReadService;
+import org.apache.fineract.portfolio.savings.DepositAccountType;
+import org.apache.fineract.portfolio.savings.SavingsApiConstants;
+import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionData;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
+import org.apache.fineract.portfolio.savings.service.search.SavingsAccountTransactionSearchService;
+import org.apache.fineract.portfolio.search.data.AdvancedQueryRequest;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsAccountTransactionsApiResourceTest {
+
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private DefaultToApiJsonSerializer<SavingsAccountTransactionData> toApiJsonSerializer;
+    @Mock
+    private PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    @Mock
+    private ApiRequestParameterHelper apiRequestParameterHelper;
+    @Mock
+    private SavingsAccountReadPlatformService savingsAccountReadPlatformService;
+    @Mock
+    private PaymentTypeReadService paymentTypeReadPlatformService;
+    @Mock
+    private SavingsAccountTransactionSearchService transactionsSearchService;
+
+    @InjectMocks
+    private SavingsAccountTransactionsApiResource underTest;
+
+    @Test
+    void retrieveTemplateBySavingsExternalId_shouldResolveSavingsIdAndDelegateToReadService() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        UriInfo uriInfo = org.mockito.Mockito.mock(UriInfo.class);
+        AppUser user = org.mockito.Mockito.mock(AppUser.class);
+        ApiRequestJsonSerializationSettings settings = org.mockito.Mockito.mock(ApiRequestJsonSerializationSettings.class);
+        SavingsAccountTransactionData templateData = org.mockito.Mockito.mock(SavingsAccountTransactionData.class);
+
+        when(context.authenticatedUser()).thenReturn(user);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(savingsAccountReadPlatformService.retrieveDepositTransactionTemplate(resolvedSavingsId, DepositAccountType.SAVINGS_DEPOSIT))
+                .thenReturn(templateData);
+        when(paymentTypeReadPlatformService.retrieveAllPaymentTypes()).thenReturn(List.of(org.mockito.Mockito.mock(PaymentTypeData.class)));
+        when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+        when(toApiJsonSerializer.serialize(eq(settings), any(SavingsAccountTransactionData.class),
+                eq(SavingsApiSetConstants.SAVINGS_TRANSACTION_RESPONSE_DATA_PARAMETERS))).thenReturn("serialized");
+
+        String result = underTest.retrieveTemplate(savingsExternalId, uriInfo);
+
+        assertThat(result).isEqualTo("serialized");
+        verify(savingsAccountReadPlatformService).retrieveDepositTransactionTemplate(resolvedSavingsId, DepositAccountType.SAVINGS_DEPOSIT);
+        verify(paymentTypeReadPlatformService).retrieveAllPaymentTypes();
+    }
+
+    @Test
+    void retrieveOneByExternalId_shouldResolveTransactionIdAndDelegateToReadService() {
+        Long savingsId = 1L;
+        String transactionExternalId = "tx-external-id";
+        Long resolvedTransactionId = 42L;
+        UriInfo uriInfo = org.mockito.Mockito.mock(UriInfo.class);
+        AppUser user = org.mockito.Mockito.mock(AppUser.class);
+        ApiRequestJsonSerializationSettings settings = org.mockito.Mockito.mock(ApiRequestJsonSerializationSettings.class);
+        SavingsAccountTransactionData transactionData = org.mockito.Mockito.mock(SavingsAccountTransactionData.class);
+
+        when(context.authenticatedUser()).thenReturn(user);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(savingsAccountReadPlatformService
+                .retrieveSavingsTransactionIdByExternalId(argThat(id -> transactionExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedTransactionId);
+        when(savingsAccountReadPlatformService.retrieveSavingsTransaction(savingsId, resolvedTransactionId,
+                DepositAccountType.SAVINGS_DEPOSIT)).thenReturn(transactionData);
+        when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+        when(settings.isTemplate()).thenReturn(false);
+        when(toApiJsonSerializer.serialize(settings, transactionData, SavingsApiSetConstants.SAVINGS_TRANSACTION_RESPONSE_DATA_PARAMETERS))
+                .thenReturn("serialized");
+
+        String result = underTest.retrieveOne(savingsId, transactionExternalId, uriInfo);
+
+        assertThat(result).isEqualTo("serialized");
+        verify(savingsAccountReadPlatformService).retrieveSavingsTransaction(savingsId, resolvedTransactionId,
+                DepositAccountType.SAVINGS_DEPOSIT);
+    }
+
+    @Test
+    void retrieveOneBySavingsExternalId_shouldResolveSavingsIdAndDelegateToReadService() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        Long transactionId = 42L;
+        UriInfo uriInfo = org.mockito.Mockito.mock(UriInfo.class);
+        AppUser user = org.mockito.Mockito.mock(AppUser.class);
+        ApiRequestJsonSerializationSettings settings = org.mockito.Mockito.mock(ApiRequestJsonSerializationSettings.class);
+        SavingsAccountTransactionData transactionData = org.mockito.Mockito.mock(SavingsAccountTransactionData.class);
+
+        when(context.authenticatedUser()).thenReturn(user);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(savingsAccountReadPlatformService.retrieveSavingsTransaction(resolvedSavingsId, transactionId,
+                DepositAccountType.SAVINGS_DEPOSIT)).thenReturn(transactionData);
+        when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+        when(settings.isTemplate()).thenReturn(false);
+        when(toApiJsonSerializer.serialize(settings, transactionData, SavingsApiSetConstants.SAVINGS_TRANSACTION_RESPONSE_DATA_PARAMETERS))
+                .thenReturn("serialized");
+
+        String result = underTest.retrieveOne(savingsExternalId, transactionId, uriInfo);
+
+        assertThat(result).isEqualTo("serialized");
+        verify(savingsAccountReadPlatformService).retrieveSavingsTransaction(resolvedSavingsId, transactionId,
+                DepositAccountType.SAVINGS_DEPOSIT);
+    }
+
+    @Test
+    void retrieveOneBySavingsAndTransactionExternalId_shouldResolveBothExternalIdsAndDelegateToReadService() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        String transactionExternalId = "tx-external-id";
+        Long resolvedTransactionId = 42L;
+        UriInfo uriInfo = org.mockito.Mockito.mock(UriInfo.class);
+        AppUser user = org.mockito.Mockito.mock(AppUser.class);
+        ApiRequestJsonSerializationSettings settings = org.mockito.Mockito.mock(ApiRequestJsonSerializationSettings.class);
+        SavingsAccountTransactionData transactionData = org.mockito.Mockito.mock(SavingsAccountTransactionData.class);
+
+        when(context.authenticatedUser()).thenReturn(user);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(savingsAccountReadPlatformService
+                .retrieveSavingsTransactionIdByExternalId(argThat(id -> transactionExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedTransactionId);
+        when(savingsAccountReadPlatformService.retrieveSavingsTransaction(resolvedSavingsId, resolvedTransactionId,
+                DepositAccountType.SAVINGS_DEPOSIT)).thenReturn(transactionData);
+        when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+        when(settings.isTemplate()).thenReturn(false);
+        when(toApiJsonSerializer.serialize(settings, transactionData, SavingsApiSetConstants.SAVINGS_TRANSACTION_RESPONSE_DATA_PARAMETERS))
+                .thenReturn("serialized");
+
+        String result = underTest.retrieveOne(savingsExternalId, transactionExternalId, uriInfo);
+
+        assertThat(result).isEqualTo("serialized");
+        verify(savingsAccountReadPlatformService).retrieveSavingsTransaction(resolvedSavingsId, resolvedTransactionId,
+                DepositAccountType.SAVINGS_DEPOSIT);
+    }
+
+    @Test
+    void searchTransactionsBySavingsExternalId_shouldResolveSavingsIdAndDelegateToSearchService() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        Page<SavingsAccountTransactionData> page = org.mockito.Mockito.mock(Page.class);
+
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(transactionsSearchService.searchTransactions(eq(resolvedSavingsId), any())).thenReturn(page);
+        when(toApiJsonSerializer.serialize(page)).thenReturn("serialized");
+
+        String result = underTest.searchTransactions(savingsExternalId, "2024-01-10", "2024-01-20", null, null, new BigDecimal("10.00"),
+                new BigDecimal("20.00"), "1,2", true, false, 1, 2, "id", Sort.Direction.ASC, "en", "yyyy-MM-dd");
+
+        assertThat(result).isEqualTo("serialized");
+        verify(transactionsSearchService).searchTransactions(eq(resolvedSavingsId),
+                argThat(request -> resolvedSavingsId.equals(request.getAccountId())
+                        && LocalDate.of(2024, 1, 10).equals(request.getFromDate()) && LocalDate.of(2024, 1, 20).equals(request.getToDate())
+                        && new BigDecimal("10.00").compareTo(request.getFromAmount()) == 0
+                        && new BigDecimal("20.00").compareTo(request.getToAmount()) == 0 && request.getCredit() && !request.getDebit()
+                        && request.getTypes().length == 2 && "1".equals(request.getTypes()[0]) && request.getPageable().getPageNumber() == 1
+                        && request.getPageable().getPageSize() == 2
+                        && "id".equals(request.getPageable().getSort().iterator().next().getProperty())));
+    }
+
+    @Test
+    void adjustTransactionByExternalId_shouldResolveTransactionIdInCommandWrapper() {
+        Long savingsId = 1L;
+        String transactionExternalId = "tx-external-id";
+        Long resolvedTransactionId = 42L;
+        CommandProcessingResult result = org.mockito.Mockito.mock(CommandProcessingResult.class);
+
+        when(savingsAccountReadPlatformService
+                .retrieveSavingsTransactionIdByExternalId(argThat(id -> transactionExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedTransactionId);
+        when(commandsSourceWritePlatformService.logCommandSource(any())).thenReturn(result);
+
+        underTest.adjustTransaction(savingsId, transactionExternalId, SavingsApiConstants.COMMAND_REVERSE_TRANSACTION, "{}");
+
+        ArgumentCaptor<CommandWrapper> captor = ArgumentCaptor.forClass(CommandWrapper.class);
+        verify(commandsSourceWritePlatformService).logCommandSource(captor.capture());
+        assertThat(captor.getValue().getSavingsId()).isEqualTo(savingsId);
+        assertThat(captor.getValue().getTransactionId()).isEqualTo(resolvedTransactionId.toString());
+        assertThat(captor.getValue().getJson()).isEqualTo("{}");
+    }
+
+    @Test
+    void createTransactionBySavingsExternalId_shouldResolveSavingsIdInCommandWrapper() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        CommandProcessingResult result = org.mockito.Mockito.mock(CommandProcessingResult.class);
+
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(commandsSourceWritePlatformService.logCommandSource(any())).thenReturn(result);
+
+        underTest.transaction(savingsExternalId, "deposit", "{}");
+
+        ArgumentCaptor<CommandWrapper> captor = ArgumentCaptor.forClass(CommandWrapper.class);
+        verify(commandsSourceWritePlatformService).logCommandSource(captor.capture());
+        assertThat(captor.getValue().getSavingsId()).isEqualTo(resolvedSavingsId);
+        assertThat(captor.getValue().getJson()).isEqualTo("{}");
+    }
+
+    @Test
+    void advancedQueryBySavingsExternalId_shouldResolveSavingsIdAndDelegateToQueryService() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        PagedLocalRequest<AdvancedQueryRequest> queryRequest = new PagedLocalRequest<>();
+        Page<com.google.gson.JsonObject> page = org.mockito.Mockito.mock(Page.class);
+        UriInfo uriInfo = org.mockito.Mockito.mock(UriInfo.class);
+
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(transactionsSearchService.queryAdvanced(resolvedSavingsId, queryRequest)).thenReturn(page);
+        when(toApiJsonSerializer.serialize(page)).thenReturn("serialized");
+
+        String result = underTest.advancedQuery(savingsExternalId, queryRequest, uriInfo);
+
+        assertThat(result).isEqualTo("serialized");
+        verify(transactionsSearchService).queryAdvanced(resolvedSavingsId, queryRequest);
+    }
+
+    @Test
+    void adjustTransactionBySavingsAndTransactionExternalId_shouldResolveIdsInCommandWrapper() {
+        String savingsExternalId = "savings-external-id";
+        Long resolvedSavingsId = 11L;
+        String transactionExternalId = "tx-external-id";
+        Long resolvedTransactionId = 42L;
+        CommandProcessingResult result = org.mockito.Mockito.mock(CommandProcessingResult.class);
+
+        when(savingsAccountReadPlatformService.retrieveAccountIdByExternalId(argThat(id -> savingsExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedSavingsId);
+        when(savingsAccountReadPlatformService
+                .retrieveSavingsTransactionIdByExternalId(argThat(id -> transactionExternalId.equals(id.getValue()))))
+                .thenReturn(resolvedTransactionId);
+        when(commandsSourceWritePlatformService.logCommandSource(any())).thenReturn(result);
+
+        underTest.adjustTransaction(savingsExternalId, transactionExternalId, SavingsApiConstants.COMMAND_REVERSE_TRANSACTION, "{}");
+
+        ArgumentCaptor<CommandWrapper> captor = ArgumentCaptor.forClass(CommandWrapper.class);
+        verify(commandsSourceWritePlatformService).logCommandSource(captor.capture());
+        assertThat(captor.getValue().getSavingsId()).isEqualTo(resolvedSavingsId);
+        assertThat(captor.getValue().getTransactionId()).isEqualTo(resolvedTransactionId.toString());
+        assertThat(captor.getValue().getJson()).isEqualTo("{}");
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
@@ -25,12 +25,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,8 +43,10 @@ import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
@@ -69,12 +73,15 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeReposito
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
+import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.apache.fineract.useradministration.domain.AppUserRepositoryWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -135,6 +142,8 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
     private GSIMRepositoy gsimRepository;
     @Mock
     private SavingsAccountInterestPostingService savingsAccountInterestPostingService;
+    @Mock
+    private ExternalIdFactory externalIdFactory;
     @Mock
     private ErrorHandler errorHandler;
 
@@ -223,6 +232,151 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         when(savingsAccount.getTransactions()).thenReturn(List.of(transaction));
 
         assertThatNoException().isThrownBy(() -> validateTransactionsForTransfer.invoke(service, savingsAccount, transferDate));
+    }
+
+    @Test
+    void holdAmount_shouldUpdateTransactionExternalId() {
+        Long savingsId = 1L;
+        LocalDate transactionDate = LocalDate.of(2024, 4, 2);
+        BigDecimal amount = BigDecimal.TEN;
+        ExternalId externalId = new ExternalId("hold-external-id");
+
+        AppUser submittedBy = mock(AppUser.class);
+        JsonCommand command = mock(JsonCommand.class);
+        SavingsAccount account = mock(SavingsAccount.class);
+        SavingsAccountTransaction transaction = mock(SavingsAccountTransaction.class);
+        MonetaryCurrency currency = new MonetaryCurrency("USD", 2, 0);
+
+        when(context.authenticatedUser()).thenReturn(submittedBy);
+        when(savingAccountAssembler.getPivotConfigStatus()).thenReturn(false);
+        when(savingAccountAssembler.assembleFrom(savingsId, false)).thenReturn(account);
+        when(command.localDateValueOfParameterNamed("transactionDate")).thenReturn(transactionDate);
+        when(command.bigDecimalValueOfParameterNamed("transactionAmount")).thenReturn(amount);
+        when(command.booleanPrimitiveValueOfParameterNamed("lienAllowed")).thenReturn(false);
+        when(command.stringValueOfParameterNamed("reasonForBlock")).thenReturn("manual hold");
+        when(command.json()).thenReturn("{\"externalId\":\"hold-external-id\"}");
+        when(externalIdFactory.createFromCommand(command, "externalId")).thenReturn(externalId);
+        when(account.getClient()).thenReturn(null);
+        when(account.group()).thenReturn(null);
+        when(account.getCurrency()).thenReturn(currency);
+        when(account.getAccountBalance()).thenReturn(BigDecimal.valueOf(100));
+        when(account.getSavingsHoldAmount()).thenReturn(null);
+        when(account.officeId()).thenReturn(1L);
+        when(account.clientId()).thenReturn(2L);
+        when(account.groupId()).thenReturn(3L);
+        when(savingsAccountDomainService.handleHold(account, amount, transactionDate, false)).thenReturn(transaction);
+        when(transaction.getTransactionDate()).thenReturn(transactionDate);
+        when(transaction.getId()).thenReturn(44L);
+
+        service.holdAmount(savingsId, command);
+
+        verify(transaction).updateExternalId(externalId);
+        verify(savingsAccountTransactionRepository).saveAndFlush(transaction);
+    }
+
+    @Test
+    void releaseAmount_shouldUpdateTransactionExternalId() {
+        Long savingsId = 1L;
+        Long holdTransactionId = 7L;
+        LocalDate transactionDate = LocalDate.of(2024, 4, 3);
+        ExternalId externalId = new ExternalId("release-external-id");
+
+        JsonCommand command = mock(JsonCommand.class);
+        SavingsAccount account = mock(SavingsAccount.class);
+        SavingsAccountTransaction holdTransaction = mock(SavingsAccountTransaction.class);
+        SavingsAccountTransaction releaseTransaction = mock(SavingsAccountTransaction.class);
+        MonetaryCurrency currency = new MonetaryCurrency("USD", 2, 0);
+
+        when(context.authenticatedUser()).thenReturn(mock(AppUser.class));
+        when(savingsAccountTransactionRepository.findOneByIdAndSavingsAccountId(holdTransactionId, savingsId)).thenReturn(holdTransaction);
+        when(savingsAccountTransactionDataValidator.validateReleaseAmountAndAssembleForm(holdTransaction)).thenReturn(releaseTransaction);
+        when(externalIdFactory.createFromCommand(command, "externalId")).thenReturn(externalId);
+        when(savingAccountAssembler.getPivotConfigStatus()).thenReturn(false);
+        when(savingAccountAssembler.assembleFrom(savingsId, false)).thenReturn(account);
+        when(account.getClient()).thenReturn(null);
+        when(account.group()).thenReturn(null);
+        when(account.getCurrency()).thenReturn(currency);
+        when(account.getAccountBalance()).thenReturn(BigDecimal.valueOf(100));
+        when(account.getSavingsHoldAmount()).thenReturn(BigDecimal.TEN);
+        when(account.officeId()).thenReturn(1L);
+        when(account.clientId()).thenReturn(2L);
+        when(account.groupId()).thenReturn(3L);
+        when(account.getId()).thenReturn(savingsId);
+        when(releaseTransaction.getAmount()).thenReturn(BigDecimal.TEN);
+        when(releaseTransaction.getTransactionDate()).thenReturn(transactionDate);
+        when(releaseTransaction.getId()).thenReturn(88L);
+
+        service.releaseAmount(savingsId, holdTransactionId, command);
+
+        verify(savingsAccountTransactionDataValidator).validateReleaseAmount(command);
+        verify(releaseTransaction).updateExternalId(externalId);
+        verify(savingsAccountTransactionRepository).saveAndFlush(releaseTransaction);
+        verify(holdTransaction).updateReleaseId(88L);
+    }
+
+    @Test
+    void releaseAmount_shouldThrowNotFoundWhenTransactionDoesNotBelongToSavingsAccount() {
+        Long savingsId = 1L;
+        Long holdTransactionId = 7L;
+        JsonCommand command = mock(JsonCommand.class);
+
+        when(context.authenticatedUser()).thenReturn(mock(AppUser.class));
+        when(command.json()).thenReturn("{\"externalId\":\"release-external-id\"}");
+        when(savingsAccountTransactionRepository.findOneByIdAndSavingsAccountId(holdTransactionId, savingsId)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.releaseAmount(savingsId, holdTransactionId, command))
+                .isInstanceOf(SavingsAccountTransactionNotFoundException.class);
+    }
+
+    @Test
+    void postInterest_shouldValidateRequestAndUpdateManualInterestPostingExternalId() {
+        Long savingsId = 1L;
+        LocalDate transactionDate = LocalDate.of(2024, 4, 5);
+        ExternalId externalId = new ExternalId("interest-posting-external-id");
+
+        JsonCommand command = mock(JsonCommand.class);
+        SavingsAccount account = mock(SavingsAccount.class);
+        SavingsAccountTransaction postingTransaction = mock(SavingsAccountTransaction.class);
+        MonetaryCurrency currency = new MonetaryCurrency("USD", 2, 0);
+        List<SavingsAccountTransaction> transactions = new ArrayList<>();
+
+        when(command.getSavingsId()).thenReturn(savingsId);
+        when(command.booleanPrimitiveValueOfParameterNamed("isPostInterestAsOn")).thenReturn(true);
+        when(command.localDateValueOfParameterNamed("transactionDate")).thenReturn(transactionDate);
+        when(externalIdFactory.createFromCommand(command, "externalId")).thenReturn(externalId);
+        when(savingAccountAssembler.getPivotConfigStatus()).thenReturn(false);
+        when(savingAccountAssembler.assembleFrom(savingsId, false)).thenReturn(account);
+        when(account.getClient()).thenReturn(null);
+        when(account.group()).thenReturn(null);
+        when(account.getTransactions()).thenReturn(transactions);
+        when(account.accountSubmittedOrActivationDate()).thenReturn(transactionDate.minusDays(1));
+        when(account.getNominalAnnualInterestRate()).thenReturn(BigDecimal.ONE);
+        when(account.allowOverdraft()).thenReturn(false);
+        when(account.findExistingTransactionIds()).thenReturn(new HashSet<>());
+        when(account.findExistingReversedTransactionIds()).thenReturn(new HashSet<>());
+        when(account.getCurrency()).thenReturn(currency);
+        when(account.deriveAccountingBridgeData(any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(Collections.emptyMap());
+        when(account.officeId()).thenReturn(1L);
+        when(account.clientId()).thenReturn(2L);
+        when(account.groupId()).thenReturn(3L);
+        when(configurationDomainService.isSavingsInterestPostingAtCurrentPeriodEnd()).thenReturn(false);
+        when(configurationDomainService.retrieveFinancialYearBeginningMonth()).thenReturn(1);
+        when(postingTransaction.getId()).thenReturn(null);
+        when(postingTransaction.getDateOf()).thenReturn(transactionDate);
+        when(postingTransaction.getTransactionDate()).thenReturn(transactionDate);
+        when(postingTransaction.isInterestPosting()).thenReturn(true);
+        when(postingTransaction.isManualTransaction()).thenReturn(true);
+
+        Mockito.doAnswer(invocation -> {
+            transactions.add(postingTransaction);
+            return null;
+        }).when(account).postInterest(any(), any(), anyBoolean(), anyBoolean(), any(), any(), anyBoolean(), anyBoolean());
+
+        service.postInterest(command);
+
+        verify(savingsAccountTransactionDataValidator).validatePostInterest(command);
+        verify(postingTransaction).updateExternalId(externalId);
+        verify(savingsAccountTransactionRepository).save(postingTransaction);
     }
 
     @Test

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
@@ -44,6 +44,7 @@ import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDoma
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
@@ -53,6 +54,7 @@ import org.apache.fineract.infrastructure.event.business.service.BusinessEventNo
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.organisation.staff.domain.StaffRepositoryWrapper;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.apache.fineract.portfolio.account.domain.StandingInstructionRepository;
@@ -76,6 +78,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRep
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
 import org.apache.fineract.useradministration.domain.AppUser;
 import org.apache.fineract.useradministration.domain.AppUserRepositoryWrapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -157,6 +160,12 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         validateTransactionsForTransfer = SavingsAccountWritePlatformServiceJpaRepositoryImpl.class
                 .getDeclaredMethod("validateTransactionsForTransfer", SavingsAccount.class, LocalDate.class);
         validateTransactionsForTransfer.setAccessible(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+        MoneyHelper.clearCache();
     }
 
     @Test
@@ -241,6 +250,8 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         BigDecimal amount = BigDecimal.TEN;
         ExternalId externalId = new ExternalId("hold-external-id");
 
+        setupTenantContext(transactionDate);
+
         AppUser submittedBy = mock(AppUser.class);
         JsonCommand command = mock(JsonCommand.class);
         SavingsAccount account = mock(SavingsAccount.class);
@@ -280,6 +291,8 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         Long holdTransactionId = 7L;
         LocalDate transactionDate = LocalDate.of(2024, 4, 3);
         ExternalId externalId = new ExternalId("release-external-id");
+
+        setupTenantContext(transactionDate);
 
         JsonCommand command = mock(JsonCommand.class);
         SavingsAccount account = mock(SavingsAccount.class);
@@ -334,6 +347,8 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         LocalDate transactionDate = LocalDate.of(2024, 4, 5);
         ExternalId externalId = new ExternalId("interest-posting-external-id");
 
+        setupTenantContext(transactionDate);
+
         JsonCommand command = mock(JsonCommand.class);
         SavingsAccount account = mock(SavingsAccount.class);
         SavingsAccountTransaction postingTransaction = mock(SavingsAccountTransaction.class);
@@ -377,6 +392,12 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         verify(savingsAccountTransactionDataValidator).validatePostInterest(command);
         verify(postingTransaction).updateExternalId(externalId);
         verify(savingsAccountTransactionRepository).save(postingTransaction);
+    }
+
+    private void setupTenantContext(final LocalDate businessDate) {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "Test Tenant", "UTC", null));
+        MoneyHelper.initializeTenantRoundingMode("test", 6);
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, businessDate)));
     }
 
     @Test

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsApiSetConstants.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsApiSetConstants.java
@@ -60,8 +60,8 @@ public class SavingsApiSetConstants extends SavingsApiConstants {
             accountMappingForPaymentParamName, interestPostedTillDate));
 
     protected static final Set<String> SAVINGS_TRANSACTION_RESPONSE_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(idParamName, "accountId", accountNoParamName, "currency", "amount", dateParamName, paymentDetailDataParamName,
-                    runningBalanceParamName, reversedParamName, noteParamName));
+            Arrays.asList(idParamName, "accountId", accountNoParamName, externalIdParamName, "currency", "amount", dateParamName,
+                    paymentDetailDataParamName, runningBalanceParamName, reversedParamName, noteParamName));
 
     protected static final Set<String> SAVINGS_ACCOUNT_CHARGES_RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(chargeIdParamName, savingsAccountChargeIdParamName, chargeNameParamName, penaltyParamName,

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
@@ -47,7 +47,7 @@ public class SavingsAccountConstant extends SavingsApiConstants {
      */
 
     protected static final Set<String> SAVINGS_ACCOUNT_TRANSACTION_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(localeParamName,
-            dateFormatParamName, transactionDateParamName, transactionAmountParamName, paymentTypeIdParamName,
+            dateFormatParamName, externalIdParamName, transactionDateParamName, transactionAmountParamName, paymentTypeIdParamName,
             transactionAccountNumberParamName, checkNumberParamName, routingCodeParamName, receiptNumberParamName, bankNumberParamName,
             retailEntriesParamName, childAccountIdParamName, noteParamName, amountParamName, dateParamName, isManualTransaction,
             lienTransaction, chargesPaidByData, submittedOnDateParamName, accountIdParamName, accountNoParamName));

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransaction.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransaction.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.fineract.infrastructure.core.domain.AbstractAuditableWithUTCDateTimeCustom;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.domain.LocalDateInterval;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
@@ -85,6 +86,9 @@ public final class SavingsAccountTransaction extends AbstractAuditableWithUTCDat
 
     @Column(name = "is_reversed", nullable = false)
     private boolean reversed;
+
+    @Column(name = "external_id", length = 100, nullable = true, unique = true)
+    private ExternalId externalId = ExternalId.empty();
 
     @Column(name = "running_balance_derived", scale = 6, precision = 19, nullable = true)
     private BigDecimal runningBalance;
@@ -369,6 +373,14 @@ public final class SavingsAccountTransaction extends AbstractAuditableWithUTCDat
 
     public LocalDate getTransactionDate() {
         return this.dateOf;
+    }
+
+    public ExternalId getExternalId() {
+        return this.externalId;
+    }
+
+    public void updateExternalId(final ExternalId externalId) {
+        this.externalId = externalId;
     }
 
     public LocalDate getEndOfBalanceDate() {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionRepository.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionRepository.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.savings.domain;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -31,9 +32,14 @@ import org.springframework.data.repository.query.Param;
 public interface SavingsAccountTransactionRepository
         extends JpaRepository<SavingsAccountTransaction, Long>, JpaSpecificationExecutor<SavingsAccountTransaction> {
 
+    SavingsAccountTransaction findByExternalId(ExternalId externalId);
+
     @Query("select sat from SavingsAccountTransaction sat where sat.id = :transactionId and sat.savingsAccount.id = :savingsId")
     SavingsAccountTransaction findOneByIdAndSavingsAccountId(@Param("transactionId") Long transactionId,
             @Param("savingsId") Long savingsId);
+
+    @Query("SELECT sat.id FROM SavingsAccountTransaction sat WHERE sat.externalId = :externalId")
+    Long findIdByExternalId(@Param("externalId") ExternalId externalId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select st from SavingsAccountTransaction st where st.savingsAccount = :savingsAccount and st.dateOf >= :transactionDate order by st.dateOf,st.createdDate,st.id")

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/exception/SavingsAccountTransactionNotFoundException.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/exception/SavingsAccountTransactionNotFoundException.java
@@ -18,7 +18,10 @@
  */
 package org.apache.fineract.portfolio.savings.exception;
 
+import java.util.Objects;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 public class SavingsAccountTransactionNotFoundException extends AbstractPlatformResourceNotFoundException {
 
@@ -28,4 +31,17 @@ public class SavingsAccountTransactionNotFoundException extends AbstractPlatform
                 savingsId, transactionId);
     }
 
+    public SavingsAccountTransactionNotFoundException(final Long savingsId, final ExternalId transactionExternalId) {
+        super("error.msg.saving.account.trasaction.external.id.invalid",
+                "Savings account with savings identifier " + savingsId + " and trasaction external identifier "
+                        + Objects.requireNonNullElse(transactionExternalId, ExternalId.empty()).getValue() + " does not exist",
+                savingsId, transactionExternalId);
+    }
+
+    public SavingsAccountTransactionNotFoundException(final Long savingsId, final Long transactionId,
+            final EmptyResultDataAccessException e) {
+        super("error.msg.saving.account.trasaction.id.invalid",
+                "Savings account with savings identifier " + savingsId + " and trasaction identifier " + transactionId + " does not exist",
+                savingsId, transactionId, e);
+    }
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformService.java
@@ -70,6 +70,8 @@ public interface SavingsAccountReadPlatformService {
 
     List<SavingsAccountTransactionData> retrieveAllTransactionData(List<String> refNo);
 
+    Long retrieveSavingsTransactionIdByExternalId(ExternalId externalId);
+
     Long retrieveAccountIdByExternalId(ExternalId externalId);
 
     List<SavingsAccrualData> retrievePeriodicAccrualData(LocalDate tillDate, SavingsAccount savings);

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
@@ -112,7 +112,7 @@ public interface SavingsAccountWritePlatformService {
 
     CommandProcessingResult unblockDebits(Long savingsId);
 
-    CommandProcessingResult releaseAmount(Long savingsId, Long transactionId);
+    CommandProcessingResult releaseAmount(Long savingsId, Long transactionId, JsonCommand command);
 
     CommandProcessingResult gsimActivate(Long gsimId, JsonCommand command);
 

--- a/fineract-savings/src/main/resources/db/changelog/tenant/module/savings/parts/parts/2005_add_external_id_to_savings_transaction.xml
+++ b/fineract-savings/src/main/resources/db/changelog/tenant/module/savings/parts/parts/2005_add_external_id_to_savings_transaction.xml
@@ -20,12 +20,15 @@
 
 -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-  <!-- Sequence is starting from 2000 to make it easier to move existing liquibase changesets here -->
-  <include file="parts/2001_add_savings_accrual_job.xml" relativeToChangelogFile="true" />
-  <include file="parts/2002_add_savings_accrual_permission.xml" relativeToChangelogFile="true" />
-  <include file="parts/2003_add_accrued_till_date_to_savings_account.xml" relativeToChangelogFile="true" />
-  <include file="parts/2004_add_savings_account_cob_infrastructure.xml" relativeToChangelogFile="true" />
-  <include file="parts/2005_add_external_id_to_savings_transaction.xml" relativeToChangelogFile="true" />
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_savings_account_transaction">
+            <column name="external_id" type="VARCHAR(100)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="fineract" id="2">
+        <addUniqueConstraint columnNames="external_id" constraintName="uk_m_sat_external_id"
+                             tableName="m_savings_account_transaction"/>
+    </changeSet>
 </databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
@@ -1175,7 +1175,9 @@ public class ClientSavingsIntegrationTest {
         }
         transactionDate = transactionDate.withDayOfMonth(1);
         transactionDateValue = dateFormat.format(transactionDate);
-        this.savingsAccountHelper.postInterestAsOnSavings(savingsId, transactionDateValue);
+        final ResponseSpecification errorResponse = new ResponseSpecBuilder().expectStatusCode(403).build();
+        final SavingsAccountHelper validationErrorHelper = new SavingsAccountHelper(this.requestSpec, errorResponse);
+        validationErrorHelper.postInterestAsOnSavings(savingsId, transactionDateValue);
         accountTransactionDetails = this.savingsAccountHelper.getSavingsDetails(savingsId);
         summary = (HashMap) accountTransactionDetails.get("summary");
         accountDetailsPostInterest = Float.parseFloat(summary.get("totalInterestPosted").toString());
@@ -1436,7 +1438,9 @@ public class ClientSavingsIntegrationTest {
         }
         transactionDate = transactionDate.withDayOfMonth(1);
         transactionDateValue = dateFormat.format(transactionDate);
-        this.savingsAccountHelper.postInterestAsOnSavings(savingsId, transactionDateValue);
+        final ResponseSpecification errorResponse = new ResponseSpecBuilder().expectStatusCode(403).build();
+        final SavingsAccountHelper validationErrorHelper = new SavingsAccountHelper(this.requestSpec, errorResponse);
+        validationErrorHelper.postInterestAsOnSavings(savingsId, transactionDateValue);
         accountTransactionDetails = this.savingsAccountHelper.getSavingsDetails(savingsId);
         summary = (HashMap) accountTransactionDetails.get("summary");
         accountDetailsPostInterest = Float.parseFloat(summary.get("totalInterestPosted").toString());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/FlexibleSavingsInterestPostingIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/FlexibleSavingsInterestPostingIntegrationTest.java
@@ -92,7 +92,7 @@ public class FlexibleSavingsInterestPostingIntegrationTest {
         ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
         HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 2);
         for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+            LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
         }
         // 1st Dec 13 to 31st March 14 - 365 days, daily compounding using daily
         // balance

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingIntegrationTest.java
@@ -101,7 +101,7 @@ public class SavingsInterestPostingIntegrationTest {
             ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
             HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 2);
             for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-                LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+                LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
             }
             assertEquals("0.274", interestPostingTransaction.get("amount").toString(), "Equality check for interest posted amount");
             assertEquals("[2021, 11, 2]", interestPostingTransaction.get("date").toString(), "Date check for Interest Posting transaction");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsInterestPostingJobIntegrationTest.java
@@ -102,7 +102,7 @@ public class SavingsInterestPostingJobIntegrationTest {
         ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) transactionObj;
         HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 48);
         for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+            LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
         }
         assertEquals("10129.582", interestPostingTransaction.get("runningBalance").toString(), "Equality check for Balance");
     }
@@ -166,7 +166,7 @@ public class SavingsInterestPostingJobIntegrationTest {
             ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) transactionObj;
             HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 3);
             for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-                LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+                LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
             }
             assertEquals("2.7405", interestPostingTransaction.get("amount").toString(), "Equality check for interest posted amount");
             assertEquals("[2022, 4, 12]", interestPostingTransaction.get("date").toString(), "Date check for Interest Posting transaction");
@@ -195,7 +195,7 @@ public class SavingsInterestPostingJobIntegrationTest {
         ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) transactionObj;
         HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 2);
         for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+            LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
         }
         assertEquals("2.7397", interestPostingTransaction.get("amount").toString(), "Equality check for overdatft interest posted amount");
         assertEquals("[2022, 4, 11]", interestPostingTransaction.get("date").toString(),
@@ -221,7 +221,7 @@ public class SavingsInterestPostingJobIntegrationTest {
         ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) transactionObj;
         HashMap<String, Object> interestPostingTransaction = transactions.get(transactions.size() - 5);
         for (Map.Entry<String, Object> entry : interestPostingTransaction.entrySet()) {
-            LOG.info("{} - {}", entry.getKey(), entry.getValue().toString());
+            LOG.info("{} - {}", entry.getKey(), String.valueOf(entry.getValue()));
         }
         assertEquals("800.4384", interestPostingTransaction.get("runningBalance").toString(), "Equality check for Balance");
     }


### PR DESCRIPTION
This PR completes savings transaction externalId support:
- add savings transaction routes by savings account externalId
- support transaction operations by transaction externalId
- add externalId support for holdAmount, releaseAmount and postInterestAsOn
- align savings transaction validation and OpenAPI metadata
- add focused tests for savings transaction externalId flows

## Checklist

- [X] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [X] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [X] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [X] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [X] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [X] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
