### PR TITLE
FINERACT-2611: Allow MakerCheckerRequest does not accept makerDateTim…

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/DateUtils.java
@@ -42,6 +42,7 @@ import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.JsonParserHelper;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.lang.NonNull;
 
 public final class DateUtils {
@@ -456,6 +457,36 @@ public final class DateUtils {
             } else {
                 LocalDate date = LocalDate.from(parsed);
                 return LocalDateTime.of(date, fallbackTime);
+            }
+        } catch (final DateTimeParseException e) {
+            final List<ApiParameterError> errors = List.of(ApiParameterError.parameterError("validation.msg.invalid.date.pattern",
+                    "The parameter date (" + dateTimeStr + ") format is invalid", "date", dateTimeStr));
+            throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.", errors, e);
+        }
+    }
+
+    public static OffsetDateTime convertDateTimeStringToOffsetDateTime(String dateTimeStr, String dateFormat, String localeStr,
+            LocalTime fallbackTime) {
+        if (Strings.isEmpty(dateTimeStr)) {
+            return null;
+        }
+        final Locale locale = localeStr == null ? null : JsonParserHelper.localeFromString(localeStr);
+        DateTimeFormatter formatter = getDateFormatter(dateFormat, locale);
+        TemporalAccessor parsed = formatter.parse(dateTimeStr);
+
+        boolean hasTime = parsed.isSupported(ChronoField.HOUR_OF_DAY) && parsed.isSupported(ChronoField.MINUTE_OF_HOUR);
+        boolean hasOffset = parsed.isSupported(ChronoField.OFFSET_SECONDS);
+
+        try {
+            if (hasTime && hasOffset) {
+                return OffsetDateTime.from(parsed);
+            } else if (hasTime) {
+                LocalDateTime localDateTime = LocalDateTime.from(parsed);
+                return localDateTime.atOffset(ZoneOffset.UTC);
+            } else {
+                LocalDate date = LocalDate.from(parsed);
+                LocalDateTime localDateTime = LocalDateTime.of(date, fallbackTime);
+                return localDateTime.atOffset(ZoneOffset.UTC);
             }
         } catch (final DateTimeParseException e) {
             final List<ApiParameterError> errors = List.of(ApiParameterError.parameterError("validation.msg.invalid.date.pattern",

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/data/request/MakerCheckerRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/data/request/MakerCheckerRequest.java
@@ -21,10 +21,12 @@ package org.apache.fineract.commands.data.request;
 import jakarta.ws.rs.QueryParam;
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.ZonedDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 
 @Setter
 @Getter
@@ -43,9 +45,9 @@ public class MakerCheckerRequest implements Serializable {
     @QueryParam("makerId")
     private Long makerId;
     @QueryParam("makerDateTimeFrom")
-    private ZonedDateTime makerDateTimeFrom;
+    private String makerDateTimeFrom;
     @QueryParam("makerDateTimeTo")
-    private ZonedDateTime makerDateTimeTo;
+    private String makerDateTimeTo;
     @QueryParam("clientId")
     private Long clientId;
     @QueryParam("loanid")
@@ -56,4 +58,16 @@ public class MakerCheckerRequest implements Serializable {
     private Long groupId;
     @QueryParam("savingsAccountId")
     private Long savingsAccountId;
+    @QueryParam("dateFormat")
+    private String dateFormat;
+    @QueryParam("locale")
+    private String locale;
+
+    public OffsetDateTime getMakerDateTimeFrom() {
+        return DateUtils.convertDateTimeStringToOffsetDateTime(makerDateTimeFrom, dateFormat, locale, LocalTime.MIN);
+    }
+
+    public OffsetDateTime getMakerDateTimeTo() {
+        return DateUtils.convertDateTimeStringToOffsetDateTime(makerDateTimeTo, dateFormat, locale, LocalTime.MAX);
+    }
 }


### PR DESCRIPTION
…eFrom and makerDateTimeTo properly

## Description

@QueryParam does not automatically convert String query parameters into java.time.ZonedDateTime.
Therefor makerDateTimeFrom and makerDateTimeTo is always resolving to null in MakerCheckerRequest.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
