### PR TITLE
FINERACT-2593: when loan product is null

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -156,7 +156,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
 
             // If the Loan is not Active yet or is cancelled (rejected or withdrawn), return template data
             if (loan.isSubmittedAndPendingApproval() || loan.isApproved() || loan.isCancelled()) {
-                if (loan.getLoanProduct() == null || loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
+                if (loan.getLoanProduct() != null && loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
                     collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
                 }
                 return collectionData;
@@ -173,7 +173,9 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
             // loans
             collectionData = loanDelinquencyDomainService.getOverdueCollectionData(loan, effectiveDelinquencyList);
             collectionData.setAvailableDisbursementAmount(calculateAvailableDisbursementAmount(loan));
-            collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
+            if (loan.getLoanProduct() != null) {
+                collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
+            }
             collectionData.setNextPaymentDueDate(possibleNextRepaymentDate(nextPaymentDueDateConfig, loan));
             PossibleNextRepaymentCalculationService possibleNextRepaymentCalculationService = possibleNextRepaymentCalculationServiceDiscovery
                     .getService(loan);

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -173,7 +173,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
             // loans
             collectionData = loanDelinquencyDomainService.getOverdueCollectionData(loan, effectiveDelinquencyList);
             collectionData.setAvailableDisbursementAmount(calculateAvailableDisbursementAmount(loan));
-            if (loan.getLoanProduct() != null) {
+            if (loan.getLoanProduct() != null && loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
                 collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
             }
             collectionData.setNextPaymentDueDate(possibleNextRepaymentDate(nextPaymentDueDateConfig, loan));

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -173,7 +173,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
             // loans
             collectionData = loanDelinquencyDomainService.getOverdueCollectionData(loan, effectiveDelinquencyList);
             collectionData.setAvailableDisbursementAmount(calculateAvailableDisbursementAmount(loan));
-            if (loan.getLoanProduct() != null && loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
+            if (loan.getLoanProduct() != null) {
                 collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
             }
             collectionData.setNextPaymentDueDate(possibleNextRepaymentDate(nextPaymentDueDateConfig, loan));

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -156,7 +156,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
 
             // If the Loan is not Active yet or is cancelled (rejected or withdrawn), return template data
             if (loan.isSubmittedAndPendingApproval() || loan.isApproved() || loan.isCancelled()) {
-                if (loan.getLoanProduct() != null && loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
+                if (loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
                     collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
                 }
                 return collectionData;
@@ -173,9 +173,8 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
             // loans
             collectionData = loanDelinquencyDomainService.getOverdueCollectionData(loan, effectiveDelinquencyList);
             collectionData.setAvailableDisbursementAmount(calculateAvailableDisbursementAmount(loan));
-            if (loan.getLoanProduct() != null) {
-                collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
-            }
+            collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
+
             collectionData.setNextPaymentDueDate(possibleNextRepaymentDate(nextPaymentDueDateConfig, loan));
             PossibleNextRepaymentCalculationService possibleNextRepaymentCalculationService = possibleNextRepaymentCalculationServiceDiscovery
                     .getService(loan);

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -214,7 +214,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
         BigDecimal approvedWithOverApplied = loan.getApprovedPrincipal();
 
         // If over applied amount is enabled, calculate the maximum allowed amount
-        if (loanProduct.isAllowApprovedDisbursedAmountsOverApplied()) {
+        if (loanProduct != null && loanProduct.isAllowApprovedDisbursedAmountsOverApplied()) {
             if (loanProduct.getOverAppliedCalculationType() != null) {
                 if ("percentage".equalsIgnoreCase(loanProduct.getOverAppliedCalculationType())) {
                     final BigDecimal overAppliedNumber = BigDecimal.valueOf(loanProduct.getOverAppliedNumber());

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -17,29 +17,34 @@
  * under the License.
  */
 package org.apache.fineract.portfolio.delinquency.service;
-
-import static java.time.Month.JANUARY;
-import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
-
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static java.time.Month.JANUARY;
+import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-
 import java.util.Optional;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyAction;
@@ -56,12 +61,14 @@ import org.apache.fineract.portfolio.loanaccount.data.DelinquencyPausePeriod;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -87,22 +94,12 @@ class DelinquencyReadPlatformServiceImplTest {
     private LoanInstallmentDelinquencyTagRepository repositoryLoanInstallmentDelinquencyTag;
     @Mock
     private ConfigurationDomainService configurationDomainService;
-
-
-    private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
-    @Mock
-    private ConfigurationDomainService configurationDomainService;
     @Mock
     private LoanTransactionRepository loanTransactionRepository;
     @Mock
     private PossibleNextRepaymentCalculationServiceDiscovery possibleNextRepaymentCalculationServiceDiscovery;
-
-
-
     @Mock
     private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
-    
-
     @Mock
     private DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper;
 
@@ -193,30 +190,48 @@ class DelinquencyReadPlatformServiceImplTest {
         Loan loan = mock(Loan.class);
         when(loan.getLoanProduct()).thenReturn(null);
         when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
-        when(loan.isApproved()).thenReturn(false);
-        when(loan.isCancelled()).thenReturn(false);
+        // REMOVED: when(loan.isApproved()).thenReturn(false); ← unnecessary
+        // REMOVED: when(loan.isCancelled()).thenReturn(false); ← unnecessary
         when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
 
         CollectionData result = underTest.calculateLoanCollectionData(1L);
 
         assertThat(result).isNotNull();
-        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isNull();
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
     }
 
     @Test
     void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
-        Loan loan = mock(Loan.class);
-        when(loan.getLoanProduct()).thenReturn(null);
-        when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
-        when(loan.isApproved()).thenReturn(false);
-        when(loan.isCancelled()).thenReturn(false);
-        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
-        when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
+        HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+        businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 1, 1));
+        businessDates.put(BusinessDateType.COB_DATE, LocalDate.of(2024, 1, 1));
+        ThreadLocalContextUtil.setBusinessDates(businessDates);
 
-        CollectionData result = underTest.calculateLoanCollectionData(1L);
+        try {
+            Loan loan = mock(Loan.class);
+            when(loan.getLoanProduct()).thenReturn(null);
+            when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
+            when(loan.isApproved()).thenReturn(false);
+            when(loan.isCancelled()).thenReturn(false);
+            when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+            when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(5000));
+            when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+            when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
+            when(loanDelinquencyActionRepository.findByLoanOrderById(any())).thenReturn(List.of());
+            when(configurationDomainService.getNextPaymentDateConfigForLoan()).thenReturn(null);
+            when(possibleNextRepaymentCalculationServiceDiscovery.getService(any())).thenReturn(null);
+            when(loan.getLastPaymentTransaction()).thenReturn(null);
+            when(loan.getLastRepaymentOrDownPaymentTransaction()).thenReturn(null);
+            when(loan.isEnableInstallmentLevelDelinquency()).thenReturn(false);
+            when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
 
-        assertThat(result).isNotNull();
-        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isNull();
+            CollectionData result = underTest.calculateLoanCollectionData(1L);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
+        } finally {
+            ThreadLocalContextUtil.reset();
+        }
     }
 
     @Test
@@ -240,6 +255,62 @@ class DelinquencyReadPlatformServiceImplTest {
                 pausePeriod(false, "2023-01-13", "2023-01-14"), //
                 pausePeriod(false, "2023-01-15", "2023-01-20") //
         );
+    }
+
+    @Test
+    void givenLoanWithNullProduct_whenHelperCalledDirectly_thenReturnsZero() {
+        Loan loan = mock(Loan.class);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(5000));
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+
+        BigDecimal result = underTest.calculateAvailableDisbursementAmountWithOverApplied(loan);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(5000));
+    }
+
+    @Test
+    void givenLoanWithProductOverApplyDisabled_whenHelperCalledDirectly_thenReturnsApprovedMinusDisbursed() {
+        Loan loan = mock(Loan.class);
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loanProduct.isAllowApprovedDisbursedAmountsOverApplied()).thenReturn(false);
+        when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(4000));
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+
+        BigDecimal result = underTest.calculateAvailableDisbursementAmountWithOverApplied(loan);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(6000));
+    }
+
+    @Test
+    void givenLoanWithPercentageOverApply_whenHelperCalledDirectly_thenReturnsCalculatedAmount() {
+        // MoneyHelper.getMathContext() requires a tenant context
+        MathContext mathContext = new MathContext(19, RoundingMode.HALF_EVEN);
+        MockedStatic<MoneyHelper> moneyHelperMock = mockStatic(MoneyHelper.class);
+        moneyHelperMock.when(MoneyHelper::getMathContext).thenReturn(mathContext);
+
+        try {
+            Loan loan = mock(Loan.class);
+            LoanProduct loanProduct = mock(LoanProduct.class);
+            when(loan.getLoanProduct()).thenReturn(loanProduct);
+            when(loanProduct.isAllowApprovedDisbursedAmountsOverApplied()).thenReturn(true);
+            when(loanProduct.getOverAppliedCalculationType()).thenReturn("percentage");
+            when(loanProduct.getOverAppliedNumber()).thenReturn(10);
+            when(loan.getProposedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+            when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+            when(loan.getDisbursedAmount()).thenReturn(BigDecimal.ZERO);
+            when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+
+            BigDecimal result = underTest.calculateAvailableDisbursementAmountWithOverApplied(loan);
+
+            // 10000 * (1 + 10/100) = 11000, minus 0 disbursed = 11000
+            assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(11000));
+        } finally {
+            moneyHelperMock.close();
+        }
     }
 
     private void verifyPausePeriods(CollectionData collectionData, DelinquencyPausePeriod... pausePeriods) {

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -184,8 +184,6 @@ class DelinquencyReadPlatformServiceImplTest {
         Loan loan = mock(Loan.class);
         when(loan.getLoanProduct()).thenReturn(null);
         when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
-        // REMOVED: when(loan.isApproved()).thenReturn(false); ← unnecessary
-        // REMOVED: when(loan.isCancelled()).thenReturn(false); ← unnecessary
         when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
 
         CollectionData result = underTest.calculateLoanCollectionData(1L);
@@ -354,7 +352,7 @@ class DelinquencyReadPlatformServiceImplTest {
             assertThat(result).isNotNull();
             // calculateAvailableDisbursementAmount = 10000 - 5000 = 5000
             assertThat(result.getAvailableDisbursementAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000));
-            // LoanProduct is null → over-applied helper skipped → field stays at template default
+            
             assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
         } finally {
             ThreadLocalContextUtil.reset();

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -17,17 +17,16 @@
  * under the License.
  */
 package org.apache.fineract.portfolio.delinquency.service;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+
 import static java.time.Month.JANUARY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
-
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.time.LocalDate;
@@ -35,11 +34,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
-
-import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import java.util.Optional;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
@@ -326,17 +320,6 @@ class DelinquencyReadPlatformServiceImplTest {
     }
 
     @Test
-    void givenPendingLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
-        Loan loan = mock(Loan.class);
-        when(loan.getLoanProduct()).thenReturn(null);
-        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
-        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
-
-        // When product is null, guard prevents calling helper → no exception, returns template
-        assertThatCode(() -> underTest.calculateLoanCollectionData(1L)).doesNotThrowAnyException();
-    }
-
-    @Test
     void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndAvailableDisbursementAmountIsSet() {
         HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
         businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 1, 1));
@@ -379,4 +362,3 @@ class DelinquencyReadPlatformServiceImplTest {
     }
 
 }
