### PR TITLE
FINERACT-2603: Add staffId filter parameter to the Retrieve All Clients API

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
@@ -146,10 +146,11 @@ public class ClientsApiResource {
             @QueryParam("orderBy") @Parameter(description = "orderBy") final String orderBy,
             @QueryParam("sortOrder") @Parameter(description = "sortOrder") final String sortOrder,
             @QueryParam("orphansOnly") @Parameter(description = "orphansOnly") final Boolean orphansOnly,
-            @QueryParam("legalForm") final Integer legalForm) {
+            @QueryParam("legalForm") final Integer legalForm,
+            @QueryParam("staffId") @Parameter(description = "staffId") final Long staffId) {
 
         return retrieveAll(uriInfo, officeId, externalId, displayName, firstname, lastname, status, legalForm, hierarchy, offset, limit,
-                orderBy, sortOrder, orphansOnly);
+                orderBy, sortOrder, orphansOnly, staffId);
     }
 
     @GET
@@ -422,7 +423,8 @@ public class ClientsApiResource {
 
     public String retrieveAll(final UriInfo uriInfo, final Long officeId, final String externalId, final String displayName,
             final String firstname, final String lastname, final String status, final Integer legalForm, final String hierarchy,
-            final Integer offset, final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly) {
+            final Integer offset, final Integer limit, final String orderBy, final String sortOrder, final Boolean orphansOnly,
+            final Long staffId) {
         context.authenticatedUser().validateHasReadPermission(ClientApiConstants.CLIENT_RESOURCE_NAME);
         sqlValidator.validate(orderBy);
         sqlValidator.validate(sortOrder);
@@ -430,7 +432,7 @@ public class ClientsApiResource {
         sqlValidator.validate(hierarchy);
         final SearchParameters searchParameters = SearchParameters.builder().limit(limit).officeId(officeId).externalId(externalId)
                 .name(displayName).hierarchy(hierarchy).firstname(firstname).lastname(lastname).status(status).orphansOnly(orphansOnly)
-                .offset(offset).orderBy(orderBy).sortOrder(sortOrder).legalForm(legalForm).build();
+                .offset(offset).orderBy(orderBy).sortOrder(sortOrder).legalForm(legalForm).staffId(staffId).build();
         final Page<ClientData> clientData = clientReadPlatformService.retrieveAll(searchParameters);
         final ApiRequestJsonSerializationSettings settings = apiRequestParameterHelper.process(uriInfo.getQueryParameters());
         return toApiJsonSerializer.serialize(settings, clientData, ClientApiConstants.CLIENT_RESPONSE_DATA_PARAMETERS);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -194,6 +194,11 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
             extraCriteria += " and c.legal_form_enum = ? ";
         }
 
+        if (searchParameters.hasStaffId()) {
+            paramList.add(searchParameters.getStaffId());
+            extraCriteria += " and c.staff_id = ? ";
+        }
+
         if (StringUtils.isNotBlank(extraCriteria)) {
             extraCriteria = extraCriteria.substring(4);
         }

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImplTest.java
@@ -19,17 +19,23 @@
 package org.apache.fineract.portfolio.client.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
+import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
+import org.apache.fineract.infrastructure.core.service.SearchParameters;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
@@ -41,6 +47,7 @@ import org.apache.fineract.portfolio.client.mapper.ClientMapper;
 import org.apache.fineract.portfolio.collateralmanagement.domain.ClientCollateralManagementRepositoryWrapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -128,5 +135,48 @@ class ClientReadPlatformServiceImplTest {
         assertThrows(org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException.class, () -> {
             clientReadPlatformService.retrieveAll(searchParameters);
         });
+    }
+
+    @Test
+    void testRetrieveAll_WithStaffIdFilter_IncludesStaffIdConditionInSql() {
+        // Arrange
+        Long staffId = 42L;
+        SearchParameters searchParameters = SearchParameters.builder().staffId(staffId).build();
+
+        when(context.officeHierarchy()).thenReturn(".");
+        when(sqlGenerator.calcFoundRows()).thenReturn("");
+        Page<ClientData> emptyPage = new Page<>(Collections.emptyList(), 0);
+        when(paginationHelper.<ClientData>fetchPage(any(JdbcTemplate.class), anyString(), any(Object[].class), any()))
+                .thenReturn(emptyPage);
+
+        // Act
+        clientReadPlatformService.retrieveAll(searchParameters);
+
+        // Assert: the generated SQL must contain the staff_id predicate
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object[]> paramsCaptor = ArgumentCaptor.forClass(Object[].class);
+        verify(paginationHelper).fetchPage(any(JdbcTemplate.class), sqlCaptor.capture(), paramsCaptor.capture(), any());
+        assertTrue(sqlCaptor.getValue().contains("c.staff_id = ?"), "SQL should contain staff_id predicate");
+        assertTrue(Arrays.asList(paramsCaptor.getValue()).contains(staffId), "Parameter list should contain staffId value");
+    }
+
+    @Test
+    void testRetrieveAll_WithoutStaffIdFilter_ExcludesStaffIdConditionFromSql() {
+        // Arrange
+        SearchParameters searchParameters = SearchParameters.builder().build();
+
+        when(context.officeHierarchy()).thenReturn(".");
+        when(sqlGenerator.calcFoundRows()).thenReturn("");
+        Page<ClientData> emptyPage = new Page<>(Collections.emptyList(), 0);
+        when(paginationHelper.<ClientData>fetchPage(any(JdbcTemplate.class), anyString(), any(Object[].class), any()))
+                .thenReturn(emptyPage);
+
+        // Act
+        clientReadPlatformService.retrieveAll(searchParameters);
+
+        // Assert: the generated SQL must NOT contain the staff_id filter predicate
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(paginationHelper).fetchPage(any(JdbcTemplate.class), sqlCaptor.capture(), any(Object[].class), any());
+        assertFalse(sqlCaptor.getValue().contains("c.staff_id = ?"), "SQL should not contain staff_id predicate when staffId is absent");
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -328,9 +328,9 @@ public class ClientSearchTest extends IntegrationTest {
         PostClientsResponse secondEntityClientResponse = clientHelper.createClient(secondEntityClientRequest);
         // when
         GetClientsResponse individualClients = ok(fineractClient().clients.retrieveAllClients(newOffice.getOfficeId(), null, null, null,
-                null, null, null, null, null, null, null, null, 1));
+                null, null, null, null, null, null, null, null, 1, null));
         GetClientsResponse entityClients = ok(fineractClient().clients.retrieveAllClients(newOffice.getOfficeId(), null, null, null, null,
-                null, null, null, null, "id", null, null, 2));
+                null, null, null, null, "id", null, null, 2, null));
         // then
         assertThat(individualClients.getTotalFilteredRecords()).isEqualTo(1);
         assertThat(individualClients.getPageItems().get(0).getId()).isEqualTo(individualClientResponse.getClientId());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientTest.java
@@ -63,7 +63,7 @@ public class ClientTest extends IntegrationTest {
 
     Optional<Long> retrieveFirst() {
         GetClientsResponse clients = ok(
-                fineractClient().clients.retrieveAllClients(null, null, null, null, null, null, null, 0, 1, null, null, false, null));
+                fineractClient().clients.retrieveAllClients(null, null, null, null, null, null, null, 0, 1, null, null, false, null, null));
         if (clients.getTotalFilteredRecords() != null && clients.getTotalFilteredRecords() > 0) {
             return clients.getPageItems().stream().findFirst().map(item -> item.getId());
         }


### PR DESCRIPTION
Add a `staffId` filter to the `GET /v1/clients` endpoint, so you can retrieve only the clients assigned to a specific staff member without having to filter results client-side.

## Checklist
- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).