### PR TITLE
FINERACT-2421: Refactor and secure GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     commit-message:
       # Prefix all commit messages with "FINERACT-2421: "
       prefix: "FINERACT-2421: "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -17,3 +19,5 @@ updates:
     commit-message:
       # Prefix all commit messages with "FINERACT-2421: "
       prefix: "FINERACT-2421: "
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -2,6 +2,9 @@ name: Fineract Build Core
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -19,6 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/build-cucumber.yml
+++ b/.github/workflows/build-cucumber.yml
@@ -2,6 +2,9 @@ name: Fineract Cucumber tests (without E2E tests)
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,6 +2,9 @@ name: Fineract Docker Builds
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,6 +1,9 @@
 name: Fineract Documentation build
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/build-e2e-tests.yml
+++ b/.github/workflows/build-e2e-tests.yml
@@ -2,6 +2,9 @@ name: Fineract E2E Tests
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -2,6 +2,9 @@ name: Fineract Cargo & Unit- & Integration tests - MariaDB
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -2,6 +2,9 @@ name: Fineract Cargo & Unit- & Integration tests - MySQL
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -2,6 +2,9 @@ name: Fineract Cargo & Unit- & Integration tests - PostgreSQL
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-progressive-loan.yml
+++ b/.github/workflows/build-progressive-loan.yml
@@ -2,6 +2,9 @@ name: Fineract Progressive Loan build
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-quality-checks.yml
+++ b/.github/workflows/build-quality-checks.yml
@@ -2,6 +2,9 @@ name: Fineract Quality Checks
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/full-build-ci.yml
+++ b/.github/workflows/full-build-ci.yml
@@ -8,94 +8,119 @@ permissions:
 jobs:
   build-core:
     uses: ./.github/workflows/build-core.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   build-embeddable-progressive-loan-jar:
     needs: build-core
     uses: ./.github/workflows/build-progressive-loan.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   build-docker-image:
     needs: build-core
     uses: ./.github/workflows/build-docker.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   build-documentation:
     needs: build-core
     uses: ./.github/workflows/build-documentation.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-quality-checks:
     needs: build-core
     uses: ./.github/workflows/build-quality-checks.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-cucumber-tests:
     needs: build-core
     uses: ./.github/workflows/build-cucumber.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-integrations-tests-on-postgresql:
     needs: build-core
     uses: ./.github/workflows/build-postgresql.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-integrations-tests-on-mysql:
     needs: build-core
     uses: ./.github/workflows/build-mysql.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-integrations-tests-on-mariadb:
     needs: build-core
     uses: ./.github/workflows/build-mariadb.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-e2e-tests:
     needs: build-core
     uses: ./.github/workflows/build-e2e-tests.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-liquibase-only-on-postgresql:
     needs: build-core
     uses: ./.github/workflows/liquibase-only-postgresql.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-messaging-smoke-tests:
     needs: build-core
     uses: ./.github/workflows/smoke-messaging.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-api-backward-compatibility:
     needs: build-core
     uses: ./.github/workflows/verify-api-backward-compatibility.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-liquibase-backward-compatibility:
     needs: build-core
     uses: ./.github/workflows/verify-liquibase-backward-compatibility.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-liquibase-ddl-safety:
     needs: build-core
     uses: ./.github/workflows/verify-liquibase-ddl-safety.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-regression-safety-db-changes:
     needs: build-core
     uses: ./.github/workflows/regression-safety-db-changes.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   run-sonarqube:
     needs: build-core
     uses: ./.github/workflows/sonarqube.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+      SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
 
   run-integration-tests-sequentially-on-postgresql:
     needs: build-core
     uses: ./.github/workflows/run-integration-test-sequentially-postgresql.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   publish-dockerhub:
     needs: build-core
     uses: ./.github/workflows/publish-dockerhub.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/liquibase-only-postgresql.yml
+++ b/.github/workflows/liquibase-only-postgresql.yml
@@ -2,6 +2,9 @@ name: Fineract Liquibase Only mode - PostgreSQL
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -1,6 +1,13 @@
 name: Fineract Publish to DockerHub
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
+      DOCKERHUB_USER:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 permissions:
   contents: read
 jobs:
@@ -36,10 +43,14 @@ jobs:
         id: git_hashes
 
       - name: Build the Apache Fineract image
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHORT_HASH: ${{ steps.git_hashes.outputs.short_hash }}
+          LONG_HASH: ${{ steps.git_hashes.outputs.long_hash }}
         run:  |
-          TAGS=${{ github.ref_name }}
+          TAGS=$REF_NAME
           if [ "$TAGS" == "develop" ]; then
-            TAGS="$TAGS,${{ steps.git_hashes.outputs.short_hash }},${{ steps.git_hashes.outputs.long_hash }}"
+            TAGS="$TAGS,$SHORT_HASH,$LONG_HASH"
           else
             TAGS=$(git tag --points-at HEAD | grep -E '^1\.' | head -n 1 || true)
             if [ -z "$TAGS" ]; then

