### PR TITLE
FINERACT-2421: Add equals() and hashCode() to LoanTransaction

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import lombok.Getter;
@@ -1014,8 +1015,24 @@ public class LoanTransaction extends AbstractAuditableWithUTCDateTimeCustom<Long
         this.amount = bigDecimal;
     }
 
-    // TODO missing hashCode(), equals(Object obj), but probably OK as long as
-    // this is never stored in a Collection.
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LoanTransaction other)) {
+            return false;
+        }
+        if (getId() == null || other.getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
 
     public void updateTransactionDate(final LocalDate transactionDate) {
         this.dateOf = transactionDate;

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -1264,7 +1264,7 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         // let's figure out the original transaction for these chargebacks, and order them by ascending order
         Comparator<LoanTransaction> comparator = LoanTransactionComparator.INSTANCE;
         List<LoanTransaction> chargebacksForTheSameOriginal = chargebacks.stream()
-                .filter(tr -> findChargebackOriginalTransaction(tr, ctx) == originalTransaction
+                .filter(tr -> Objects.equals(findChargebackOriginalTransaction(tr, ctx), originalTransaction)
                         && comparator.compare(tr, chargebackTransaction) < 0)
                 .sorted(comparator).toList();
 
@@ -1355,7 +1355,7 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
 
     private Predicate<LoanTransactionRelation> hasMatchingToLoanTransaction(LoanTransaction loanTransaction,
             LoanTransactionRelationTypeEnum typeEnum) {
-        return relation -> relation.getRelationType().equals(typeEnum) && relation.getToTransaction() == loanTransaction;
+        return relation -> relation.getRelationType().equals(typeEnum) && Objects.equals(relation.getToTransaction(), loanTransaction);
     }
 
     protected void handleRefund(LoanTransaction loanTransaction, TransactionCtx ctx) {


### PR DESCRIPTION
## Description

`LoanTransaction` was missing `equals()` and `hashCode()` implementations,
flagged by a long-standing TODO comment in the code:

> `// TODO missing hashCode(), equals(Object obj), but probably OK as long as`
> `// this is never stored in a Collection.`

The parent class `AbstractPersistableCustom` intentionally omits these methods
(documented in its own Javadoc). Added id-based implementations consistent with
the pattern already used in `LoanDisbursementDetails`, ensuring correct behavior
if `LoanTransaction` is ever used in hash-based collections.

### Changes
- Removed stale TODO comment
- Added `equals()` based on entity id with null-safety for unsaved entities
- Added `hashCode()` based on entity id
- Added missing `java.util.Objects` import


---
I am exploring this codebase as part of my DMP 2026 (C4GT) application for the
"Dynamic Pricing of Micro-loans Using Reinforcement Learning" project under
openMF/Mifos. The loan module is directly relevant as it contains the core
transaction logic that my RL environment will model for dynamic pricing decisions.

## Checklist
- [x] Write the commit message as per our guidelines
- [x] Acknowledge that we will not review PRs that are not passing the build
- [ ] Create/update unit or integration tests for verifying the changes made
- [x] Follow our coding conventions
- [ ] Add required Swagger annotation and update API documentation
- [x] This PR must not be a "code dump"