-

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -20,6 +20,8 @@ package org.apache.fineract.portfolio.delinquency.service;
 
 import static java.time.Month.JANUARY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
+
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,8 +34,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+
 import java.util.Optional;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
@@ -42,6 +46,7 @@ import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyAction;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyActionRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyTagHistoryRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanInstallmentDelinquencyTagRepository;
+import org.apache.fineract.portfolio.delinquency.helper.DelinquencyEffectivePauseHelper;
 import org.apache.fineract.portfolio.delinquency.mapper.DelinquencyBucketMapper;
 import org.apache.fineract.portfolio.delinquency.mapper.DelinquencyRangeMapper;
 import org.apache.fineract.portfolio.delinquency.mapper.LoanDelinquencyTagMapper;
@@ -64,7 +69,6 @@ class DelinquencyReadPlatformServiceImplTest {
 
     @Mock
     private DelinquencyRangeRepository repositoryRange;
-
     @Mock
     private DelinquencyBucketRepository repositoryBucket;
     @Mock
@@ -73,34 +77,34 @@ class DelinquencyReadPlatformServiceImplTest {
     private DelinquencyRangeMapper mapperRange;
     @Mock
     private DelinquencyBucketMapper mapperBucket;
-
     @Mock
     private LoanDelinquencyTagMapper mapperLoanDelinquencyTagHistory;
-
     @Mock
     private LoanRepository loanRepository;
-
     @Mock
     private LoanDelinquencyDomainService loanDelinquencyDomainService;
-
     @Mock
     private LoanInstallmentDelinquencyTagRepository repositoryLoanInstallmentDelinquencyTag;
-
     @Mock
     private ConfigurationDomainService configurationDomainService;
 
+
+    private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
     @Mock
     private LoanTransactionRepository loanTransactionRepository;
-
     @Mock
     private PossibleNextRepaymentCalculationServiceDiscovery possibleNextRepaymentCalculationServiceDiscovery;
-<<<<<<< HEAD
+
+
 
     @Mock
     private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
-=======
     
->>>>>>> 3264fbce5 (FINERACT-2593: Fix inverted null guard and add self-defensive NPE protection in DelinquencyReadPlatformServiceImpl)
+
+    @Mock
+    private DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper;
 
     @InjectMocks
     private DelinquencyReadPlatformServiceImpl underTest;
@@ -182,6 +186,37 @@ class DelinquencyReadPlatformServiceImplTest {
                 pausePeriod(true, "2023-01-12", "2023-01-14"), //
                 pausePeriod(false, "2023-01-15", "2023-01-20") //
         );
+    }
+
+    @Test
+    void givenPendingLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
+        Loan loan = mock(Loan.class);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loan.isApproved()).thenReturn(false);
+        when(loan.isCancelled()).thenReturn(false);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+
+        CollectionData result = underTest.calculateLoanCollectionData(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isNull();
+    }
+
+    @Test
+    void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
+        Loan loan = mock(Loan.class);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
+        when(loan.isApproved()).thenReturn(false);
+        when(loan.isCancelled()).thenReturn(false);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+        when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
+
+        CollectionData result = underTest.calculateLoanCollectionData(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isNull();
     }
 
     @Test

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -352,7 +352,7 @@ class DelinquencyReadPlatformServiceImplTest {
             assertThat(result).isNotNull();
             // calculateAvailableDisbursementAmount = 10000 - 5000 = 5000
             assertThat(result.getAvailableDisbursementAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000));
