### PR TITLE
FINERACT-2165: Migrate TaxComponentHelper and TaxGroupHelper to fineract-client-feign

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientSavingsIntegrationTest.java
@@ -34,13 +34,16 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import org.apache.fineract.client.models.PaymentTypeCreateRequest;
+import org.apache.fineract.client.models.PostTaxesComponentsRequest;
+import org.apache.fineract.client.models.PostTaxesGroupRequest;
+import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
@@ -2181,10 +2184,14 @@ public class ClientSavingsIntegrationTest {
     }
 
     private Integer createTaxGroup(final String percentage) {
-        final Integer liabilityAccountId = null;
-        final Integer taxComponentId = TaxComponentHelper.createTaxComponent(this.requestSpec, this.responseSpec, percentage,
-                liabilityAccountId);
-        return TaxGroupHelper.createTaxGroup(this.requestSpec, this.responseSpec, Arrays.asList(taxComponentId));
+        final PostTaxesComponentsRequest componentRequest = new PostTaxesComponentsRequest()
+                .name(Utils.randomStringGenerator("Tax_component_Name_", 5)).percentage(Float.parseFloat(percentage))
+                .startDate("01 January 2013").dateFormat("dd MMMM yyyy").locale("en");
+        final var componentResponse = TaxComponentHelper.createTaxComponent(componentRequest);
+        final PostTaxesGroupRequest groupRequest = new PostTaxesGroupRequest().name(Utils.randomStringGenerator("Tax_group_Name_", 5))
+                .dateFormat("dd MMMM yyyy").locale("en").taxComponents(Set.of(
+                        new PostTaxesGroupTaxComponents().taxComponentId(componentResponse.getResourceId()).startDate("01 January 2013")));
+        return TaxGroupHelper.createTaxGroup(groupRequest).getResourceId().intValue();
     }
 
     /*

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/FixedDepositTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/FixedDepositTest.java
@@ -40,15 +40,18 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.accounting.common.AccountingConstants.FinancialActivity;
 import org.apache.fineract.client.models.GetFixedDepositAccountsAccountIdTransactionsResponse;
+import org.apache.fineract.client.models.PostTaxesComponentsRequest;
+import org.apache.fineract.client.models.PostTaxesGroupRequest;
+import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
@@ -2944,10 +2947,15 @@ public class FixedDepositTest extends IntegrationTest {
     }
 
     private Integer createTaxGroup(final String percentage, final Account liabilityAccountForTax) {
-        final Integer liabilityAccountId = liabilityAccountForTax.getAccountID();
-        final Integer taxComponentId = TaxComponentHelper.createTaxComponent(this.requestSpec, this.responseSpec, percentage,
-                liabilityAccountId);
-        return TaxGroupHelper.createTaxGroup(this.requestSpec, this.responseSpec, Arrays.asList(taxComponentId));
+        final PostTaxesComponentsRequest componentRequest = new PostTaxesComponentsRequest()
+                .name(Utils.randomStringGenerator("Tax_component_Name_", 5)).percentage(Float.parseFloat(percentage))
+                .startDate("01 January 2013").dateFormat("dd MMMM yyyy").locale("en").creditAccountType(2)
+                .creditAccountId(liabilityAccountForTax.getAccountID().longValue());
+        final var componentResponse = TaxComponentHelper.createTaxComponent(componentRequest);
+        final PostTaxesGroupRequest groupRequest = new PostTaxesGroupRequest().name(Utils.randomStringGenerator("Tax_group_Name_", 5))
+                .dateFormat("dd MMMM yyyy").locale("en").taxComponents(Set.of(
+                        new PostTaxesGroupTaxComponents().taxComponentId(componentResponse.getResourceId()).startDate("01 January 2013")));
+        return TaxGroupHelper.createTaxGroup(groupRequest).getResourceId().intValue();
     }
 
     /**

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/RecurringDepositTest.java
@@ -33,13 +33,16 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.TimeZone;
 import org.apache.fineract.accounting.common.AccountingConstants.FinancialActivity;
+import org.apache.fineract.client.models.PostTaxesComponentsRequest;
+import org.apache.fineract.client.models.PostTaxesGroupRequest;
+import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
 import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
@@ -3097,10 +3100,15 @@ public class RecurringDepositTest {
     }
 
     private Integer createTaxGroup(final String percentage, final Account liabilityAccountForTax) {
-        final Integer liabilityAccountId = liabilityAccountForTax.getAccountID();
-        final Integer taxComponentId = TaxComponentHelper.createTaxComponent(this.requestSpec, this.responseSpec, percentage,
-                liabilityAccountId);
-        return TaxGroupHelper.createTaxGroup(this.requestSpec, this.responseSpec, Arrays.asList(taxComponentId));
+        final PostTaxesComponentsRequest componentRequest = new PostTaxesComponentsRequest()
+                .name(Utils.randomStringGenerator("Tax_component_Name_", 5)).percentage(Float.parseFloat(percentage))
+                .startDate("01 January 2013").dateFormat("dd MMMM yyyy").locale("en").creditAccountType(2)
+                .creditAccountId(liabilityAccountForTax.getAccountID().longValue());
+        final var componentResponse = TaxComponentHelper.createTaxComponent(componentRequest);
+        final PostTaxesGroupRequest groupRequest = new PostTaxesGroupRequest().name(Utils.randomStringGenerator("Tax_group_Name_", 5))
+                .dateFormat("dd MMMM yyyy").locale("en").taxComponents(Set.of(
+                        new PostTaxesGroupTaxComponents().taxComponentId(componentResponse.getResourceId()).startDate("01 January 2013")));
+        return TaxGroupHelper.createTaxGroup(groupRequest).getResourceId().intValue();
     }
 
     /**

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/TaxComponentHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/TaxComponentHelper.java
@@ -18,72 +18,21 @@
  */
 package org.apache.fineract.integrationtests.common;
 