--- a/.github/workflows/regression-safety-db-changes.yml
+++ b/.github/workflows/regression-safety-db-changes.yml
@@ -2,6 +2,9 @@ name: Regression Safety - Database Changes
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -24,15 +27,18 @@ jobs:
 
       - name: Detect Liquibase changes
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "Not a pull request event."
             exit 0
           fi
 
-          git fetch origin "${{ github.event.pull_request.base.ref }}" --no-tags
-          MERGE_BASE=$(git merge-base "origin/${{ github.event.pull_request.base.ref }}" HEAD)
+          git fetch origin "$BASE_REF" --no-tags
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
           CHANGES=$(git diff --name-only "$MERGE_BASE"..HEAD -- '**/db/changelog/**/*.xml' || true)
 
           if [ -n "$CHANGES" ]; then
@@ -96,6 +102,7 @@ jobs:
       - name: Checkout base commit (baseline)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
@@ -352,25 +359,29 @@ jobs:
       # ============================================================
       - name: Generate results summary
         if: always()
+        env:
+          INSTANCE1_OUTCOME: ${{ steps.instance1.outcome }}
+          INSTANCE2_OUTCOME: ${{ steps.instance2.outcome }}
+          INSTANCE3_OUTCOME: ${{ steps.instance3.outcome }}
         run: |
           echo "## Regression Safety - Database Changes" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Instance | Description | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.instance1.outcome }}" == "success" ]; then
+          if [ "$INSTANCE1_OUTCOME" == "success" ]; then
             echo "| #1 Baseline | develop code + fresh DB | PASSED |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| #1 Baseline | develop code + fresh DB | FAILED |" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.instance2.outcome }}" == "success" ]; then
+          if [ "$INSTANCE2_OUTCOME" == "success" ]; then
             echo "| #2 Hybrid | develop code + PR schema | PASSED |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| #2 Hybrid | develop code + PR schema | **FAILED** — PR schema breaks old code |" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.instance3.outcome }}" == "success" ]; then
+          if [ "$INSTANCE3_OUTCOME" == "success" ]; then
             echo "| #3 Full PR | PR code + PR schema | PASSED |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| #3 Full PR | PR code + PR schema | FAILED |" >> $GITHUB_STEP_SUMMARY
@@ -387,17 +398,21 @@ jobs:
 
       - name: Fail if any instance failed
         if: always()
+        env:
+          INSTANCE1_OUTCOME: ${{ steps.instance1.outcome }}
+          INSTANCE2_OUTCOME: ${{ steps.instance2.outcome }}
+          INSTANCE3_OUTCOME: ${{ steps.instance3.outcome }}
         run: |
           FAILED=0
-          if [ "${{ steps.instance1.outcome }}" != "success" ]; then
+          if [ "$INSTANCE1_OUTCOME" != "success" ]; then
             echo "::error::Instance #1 (baseline) FAILED — golden path broken on develop"
             FAILED=1
           fi
-          if [ "${{ steps.instance2.outcome }}" != "success" ]; then
+          if [ "$INSTANCE2_OUTCOME" != "success" ]; then
             echo "::error::Instance #2 (hybrid) FAILED — PR's Liquibase changes break backward compatibility!"
             FAILED=1
           fi
-          if [ "${{ steps.instance3.outcome }}" != "success" ]; then
+          if [ "$INSTANCE3_OUTCOME" != "success" ]; then
             echo "::error::Instance #3 (full PR) FAILED — functional regression in the PR"
             FAILED=1
           fi

--- a/.github/workflows/run-integration-test-sequentially-postgresql.yml
+++ b/.github/workflows/run-integration-test-sequentially-postgresql.yml
@@ -2,6 +2,9 @@ name: Fineract Cargo & Unit- & Integration tests - Sequential Execution - Postgr
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/smoke-messaging.yml
+++ b/.github/workflows/smoke-messaging.yml
@@ -2,6 +2,9 @@ name: Fineract Messaging Smoke Tests
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,6 +1,17 @@
 name: Fineract Sonarqube
 on:
   workflow_call:
+    secrets:
+      SONAR_ORGANIZATION:
+        required: false
+      SONAR_PROJECT_KEY:
+        required: false
+      SONAR_HOST_URL:
+        required: false
+      SONARCLOUD_TOKEN:
+        required: false
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/verify-api-backward-compatibility.yml
+++ b/.github/workflows/verify-api-backward-compatibility.yml
@@ -2,6 +2,9 @@ name: Verify API Backward Compatibility
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -19,6 +22,7 @@ jobs:
       - name: Checkout base branch for baseline
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout base branch for merged PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
@@ -214,7 +219,11 @@ jobs:
           retention-days: 30
 
       - name: Fail if breaking changes detected
-        if: steps.breaking-check.outcome == 'failure'
+        if: always()
+        env:
+          BREAKING_CHECK_OUTCOME: ${{ steps.breaking-check.outcome }}
         run: |