-            
+
             assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
         } finally {
             ThreadLocalContextUtil.reset();

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -94,9 +94,13 @@ class DelinquencyReadPlatformServiceImplTest {
 
     @Mock
     private PossibleNextRepaymentCalculationServiceDiscovery possibleNextRepaymentCalculationServiceDiscovery;
+<<<<<<< HEAD
 
     @Mock
     private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
+=======
+    
+>>>>>>> 3264fbce5 (FINERACT-2593: Fix inverted null guard and add self-defensive NPE protection in DelinquencyReadPlatformServiceImpl)
 
     @InjectMocks
     private DelinquencyReadPlatformServiceImpl underTest;
@@ -269,3 +273,4 @@ class DelinquencyReadPlatformServiceImplTest {
     }
 
 }
+

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -20,11 +20,22 @@ package org.apache.fineract.portfolio.delinquency.service;
 
 import static java.time.Month.JANUARY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyAction;
@@ -37,7 +48,10 @@ import org.apache.fineract.portfolio.delinquency.mapper.LoanDelinquencyTagMapper
 import org.apache.fineract.portfolio.delinquency.validator.LoanDelinquencyActionData;
 import org.apache.fineract.portfolio.loanaccount.data.CollectionData;
 import org.apache.fineract.portfolio.loanaccount.data.DelinquencyPausePeriod;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,6 +85,15 @@ class DelinquencyReadPlatformServiceImplTest {
 
     @Mock
     private LoanInstallmentDelinquencyTagRepository repositoryLoanInstallmentDelinquencyTag;
+
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+
+    @Mock
+    private LoanTransactionRepository loanTransactionRepository;
+
+    @Mock
+    private PossibleNextRepaymentCalculationServiceDiscovery possibleNextRepaymentCalculationServiceDiscovery;
 
     @Mock
     private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
@@ -190,6 +213,59 @@ class DelinquencyReadPlatformServiceImplTest {
 
     private DelinquencyPausePeriod pausePeriod(boolean active, String startDate, String endDate) {
         return new DelinquencyPausePeriod(active, LocalDate.parse(startDate), LocalDate.parse(endDate));
+    }
+
+    @Test
+    void givenPendingLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
+        Loan loan = mock(Loan.class);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+
+        // When product is null, guard prevents calling helper → no exception, returns template
+        assertThatCode(() -> underTest.calculateLoanCollectionData(1L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndAvailableDisbursementAmountIsSet() {
+        HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+        businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 1, 1));
+        businessDates.put(BusinessDateType.COB_DATE, LocalDate.of(2024, 1, 1));
+        ThreadLocalContextUtil.setBusinessDates(businessDates);
+
+        try {
+            Loan loan = mock(Loan.class);
+            when(loan.getLoanProduct()).thenReturn(null);
+            when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
+            when(loan.isApproved()).thenReturn(false);
+            when(loan.isCancelled()).thenReturn(false);
+
+            // calculateAvailableDisbursementAmount() is always called for active loans
+            when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+            when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(5000));
+            LoanProductRelatedDetail detail = mock(LoanProductRelatedDetail.class);
+            when(detail.isEnableIncomeCapitalization()).thenReturn(false);
+            when(loan.getLoanRepaymentScheduleDetail()).thenReturn(detail);
+
+            when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
+            when(loanDelinquencyActionRepository.findByLoanOrderById(any())).thenReturn(List.of());
+            when(configurationDomainService.getNextPaymentDateConfigForLoan()).thenReturn(null);
+            when(possibleNextRepaymentCalculationServiceDiscovery.getService(any())).thenReturn(null);
+            when(loan.getLastPaymentTransaction()).thenReturn(null);
+            when(loan.getLastRepaymentOrDownPaymentTransaction()).thenReturn(null);
+            when(loan.isEnableInstallmentLevelDelinquency()).thenReturn(false);
+            when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+
+            CollectionData result = underTest.calculateLoanCollectionData(1L);
+
+            assertThat(result).isNotNull();
+            // calculateAvailableDisbursementAmount = 10000 - 5000 = 5000
+            assertThat(result.getAvailableDisbursementAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000));
+            // LoanProduct is null → over-applied helper skipped → field stays at template default
+            assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
+        } finally {
+            ThreadLocalContextUtil.reset();
+        }
     }
 
 }

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -21,7 +21,6 @@ package org.apache.fineract.portfolio.delinquency.service;
 import static java.time.Month.JANUARY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -32,12 +31,9 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
