### PR TITLE
FINERACT-1315: Add accrual journal entries for loan transfers

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
@@ -104,6 +104,11 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
                 createJournalEntriesForWriteOffs(loanDTO, loanTransactionDTO, office);
             }
 
+            // Handle Transfers
+            else if (transactionType.isInitiateTransfer() || transactionType.isApproveTransfer() || transactionType.isWithdrawTransfer()) {
+                createJournalEntriesForTransfers(loanDTO, loanTransactionDTO, office);
+            }
+
             // Logic for Refunds of Active Loans
             else if (transactionType.isRefundForActiveLoans()) {
                 createJournalEntriesForRefundForActiveLoan(loanDTO, loanTransactionDTO, office);
@@ -156,6 +161,27 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
             if (transactionType.isBuyDownFeeAmortizationAdjustment()) {
                 createJournalEntriesForBuyDownFeeAmortizationAdjustment(loanDTO, loanTransactionDTO, office);
             }
+        }
+    }
+
+    private void createJournalEntriesForTransfers(final LoanDTO loanDTO, final LoanTransactionDTO loanTransactionDTO, final Office office) {
+        final Long loanProductId = loanDTO.getLoanProductId();
+        final Long loanId = loanDTO.getLoanId();
+        final String currencyCode = loanDTO.getCurrencyCode();
+
+        final String transactionId = loanTransactionDTO.getTransactionId();
+        final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
+        final BigDecimal principalAmount = loanTransactionDTO.getPrincipal();
+
+        if (loanTransactionDTO.getTransactionType().isInitiateTransfer()) {
+            this.helper.createJournalEntriesForLoan(office, currencyCode, AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(),
+                    AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(), loanProductId, null, loanId, transactionId, transactionDate,
+                    principalAmount);
+        } else if (loanTransactionDTO.getTransactionType().isApproveTransfer()
+                || loanTransactionDTO.getTransactionType().isWithdrawTransfer()) {
+            this.helper.createJournalEntriesForLoan(office, currencyCode, AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(),
+                    AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(), loanProductId, null, loanId, transactionId, transactionDate,
+                    principalAmount);
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
@@ -52,10 +52,10 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
 
     @Override
     public void createJournalEntriesForLoan(final LoanDTO loanDTO) {
-        final Long officeId = loanDTO.getOfficeId();
-        final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
-        final Office office = this.helper.getOfficeById(officeId);
         for (final LoanTransactionDTO loanTransactionDTO : loanDTO.getNewLoanTransactions()) {
+            final Long officeId = loanTransactionDTO.getOfficeId() == null ? loanDTO.getOfficeId() : loanTransactionDTO.getOfficeId();
+            final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
+            final Office office = this.helper.getOfficeById(officeId);
             final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
             this.helper.checkForBranchClosures(latestGLClosure, transactionDate);
             final LoanTransactionEnumData transactionType = loanTransactionDTO.getTransactionType();

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
@@ -21,6 +21,7 @@ package org.apache.fineract.accounting.journalentry.service;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,10 +53,12 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
 
     @Override
     public void createJournalEntriesForLoan(final LoanDTO loanDTO) {
+        final Map<Long, GLClosure> latestGLClosureByOfficeId = new HashMap<>();
+        final Map<Long, Office> officeById = new HashMap<>();
         for (final LoanTransactionDTO loanTransactionDTO : loanDTO.getNewLoanTransactions()) {
             final Long officeId = loanTransactionDTO.getOfficeId() == null ? loanDTO.getOfficeId() : loanTransactionDTO.getOfficeId();
-            final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
-            final Office office = this.helper.getOfficeById(officeId);
+            final GLClosure latestGLClosure = latestGLClosureByOfficeId.computeIfAbsent(officeId, this.helper::getLatestClosureByBranch);
+            final Office office = officeById.computeIfAbsent(officeId, this.helper::getOfficeById);
             final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
             this.helper.checkForBranchClosures(latestGLClosure, transactionDate);
             final LoanTransactionEnumData transactionType = loanTransactionDTO.getTransactionType();
@@ -173,16 +176,18 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
         final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
         final BigDecimal principalAmount = loanTransactionDTO.getPrincipal();
 
-        if (loanTransactionDTO.getTransactionType().isInitiateTransfer()) {
-            this.helper.createJournalEntriesForLoan(office, currencyCode, AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(),
-                    AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(), loanProductId, null, loanId, transactionId, transactionDate,
-                    principalAmount);
-        } else if (loanTransactionDTO.getTransactionType().isApproveTransfer()
-                || loanTransactionDTO.getTransactionType().isWithdrawTransfer()) {
-            this.helper.createJournalEntriesForLoan(office, currencyCode, AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(),
-                    AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(), loanProductId, null, loanId, transactionId, transactionDate,
-                    principalAmount);
+        if (!MathUtil.isGreaterThanZero(principalAmount)) {
+            return;
         }
+
+        final boolean isInitiateTransfer = loanTransactionDTO.getTransactionType().isInitiateTransfer();
+        final Integer debitAccount = isInitiateTransfer ? AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue()
+                : AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue();
+        final Integer creditAccount = isInitiateTransfer ? AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue()
+                : AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue();
+
+        this.helper.createJournalEntriesForLoan(office, currencyCode, debitAccount, creditAccount, loanProductId, null, loanId,
+                transactionId, transactionDate, principalAmount);
     }
 
     private void createJournalEntriesForCapitalizedIncome(final LoanDTO loanDTO, final LoanTransactionDTO loanTransactionDTO,

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForLoan.java
@@ -21,6 +21,7 @@ package org.apache.fineract.accounting.journalentry.service;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,10 +50,12 @@ public class CashBasedAccountingProcessorForLoan implements AccountingProcessorF
     public void createJournalEntriesForLoan(final LoanDTO loanDTO) {
         final Long loanProductId = loanDTO.getLoanProductId();
         final String currencyCode = loanDTO.getCurrencyCode();
+        final Map<Long, GLClosure> latestGLClosureByOfficeId = new HashMap<>();
+        final Map<Long, Office> officeById = new HashMap<>();
         for (final LoanTransactionDTO loanTransactionDTO : loanDTO.getNewLoanTransactions()) {
             final Long officeId = loanTransactionDTO.getOfficeId() == null ? loanDTO.getOfficeId() : loanTransactionDTO.getOfficeId();
-            final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
-            final Office office = this.helper.getOfficeById(officeId);
+            final GLClosure latestGLClosure = latestGLClosureByOfficeId.computeIfAbsent(officeId, this.helper::getLatestClosureByBranch);
+            final Office office = officeById.computeIfAbsent(officeId, this.helper::getOfficeById);
             final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
             final String transactionId = loanTransactionDTO.getTransactionId();
             final Long paymentTypeId = loanTransactionDTO.getPaymentTypeId();

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForLoan.java
@@ -47,12 +47,12 @@ public class CashBasedAccountingProcessorForLoan implements AccountingProcessorF
 
     @Override
     public void createJournalEntriesForLoan(final LoanDTO loanDTO) {
-        final Long officeId = loanDTO.getOfficeId();
-        final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
         final Long loanProductId = loanDTO.getLoanProductId();
         final String currencyCode = loanDTO.getCurrencyCode();
-        final Office office = this.helper.getOfficeById(officeId);
         for (final LoanTransactionDTO loanTransactionDTO : loanDTO.getNewLoanTransactions()) {
+            final Long officeId = loanTransactionDTO.getOfficeId() == null ? loanDTO.getOfficeId() : loanTransactionDTO.getOfficeId();
+            final GLClosure latestGLClosure = this.helper.getLatestClosureByBranch(officeId);
+            final Office office = this.helper.getOfficeById(officeId);
             final LocalDate transactionDate = loanTransactionDTO.getTransactionDate();
             final String transactionId = loanTransactionDTO.getTransactionId();
             final Long paymentTypeId = loanTransactionDTO.getPaymentTypeId();

--- a/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.accounting.journalentry;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.accounting.closure.domain.GLClosure;
+import org.apache.fineract.accounting.common.AccountingConstants.AccrualAccountsForLoan;
+import org.apache.fineract.accounting.journalentry.data.LoanDTO;
+import org.apache.fineract.accounting.journalentry.data.LoanTransactionDTO;
+import org.apache.fineract.accounting.journalentry.service.AccountingProcessorHelper;
+import org.apache.fineract.accounting.journalentry.service.AccrualBasedAccountingProcessorForLoan;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.portfolio.loanaccount.data.LoanTransactionEnumData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateJournalEntriesForTransferLoanTest {
+
+    private static final Long LOAN_ID = 1L;
+    private static final Long LOAN_PRODUCT_ID = 1L;
+    private static final Long OFFICE_ID = 1L;
+    private static final String CURRENCY_CODE = "USD";
+    private static final String TRANSACTION_ID = "txn-transfer";
+    private static final LocalDate TRANSACTION_DATE = LocalDate.of(2021, 2, 11);
+    private static final BigDecimal TRANSACTION_AMOUNT = new BigDecimal("600.00");
+    private static final BigDecimal PRINCIPAL_AMOUNT = new BigDecimal("500.00");
+
+    @Mock
+    private AccountingProcessorHelper helper;
+    @InjectMocks
+    private AccrualBasedAccountingProcessorForLoan processor;
+    private Office office;
+
+    @BeforeEach
+    void setUp() {
+        office = Office.headOffice("Main Office", TRANSACTION_DATE, null);
+        when(helper.getOfficeById(OFFICE_ID)).thenReturn(office);
+
+        GLClosure mockClosure = mock(GLClosure.class);
+        when(helper.getLatestClosureByBranch(OFFICE_ID)).thenReturn(mockClosure);
+    }
+
+    @Test
+    void shouldCreateJournalEntriesForTransferInitiation() {
+        LoanTransactionEnumData transactionType = mock(LoanTransactionEnumData.class);
+        when(transactionType.isInitiateTransfer()).thenReturn(true);
+
+        processor.createJournalEntriesForLoan(createLoanDTO(transactionType));
+
+        verify(helper).createJournalEntriesForLoan(office, CURRENCY_CODE, AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(),
+                AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(), LOAN_PRODUCT_ID, null, LOAN_ID, TRANSACTION_ID, TRANSACTION_DATE,
+                PRINCIPAL_AMOUNT);
+    }
+
+    @Test
+    void shouldCreateJournalEntriesForTransferApproval() {
+        LoanTransactionEnumData transactionType = mock(LoanTransactionEnumData.class);
+        when(transactionType.isApproveTransfer()).thenReturn(true);
+
+        processor.createJournalEntriesForLoan(createLoanDTO(transactionType));
+
+        verify(helper).createJournalEntriesForLoan(office, CURRENCY_CODE, AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(),
+                AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(), LOAN_PRODUCT_ID, null, LOAN_ID, TRANSACTION_ID, TRANSACTION_DATE,
+                PRINCIPAL_AMOUNT);
+    }
+
+    @Test
+    void shouldCreateJournalEntriesForTransferWithdrawal() {
+        LoanTransactionEnumData transactionType = mock(LoanTransactionEnumData.class);
+        when(transactionType.isWithdrawTransfer()).thenReturn(true);
+
+        processor.createJournalEntriesForLoan(createLoanDTO(transactionType));
+
+        verify(helper).createJournalEntriesForLoan(office, CURRENCY_CODE, AccrualAccountsForLoan.LOAN_PORTFOLIO.getValue(),
+                AccrualAccountsForLoan.TRANSFERS_SUSPENSE.getValue(), LOAN_PRODUCT_ID, null, LOAN_ID, TRANSACTION_ID, TRANSACTION_DATE,
+                PRINCIPAL_AMOUNT);
+    }
+
+    private LoanDTO createLoanDTO(final LoanTransactionEnumData transactionType) {
+        LoanTransactionDTO loanTransactionDTO = new LoanTransactionDTO(OFFICE_ID, null, TRANSACTION_ID, TRANSACTION_DATE, transactionType,
+                TRANSACTION_AMOUNT, PRINCIPAL_AMOUNT, null, null, null, null, false, Collections.emptyList(), Collections.emptyList(),
+                false, "", null, null, null, null);
+
+        return new LoanDTO(LOAN_ID, LOAN_PRODUCT_ID, OFFICE_ID, CURRENCY_CODE, false, true, true, List.of(loanTransactionDTO), false, false,
+                null, false, false, null, null, null);
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
@@ -46,7 +46,8 @@ class CreateJournalEntriesForTransferLoanTest {
 
     private static final Long LOAN_ID = 1L;
     private static final Long LOAN_PRODUCT_ID = 1L;
-    private static final Long OFFICE_ID = 1L;
+    private static final Long LOAN_OFFICE_ID = 1L;
+    private static final Long TRANSACTION_OFFICE_ID = 2L;
     private static final String CURRENCY_CODE = "USD";
     private static final String TRANSACTION_ID = "txn-transfer";
     private static final LocalDate TRANSACTION_DATE = LocalDate.of(2021, 2, 11);
@@ -61,11 +62,11 @@ class CreateJournalEntriesForTransferLoanTest {
 
     @BeforeEach
     void setUp() {
-        office = Office.headOffice("Main Office", TRANSACTION_DATE, null);
-        when(helper.getOfficeById(OFFICE_ID)).thenReturn(office);
+        office = Office.headOffice("Transaction Office", TRANSACTION_DATE, null);
+        when(helper.getOfficeById(TRANSACTION_OFFICE_ID)).thenReturn(office);
 
         GLClosure mockClosure = mock(GLClosure.class);
-        when(helper.getLatestClosureByBranch(OFFICE_ID)).thenReturn(mockClosure);
+        when(helper.getLatestClosureByBranch(TRANSACTION_OFFICE_ID)).thenReturn(mockClosure);
     }
 
     @Test
@@ -105,11 +106,11 @@ class CreateJournalEntriesForTransferLoanTest {
     }
 
     private LoanDTO createLoanDTO(final LoanTransactionEnumData transactionType) {
-        LoanTransactionDTO loanTransactionDTO = new LoanTransactionDTO(OFFICE_ID, null, TRANSACTION_ID, TRANSACTION_DATE, transactionType,
-                TRANSACTION_AMOUNT, PRINCIPAL_AMOUNT, null, null, null, null, false, Collections.emptyList(), Collections.emptyList(),
-                false, "", null, null, null, null);
+        LoanTransactionDTO loanTransactionDTO = new LoanTransactionDTO(TRANSACTION_OFFICE_ID, null, TRANSACTION_ID, TRANSACTION_DATE,
+                transactionType, TRANSACTION_AMOUNT, PRINCIPAL_AMOUNT, null, null, null, null, false, Collections.emptyList(),
+                Collections.emptyList(), false, "", null, null, null, null);
 
-        return new LoanDTO(LOAN_ID, LOAN_PRODUCT_ID, OFFICE_ID, CURRENCY_CODE, false, true, true, List.of(loanTransactionDTO), false, false,
-                null, false, false, null, null, null);
+        return new LoanDTO(LOAN_ID, LOAN_PRODUCT_ID, LOAN_OFFICE_ID, CURRENCY_CODE, false, true, true, List.of(loanTransactionDTO), false,
+                false, null, false, false, null, null, null);
     }
 }

--- a/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/CreateJournalEntriesForTransferLoanTest.java
@@ -18,7 +18,11 @@
  */
 package org.apache.fineract.accounting.journalentry;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,9 +109,24 @@ class CreateJournalEntriesForTransferLoanTest {
                 PRINCIPAL_AMOUNT);
     }
 
+    @Test
+    void shouldNotCreateJournalEntriesForTransferWithoutPrincipalAmount() {
+        LoanTransactionEnumData transactionType = mock(LoanTransactionEnumData.class);
+        when(transactionType.isInitiateTransfer()).thenReturn(true);
+
+        processor.createJournalEntriesForLoan(createLoanDTO(transactionType, null));
+
+        verify(helper, never()).createJournalEntriesForLoan(any(Office.class), anyString(), any(Integer.class), any(Integer.class),
+                any(Long.class), isNull(), any(Long.class), anyString(), any(LocalDate.class), any(BigDecimal.class));
+    }
+
     private LoanDTO createLoanDTO(final LoanTransactionEnumData transactionType) {
+        return createLoanDTO(transactionType, PRINCIPAL_AMOUNT);
+    }
+
+    private LoanDTO createLoanDTO(final LoanTransactionEnumData transactionType, final BigDecimal principalAmount) {
         LoanTransactionDTO loanTransactionDTO = new LoanTransactionDTO(TRANSACTION_OFFICE_ID, null, TRANSACTION_ID, TRANSACTION_DATE,
-                transactionType, TRANSACTION_AMOUNT, PRINCIPAL_AMOUNT, null, null, null, null, false, Collections.emptyList(),
+                transactionType, TRANSACTION_AMOUNT, principalAmount, null, null, null, null, false, Collections.emptyList(),
                 Collections.emptyList(), false, "", null, null, null, null);
 
         return new LoanDTO(LOAN_ID, LOAN_PRODUCT_ID, LOAN_OFFICE_ID, CURRENCY_CODE, false, true, true, List.of(loanTransactionDTO), false,


### PR DESCRIPTION
## Description
When a client is transferred between offices, active loans now create the expected accounting journal entries for the loan transfer transactions. This covers accrual accounting and the transfer flow for:
 - Transfer initiated
 - Transfer approved
 - Transfer withdrawn

## Note
During manual validation, I also found that journal entries could be posted to the loan’s current office instead of the office stored on the loan transaction (2nd commit).

### Loan transactions
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab8d28a0-7194-4a91-ad42-be0d3ad1d5b2" />

### Transfer initiated

<img width="1358" height="446" alt="2026-04-29_00-31_2" src="https://github.com/user-attachments/assets/13610fbb-5e0e-495a-856b-0613a2761fa7" />

### Transfer aproved

<img width="1337" height="452" alt="2026-04-29_00-32" src="https://github.com/user-attachments/assets/7f9cd2d1-1e5d-4256-95c6-693f4046bc16" />

### Transfer withdraw (after another initiated)
<img width="1366" height="438" alt="image" src="https://github.com/user-attachments/assets/c99a8074-e250-4bfe-b0c8-1bce446891ba" />