-          echo "::error::Breaking API changes detected. See the report above for details."
-          exit 1
+          if [ "$BREAKING_CHECK_OUTCOME" == "failure" ]; then
+            echo "::error::Breaking API changes detected. See the report above for details."
+            exit 1
+          fi

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -33,15 +33,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF"
 
       - name: Verify signatures
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/verify-signed-commits.sh
           ./scripts/verify-signed-commits.sh \
-            --base-ref origin/${{ github.base_ref }} \
-            --head-ref ${{ github.event.pull_request.head.sha }} \
+            --base-ref "origin/$BASE_REF" \
+            --head-ref "$HEAD_SHA" \
             --strict

--- a/.github/workflows/verify-liquibase-backward-compatibility.yml
+++ b/.github/workflows/verify-liquibase-backward-compatibility.yml
@@ -2,6 +2,9 @@ name: Verify Liquibase Backward Compatibility
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -36,6 +39,7 @@ jobs:
       - name: Checkout base commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
@@ -70,14 +74,19 @@ jobs:
           ./gradlew --no-daemon createPGDB -PdbName=$DB_NAME
 
       - name: Print checked out revisions
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Base branch ref: ${{ github.event.pull_request.base.ref }}"
+          echo "Base branch ref: $BASE_REF"
           echo "Base branch event SHA:"
-          echo "${{ github.event.pull_request.base.sha }}"
+          echo "$BASE_SHA"
           echo "PR head SHA:"
-          echo "${{ github.event.pull_request.head.sha }}"
+          echo "$HEAD_SHA"
           echo "GitHub PR merge ref:"
-          echo "refs/pull/${{ github.event.pull_request.number }}/merge"
+          echo "refs/pull/$PR_NUMBER/merge"
           echo "Baseline revision:"
           git -C baseline rev-parse HEAD
           git -C baseline log -1 --oneline

--- a/.github/workflows/verify-liquibase-ddl-safety.yml
+++ b/.github/workflows/verify-liquibase-ddl-safety.yml
@@ -2,6 +2,9 @@ name: Verify Liquibase DDL Safety
 
 on:
   workflow_call:
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -23,12 +26,16 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Fetch base branch
-        run: git fetch origin "${{ github.event.pull_request.base.ref }}" --no-tags
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_REF" --no-tags
 
       - name: Detect Liquibase changes
         id: changes
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          MERGE_BASE=$(git merge-base "origin/${{ github.event.pull_request.base.ref }}" HEAD)
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
           CHANGES=$(git diff --name-only "$MERGE_BASE"..HEAD -- '**/db/changelog/**/*.xml' || true)
           if [ -n "$CHANGES" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -43,8 +50,9 @@ jobs:
         id: override
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' 2>/dev/null || true)
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || true)
           if echo "$LABELS" | grep -q "ddl-safety-override"; then
             echo "override=true" >> $GITHUB_OUTPUT
             echo "Override label found — check will report but not block."
@@ -56,23 +64,29 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         id: ddl-check
         continue-on-error: true
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          REPORT_DIR: ${{ runner.temp }}/ddl-safety-report
         run: |
           chmod +x scripts/check-liquibase-ddl-safety.sh
           ./scripts/check-liquibase-ddl-safety.sh \
-            --base-ref origin/${{ github.event.pull_request.base.ref }} \
+            --base-ref "origin/$BASE_REF" \
             --head-ref HEAD \
             --config config/liquibase \
-            --output-dir ${{ runner.temp }}/ddl-safety-report
+            --output-dir "$REPORT_DIR"
 
       - name: Write step summary
         if: always()
+        env:
+          HAS_CHANGES: ${{ steps.changes.outputs.has_changes }}
+          REPORT_FILE: ${{ runner.temp }}/ddl-safety-report/report.md
         run: |
-          if [ "${{ steps.changes.outputs.has_changes }}" != "true" ]; then
+          if [ "$HAS_CHANGES" != "true" ]; then
             echo "## Liquibase DDL Safety Check - SKIPPED" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "No Liquibase changelog XML changes detected." >> $GITHUB_STEP_SUMMARY
-          elif [ -f "${{ runner.temp }}/ddl-safety-report/report.md" ]; then
-            cat "${{ runner.temp }}/ddl-safety-report/report.md" >> $GITHUB_STEP_SUMMARY
+          elif [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE" >> $GITHUB_STEP_SUMMARY
           else
             echo "## Liquibase DDL Safety Check - PASSED" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["develop"]
+    paths:
+      - ".github/workflows/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          min-severity: informational
+          min-confidence: low
+          online-audits: false


### PR DESCRIPTION
- Added a new GitHub workflow (`.github/workflows/zizmor.yml`) to automatically scan workflow files for security vulnerabilities using zizmor.
- Configured the scan to trigger on pushes to any branch and pull requests to `develop` whenever files in `.github/workflows/**` are modified.
- Configured the zizmor action with pinned SHAs for security, enforcing a minimum severity and confidence level of `medium`, and disabling online audits.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
