### PR TITLE
FINERACT-2607: Use correct enum for processing results in audits

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/commands/service/AuditReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/service/AuditReadPlatformServiceImpl.java
@@ -107,7 +107,7 @@ public class AuditReadPlatformServiceImpl implements AuditReadPlatformService {
             String partSql = " aud.id as id, aud.action_name as actionName, aud.entity_name as entityName,"
                     + " aud.resource_id as resourceId, aud.subresource_id as subresourceId,aud.client_id as clientId, aud.loan_id as loanId,"
                     + " mk.username as maker, aud.made_on_date as madeOnDate, aud.made_on_date_utc as madeOnDateUTC, aud.api_get_url as resourceGetUrl, "
-                    + "ck.username as checker, aud.checked_on_date as checkedOnDate, aud.checked_on_date_utc as checkedOnDateUTC,  ev.enum_message_property as processingResult "
+                    + "ck.username as checker, aud.checked_on_date as checkedOnDate, aud.checked_on_date_utc as checkedOnDateUTC,  ev.enum_value as processingResult "
                     + commandAsJsonString + ", "
                     + " o.name as officeName, gl.level_name as groupLevelName, g.display_name as groupName, c.display_name as clientName, "
                     + " l.account_no as loanAccountNo, s.account_no as savingsAccountNo , aud.client_ip  as ip "
@@ -116,7 +116,7 @@ public class AuditReadPlatformServiceImpl implements AuditReadPlatformService {
                     + " left join m_group g on g.id = aud.group_id" + " left join m_group_level gl on gl.id = g.level_id"
                     + " left join m_client c on c.id = aud.client_id" + " left join m_loan l on l.id = aud.loan_id"
                     + " left join m_savings_account s on s.id = aud.savings_account_id"
-                    + " left join r_enum_value ev on ev.enum_name = 'status' and ev.enum_id = aud.status";
+                    + " left join r_enum_value ev on ev.enum_name = 'processing_result_enum' and ev.enum_id = aud.status";
 
             // data scoping: head office (hierarchy = ".") can see all audit
             // entries
@@ -501,7 +501,7 @@ public class AuditReadPlatformServiceImpl implements AuditReadPlatformService {
         }
 
         public String schema() {
-            return " select enum_id as id, enum_message_property as status from r_enum_value where enum_name = 'status' "
+            return " select enum_id as id, enum_value as status from r_enum_value where enum_name = 'processing_result_enum' "
                     + " order by enum_id";
         }
     }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -252,4 +252,5 @@
     <include file="parts/0231_remove_clientcharge_inactivate_permissions.xml" relativeToChangelogFile="true" />
     <include file="parts/0232_add_repayment_start_date_to_loan.xml" relativeToChangelogFile="true" />
     <include file="parts/0233_backfill_repayment_start_date_type_on_loan.xml" relativeToChangelogFile="true" />
+    <include file="parts/0234_add_missing_processing_result_enum_values.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0234_add_missing_processing_result_enum_values.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0234_add_missing_processing_result_enum_values.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="1">
+        <insert tableName="r_enum_value">
+            <column name="enum_name" value="processing_result_enum"/>
+            <column name="enum_id" valueNumeric="4"/>
+            <column name="enum_message_property" value="underProcessing"/>
+            <column name="enum_value" value="Under Processing"/>
+            <column name="enum_type" valueBoolean="false"/>
+        </insert>
+        <insert tableName="r_enum_value">
+            <column name="enum_name" value="processing_result_enum"/>
+            <column name="enum_id" valueNumeric="5"/>
+            <column name="enum_message_property" value="error"/>
+            <column name="enum_value" value="Error"/>
+            <column name="enum_type" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuditIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AuditIntegrationTest.java
@@ -80,6 +80,21 @@ public class AuditIntegrationTest {
         assertNotNull(auditSearchTemplate);
         assertEquals(4, auditSearchTemplate.size()); // appUsers, actionNames, entityNames, processingResults
         assertTrue(((List) auditSearchTemplate.get("actionNames")).size() > 0);
+
+        // verify all command processing status enum values are present and use enum_value (not enum_message_property)
+        List<LinkedHashMap> statuses = (List<LinkedHashMap>) auditSearchTemplate.get("statuses");
+        assertNotNull(statuses);
+        assertEquals(6, statuses.size());
+
+        List<String> statusValues = statuses.stream().map(r -> (String) r.get("processingResult"))
+                .collect(java.util.stream.Collectors.toList());
+
+        assertTrue(statusValues.contains("Invalid"));
+        assertTrue(statusValues.contains("Processed"));
+        assertTrue(statusValues.contains("Awaiting Approval"));
+        assertTrue(statusValues.contains("Rejected"));
+        assertTrue(statusValues.contains("Under Processing"));
+        assertTrue(statusValues.contains("Error"));
     }
 
     /**


### PR DESCRIPTION
## Description

These values were never persisted on new migration files; they existed on [old migrations](https://github.com/apache/fineract/blob/develop/fineract-db/old-schema-files/0002-mifosx-base-reference-data-utf8.sql#L50-L55).
Additionally I also return the `enum_value` instead of `enum_message_property` since it's more readable and it will look better on the UI.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
