### PR TITLE
FINERACT-2421: Working Capital Delinquency pause different calculation

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDelinquencyPause.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDelinquencyPause.feature
@@ -200,8 +200,8 @@ Feature: Working Capital Delinquency Pause
       | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                  | 270.0             | 3           |
       | 2            | 2026-03-13 | 2026-04-11 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
 
-  @TestRailId:C74485-1
-  Scenario: Verify working capital loan delinquency pause - UC6: delinquency pause in the middle of first period with pause overlapping to second period
+  @TestRailId:C78810
+  Scenario: Verify working capital loan delinquency pause - UC6.1: delinquency pause in the middle of first period with future pauses overlapping to a few periods
     When Admin sets the business date to "01 January 2026"
     And Admin creates a client with random data
     And Admin creates a working capital loan with the following data:
@@ -235,6 +235,15 @@ Feature: Working Capital Delinquency Pause
     When Admin sets the business date to "13 March 2026"
     And Admin runs inline COB job for Working Capital Loan by loanId
     And Admin initiate a Working Capital loan delinquency pause with startDate "13 March 2026" and endDate "17 March 2026"
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-04-16 | 2026-04-23 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 1              |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
     When Admin sets the business date to "20 March 2026"
     And Admin runs inline COB job for Working Capital Loan by loanId
     Then Working Capital loan delinquency action has the following data:
@@ -248,6 +257,84 @@ Feature: Working Capital Delinquency Pause
       | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
     When Admin sets the business date to "30 April 2026"
     And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 49             |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 15             |
+      | 3            | 2026-04-16 | 2026-05-22 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+
+  @TestRailId:C78811
+  Scenario: Verify working capital loan delinquency pause - UC6.2: delinquency pause in the middle of first period with pauses overlapping to a few periods
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a client with random data
+    And Admin creates a working capital loan with the following data:
+      | LoanProduct | submittedOnDate | expectedDisbursementDate | principalAmount | totalPayment | periodPaymentRate | discount |
+      | WCLP        | 01 January 2026 | 01 January 2026          | 9000            | 100000       | 18                | 0        |
+    And Admin successfully approves the working capital loan on "01 January 2026" with "9000" amount and expected disbursement date on "01 January 2026"
+    Then Working capital loan approval was successful
+    And Working capital loan account has the correct data:
+      | product.name | submittedOnDate | expectedDisbursementDate | status   | principal | approvedPrincipal | totalPayment | periodPaymentRate | discount |
+      | WCLP         | 2026-01-01      | 2026-01-01               | Approved | 9000.0    | 9000.0            | 100000.0     | 18.0              | 0.0      |
+    When Admin successfully disburse the Working Capital loan on "01 January 2026" with "9000" EUR transaction amount
+    Then Working Capital loan status will be "ACTIVE"
+    And Verify Working Capital loan disbursement was successful on "01 January 2026" with "9000" EUR transaction amount
+    And Working capital loan account has the correct data:
+      | product.name | submittedOnDate | expectedDisbursementDate | status | principal | approvedPrincipal | totalPayment | periodPaymentRate | discount |
+      | WCLP         | 2026-01-01      | 2026-01-01               | Active | 9000.0    | 9000.0            | 100000.0     | 18.0              | 0.0      |
+    When Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-01-30 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    When Admin sets the business date to "15 January 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    And Admin initiate a Working Capital loan delinquency pause with startDate "15 January 2026" and endDate "25 February 2026"
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    When Admin sets the business date to "13 March 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 1              |
+      | 2            | 2026-03-13 | 2026-04-11 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    And Admin initiate a Working Capital loan delinquency pause with startDate "13 March 2026" and endDate "17 March 2026"
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+    When Admin sets the business date to "20 March 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 8              |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    When Admin sets the business date to "30 April 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+    Then Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 49             |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 15             |
+      | 3            | 2026-04-16 | 2026-05-15 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    And Admin initiate a Working Capital loan delinquency pause with startDate "16 April 2026" and endDate "23 April 2026"
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+      | PAUSE  | 2026-04-16 | 2026-04-23 |
     Then Working Capital loan delinquency range schedule has the following data:
       | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
       | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 49             |

--- a/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDelinquencyPause.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDelinquencyPause.feature
@@ -200,6 +200,60 @@ Feature: Working Capital Delinquency Pause
       | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                  | 270.0             | 3           |
       | 2            | 2026-03-13 | 2026-04-11 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
 