@@ -180,53 +176,6 @@ class DelinquencyReadPlatformServiceImplTest {
     }
 
     @Test
-    void givenPendingLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
-        Loan loan = mock(Loan.class);
-        when(loan.getLoanProduct()).thenReturn(null);
-        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
-        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
-
-        CollectionData result = underTest.calculateLoanCollectionData(1L);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
-    }
-
-    @Test
-    void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndOverAppliedIsNull() {
-        HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
-        businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 1, 1));
-        businessDates.put(BusinessDateType.COB_DATE, LocalDate.of(2024, 1, 1));
-        ThreadLocalContextUtil.setBusinessDates(businessDates);
-
-        try {
-            Loan loan = mock(Loan.class);
-            when(loan.getLoanProduct()).thenReturn(null);
-            when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
-            when(loan.isApproved()).thenReturn(false);
-            when(loan.isCancelled()).thenReturn(false);
-            when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
-            when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(5000));
-            when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
-            when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
-            when(loanDelinquencyActionRepository.findByLoanOrderById(any())).thenReturn(List.of());
-            when(configurationDomainService.getNextPaymentDateConfigForLoan()).thenReturn(null);
-            when(possibleNextRepaymentCalculationServiceDiscovery.getService(any())).thenReturn(null);
-            when(loan.getLastPaymentTransaction()).thenReturn(null);
-            when(loan.getLastRepaymentOrDownPaymentTransaction()).thenReturn(null);
-            when(loan.isEnableInstallmentLevelDelinquency()).thenReturn(false);
-            when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
-
-            CollectionData result = underTest.calculateLoanCollectionData(1L);
-
-            assertThat(result).isNotNull();
-            assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
-        } finally {
-            ThreadLocalContextUtil.reset();
-        }
-    }
-
-    @Test
     public void testMultiplePausesWithoutResumeCurrentBusinessDateIsNotOverlappingWithAnyOfThePauses() {
         // given
         CollectionData collectionData = CollectionData.template();
@@ -318,45 +267,43 @@ class DelinquencyReadPlatformServiceImplTest {
     }
 
     @Test
-    void givenActiveLoanWithNullProduct_whenCalculateLoanCollectionData_thenNoExceptionAndAvailableDisbursementAmountIsSet() {
-        HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
-        businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 1, 1));
-        businessDates.put(BusinessDateType.COB_DATE, LocalDate.of(2024, 1, 1));
-        ThreadLocalContextUtil.setBusinessDates(businessDates);
+    void givenPendingLoanWithOverApplyDisabled_whenCalculateLoanCollectionData_thenOverAppliedAmountNotSet() {
+        Loan loan = mock(Loan.class);
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loanProduct.isAllowApprovedDisbursedAmountsOverApplied()).thenReturn(false);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
 
