### PR TITLE
FINERACT-2606: Add support for rejecting loan reschedule requests via Batch API

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/batch/command/CommandStrategyProvider.java
+++ b/fineract-core/src/main/java/org/apache/fineract/batch/command/CommandStrategyProvider.java
@@ -201,6 +201,8 @@ public class CommandStrategyProvider {
                 "createLoanRescheduleRequestCommandStrategy");
         commandStrategies.put(CommandContext.resource("v1\\/rescheduleloans\\/" + NUMBER_REGEX + "\\?command=approve").method(POST).build(),
                 "approveLoanRescheduleCommandStrategy");
+        commandStrategies.put(CommandContext.resource("v1\\/rescheduleloans\\/" + NUMBER_REGEX + "\\?command=reject").method(POST).build(),
+                "rejectLoanRescheduleCommandStrategy");
         commandStrategies.put(
                 CommandContext.resource("v1\\/loans\\/" + NUMBER_REGEX + "\\/transactions\\/" + NUMBER_REGEX).method(GET).build(),
                 "getLoanTransactionByIdCommandStrategy");

--- a/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/RejectLoanRescheduleCommandStrategy.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/batch/command/internal/RejectLoanRescheduleCommandStrategy.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.batch.command.internal;
+
+import static org.apache.fineract.batch.command.CommandStrategyUtils.relativeUrlWithoutVersion;
+
+import com.google.common.base.Splitter;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.batch.command.CommandStrategy;
+import org.apache.fineract.batch.domain.BatchRequest;
+import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.portfolio.loanaccount.rescheduleloan.api.RescheduleLoansApiResource;
+import org.apache.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RejectLoanRescheduleCommandStrategy implements CommandStrategy {
+
+    private final RescheduleLoansApiResource rescheduleLoansApiResource;
+
+    @Override
+    public BatchResponse execute(BatchRequest request, final UriInfo uriInfo) {
+        final BatchResponse response = new BatchResponse();
+        final String responseBody;
+
+        response.setRequestId(request.getRequestId());
+        response.setHeaders(request.getHeaders());
+
+        final List<String> pathParameters = Splitter.on('/').splitToList(relativeUrlWithoutVersion(request));
+        final Long scheduleId = Long.parseLong(pathParameters.get(1).substring(0, pathParameters.get(1).indexOf("?")));
+
+        responseBody = rescheduleLoansApiResource.updateLoanRescheduleRequest(scheduleId, "reject", request.getBody());
+
+        response.setStatusCode(HttpStatus.SC_OK);
+        response.setBody(responseBody);
+
+        return response;
+    }
+
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/batch/command/CommandStrategyProviderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/batch/command/CommandStrategyProviderTest.java
@@ -60,6 +60,7 @@ import org.apache.fineract.batch.command.internal.GetReagePreviewByLoanIdCommand
 import org.apache.fineract.batch.command.internal.LoanStateTransistionsByExternalIdCommandStrategy;
 import org.apache.fineract.batch.command.internal.ModifyLoanApplicationCommandStrategy;
 import org.apache.fineract.batch.command.internal.PaySavingsAccountChargeCommandStrategy;
+import org.apache.fineract.batch.command.internal.RejectLoanRescheduleCommandStrategy;
 import org.apache.fineract.batch.command.internal.UnknownCommandStrategy;
 import org.apache.fineract.batch.command.internal.UpdateClientCommandStrategy;
 import org.apache.fineract.batch.command.internal.UpdateDatatableEntryOneToManyCommandStrategy;
@@ -182,6 +183,8 @@ public class CommandStrategyProviderTest {
                         mock(CreateLoanRescheduleRequestCommandStrategy.class)),
                 Arguments.of("rescheduleloans/123?command=approve", HttpMethod.POST, "approveLoanRescheduleCommandStrategy",
                         mock(ApproveLoanRescheduleCommandStrategy.class)),
+                Arguments.of("rescheduleloans/123?command=reject", HttpMethod.POST, "rejectLoanRescheduleCommandStrategy",
+                        mock(RejectLoanRescheduleCommandStrategy.class)),
                 Arguments.of("loans/123/transactions/123", HttpMethod.GET, "getLoanTransactionByIdCommandStrategy",
                         mock(GetLoanTransactionByIdCommandStrategy.class)),
                 Arguments.of(


### PR DESCRIPTION
I need to be able to **reject** loan reschedule requests through the batch API, so that I can manage loan reschedule workflows without making individual API calls.

Currently, the batch API supports **approving** loan reschedule requests. This change extends that functionality to also support rejecting them.

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).