+  @TestRailId:C74485-1
+  Scenario: Verify working capital loan delinquency pause - UC6: delinquency pause in the middle of first period with pause overlapping to second period
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a client with random data
+    And Admin creates a working capital loan with the following data:
+      | LoanProduct | submittedOnDate | expectedDisbursementDate | principalAmount | totalPayment | periodPaymentRate | discount |
+      | WCLP        | 01 January 2026 | 01 January 2026          | 9000            | 100000       | 18                | 0        |
+    And Admin successfully approves the working capital loan on "01 January 2026" with "9000" amount and expected disbursement date on "01 January 2026"
+    Then Working capital loan approval was successful
+    And Working capital loan account has the correct data:
+      | product.name | submittedOnDate | expectedDisbursementDate | status   | principal | approvedPrincipal | totalPayment | periodPaymentRate | discount |
+      | WCLP         | 2026-01-01      | 2026-01-01               | Approved | 9000.0    | 9000.0            | 100000.0     | 18.0              | 0.0      |
+    When Admin successfully disburse the Working Capital loan on "01 January 2026" with "9000" EUR transaction amount
+    Then Working Capital loan status will be "ACTIVE"
+    And Verify Working Capital loan disbursement was successful on "01 January 2026" with "9000" EUR transaction amount
+    And Working capital loan account has the correct data:
+      | product.name | submittedOnDate | expectedDisbursementDate | status | principal | approvedPrincipal | totalPayment | periodPaymentRate | discount |
+      | WCLP         | 2026-01-01      | 2026-01-01               | Active | 9000.0    | 9000.0            | 100000.0     | 18.0              | 0.0      |
+    When Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-01-30 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    When Admin sets the business date to "15 January 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    And Admin initiate a Working Capital loan delinquency pause with startDate "15 January 2026" and endDate "25 February 2026"
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    And Admin initiate a Working Capital loan delinquency pause with startDate "16 April 2026" and endDate "23 April 2026"
+    When Admin sets the business date to "13 March 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    And Admin initiate a Working Capital loan delinquency pause with startDate "13 March 2026" and endDate "17 March 2026"
+    When Admin sets the business date to "20 March 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency action has the following data:
+      | action | startDate  | endDate    |
+      | PAUSE  | 2026-01-15 | 2026-02-25 |
+      | PAUSE  | 2026-04-16 | 2026-04-23 |
+      | PAUSE  | 2026-03-13 | 2026-03-17 |
+    And Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 8              |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+    When Admin sets the business date to "30 April 2026"
+    And Admin runs inline COB job for Working Capital Loan by loanId
+    Then Working Capital loan delinquency range schedule has the following data:
+      | periodNumber | fromDate   | toDate     | expectedAmount | paidAmount | outstandingAmount | minPaymentCriteriaMet | delinquentAmount | delinquentDays |
+      | 1            | 2026-01-01 | 2026-03-12 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 49             |
+      | 2            | 2026-03-13 | 2026-04-15 | 270.0          | 0.0        | 270.0             | false                 | 270.0            | 15             |
+      | 3            | 2026-04-16 | 2026-05-22 | 270.0          | 0.0        | 270.0             | null                  | null             | null           |
+
   @TestRailId:C74486
   Scenario: Verify working capital loan delinquency pause - UC7: backdated delinquency pause to an already evaluated period results an error (Negative)
     When Admin sets the business date to "01 January 2026"

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/portfolio/workingcapitalloan/service/WorkingCapitalLoanDelinquencyRangeScheduleServiceImpl.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/portfolio/workingcapitalloan/service/WorkingCapitalLoanDelinquencyRangeScheduleServiceImpl.java
@@ -112,6 +112,8 @@ public class WorkingCapitalLoanDelinquencyRangeScheduleServiceImpl implements Wo
         final DelinquencyFrequencyType effectiveFreqType = latestReschedule.map(WorkingCapitalLoanDelinquencyAction::getFrequencyType)
                 .orElse(rule.getFrequencyType());
 
+        final List<WorkingCapitalLoanDelinquencyAction> recordedPauses = findAllPauseActions(loan.getId());
+
         WorkingCapitalLoanDelinquencyRangeSchedule latestPeriod = latestPeriodOpt.get();
         while (!latestPeriod.getToDate().isAfter(businessDate)) {
             final LocalDate newFromDate = latestPeriod.getToDate().plusDays(1);
@@ -127,6 +129,8 @@ public class WorkingCapitalLoanDelinquencyRangeScheduleServiceImpl implements Wo
             nextPeriod.setPaidAmount(BigDecimal.ZERO);
             nextPeriod.setOutstandingAmount(expectedAmount);
             nextPeriod.setMinPaymentCriteriaMet(null);
+
+            applyRecordedPauses(nextPeriod, recordedPauses);
 
             latestPeriod = loanDelinquencyRangeScheduleRepository.saveAndFlush(nextPeriod);
             log.debug("Generated next delinquency range schedule period {} for WC loan {}", nextPeriod.getPeriodNumber(), loan.getId());
@@ -258,6 +262,27 @@ public class WorkingCapitalLoanDelinquencyRangeScheduleServiceImpl implements Wo
 
     private Optional<WorkingCapitalLoanDelinquencyAction> findLatestRescheduleAction(final Long loanId) {
         return loanDelinquencyActionRepository.findTopByWorkingCapitalLoanIdAndActionOrderByIdDesc(loanId, DelinquencyAction.RESCHEDULE);
+    }
+
+    private List<WorkingCapitalLoanDelinquencyAction> findAllPauseActions(final Long loanId) {
+        return loanDelinquencyActionRepository.findByWorkingCapitalLoanIdOrderById(loanId).stream()
+                .filter(a -> DelinquencyAction.PAUSE.equals(a.getAction())).toList();
+    }
+
+    private void applyRecordedPauses(final WorkingCapitalLoanDelinquencyRangeSchedule period,
+            final List<WorkingCapitalLoanDelinquencyAction> pauseActions) {
+        for (final WorkingCapitalLoanDelinquencyAction pause : pauseActions) {
+            final LocalDate pauseStart = pause.getStartDate();
+            final LocalDate pauseEnd = pause.getEndDate();
+            // Apply only if the pause overlaps this period's date range
+            if (pauseEnd.isAfter(period.getFromDate()) && !pauseStart.isAfter(period.getToDate())) {
+                final long pauseDays = ChronoUnit.DAYS.between(pauseStart, pauseEnd);
+                period.setToDate(period.getToDate().plusDays(pauseDays));
+                if (period.getFromDate().isAfter(pauseStart)) {
+                    period.setFromDate(period.getFromDate().plusDays(pauseDays));
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

There was an issue with the different calculation of range schedule durations with diff endDate in case the same delinquency pauses were added, but in different order(from diff biz date)

[FINERACT-2421](https://issues.apache.org/jira/browse/FINERACT-2421)

<img width="1482" height="972" alt="Screenshot 2026-04-24 at 2 25 48 PM" src="https://github.com/user-attachments/assets/a5993664-2734-4fc5-a58e-9093b5fd843e" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