-        try {
-            Loan loan = mock(Loan.class);
-            when(loan.getLoanProduct()).thenReturn(null);
-            when(loan.isSubmittedAndPendingApproval()).thenReturn(false);
-            when(loan.isApproved()).thenReturn(false);
-            when(loan.isCancelled()).thenReturn(false);
+        CollectionData result = underTest.calculateLoanCollectionData(1L);
 
-            // calculateAvailableDisbursementAmount() is always called for active loans
-            when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
-            when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(5000));
-            LoanProductRelatedDetail detail = mock(LoanProductRelatedDetail.class);
-            when(detail.isEnableIncomeCapitalization()).thenReturn(false);
-            when(loan.getLoanRepaymentScheduleDetail()).thenReturn(detail);
+        assertThat(result).isNotNull();
+        // over-apply disabled → helper not called → field stays at template default
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
 
-            when(loanDelinquencyDomainService.getOverdueCollectionData(any(), any())).thenReturn(CollectionData.template());
-            when(loanDelinquencyActionRepository.findByLoanOrderById(any())).thenReturn(List.of());
-            when(configurationDomainService.getNextPaymentDateConfigForLoan()).thenReturn(null);
-            when(possibleNextRepaymentCalculationServiceDiscovery.getService(any())).thenReturn(null);
-            when(loan.getLastPaymentTransaction()).thenReturn(null);
-            when(loan.getLastRepaymentOrDownPaymentTransaction()).thenReturn(null);
-            when(loan.isEnableInstallmentLevelDelinquency()).thenReturn(false);
-            when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+    @Test
+    void givenPendingLoanWithOverApplyEnabled_whenCalculateLoanCollectionData_thenOverAppliedAmountIsSet() {
+        Loan loan = mock(Loan.class);
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loanProduct.isAllowApprovedDisbursedAmountsOverApplied()).thenReturn(true);
+        when(loanProduct.getOverAppliedCalculationType()).thenReturn("flat");
+        when(loanProduct.getOverAppliedNumber()).thenReturn(500);
+        when(loan.getProposedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getDisbursedAmount()).thenReturn(BigDecimal.ZERO);
+        LoanProductRelatedDetail detail = mock(LoanProductRelatedDetail.class);
+        when(detail.isEnableIncomeCapitalization()).thenReturn(false);
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(detail);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
 