-import com.google.gson.Gson;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.util.HashMap;
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
 import org.apache.fineract.client.models.GetTaxesComponentsResponse;
 import org.apache.fineract.client.models.PostTaxesComponentsRequest;
 import org.apache.fineract.client.models.PostTaxesComponentsResponse;
-import org.apache.fineract.client.util.Calls;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class TaxComponentHelper {
 
-    private TaxComponentHelper() {
-
-    }
-
-    private static final Logger LOG = LoggerFactory.getLogger(TaxComponentHelper.class);
-    private static final String CREATE_TAX_COMPONENT_URL = "/fineract-provider/api/v1/taxes/component?" + Utils.TENANT_IDENTIFIER;
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Integer createTaxComponent(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final String percentage, final Integer liabilityAccountId) {
-        LOG.info("---------------------------------CREATING A TAX COMPONENT---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_TAX_COMPONENT_URL,
-                getTaxComponentAsJSON(percentage, liabilityAccountId), "resourceId");
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String getTaxComponentAsJSON(final String percentage, final Integer creditAccountId) {
-        final HashMap<String, String> map = getBasicTaxComponentMap(percentage);
-        if (creditAccountId != null) {
-            map.put("creditAccountType", Account.AccountType.LIABILITY.toString());
-            map.put("creditAccountId", String.valueOf(creditAccountId));
-        }
-        LOG.info("map :  {}", map);
-        return new Gson().toJson(map);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static HashMap<String, String> getBasicTaxComponentMap(final String percentage) {
-        final HashMap<String, String> map = new HashMap<>();
-        map.put("name", Utils.randomStringGenerator("Tax_component_Name_", 5));
-        map.put("dateFormat", "dd MMMM yyyy");
-        map.put("locale", "en");
-        map.put("percentage", percentage);
-        map.put("startDate", "01 January 2013");
-        return map;
-    }
+    private TaxComponentHelper() {}
 
     public static PostTaxesComponentsResponse createTaxComponent(PostTaxesComponentsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().taxComponents.createTaxComponent(request));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().taxComponents().createTaxComponent(request));
     }
 
     public static GetTaxesComponentsResponse retrieveTaxComponent(Long taxComponentId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().taxComponents.retrieveOneTaxComponent(taxComponentId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().taxComponents().retrieveOneTaxComponent(taxComponentId));
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/TaxGroupHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/TaxGroupHelper.java
@@ -18,86 +18,26 @@
  */
 package org.apache.fineract.integrationtests.common;
 
-import com.google.gson.Gson;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
 import java.util.List;
 import org.apache.fineract.client.models.GetTaxesGroupResponse;
 import org.apache.fineract.client.models.PostTaxesGroupRequest;
 import org.apache.fineract.client.models.PostTaxesGroupResponse;
-import org.apache.fineract.client.util.Calls;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class TaxGroupHelper {
 
-    private TaxGroupHelper() {
-
-    }
-
-    private static final Logger LOG = LoggerFactory.getLogger(TaxGroupHelper.class);
-    private static final String CREATE_TAX_COMPONENT_URL = "/fineract-provider/api/v1/taxes/group?" + Utils.TENANT_IDENTIFIER;
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static Integer createTaxGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
-            final Collection<Integer> taxComponentIds) {
-        LOG.info("---------------------------------CREATING A TAX GROUP---------------------------------------------");
-        return Utils.performServerPost(requestSpec, responseSpec, CREATE_TAX_COMPONENT_URL, getTaxGroupAsJSON(taxComponentIds),
-                "resourceId");
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static String getTaxGroupAsJSON(final Collection<Integer> taxComponentIds) {
-        final HashMap<String, Object> map = new HashMap<>();
-        map.put("name", Utils.randomStringGenerator("Tax_group_Name_", 5));
-        map.put("dateFormat", "dd MMMM yyyy");
-        map.put("locale", "en");
-        map.put("taxComponents", getTaxGroupComponents(taxComponentIds));
-        return new Gson().toJson(map);
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static List<HashMap<String, String>> getTaxGroupComponents(final Collection<Integer> taxComponentIds) {
-        List<HashMap<String, String>> taxGroupComponents = new ArrayList<>();
-        for (Integer taxComponentId : taxComponentIds) {
-            taxGroupComponents.add(getTaxComponentMap(taxComponentId));
-        }
-        return taxGroupComponents;
-    }
-
-    // TODO: Rewrite to use fineract-client instead!
-    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
-    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
-    @Deprecated(forRemoval = true)
-    public static HashMap<String, String> getTaxComponentMap(final Integer taxComponentId) {
-        final HashMap<String, String> map = new HashMap<>();
-        map.put("taxComponentId", String.valueOf(taxComponentId));
-        map.put("startDate", "01 January 2013");
-        return map;
-    }
+    private TaxGroupHelper() {}
 
     public static PostTaxesGroupResponse createTaxGroup(PostTaxesGroupRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().taxGroups.createTaxGroup(request));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().taxGroup().createTaxGroup(request));
     }
 
     public static GetTaxesGroupResponse retrieveTaxGroup(Long taxGroupId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().taxGroups.retrieveOneTaxGroup(taxGroupId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().taxGroup().retrieveOneTaxGroup(taxGroupId));
     }
 
     public static List<GetTaxesGroupResponse> retrieveAllTaxGroups() {
-        return Calls.ok(FineractClientHelper.getFineractClient().taxGroups.retrieveAllTaxGroups());
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().taxGroup().retrieveAllTaxGroups());
     }
-
 }


### PR DESCRIPTION
## Description

Part of [FINERACT-2165](https://issues.apache.org/jira/browse/FINERACT-2165) — system-wide migration of integration tests from RestAssured to `fineract-client-feign`.

This PR completes the migration of `TaxComponentHelper` and `TaxGroupHelper`, and updates the 3 test files that called their now-removed deprecated methods.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
