### PR TITLE
FINERACT-1122: Fix deposit interest rate chart NPE

### DIFF
--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountInterestRateChartData.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountInterestRateChartData.java
@@ -70,6 +70,10 @@ public final class DepositAccountInterestRateChartData {
     }
 
     public static DepositAccountInterestRateChartData from(InterestRateChartData productChartData) {
+        if (productChartData == null) {
+            return null;
+        }
+
         final Long id = null;
         final Long accountId = null;
         final String accountNumber = null;

--- a/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/data/DepositAccountInterestRateChartDataTest.java
+++ b/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/data/DepositAccountInterestRateChartDataTest.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.data;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class DepositAccountInterestRateChartDataTest {
+
+    @Test
+    void fromShouldReturnNullWhenProductChartDataIsNull() {
+        assertNull(DepositAccountInterestRateChartData.from(null));
+    }
+}


### PR DESCRIPTION
## Description
Fixes FINERACT-1122 by preventing a `NullPointerException` in `DepositAccountInterestRateChartData.from()` when no product interest rate chart is available while retrieving fixed or recurring deposit account templates.

## Key Changes
- Added a null guard in `DepositAccountInterestRateChartData.from()`.
- Return `null` when the source `InterestRateChartData` is absent, matching existing account template behavior where `accountChart` can be null.
- Added a regression unit test for the null chart mapping case.

## Testing
- Ran:
  `./gradlew :fineract-savings:test --tests org.apache.fineract.portfolio.savings.data.DepositAccountInterestRateChartDataTest`

## Checklist
- [x] Code compiles
- [x] Unit test added
- [x] Targeted test passed
- [x] No unrelated files included
- [x] No AI-generated commit or metadata added