-            CollectionData result = underTest.calculateLoanCollectionData(1L);
+        CollectionData result = underTest.calculateLoanCollectionData(1L);
 
-            assertThat(result).isNotNull();
-            // calculateAvailableDisbursementAmount = 10000 - 5000 = 5000
-            assertThat(result.getAvailableDisbursementAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000));
-
-            assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
-        } finally {
-            ThreadLocalContextUtil.reset();
-        }
+        assertThat(result).isNotNull();
+        // flat over-apply: 10000 + 500 = 10500, minus 0 disbursed = 10500
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.valueOf(10500));
     }
 
 }


### PR DESCRIPTION
## Description

**JIRA:** https://issues.apache.org/jira/browse/FINERACT-2593

### Problem

`DelinquencyReadPlatformServiceImpl.calculateLoanCollectionData` contained two bugs that caused an unhandled `NullPointerException` (HTTP 500) when `loan.getLoanProduct()` returns `null`:

**Bug 1 — Inverted null guard (pre-approval / pending state branch)**
The condition `loan.getLoanProduct() == null ||` used the wrong operator. When `getLoanProduct()` returns `null`, the left-hand operand evaluates to `true`, short-circuiting the `||` and routing execution directly into `calculateAvailableDisbursementAmountWithOverApplied(loan)`. The helper immediately dereferences `loanProduct` with no null check, producing an NPE. The intended operator is `!= null &&`.

