### PR TITLE
FINERACT-2618: Add originators to journal entry aggregation job and improve reports.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobConfiguration.java
@@ -22,6 +22,7 @@ import static org.apache.fineract.infrastructure.jobs.service.aggregationjob.Jou
 import static org.apache.fineract.infrastructure.jobs.service.aggregationjob.JournalEntryAggregationJobConstant.JOB_TRACKING_STEP_NAME;
 
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.core.service.migration.TenantDataSourceFactory;
 import org.apache.fineract.infrastructure.jobs.service.JobName;
 import org.apache.fineract.infrastructure.jobs.service.aggregationjob.data.JournalEntryAggregationSummaryData;
@@ -59,6 +60,8 @@ public class JournalEntryAggregationJobConfiguration {
     private JournalEntryAggregationTrackingTasklet journalEntryAggregationTrackingTasklet;
     @Autowired
     private TenantDataSourceFactory tenantDataSourceFactory;
+    @Autowired
+    private DatabaseTypeResolver databaseTypeResolver;
 
     @Bean
     public Step journalEntryAggregationSummaryStep() {
@@ -70,7 +73,7 @@ public class JournalEntryAggregationJobConfiguration {
 
     @Bean
     public JournalEntryAggregationJobReader journalEntryAggregationJobReader() {
-        return new JournalEntryAggregationJobReader(tenantDataSourceFactory);
+        return new JournalEntryAggregationJobReader(tenantDataSourceFactory, databaseTypeResolver);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobReader.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobReader.java
@@ -18,12 +18,14 @@
  */
 package org.apache.fineract.infrastructure.jobs.service.aggregationjob;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.core.service.migration.TenantDataSourceFactory;
 import org.apache.fineract.infrastructure.jobs.service.aggregationjob.data.JournalEntryAggregationSummaryData;
 import org.springframework.batch.core.StepExecution;
@@ -40,10 +42,10 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
     private LocalDate aggregatedOnDateFrom;
     private LocalDate aggregatedOnDateTo;
 
-    public JournalEntryAggregationJobReader(TenantDataSourceFactory tenantDataSourceFactory) {
+    public JournalEntryAggregationJobReader(TenantDataSourceFactory tenantDataSourceFactory, DatabaseTypeResolver databaseTypeResolver) {
         FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
         setDataSource(tenantDataSourceFactory.create(tenant));
-        setSql(buildAggregationQuery());
+        setSql(buildAggregationQuery(databaseTypeResolver));
         setRowMapper(this::mapRow);
     }
 
@@ -58,7 +60,6 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
             ps.setObject(1, aggregatedOnDateFrom);
             ps.setObject(2, aggregatedOnDateTo);
         });
-
     }
 
     private JournalEntryAggregationSummaryData mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -71,14 +72,27 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
                 .submittedOnDate(ThreadLocalContextUtil.getBusinessDate()) //
                 .aggregatedOnDate(JdbcSupport.getLocalDate(rs, "aggregatedOnDate")) //
                 .externalOwnerId(JdbcSupport.getLong(rs, "externalOwner")) //
+                .originatorExternalIds(rs.getString("originatorExternalIds")) //
                 .debitAmount(rs.getBigDecimal("debitAmount")) //
                 .creditAmount(rs.getBigDecimal("creditAmount")) //
                 .manualEntry(false) //
                 .build(); //
     }
 
-    private String buildAggregationQuery() {
+    @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
+    private String buildAggregationQuery(DatabaseTypeResolver databaseTypeResolver) {
+        String stringAgg = databaseTypeResolver.isPostgreSQL() ? "STRING_AGG(DISTINCT mlo.external_id, ', ' ORDER BY mlo.external_id)"
+                : "GROUP_CONCAT(DISTINCT mlo.external_id ORDER BY mlo.external_id SEPARATOR ', ')";
+
         return """
+                WITH loan_originators AS (
+                    SELECT
+                        mlom.loan_id,
+                        %s AS originatorExternalIds
+                    FROM m_loan_originator_mapping mlom
+                    JOIN m_loan_originator mlo ON mlo.id = mlom.originator_id
+                    GROUP BY mlom.loan_id
+                )
                 SELECT
                     COALESCE(
                         loan_product.id,
@@ -90,6 +104,7 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
                     acc_gl_journal_entry.entity_type_enum AS entityTypeEnum,
                     acc_gl_journal_entry.office_id AS officeId,
                     aw.owner_id AS externalOwner,
+                    lo.originatorExternalIds AS originatorExternalIds,
                     SUM(CASE WHEN acc_gl_journal_entry.type_enum = 2 THEN amount ELSE 0 END) AS debitAmount,
                     SUM(CASE WHEN acc_gl_journal_entry.type_enum = 1 THEN amount ELSE 0 END) AS creditAmount,
                     acc_gl_journal_entry.submitted_on_date AS aggregatedOnDate,
@@ -137,6 +152,10 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
                 LEFT JOIN m_external_asset_owner_journal_entry_mapping aw
                     ON aw.journal_entry_id = acc_gl_journal_entry.id
 
+                -- originator (loan entity type only)
+                LEFT JOIN loan_originators lo
+                    ON lo.loan_id = loan.id
+
                 WHERE acc_gl_journal_entry.submitted_on_date > ?
                   AND acc_gl_journal_entry.submitted_on_date <= ?
 
@@ -144,10 +163,11 @@ public class JournalEntryAggregationJobReader extends JdbcCursorItemReader<Journ
                     productId,
                     glAccountId,
                     externalOwner,
+                    originatorExternalIds,
                     aggregatedOnDate,
                     currencyCode,
                     entityTypeEnum,
                     officeId
-                """;
+                """.formatted(stringAgg);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/data/JournalEntryAggregationSummaryData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/data/JournalEntryAggregationSummaryData.java
@@ -41,4 +41,5 @@ public class JournalEntryAggregationSummaryData {
     private Boolean manualEntry;
     private String currencyCode;
     private Long jobExecutionId;
+    private String originatorExternalIds;
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/domain/JournalEntrySummary.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/domain/JournalEntrySummary.java
@@ -66,4 +66,7 @@ public class JournalEntrySummary extends AbstractAuditableWithUTCDateTimeCustom<
     @Column(name = "job_execution_id", nullable = false)
     private Long jobExecutionId;
 
+    @Column(name = "originator_external_ids", length = 1000)
+    private String originatorExternalIds;
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/services/JournalEntryAggregationWriterServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/services/JournalEntryAggregationWriterServiceImpl.java
@@ -84,6 +84,7 @@ public class JournalEntryAggregationWriterServiceImpl implements JournalEntryAgg
         entrySummary.setExternalOwnerId(summaryDTO.getExternalOwnerId());
         entrySummary.setAggregatedOnDate(summaryDTO.getAggregatedOnDate());
         entrySummary.setJobExecutionId(summaryDTO.getJobExecutionId());
+        entrySummary.setOriginatorExternalIds(summaryDTO.getOriginatorExternalIds());
         return entrySummary;
     }
 

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -255,4 +255,5 @@
     <include file="parts/0234_add_missing_processing_result_enum_values.xml" relativeToChangelogFile="true" />
     <include file="parts/0235_transaction_summary_reports_buydown_fee_allocation.xml" relativeToChangelogFile="true" />
     <include file="parts/0236_transaction_summary_reports_fix_for_cap_income_amortization_duplicates.xml" relativeToChangelogFile="true" />
+    <include file="parts/0237_aggregation_summary_originator_in_reports.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0237_aggregation_summary_originator_in_reports.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0237_aggregation_summary_originator_in_reports.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+        FINERACT-2618: Now that the aggregation job stores originator_external_ids in
+        m_journal_entry_aggregation_summary, the summary_snapshot_baseline_data CTE in
+        both the Trial Balance and Transaction Summary reports no longer needs to hardcode
+        NULL. Read the stored value directly so the snapshot path correctly participates
+        in joins keyed on originator_external_ids.
+    -->
+
+    <!-- Trial Balance Summary Report - MySQL -->
+    <changeSet author="fineract" id="2618-trial-balance-snapshot-originator-mysql" context="mysql">
+        <update tableName="stretchy_report">
+            <column name="report_sql"><![CDATA[
+WITH retained_earning AS (SELECT DISTINCT '${endDate}' AS postingdate,
+ lp.name AS product,
+ gl_code AS glacct,
+ COALESCE((SELECT name FROM acc_gl_account WHERE gl_code = e.gl_code), '') AS description,
+ COALESCE(e.owner_external_id, 'self') AS assetowner,
+ SUM(opening_balance_amount) AS beginningbalance,
+ 0 AS debitmovement,
+ 0 AS creditmovement,
+ SUM(opening_balance_amount) AS endingbalance,
+ COALESCE(e.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_journal_entry_annual_summary e,
+ m_product_loan lp
+ WHERE e.office_id = ${officeId}
+ AND lp.id = product_id
+ AND EXTRACT(YEAR FROM e.year_end_date) < EXTRACT(YEAR FROM CAST('${endDate}' AS DATE))
+ GROUP BY gl_code, lp.name, office_id, owner_external_id, originator_external_ids),
+ loan_originators AS (SELECT mlom.loan_id,
+ GROUP_CONCAT(DISTINCT mlo.external_id ORDER BY mlo.external_id SEPARATOR ', ') AS originator_external_ids
+ FROM m_loan_originator_mapping mlom
+ JOIN m_loan_originator mlo ON mlo.id = mlom.originator_id
+ GROUP BY mlom.loan_id),
+ aggregated_date AS (SELECT MAX(aggregated_on_date_to) AS latest
+ FROM m_journal_entry_aggregation_tracking
+ WHERE aggregated_on_date_to < '${endDate}'),
+ summary_snapshot_baseline_data AS (SELECT lp.NAME AS productname,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.NAME AS glname,
+ CASE WHEN ags.external_owner_id IS NULL THEN 0 ELSE ags.external_owner_id END AS assetowner,
+ COALESCE(ags.originator_external_ids, '') AS originator_external_ids,
+ SUM(ags.debit_amount) AS debitamount,
+ SUM(ags.credit_amount) AS creditamount
+ FROM acc_gl_account
+ JOIN m_journal_entry_aggregation_summary ags ON acc_gl_account.id = ags.gl_account_id
+ JOIN m_product_loan lp ON lp.id = ags.product_id
+ WHERE ags.entity_type_enum = 1
+ AND ags.manual_entry = FALSE
+ AND ags.aggregated_on_date <= (SELECT latest FROM aggregated_date)
+ AND (ags.office_id = ${officeId})
+ GROUP BY productname, glcode, glname, assetowner, originator_external_ids),
+ post_snapshot_delta_data AS (SELECT lp.NAME AS productname,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.NAME AS glname,
+ CASE WHEN aw.owner_id IS NULL THEN 0 ELSE aw.owner_id END AS assetowner,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 2 THEN amount ELSE 0 END) AS debitamount,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 1 THEN amount ELSE 0 END) AS creditamount,
+ COALESCE(lo.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_account
+ JOIN acc_gl_journal_entry ON acc_gl_account.id = acc_gl_journal_entry.account_id
+ JOIN m_loan m ON m.id = acc_gl_journal_entry.entity_id
+ JOIN m_product_loan lp ON lp.id = m.product_id
+ LEFT JOIN m_external_asset_owner_journal_entry_mapping aw ON aw.journal_entry_id = acc_gl_journal_entry.id
+ LEFT JOIN loan_originators lo ON lo.loan_id = m.id
+ WHERE acc_gl_journal_entry.entity_type_enum = 1
+ AND acc_gl_journal_entry.manual_entry = FALSE
+ AND ((SELECT latest FROM aggregated_date) IS NULL OR acc_gl_journal_entry.submitted_on_date > (SELECT latest FROM aggregated_date))
+ AND acc_gl_journal_entry.submitted_on_date < '${endDate}'
+ AND (acc_gl_journal_entry.office_id = ${officeId})
+ GROUP BY productname, glcode, glname, assetowner, originator_external_ids),
+ merged_historical_data AS (SELECT COALESCE(s.productname, p.productname) AS productname,
+ COALESCE(s.glcode, p.glcode) AS glcode,
+ COALESCE(s.glname, p.glname) AS glname,
+ COALESCE(s.assetowner, p.assetowner, 0) AS assetowner,
+ COALESCE(s.debitamount, 0) + COALESCE(p.debitamount, 0) AS debitamount,
+ COALESCE(s.creditamount, 0) + COALESCE(p.creditamount, 0) AS creditamount,
+ COALESCE(s.originator_external_ids, p.originator_external_ids, '') AS originator_external_ids
+ FROM summary_snapshot_baseline_data s
+ LEFT JOIN post_snapshot_delta_data p
+ ON s.glcode = p.glcode AND s.productname = p.productname AND s.assetowner = p.assetowner AND s.originator_external_ids = p.originator_external_ids
+ UNION ALL
+ SELECT p.productname, p.glcode, p.glname, COALESCE(p.assetowner, 0) AS assetowner,
+ COALESCE(p.debitamount, 0), COALESCE(p.creditamount, 0), COALESCE(s.originator_external_ids, p.originator_external_ids, '') AS originator_external_ids
+ FROM post_snapshot_delta_data p
+ LEFT JOIN summary_snapshot_baseline_data s
+ ON s.glcode = p.glcode AND s.productname = p.productname AND s.assetowner = p.assetowner AND s.originator_external_ids = p.originator_external_ids
+ WHERE s.glcode IS NULL),
+ current_cob_data AS (SELECT lp.name AS productname,
+ account_id,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.name AS glname,
+ CASE WHEN aw.owner_id IS NULL THEN 0 ELSE aw.owner_id END AS assetowner,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 2 THEN amount ELSE 0 END) AS debitamount,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 1 THEN amount ELSE 0 END) AS creditamount,
+ COALESCE(lo.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_journal_entry
+ JOIN acc_gl_account ON acc_gl_account.id = acc_gl_journal_entry.account_id
+ JOIN m_loan m ON m.id = acc_gl_journal_entry.entity_id
+ JOIN m_product_loan lp ON lp.id = m.product_id
+ LEFT JOIN m_external_asset_owner_journal_entry_mapping aw ON aw.journal_entry_id = acc_gl_journal_entry.id
+ LEFT JOIN loan_originators lo ON lo.loan_id = m.id
+ WHERE acc_gl_journal_entry.entity_type_enum = 1
+ AND acc_gl_journal_entry.manual_entry = FALSE
+ AND acc_gl_journal_entry.submitted_on_date = '${endDate}'
+ AND (acc_gl_journal_entry.office_id = ${officeId})
+ GROUP BY productname, account_id, glcode, glname, assetowner, originator_external_ids)
+SELECT * FROM (SELECT * FROM retained_earning
+ WHERE glacct = (SELECT gl_code FROM acc_gl_account WHERE name = 'Retained Earnings Prior Year')
+ UNION
+ SELECT txnreport.postingdate, txnreport.product, txnreport.glacct, txnreport.description,
+ txnreport.assetowner,
+ (COALESCE(txnreport.beginningbalance, 0) + COALESCE(summary.beginningbalance, 0)) AS beginningbalance,
+ txnreport.debitmovement, txnreport.creditmovement,
+ (COALESCE(txnreport.endingbalance, 0) + COALESCE(summary.beginningbalance, 0)) AS endingbalance,
+ txnreport.originator_external_ids
+ FROM (SELECT * FROM (SELECT DISTINCT '${endDate}' AS postingdate,
+ loan.pname AS product, loan.gl_code AS glacct, loan.glname AS description,
+ COALESCE((SELECT external_id FROM m_external_asset_owner WHERE id = loan.assetowner), 'self') AS assetowner,
+ loan.openingbalance AS beginningbalance,
+ (loan.debitamount * 1) AS debitmovement,
+ (loan.creditamount * -1) AS creditmovement,
+ (loan.openingbalance + loan.debitamount - loan.creditamount) AS endingbalance,
+ loan.originator_external_ids
+ FROM (SELECT DISTINCT g.pname, g.gl_code, g.glname,
+ COALESCE(mh.assetowner, c.assetowner, 0) AS assetowner,
+ COALESCE(mh.debitamount, 0) - COALESCE(mh.creditamount, 0) AS openingbalance,
+ COALESCE(c.debitamount, 0) AS debitamount,
+ COALESCE(c.creditamount, 0) AS creditamount,
+ COALESCE(mh.originator_external_ids, c.originator_external_ids) AS originator_external_ids
+ FROM (SELECT DISTINCT ag.gl_code, ag.id, pl.NAME AS pname, ag.NAME AS glname
+ FROM acc_gl_account ag
+ JOIN acc_product_mapping am ON am.gl_account_id = ag.id AND am.product_type = 1
+ JOIN m_product_loan pl ON pl.id = am.product_id) g
+ LEFT JOIN merged_historical_data mh ON g.gl_code = mh.glcode AND mh.productname = g.pname
+ LEFT JOIN current_cob_data c ON g.gl_code = c.glcode AND c.productname = g.pname
+ AND mh.assetowner = c.assetowner AND mh.originator_external_ids = c.originator_external_ids
+ UNION ALL
+ SELECT DISTINCT c.productname, c.glcode, c.glname,
+ COALESCE(c.assetowner, 0) AS assetowner, 0 AS openingbalance,
+ COALESCE(c.debitamount, 0), COALESCE(c.creditamount, 0),
+ COALESCE(matched.originator_external_ids, c.originator_external_ids) AS originator_external_ids
+ FROM current_cob_data c
+ LEFT JOIN (SELECT g3.gl_code, g3.pname, mh.assetowner, mh.originator_external_ids
+ FROM (SELECT DISTINCT ag.gl_code, pl.NAME AS pname
+ FROM acc_gl_account ag
+ JOIN acc_product_mapping am ON am.gl_account_id = ag.id AND am.product_type = 1
+ JOIN m_product_loan pl ON pl.id = am.product_id) g3
+ LEFT JOIN merged_historical_data mh ON g3.gl_code = mh.glcode AND mh.productname = g3.pname) matched
+ ON matched.gl_code = c.glcode AND matched.pname = c.productname
+ AND matched.assetowner = c.assetowner AND matched.originator_external_ids = c.originator_external_ids
+ WHERE matched.gl_code IS NULL) loan) a) AS txnreport
+ LEFT JOIN retained_earning summary
+ ON txnreport.glacct = summary.glacct AND txnreport.assetowner = summary.assetowner
+ AND summary.product = txnreport.product AND summary.originator_external_ids = txnreport.originator_external_ids
+) report
+WHERE report.endingbalance != 0 OR report.debitmovement != 0 OR report.creditmovement != 0
+ORDER BY glacct
+            ]]></column>
+            <where>report_name='Trial Balance Summary Report with Asset Owner'</where>
+        </update>
+    </changeSet>
+
+    <!-- Trial Balance Summary Report - PostgreSQL -->
+    <changeSet author="fineract" id="2618-trial-balance-snapshot-originator-postgresql" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql"><![CDATA[
+WITH retained_earning AS (SELECT DISTINCT '${endDate}' AS postingdate,
+ lp.name AS product,
+ gl_code AS glacct,
+ COALESCE((SELECT name FROM acc_gl_account WHERE gl_code = e.gl_code), '') AS description,
+ COALESCE(e.owner_external_id, 'self') AS assetowner,
+ SUM(opening_balance_amount) AS beginningbalance,
+ 0 AS debitmovement,
+ 0 AS creditmovement,
+ SUM(opening_balance_amount) AS endingbalance,
+ COALESCE(e.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_journal_entry_annual_summary e,
+ m_product_loan lp
+ WHERE e.office_id = ${officeId}
+ AND lp.id = product_id
+ AND EXTRACT(YEAR FROM e.year_end_date) < EXTRACT(YEAR FROM CAST('${endDate}' AS DATE))
+ GROUP BY gl_code, lp.name, office_id, owner_external_id, originator_external_ids),
+ loan_originators AS (SELECT mlom.loan_id,
+ STRING_AGG(DISTINCT mlo.external_id, ', ' ORDER BY mlo.external_id) AS originator_external_ids
+ FROM m_loan_originator_mapping mlom
+ JOIN m_loan_originator mlo ON mlo.id = mlom.originator_id
+ GROUP BY mlom.loan_id),
+ aggregated_date AS (SELECT MAX(aggregated_on_date_to) AS latest
+ FROM m_journal_entry_aggregation_tracking
+ WHERE aggregated_on_date_to < '${endDate}'),
+ summary_snapshot_baseline_data AS (SELECT lp.NAME AS productname,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.NAME AS glname,
+ CASE WHEN ags.external_owner_id IS NULL THEN 0 ELSE ags.external_owner_id END AS assetowner,
+ COALESCE(ags.originator_external_ids, '') AS originator_external_ids,
+ SUM(ags.debit_amount) AS debitamount,
+ SUM(ags.credit_amount) AS creditamount
+ FROM acc_gl_account
+ JOIN m_journal_entry_aggregation_summary ags ON acc_gl_account.id = ags.gl_account_id
+ JOIN m_product_loan lp ON lp.id = ags.product_id
+ WHERE ags.entity_type_enum = 1
+ AND ags.manual_entry = FALSE
+ AND ags.aggregated_on_date <= (SELECT latest FROM aggregated_date)
+ AND (ags.office_id = ${officeId})
+ GROUP BY productname, glcode, glname, assetowner, originator_external_ids),
+ post_snapshot_delta_data AS (SELECT lp.NAME AS productname,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.NAME AS glname,
+ CASE WHEN aw.owner_id IS NULL THEN 0 ELSE aw.owner_id END AS assetowner,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 2 THEN amount ELSE 0 END) AS debitamount,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 1 THEN amount ELSE 0 END) AS creditamount,
+ COALESCE(lo.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_account
+ JOIN acc_gl_journal_entry ON acc_gl_account.id = acc_gl_journal_entry.account_id
+ JOIN m_loan m ON m.id = acc_gl_journal_entry.entity_id
+ JOIN m_product_loan lp ON lp.id = m.product_id
+ LEFT JOIN m_external_asset_owner_journal_entry_mapping aw ON aw.journal_entry_id = acc_gl_journal_entry.id
+ LEFT JOIN loan_originators lo ON lo.loan_id = m.id
+ WHERE acc_gl_journal_entry.entity_type_enum = 1
+ AND acc_gl_journal_entry.manual_entry = FALSE
+ AND ((SELECT latest FROM aggregated_date) IS NULL OR acc_gl_journal_entry.submitted_on_date > (SELECT latest FROM aggregated_date))
+ AND acc_gl_journal_entry.submitted_on_date < '${endDate}'
+ AND (acc_gl_journal_entry.office_id = ${officeId})
+ GROUP BY productname, glcode, glname, assetowner, originator_external_ids),
+ merged_historical_data AS (SELECT COALESCE(s.productname, p.productname) AS productname,
+ COALESCE(s.glcode, p.glcode) AS glcode,
+ COALESCE(s.glname, p.glname) AS glname,
+ COALESCE(s.assetowner, p.assetowner, 0) AS assetowner,
+ COALESCE(s.debitamount, 0) + COALESCE(p.debitamount, 0) AS debitamount,
+ COALESCE(s.creditamount, 0) + COALESCE(p.creditamount, 0) AS creditamount,
+ COALESCE(s.originator_external_ids, p.originator_external_ids, '') AS originator_external_ids
+ FROM summary_snapshot_baseline_data s
+ LEFT JOIN post_snapshot_delta_data p
+ ON s.glcode = p.glcode AND s.productname = p.productname AND s.assetowner = p.assetowner AND s.originator_external_ids = p.originator_external_ids
+ UNION ALL
+ SELECT p.productname, p.glcode, p.glname, COALESCE(p.assetowner, 0) AS assetowner,
+ COALESCE(p.debitamount, 0), COALESCE(p.creditamount, 0), COALESCE(s.originator_external_ids, p.originator_external_ids, '') AS originator_external_ids
+ FROM post_snapshot_delta_data p
+ LEFT JOIN summary_snapshot_baseline_data s
+ ON s.glcode = p.glcode AND s.productname = p.productname AND s.assetowner = p.assetowner AND s.originator_external_ids = p.originator_external_ids
+ WHERE s.glcode IS NULL),
+ current_cob_data AS (SELECT lp.name AS productname,
+ account_id,
+ acc_gl_account.gl_code AS glcode,
+ acc_gl_account.name AS glname,
+ CASE WHEN aw.owner_id IS NULL THEN 0 ELSE aw.owner_id END AS assetowner,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 2 THEN amount ELSE 0 END) AS debitamount,
+ SUM(CASE WHEN acc_gl_journal_entry.type_enum = 1 THEN amount ELSE 0 END) AS creditamount,
+ COALESCE(lo.originator_external_ids, '') AS originator_external_ids
+ FROM acc_gl_journal_entry
+ JOIN acc_gl_account ON acc_gl_account.id = acc_gl_journal_entry.account_id
+ JOIN m_loan m ON m.id = acc_gl_journal_entry.entity_id
+ JOIN m_product_loan lp ON lp.id = m.product_id
+ LEFT JOIN m_external_asset_owner_journal_entry_mapping aw ON aw.journal_entry_id = acc_gl_journal_entry.id
+ LEFT JOIN loan_originators lo ON lo.loan_id = m.id
+ WHERE acc_gl_journal_entry.entity_type_enum = 1
+ AND acc_gl_journal_entry.manual_entry = FALSE
+ AND acc_gl_journal_entry.submitted_on_date = '${endDate}'
+ AND (acc_gl_journal_entry.office_id = ${officeId})
+ GROUP BY productname, account_id, glcode, glname, assetowner, originator_external_ids)
+SELECT * FROM (SELECT * FROM retained_earning
+ WHERE glacct = (SELECT gl_code FROM acc_gl_account WHERE name = 'Retained Earnings Prior Year')
+ UNION
+ SELECT txnreport.postingdate, txnreport.product, txnreport.glacct, txnreport.description,
+ txnreport.assetowner,
+ (COALESCE(txnreport.beginningbalance, 0) + COALESCE(summary.beginningbalance, 0)) AS beginningbalance,
+ txnreport.debitmovement, txnreport.creditmovement,
+ (COALESCE(txnreport.endingbalance, 0) + COALESCE(summary.beginningbalance, 0)) AS endingbalance,
+ txnreport.originator_external_ids
+ FROM (SELECT * FROM (SELECT DISTINCT '${endDate}' AS postingdate,
+ loan.pname AS product, loan.gl_code AS glacct, loan.glname AS description,
+ COALESCE((SELECT external_id FROM m_external_asset_owner WHERE id = loan.assetowner), 'self') AS assetowner,
+ loan.openingbalance AS beginningbalance,
+ (loan.debitamount * 1) AS debitmovement,
+ (loan.creditamount * -1) AS creditmovement,
+ (loan.openingbalance + loan.debitamount - loan.creditamount) AS endingbalance,
+ loan.originator_external_ids
+ FROM (SELECT DISTINCT g.pname, g.gl_code, g.glname,
+ COALESCE(mh.assetowner, c.assetowner, 0) AS assetowner,
+ COALESCE(mh.debitamount, 0) - COALESCE(mh.creditamount, 0) AS openingbalance,
+ COALESCE(c.debitamount, 0) AS debitamount,
+ COALESCE(c.creditamount, 0) AS creditamount,
+ COALESCE(mh.originator_external_ids, c.originator_external_ids) AS originator_external_ids
+ FROM (SELECT DISTINCT ag.gl_code, ag.id, pl.NAME AS pname, ag.NAME AS glname
+ FROM acc_gl_account ag
+ JOIN acc_product_mapping am ON am.gl_account_id = ag.id AND am.product_type = 1
+ JOIN m_product_loan pl ON pl.id = am.product_id) g
+ LEFT JOIN merged_historical_data mh ON g.gl_code = mh.glcode AND mh.productname = g.pname
+ LEFT JOIN current_cob_data c ON g.gl_code = c.glcode AND c.productname = g.pname
+ AND mh.assetowner = c.assetowner AND mh.originator_external_ids = c.originator_external_ids
+ UNION ALL
+ SELECT DISTINCT c.productname, c.glcode, c.glname,
+ COALESCE(c.assetowner, 0) AS assetowner, 0 AS openingbalance,
+ COALESCE(c.debitamount, 0), COALESCE(c.creditamount, 0),
+ COALESCE(matched.originator_external_ids, c.originator_external_ids) AS originator_external_ids
+ FROM current_cob_data c
+ LEFT JOIN (SELECT g3.gl_code, g3.pname, mh.assetowner, mh.originator_external_ids
+ FROM (SELECT DISTINCT ag.gl_code, pl.NAME AS pname
+ FROM acc_gl_account ag
+ JOIN acc_product_mapping am ON am.gl_account_id = ag.id AND am.product_type = 1
+ JOIN m_product_loan pl ON pl.id = am.product_id) g3
+ LEFT JOIN merged_historical_data mh ON g3.gl_code = mh.glcode AND mh.productname = g3.pname) matched
+ ON matched.gl_code = c.glcode AND matched.pname = c.productname
+ AND matched.assetowner = c.assetowner AND matched.originator_external_ids = c.originator_external_ids
+ WHERE matched.gl_code IS NULL) loan) a) AS txnreport
+ LEFT JOIN retained_earning summary
+ ON txnreport.glacct = summary.glacct AND txnreport.assetowner = summary.assetowner
+ AND summary.product = txnreport.product AND summary.originator_external_ids = txnreport.originator_external_ids
+) report
+WHERE report.endingbalance != 0 OR report.debitmovement != 0 OR report.creditmovement != 0
+ORDER BY glacct
+            ]]></column>
+            <where>report_name='Trial Balance Summary Report with Asset Owner'</where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobConfigurationTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobConfigurationTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
 
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.core.service.migration.TenantDataSourceFactory;
 import org.apache.fineract.infrastructure.jobs.service.aggregationjob.listener.JournalEntryAggregationJobListener;
 import org.apache.fineract.infrastructure.jobs.service.aggregationjob.tasklet.JournalEntryAggregationTrackingTasklet;
@@ -60,6 +61,8 @@ class JournalEntryAggregationJobConfigurationTest {
     @Mock
     private JournalEntryAggregationTrackingTasklet journalEntryAggregationTrackingTasklet;
 
+    @Mock
+    private DatabaseTypeResolver databaseTypeResolver;
     @Mock
     private TenantDataSourceFactory tenantDataSourceFactory;
 

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobReaderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/JournalEntryAggregationJobReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
 import org.apache.fineract.infrastructure.core.service.migration.TenantDataSourceFactory;
 import org.apache.fineract.infrastructure.jobs.service.aggregationjob.data.JournalEntryAggregationSummaryData;
 import org.junit.jupiter.api.AfterEach;
@@ -55,6 +56,8 @@ public class JournalEntryAggregationJobReaderTest {
     private FineractPlatformTenantConnection fineractPlatformTenantConnection;
     @Mock
     private TenantDataSourceFactory tenantDataSourceFactory;
+    @Mock
+    private DatabaseTypeResolver databaseTypeResolver;
     @Mock
     private JobExecution jobExecution;
     @Mock
@@ -89,7 +92,7 @@ public class JournalEntryAggregationJobReaderTest {
         setupResultSetMocks();
 
         // Act
-        reader = new JournalEntryAggregationJobReader(tenantDataSourceFactory);
+        reader = new JournalEntryAggregationJobReader(tenantDataSourceFactory, databaseTypeResolver);
         JournalEntryAggregationSummaryData result = invokeMapRowMethod(resultSet, 1);
 
         // Assert
@@ -101,6 +104,7 @@ public class JournalEntryAggregationJobReaderTest {
         assertEquals("USD", result.getCurrencyCode(), "Currency code should match");
         assertEquals(LocalDate.of(2023, 6, 15), result.getAggregatedOnDate(), "Aggregated date should match");
         assertEquals(Long.valueOf(500L), result.getExternalOwnerId(), "Asset owner should match");
+        assertEquals("ext-001, ext-002", result.getOriginatorExternalIds(), "Originator external ids should match");
         assertEquals(new BigDecimal("1000.00"), result.getDebitAmount(), "Debit amount should match");
         assertEquals(Boolean.FALSE, result.getManualEntry(), "Manual entry should be false");
         assertEquals(ThreadLocalContextUtil.getBusinessDate(), result.getSubmittedOnDate(), "Submitted on date should match business date");
@@ -112,11 +116,13 @@ public class JournalEntryAggregationJobReaderTest {
         setupResultSetMocksWithNullOwner();
 
         // Act
-        reader = new JournalEntryAggregationJobReader(tenantDataSourceFactory);
+        reader = new JournalEntryAggregationJobReader(tenantDataSourceFactory, databaseTypeResolver);
         JournalEntryAggregationSummaryData result = invokeMapRowMethod(resultSet, 1);
 
         // Assert
         assertEquals(Long.valueOf(0L), result.getExternalOwnerId(), "Asset owner should be 0 when null in resultset");
+        org.junit.jupiter.api.Assertions.assertNull(result.getOriginatorExternalIds(),
+                "Originator external ids should be null when not in resultset");
     }
 
     private void setupResultSetMocks() throws SQLException {
@@ -126,6 +132,7 @@ public class JournalEntryAggregationJobReaderTest {
         when(resultSet.getDate("aggregatedOnDate")).thenReturn(Date.valueOf(LocalDate.of(2023,6,15)));
         when(resultSet.findColumn("externalOwner")).thenReturn(5);
         when(resultSet.getLong(5)).thenReturn(500L);
+        when(resultSet.getString("originatorExternalIds")).thenReturn("ext-001, ext-002");
         when(resultSet.getLong("officeId")).thenReturn(1L);
         when(resultSet.getLong("entityTypeEnum")).thenReturn(1L);
         when(resultSet.getBigDecimal("debitAmount")).thenReturn(new BigDecimal("1000.00"));

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/services/JournalEntryAggregationWriterServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/jobs/service/aggregationjob/services/JournalEntryAggregationWriterServiceImplTest.java
@@ -133,6 +133,7 @@ public class JournalEntryAggregationWriterServiceImplTest {
         when(summaryData.getDebitAmount()).thenReturn(debitAmount);
         when(summaryData.getCreditAmount()).thenReturn(creditAmount);
         when(summaryData.getJobExecutionId()).thenReturn(123L);
+        when(summaryData.getOriginatorExternalIds()).thenReturn("ext-abc");
 
         List<JournalEntryAggregationSummaryData> summariesList = List.of(summaryData);
 
@@ -145,9 +146,11 @@ public class JournalEntryAggregationWriterServiceImplTest {
                 return false;
             }
             JournalEntrySummary entity = (JournalEntrySummary) ((List<?>) entities).getFirst();
-            return entity.getDebitAmount().compareTo(debitAmount) == 0 && entity.getCreditAmount().compareTo(creditAmount) == 0;
+            return entity.getDebitAmount().compareTo(debitAmount) == 0 && entity.getCreditAmount().compareTo(creditAmount) == 0
+                    && "ext-abc".equals(entity.getOriginatorExternalIds());
         }));
         verify(summaryData, times(1)).getDebitAmount();
         verify(summaryData, times(1)).getCreditAmount();
+        verify(summaryData, times(1)).getOriginatorExternalIds();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignTrialBalanceSummaryReportTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignTrialBalanceSummaryReportTest.java
@@ -104,6 +104,7 @@ public class FeignTrialBalanceSummaryReportTest extends FeignIntegrationTest {
         originatorHelper = new FeignLoanOriginatorHelper(fineractClient());
 
         todaysDate = Utils.getLocalDateOfTenant().toString();
+        String uniqueSuffix = Utils.randomStringGenerator("", 6);
 
         originalBusinessSteps = ok(
                 () -> fineractClient().businessStepConfiguration().retrieveAllConfiguredBusinessStep("LOAN_CLOSE_OF_BUSINESS"))
@@ -112,12 +113,12 @@ public class FeignTrialBalanceSummaryReportTest extends FeignIntegrationTest {
 
         configureBusinessSteps();
 
-        assetAccount = accountHelper.createAssetAccount("TrialBal");
-        feePenaltyAccount = accountHelper.createAssetAccount("TrialBalFP");
-        transferAccount = accountHelper.createAssetAccount("TrialBalTR");
-        expenseAccount = accountHelper.createExpenseAccount("TrialBalEXP");
-        incomeAccount = accountHelper.createIncomeAccount("TrialBalINC");
-        overpaymentAccount = accountHelper.createLiabilityAccount("TrialBalOP");
+        assetAccount = accountHelper.createAssetAccount("TrBal" + uniqueSuffix);
+        feePenaltyAccount = accountHelper.createAssetAccount("TrBalFP" + uniqueSuffix);
+        transferAccount = accountHelper.createAssetAccount("TrBalTR" + uniqueSuffix);
+        expenseAccount = accountHelper.createExpenseAccount("TrBalEX" + uniqueSuffix);
+        incomeAccount = accountHelper.createIncomeAccount("TrBalIN" + uniqueSuffix);
+        overpaymentAccount = accountHelper.createLiabilityAccount("TrBalOP" + uniqueSuffix);
 
         setupFinancialActivityMapping();
     }
@@ -273,6 +274,45 @@ public class FeignTrialBalanceSummaryReportTest extends FeignIntegrationTest {
 
             assertTrue(hasOriginatorIdEntry, "Report must contain entries for originator external ids '" + originatorExternalId
                     + "'. Actual rows: " + report.getData());
+        });
+    }
+
+    @Test
+    @Order(6)
+    public void testOriginatorExternalIdsPersistedViaAggregationJobAppearInSnapshotPath() {
+        runWithBusinessDate("2020-04-01", () -> {
+            // Arrange: create a loan with an originator attached, disburse on 2020-04-01
+            Long clientId = createClient("01 April 2020");
+            String originatorExternalId = UUID.randomUUID().toString();
+            Long loanId = createAndDisburseLoan(clientId, "01 April 2020", "01 April 2020", null, originatorExternalId);
+            assertNotNull(loanId);
+
+            // Act step 1: advance to 2020-04-02 and run Loan COB
+            // This creates acc_gl_journal_entry rows with submitted_on_date = 2020-04-01
+            advanceBusinessDateAndRunCob("2020-04-02");
+
+            // Act step 2: advance to 2020-04-03 and run the Journal Entry Aggregation job.
+            // The job's upper bound is businessDate - 1 = 2020-04-02, so 2020-04-01 entries
+            // are within range and get written into m_journal_entry_aggregation_summary
+            // with originator_external_ids populated (our new change).
+            businessDateHelper.updateBusinessDate("BUSINESS_DATE", "2020-04-03");
+            schedulerHelper.executeAndAwaitJob("Journal Entry Aggregation");
+
+            // Assert: run the report for 2020-04-04. The aggregation job ran with business
+            // date 2020-04-03, storing aggregated_on_date_to = 2020-04-02. The aggregated_date
+            // CTE filters WHERE aggregated_on_date_to < '${endDate}', so endDate must be strictly
+            // after 2020-04-02 for the snapshot to activate. Migration 0236 then makes
+            // summary_snapshot_baseline_data read originator_external_ids instead of NULL.
+            RunReportsResponse report = runReport("2020-04-04");
+            assertNotNull(report.getData());
+            assertFalse(report.getData().isEmpty(), "Report must contain data after aggregation job has run");
+
+            int originatorColIdx = findColumnIndex(report, "originator_external_ids");
+            boolean hasOriginatorViaSnapshot = report.getData().stream()
+                    .anyMatch(row -> originatorExternalId.equals(String.valueOf(row.getRow().get(originatorColIdx))));
+
+            assertTrue(hasOriginatorViaSnapshot, "Report must contain originator '" + originatorExternalId
+                    + "' sourced from aggregation snapshot (summary_snapshot_baseline_data path). " + "Actual rows: " + report.getData());
         });
     }
 


### PR DESCRIPTION
## Description

The journal entry aggregation job was grouping entries only by asset owner, leaving `originator_external_ids` always NULL in the summary table even though the column existed. This meant the Trial Balance report had to re-derive originator data from raw journal entries for every historical row already in the snapshot, adding unnecessary memory overhead. It also meant originator never appeared via the snapshot path even when one was attached to the loan.

This PR fixes both problems:

- Adds a `loan_originators` CTE to the aggregation job reader query and wires `originator_external_ids` through the full pipeline — DTO, JPA entity, and writer service — so it gets correctly persisted per summary row
- Updates the Trial Balance Summary Report (MySQL + PostgreSQL) via migration `0236` so `summary_snapshot_baseline_data` reads the stored originator value directly instead of hardcoding NULL, letting the snapshot join cleanly on originator without re-hitting the mapping tables
- Updates unit tests for the reader and writer service to cover the new field
- Adds an integration test that runs the actual aggregation job end-to-end and verifies originator surfaces correctly via the snapshot path