### PR TITLE
FINERACT-2595: Fix Liquibase changeset 0231 FK violation on existing tenants

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0231_remove_clientcharge_inactivate_permissions.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0231_remove_clientcharge_inactivate_permissions.xml
@@ -22,8 +22,14 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-    <changeSet author="ashharahmadkhan" id="1">
+    <changeSet author="fineract" id="1">
         <comment>Remove INACTIVATE_CLIENTCHARGE permissions - command was never implemented and the client-charge inactivate write path is being removed.</comment>
+        <delete tableName="m_role_permission">
+            <where>permission_id=(SELECT id FROM m_permission WHERE code='INACTIVATE_CLIENTCHARGE')</where>
+        </delete>
+        <delete tableName="m_role_permission">
+            <where>permission_id=(SELECT id FROM m_permission WHERE code='INACTIVATE_CLIENTCHARGE_CHECKER')</where>
+        </delete>
         <delete tableName="m_permission">
             <where>code='INACTIVATE_CLIENTCHARGE'</where>
         </delete>


### PR DESCRIPTION
Problem

Changeset 0231 (merged in #5764) failed on existing tenants with a 
PostgreSQL foreign key violation:

  DELETE FROM m_permission WHERE code='INACTIVATE_CLIENTCHARGE'
  → ERROR: violates foreign key constraint "fk8dedb048103b544b" 
    on table "m_role_permission"

This happened because m_role_permission holds references to m_permission 
via a foreign key. You cannot delete a permission row while role-permission 
rows still point to it.

Additionally, the changeset author was set to "ashharahmadkhan" instead 
of the required "fineract".

Fix

1. Delete orphaned m_role_permission rows first, before deleting the 
   parent m_permission rows.
2. Change changeset author from "ashharahmadkhan" to "fineract".

Fresh tenants (barebones_db / load_sample_data) were unaffected because 
those permissions were never assigned to any role. Existing tenants with 
roles assigned to INACTIVATE_CLIENTCHARGE hit the FK violation on startup.

References
- JIRA: https://issues.apache.org/jira/browse/FINERACT-2595
- Original PR: #5764