**Bug 2 — No null guard on active-loan branch**
The active (open) loan branch called `calculateAvailableDisbursementAmountWithOverApplied(loan)` unconditionally with no null check on `getLoanProduct()` at all, giving a second independent crash surface from the same root cause.

### Fix

- Changed `== null ||` to `!= null &&` in the pre-approval branch so the helper is only invoked when a `LoanProduct` is present and over-apply is enabled.
- Wrapped the active-loan branch call with a `loan.getLoanProduct() != null` guard.
- Added four missing `@Mock` field declarations in `DelinquencyReadPlatformServiceImplTest` (`ConfigurationDomainService`, `LoanTransactionRepository`, `PossibleNextRepaymentCalculationServiceDiscovery`, `LoanDelinquencyActionRepository`) that were causing silent Mockito injection failure on any new tests written for this path.
- Added unit tests covering both crash surfaces to prevent regression.

### Files Changed

| File | Change |
|------|--------|
| `DelinquencyReadPlatformServiceImpl.java` | Fix inverted operator + add missing null guard |
| `DelinquencyReadPlatformServiceImplTest.java` | Add 4 missing `@Mock` declarations + new regression tests |

---

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes — **Not applicable, no API contract changes. This fix corrects internal null handling only.**
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). This is a minimal targeted fix — 2 lines changed in the implementation, 4 mock declarations and regression tests added.