### PR TITLE
FINERACT-2346: Remove stale IDE-generated TODO comments from loan module

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
@@ -73,9 +73,7 @@ public class LoanInstallmentCharge extends AbstractPersistableCustom<Long> imple
     @Column(name = "waived", nullable = false)
     private boolean waived = false;
 
-    public LoanInstallmentCharge() {
-        // TODO Auto-generated constructor stub
-    }
+    public LoanInstallmentCharge() {}
 
     @Override
     public int compareTo(LoanInstallmentCharge o) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
@@ -864,7 +864,6 @@ public class LoanTransaction extends AbstractAuditableWithUTCDateTimeCustom<Long
     }
 
     public boolean isNotRefundForActiveLoan() {
-        // TODO Auto-generated method stub
         return !isRefundForActiveLoan();
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/exception/DuplicateGuarantorException.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/exception/DuplicateGuarantorException.java
@@ -25,6 +25,5 @@ public class DuplicateGuarantorException extends AbstractPlatformDomainRuleExcep
     public DuplicateGuarantorException(final String action, final String postFix, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
         super("error.msg." + action + "." + postFix, defaultUserMessage, defaultUserMessageArgs);
-        // TODO Auto-generated constructor stub
     }
 }


### PR DESCRIPTION
## Description

Several files in the `fineract-loan` module contained stale IDE-generated 
comments (`// TODO Auto-generated constructor stub` and 
`// TODO Auto-generated method stub`) that were accidentally left behind 
when these methods were implemented.

These comments serve no purpose and can mislead contributors into thinking 
the methods are incomplete or unimplemented — when in reality they are 
fully functional. Every other similar constructor/method in the codebase 
does not have these noise comments.

Fixed by removing 3 stale TODO comments from:
- `LoanInstallmentCharge.java` — empty default constructor
- `DuplicateGuarantorException.java` — constructor with super() call  
- `LoanTransaction.java` — `isNotRefundForActiveLoan()` method

I am exploring this codebase as part of my DMP 2026 application for the 
Dynamic Pricing of Micro-loans Using Reinforcement Learning project. 
The loan module is directly relevant as it contains the core installment 
and transaction logic that my RL environment will model for dynamic 
pricing decisions.

## Checklist
- [x] Write the commit message as per our guidelines
- [ ] Acknowledge that we will not review PRs that are not passing the build — it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [x] Follow our coding conventions.
- [ ] Add required Swagger annotation and update API documentation
- [x] This PR must not be a "code dump".