### PR TITLE
Runreports prepared statement and input sanitization

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataService.java
@@ -27,6 +27,8 @@ public interface GenericDataService {
 
     GenericResultsetData fillGenericResultSet(String sql);
 
+    GenericResultsetData fillGenericResultSet(String sql, Object... args);
+
     List<ResultsetColumnHeaderData> fillResultsetColumnHeaders(String tableName);
 
     List<ResultsetRowData> fillResultsetRowData(String sql, List<ResultsetColumnHeaderData> columnHeaders);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessService.java
@@ -33,6 +33,7 @@ import org.apache.fineract.infrastructure.dataqueries.service.export.DatatableRe
 import org.apache.fineract.infrastructure.dataqueries.service.export.ResponseHolder;
 import org.apache.fineract.infrastructure.report.annotation.ReportService;
 import org.apache.fineract.infrastructure.report.service.AbstractReportingProcessService;
+import org.apache.fineract.infrastructure.report.service.ReportParameterTypeResolver;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
 import org.apache.fineract.util.StreamUtil;
 import org.springframework.stereotype.Service;
@@ -44,8 +45,9 @@ public class DatatableReportingProcessService extends AbstractReportingProcessSe
 
     private final List<DatatableReportExportService> exportServices;
 
-    public DatatableReportingProcessService(List<DatatableReportExportService> exportServices, SqlValidator sqlValidator) {
-        super(sqlValidator);
+    public DatatableReportingProcessService(List<DatatableReportExportService> exportServices, SqlValidator sqlValidator,
+            ReportParameterTypeResolver reportParameterTypeResolver) {
+        super(sqlValidator, reportParameterTypeResolver);
 
         this.exportServices = exportServices;
     }
@@ -55,7 +57,7 @@ public class DatatableReportingProcessService extends AbstractReportingProcessSe
 
         DatatableExportTargetParameter exportMode = DatatableExportTargetParameter.resolverExportTarget(queryParams);
         final String parameterTypeValue = ApiParameterHelper.parameterType(queryParams) ? "parameter" : "report";
-        final Map<String, String> reportParams = getReportParams(queryParams);
+        final Map<String, String> reportParams = getReportParams(reportName, queryParams);
         ResponseHolder response = findReportExportService(exportMode) //
                 .orElseThrow(() -> new GeneralPlatformDomainRuleException("error.msg.report.export.mode.unavailable",
                         "Export mode %s unavailable".formatted(exportMode.name()))) //

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImpl.java
@@ -93,6 +93,32 @@ public class GenericDataServiceImpl implements GenericDataService {
     }
 
     @Override
+    public GenericResultsetData fillGenericResultSet(final String sql, final Object... args) {
+        try {
+            final SqlRowSet rs = this.jdbcTemplate.queryForRowSet(sql, args);
+
+            final List<ResultsetColumnHeaderData> columnHeaders = new ArrayList<>();
+
+            final SqlRowSetMetaData rsmd = rs.getMetaData();
+            for (int i = 0; i < rsmd.getColumnCount(); i++) {
+                final String columnName = rsmd.getColumnName(i + 1);
+                final String columnType = rsmd.getColumnTypeName(i + 1);
+
+                final ResultsetColumnHeaderData columnHeader = ResultsetColumnHeaderData.basic(columnName, columnType,
+                        databaseTypeResolver.databaseType());
+                columnHeaders.add(columnHeader);
+            }
+
+            final List<ResultsetRowData> resultsetDataRows = fillResultsetRowData(rs, columnHeaders);
+
+            return new GenericResultsetData(columnHeaders, resultsetDataRows);
+        } catch (DataAccessException e) {
+            log.error("Reporting error: {}", e.getMessage());
+            throw ErrorHandler.getMappable(e, "error.msg.report.unknown.data.integrity.issue", e.getClass().getName(), null, e);
+        }
+    }
+
+    @Override
     public List<ResultsetColumnHeaderData> fillResultsetColumnHeaders(final String tableName) {
         final SqlRowSet columnDefinitions = getTableMetaData(tableName);
         final List<IndexDetail> indexDefinitions = getDatatableIndexData(tableName);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/PreparedQuery.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/PreparedQuery.java
@@ -16,19 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.infrastructure.report.service;
+package org.apache.fineract.infrastructure.dataqueries.service;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
 import java.util.List;
-import java.util.Map;
-import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 
-public interface ReportingProcessService {
-
-    Response processRequest(String reportName, MultivaluedMap<String, String> queryParams);
-
-    List<ReportExportType> getAvailableExportTargets();
-
-    Map<String, String> getReportParams(String reportName, MultivaluedMap<String, String> queryParams);
+/**
+ * Holds a SQL string with {@code ?} bind-variable placeholders alongside the ordered list of parameter values to be
+ * passed to JDBC. User-supplied report parameters are never concatenated into the SQL string — they are always
+ * represented as {@code ?} and bound via JDBC, eliminating SQL-injection at the execution layer.
+ */
+public record PreparedQuery(String sql, List<Object> params) {
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,14 +35,17 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.core.service.database.JdbcJavaType;
 import org.apache.fineract.infrastructure.dataqueries.data.GenericResultsetData;
@@ -52,6 +56,7 @@ import org.apache.fineract.infrastructure.dataqueries.data.ResultsetColumnHeader
 import org.apache.fineract.infrastructure.dataqueries.data.ResultsetRowData;
 import org.apache.fineract.infrastructure.dataqueries.domain.ReportType;
 import org.apache.fineract.infrastructure.dataqueries.exception.ReportNotFoundException;
+import org.apache.fineract.infrastructure.report.service.ReportParameterTypeResolver;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
 import org.apache.fineract.infrastructure.security.utils.LogParameterEscapeUtil;
@@ -70,12 +75,23 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReadReportingServiceImpl implements ReadReportingService {
 
+    /**
+     * Server-controlled placeholders resolved from the authenticated session. These are never user-supplied and must be
+     * substituted as plain strings before building the prepared statement. They must NOT become {@code ?} bind
+     * variables.
+     */
+    private static final Set<String> SERVER_PARAMS = Set.of("currentUserHierarchy", "currentUserId", "currentDate");
+
+    /** Matches any {@code ${placeholderName}} token in a report SQL template. */
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+
     private final JdbcTemplate jdbcTemplate;
     private final PlatformSecurityContext context;
     private final GenericDataService genericDataService;
     private final SqlInjectionPreventerService sqlInjectionPreventerService;
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final FineractProperties fineractProperties;
+    private final ReportParameterTypeResolver reportParameterTypeResolver;
 
     @Override
     public StreamingOutput retrieveReportCSV(final String name, final String type, final Map<String, String> queryParams) {
@@ -113,9 +129,10 @@ public class ReadReportingServiceImpl implements ReadReportingService {
                     LogParameterEscapeUtil.escapeLogParameter(type));
         }
 
-        final String sql = getSQLtoRun(name, type, queryParams);
+        final PreparedQuery preparedQuery = getSQLtoRun(name, type, queryParams);
 
-        final GenericResultsetData result = this.genericDataService.fillGenericResultSet(sql);
+        final GenericResultsetData result = this.genericDataService.fillGenericResultSet(preparedQuery.sql(),
+                preparedQuery.params().toArray());
 
         final long elapsed = System.currentTimeMillis() - startTime;
         if (log.isDebugEnabled()) {
@@ -125,28 +142,117 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         return result;
     }
 
-    private String getSQLtoRun(final String name, final String type, final Map<String, String> queryParams) {
+    private Object castParamValue(String value, String formatType) {
+        if (value == null) {
+            return null;
+        }
+        if ("NUMBER".equalsIgnoreCase(formatType) || "INTEGER".equalsIgnoreCase(formatType)) {
+            try {
+                if (value.contains(".")) {
+                    return new BigDecimal(value);
+                }
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                throw new PlatformDataIntegrityException("error.msg.report.invalid.numeric.parameter",
+                        "Parameter value '" + value + "' is not a valid number", e);
+            }
+        }
+        if ("DATE".equalsIgnoreCase(formatType)) {
+            return java.sql.Date.valueOf(value);
+        }
+        return value;
+    }
+
+    /**
+     * Builds a {@link PreparedQuery} from the stored report SQL template.
+     *
+     * <p>
+     * Processing order:
+     * <ol>
+     * <li>Server-controlled placeholders ({@code ${currentUserHierarchy}}, {@code ${currentUserId}},
+     * {@code ${currentDate}}) are resolved from the authenticated session and substituted as plain strings — they are
+     * not user input.</li>
+     * <li>SQL function aliases ({@code NOW()}, {@code curdate()}, {@code CURRENT_DATE}) are replaced with tenant-aware
+     * equivalents.</li>
+     * <li>Remaining {@code ${...}} placeholders (user-supplied report parameters) are replaced with {@code ?} bind
+     * variables left-to-right via a single regex pass. Values are collected in the same left-to-right order into
+     * {@code paramValues} so that JDBC receives them in the correct position. User values are never concatenated into
+     * the SQL string.</li>
+     * </ol>
+     */
+    private PreparedQuery getSQLtoRun(final String name, final String type, final Map<String, String> queryParams) {
+
+        final Map<String, String> paramFormatTypes = this.reportParameterTypeResolver.loadParamFormatTypes(name);
 
         String sql = getSql(name, type);
 
-        for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-            sql = this.genericDataService.replace(sql, entry.getKey(), entry.getValue());
-        }
-
+        // Step 1 — resolve server-controlled placeholders as plain strings (not user input)
         final AppUser currentUser = this.context.authenticatedUser();
-        // Allows sql query to restrict data by office hierarchy if required
         sql = this.genericDataService.replace(sql, "${currentUserHierarchy}", currentUser.getOffice().getHierarchy());
-        // Allows sql query to restrict data by current user Id if required
-        // (typically used to return report lists containing only reports
-        // permitted to be run by the user
         sql = this.genericDataService.replace(sql, "${currentUserId}", currentUser.getId().toString());
         sql = this.genericDataService.replace(sql, "${currentDate}", sqlGenerator.currentBusinessDate());
-        sql = StringUtils.replaceIgnoreCase(sql, "NOW()", sqlGenerator.currentTenantDateTime());
-        sql = StringUtils.replaceIgnoreCase(sql, "curdate()", sqlGenerator.currentBusinessDate());
-        sql = StringUtils.replaceIgnoreCase(sql, "CURRENT_DATE", sqlGenerator.currentBusinessDate());
-        sql = this.genericDataService.wrapSQL(sql);
 
-        return sql;
+        // Step 2 — replace SQL function aliases with tenant-aware equivalents (case-insensitive, literal match)
+        sql = Pattern.compile(Pattern.quote("NOW()"), Pattern.CASE_INSENSITIVE).matcher(sql)
+                .replaceAll(Matcher.quoteReplacement(sqlGenerator.currentTenantDateTime()));
+        sql = Pattern.compile(Pattern.quote("curdate()"), Pattern.CASE_INSENSITIVE).matcher(sql)
+                .replaceAll(Matcher.quoteReplacement(sqlGenerator.currentBusinessDate()));
+        sql = Pattern.compile(Pattern.quote("CURRENT_DATE"), Pattern.CASE_INSENSITIVE).matcher(sql)
+                .replaceAll(Matcher.quoteReplacement(sqlGenerator.currentBusinessDate()));
+
+        // Step 2.5a — resolve display-literal placeholders: '${param}' AS alias
+        // These are not filter values so direct substitution is safe.
+        for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+            if (entry.getKey().startsWith("${")) {
+                String paramName = entry.getKey().substring(2, entry.getKey().length() - 1);
+                // Replace display-literal pattern: '${param}' followed by AS
+                sql = sql.replaceAll("'" + Pattern.quote("${" + paramName + "}") + "'(\\s+AS\\s+)",
+                        "'" + Matcher.quoteReplacement(entry.getValue()) + "'$1");
+            }
+        }
+
+        // Step 2.5b — strip remaining quotes around filter placeholders
+        sql = sql.replaceAll("'(\\$\\{\\w+})'", "$1");
+        sql = sql.replaceAll("\"(\\$\\{\\w+})\"", "$1");
+        sql = sql.replaceAll("\"(-?\\d+)\"", "$1");
+
+        // Step 3 — single left-to-right regex pass: convert remaining ${param} tokens to ? bind variables.
+        // Values are appended to paramValues in the same left-to-right order so JDBC positional binding is correct.
+        // Repeated occurrences of the same parameter are each replaced and each value appended separately.
+        final List<Object> paramValues = new ArrayList<>();
+        final Matcher matcher = PLACEHOLDER_PATTERN.matcher(sql);
+        final StringBuilder preparedSql = new StringBuilder();
+
+        while (matcher.find()) {
+            final String paramName = matcher.group(1);
+            if (SERVER_PARAMS.contains(paramName)) {
+                // should already be resolved in step 1; leave as-is if somehow still present
+                matcher.appendReplacement(preparedSql, Matcher.quoteReplacement(matcher.group(0)));
+            } else {
+                // queryParams keys are stored as "${paramName}" by getReportParams — match accordingly
+                final String mapKey = "${" + paramName + "}";
+                if (queryParams.containsKey(mapKey)) {
+                    matcher.appendReplacement(preparedSql, "?");
+                    String value = queryParams.get(mapKey);
+                    String formatType = paramFormatTypes.get(paramName);
+                    paramValues.add(castParamValue(value, formatType));
+                } else {
+                    // unknown placeholder — leave as-is so the query fails explicitly rather than silently
+                    matcher.appendReplacement(preparedSql, Matcher.quoteReplacement(matcher.group(0)));
+                    log.warn("Report '{}' contains placeholder '{}' with no matching query parameter", name, paramName);
+                }
+            }
+        }
+        matcher.appendTail(preparedSql);
+
+        final String wrappedSql = this.genericDataService.wrapSQL(preparedSql.toString());
+
+        if (log.isDebugEnabled()) {
+            log.debug("Report '{}' prepared SQL:  {}", name, wrappedSql);
+            log.debug("Report '{}' bind params ({} total): {}", name, paramValues.size(), paramValues);
+        }
+
+        return new PreparedQuery(wrappedSql, paramValues);
     }
 
     private String getSql(final String name, final String type) {
@@ -475,25 +581,41 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         final long startTime = System.currentTimeMillis();
         log.debug("STARTING REPORT: {}   Type: {}", name, type);
 
-        final String sql = sqlToRunForSmsEmailCampaign(name, type, queryParams);
+        final PreparedQuery preparedQuery = sqlToRunForSmsEmailCampaign(name, type, queryParams);
 
-        final GenericResultsetData result = this.genericDataService.fillGenericResultSet(sql);
+        final GenericResultsetData result = this.genericDataService.fillGenericResultSet(preparedQuery.sql(),
+                preparedQuery.params().toArray());
 
         final long elapsed = System.currentTimeMillis() - startTime;
         log.debug("FINISHING Report/Request Name: {} - {}     Elapsed Time: {}", name, type, elapsed);
         return result;
     }
 
-    private String sqlToRunForSmsEmailCampaign(final String name, final String type, final Map<String, String> queryParams) {
+    /**
+     * Builds a {@link PreparedQuery} for SMS/email campaign reports. Security context is not available in this path
+     * (called from background jobs), so server-controlled placeholders are not resolved here. User-supplied parameters
+     * are bound as {@code ?} variables — never concatenated into the SQL string.
+     */
+    private PreparedQuery sqlToRunForSmsEmailCampaign(final String name, final String type, final Map<String, String> queryParams) {
         String sql = getSql(name, type);
 
-        for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-            sql = this.genericDataService.replace(sql, "${" + entry.getKey() + "}", entry.getValue());
+        final List<Object> paramValues = new ArrayList<>();
+        final Matcher matcher = PLACEHOLDER_PATTERN.matcher(sql);
+        final StringBuilder preparedSql = new StringBuilder();
+
+        while (matcher.find()) {
+            final String paramName = matcher.group(1);
+            if (queryParams.containsKey(paramName)) {
+                matcher.appendReplacement(preparedSql, "?");
+                paramValues.add(queryParams.get(paramName));
+            } else {
+                matcher.appendReplacement(preparedSql, Matcher.quoteReplacement(matcher.group(0)));
+                log.warn("SMS/email campaign report '{}' contains placeholder '{}' with no matching parameter", name, paramName);
+            }
         }
+        matcher.appendTail(preparedSql);
 
-        sql = this.genericDataService.wrapSQL(sql);
-
-        return sql;
+        return new PreparedQuery(this.genericDataService.wrapSQL(preparedSql.toString()), paramValues);
     }
 
     @Override

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessServiceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/DatatableReportingProcessServiceTest.java
@@ -30,12 +30,15 @@ import java.util.List;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.dataqueries.service.export.DatatableReportExportService;
 import org.apache.fineract.infrastructure.dataqueries.service.export.ResponseHolder;
+import org.apache.fineract.infrastructure.report.service.ReportParameterTypeResolver;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class DatatableReportingProcessServiceTest {
+
+    private final ReportParameterTypeResolver reportParameterTypeResolver = Mockito.mock(ReportParameterTypeResolver.class);
 
     @Test
     void exportToS3ThrowsGeneralPlatformDomainRuleException() {
@@ -45,7 +48,7 @@ class DatatableReportingProcessServiceTest {
         SqlValidator sqlValidator = Mockito.mock(SqlValidator.class);
 
         DatatableReportingProcessService datatableReportingProcessService = new DatatableReportingProcessService(List.of(jsonExportService),
-                sqlValidator);
+                sqlValidator, reportParameterTypeResolver);
 
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.put("R_officeId", List.of("2"));
@@ -72,7 +75,7 @@ class DatatableReportingProcessServiceTest {
         SqlValidator sqlValidator = Mockito.mock(SqlValidator.class);
 
         DatatableReportingProcessService datatableReportingProcessService = new DatatableReportingProcessService(List.of(jsonExportService),
-                sqlValidator);
+                sqlValidator, reportParameterTypeResolver);
 
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.put("R_officeId", List.of("2"));

--- a/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/AbstractReportingProcessService.java
+++ b/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/AbstractReportingProcessService.java
@@ -22,27 +22,73 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.security.exception.SqlValidationException;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
 
+@Slf4j
 public abstract class AbstractReportingProcessService implements ReportingProcessService {
 
-    private final SqlValidator sqlValidator;
+    private static final String NUMERIC_FORMAT_TYPE = "number";
+    private static final String DATE_FORMAT_TYPE = "date";
+    private static final String NUMERIC_LITERAL_PATTERN = "^-?\\d+(\\.\\d+)?$";
+    private static final String DATE_LITERAL_PATTERN = "^\\d{4}-\\d{2}-\\d{2}$";
 
-    protected AbstractReportingProcessService(SqlValidator sqlValidator) {
+    private final SqlValidator sqlValidator;
+    private final ReportParameterTypeResolver reportParameterTypeResolver;
+
+    protected AbstractReportingProcessService(SqlValidator sqlValidator, ReportParameterTypeResolver reportParameterTypeResolver) {
         this.sqlValidator = sqlValidator;
+        this.reportParameterTypeResolver = reportParameterTypeResolver;
     }
 
     @Override
-    public Map<String, String> getReportParams(final MultivaluedMap<String, String> queryParams) {
+    public Map<String, String> getReportParams(final String reportName, final MultivaluedMap<String, String> queryParams) {
+        final Map<String, String> paramFormatTypes = this.reportParameterTypeResolver.loadParamFormatTypes(reportName);
+        final boolean hasRegisteredParams = !paramFormatTypes.isEmpty();
         final Map<String, String> reportParams = new HashMap<>();
+
         for (Map.Entry<String, List<String>> entry : queryParams.entrySet()) {
             if (entry.getKey().startsWith("R_")) {
-                String pKey = "${" + entry.getKey().substring(2) + "}";
+                String paramVariable = entry.getKey().substring(2);
+                String pKey = "${" + paramVariable + "}";
                 String pValue = entry.getValue().get(0);
+
+                if (hasRegisteredParams) {
+                    String formatType = paramFormatTypes.get(paramVariable);
+                    if (formatType == null) {
+                        log.warn("Report '{}' received unknown parameter '{}' with no registered type — rejected", reportName,
+                                paramVariable);
+                        throw new SqlValidationException(String.format("unknown report parameter '%s' is not registered for report '%s'",
+                                paramVariable, reportName));
+                    }
+
+                    validateParamByType(paramVariable, pValue, formatType);
+                }
+
+                // backstop: SqlValidator catches any remaining keyword-based patterns (UNION ALL, etc.)
                 sqlValidator.validate(pValue);
+
                 reportParams.put(pKey, pValue);
             }
         }
         return reportParams;
+    }
+
+    private void validateParamByType(final String paramName, final String value, final String formatType) {
+        if (NUMERIC_FORMAT_TYPE.equalsIgnoreCase(formatType)) {
+            if (!value.matches(NUMERIC_LITERAL_PATTERN)) {
+                log.warn("Numeric parameter '{}' failed literal validation: '{}'", paramName, value);
+                throw new SqlValidationException(
+                        String.format("parameter '%s' must be a numeric literal but received: '%s'", paramName, value));
+            }
+        } else if (DATE_FORMAT_TYPE.equalsIgnoreCase(formatType)) {
+            if (!value.matches(DATE_LITERAL_PATTERN)) {
+                log.warn("Date parameter '{}' failed literal validation: '{}'", paramName, value);
+                throw new SqlValidationException(
+                        String.format("parameter '%s' must be a date literal (yyyy-MM-dd) but received: '%s'", paramName, value));
+            }
+        }
+        // string type: no literal constraint — falls through to SqlValidator backstop
     }
 }

--- a/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/ReportParameterTypeResolver.java
+++ b/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/ReportParameterTypeResolver.java
@@ -18,17 +18,9 @@
  */
 package org.apache.fineract.infrastructure.report.service;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
-import java.util.List;
 import java.util.Map;
-import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 
-public interface ReportingProcessService {
+public interface ReportParameterTypeResolver {
 
-    Response processRequest(String reportName, MultivaluedMap<String, String> queryParams);
-
-    List<ReportExportType> getAvailableExportTargets();
-
-    Map<String, String> getReportParams(String reportName, MultivaluedMap<String, String> queryParams);
+    Map<String, String> loadParamFormatTypes(String reportName);
 }

--- a/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/ReportParameterTypeResolverImpl.java
+++ b/fineract-report/src/main/java/org/apache/fineract/infrastructure/report/service/ReportParameterTypeResolverImpl.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.stereotype.Service;
+
+@Service
+public final class ReportParameterTypeResolverImpl implements ReportParameterTypeResolver {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final String PARAM_TYPE_SQL_PREFIX = "SELECT sp.parameter_variable, sp.";
+    private static final String PARAM_TYPE_SQL_SUFFIX = """
+             AS format_type
+            FROM stretchy_report_parameter srp
+            JOIN stretchy_parameter sp ON sp.id = srp.parameter_id
+            WHERE srp.report_id = (SELECT id FROM stretchy_report WHERE report_name = ?)
+            """;
+
+    private volatile String databaseProductName;
+
+    public ReportParameterTypeResolverImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private String getDatabaseProductName() {
+        if (databaseProductName == null) {
+            synchronized (this) {
+                if (databaseProductName == null) {
+                    try (var connection = jdbcTemplate.getDataSource().getConnection()) {
+                        databaseProductName = connection.getMetaData().getDatabaseProductName().toLowerCase();
+                    } catch (SQLException e) {
+                        throw new RuntimeException("Failed to detect database product name", e);
+                    }
+                }
+            }
+        }
+        return databaseProductName;
+    }
+
+    private String getQuotedColumnName(String columnName) {
+        if (getDatabaseProductName().contains("postgresql")) {
+            return "\"" + columnName + "\"";
+        } else {
+            return columnName;
+        }
+    }
+
+    @Override
+    public Map<String, String> loadParamFormatTypes(String reportName) {
+        final Map<String, String> formatTypes = new HashMap<>();
+        final String quotedColumnName = getQuotedColumnName("parameter_FormatType");
+        final String PARAM_TYPE_SQL = PARAM_TYPE_SQL_PREFIX + quotedColumnName + PARAM_TYPE_SQL_SUFFIX;
+        final SqlRowSet rs = jdbcTemplate.queryForRowSet(PARAM_TYPE_SQL, reportName);
+        while (rs.next()) {
+            formatTypes.put(rs.getString("parameter_variable"), rs.getString("format_type"));
+        }
+        return formatTypes;
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportsTest.java
@@ -27,11 +27,14 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
 import org.apache.fineract.client.models.RunReportsResponse;
+import org.apache.fineract.client.services.RunReportsApi;
 import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import retrofit2.Response;
 
 /**
@@ -119,5 +122,57 @@ public class ReportsTest extends IntegrationTest {
         Response<RunReportsResponse> response = okR(
                 fineractClient().reportsRun.runReportGetData("Balance Sheet Table", Map.of("R_endDate", "2013-04-30", "R_officeId", "1")));
         assertEquals(200, response.code());
+    }
+
+    // --- SQL injection regression tests (CVE fix) ---
+    // These tests use "Client Listing" because officeId is registered in stretchy_parameter
+    // as type 'number', giving the type-validation layer a real fixture to work against.
+
+    /**
+     * A valid numeric literal for a number-typed parameter must be accepted (200). This is the non-regression
+     * counterpart to the injection tests below — it confirms the fix does not break the happy path.
+     */
+    @Test
+    void numericParamWithValidLiteralIsAccepted() {
+        Response<RunReportsResponse> response = okR(
+                fineractClient().reportsRun.runReportGetData("Client Listing", Map.of("R_officeId", "1")));
+        assertEquals(200, response.code());
+    }
+
+    /**
+     * A number-typed parameter containing an arithmetic expression used in the reported time-based blind SQL injection
+     * (e.g. {@code 1-SLEEP(5)}) must be rejected with 403 before reaching SQL execution. Prepared statements would
+     * neutralise it at the driver level, but type-literal validation must reject it earlier.
+     */
+    @ParameterizedTest(name = "Arithmetic injection in number param rejected: {0}")
+    @ValueSource(strings = { "1-SLEEP(5)", "1*SLEEP(5)", "1+SLEEP(5)", "0-pg_sleep(5)", "1-benchmark(1000000,MD5(1))" })
+    void numericParamWithArithmeticExpressionIsRejected(String maliciousValue) throws IOException {
+        Response<RunReportsResponse> response = fineractClient().createService(RunReportsApi.class)
+                .runReportGetData("Client Listing", Map.of("R_officeId", maliciousValue)).execute();
+        assertThat(response.code()).isEqualTo(403);
+    }
+
+    /**
+     * A UNION-based injection payload in a number-typed parameter must be rejected with 403. This covers the second
+     * reported vulnerability pattern.
+     */
+    @ParameterizedTest(name = "UNION injection in number param rejected: {0}")
+    @ValueSource(strings = { "1 UNION ALL SELECT 1,2,3", "1 UNION SELECT username,password FROM m_appuser",
+            "0 UNION ALL SELECT NULL,NULL" })
+    void numericParamWithUnionInjectionIsRejected(String maliciousValue) throws IOException {
+        Response<RunReportsResponse> response = fineractClient().createService(RunReportsApi.class)
+                .runReportGetData("Client Listing", Map.of("R_officeId", maliciousValue)).execute();
+        assertThat(response.code()).isEqualTo(403);
+    }
+
+    /**
+     * A parameter name not registered in stretchy_parameter for the given report must be rejected with 403. Allowing
+     * unknown parameters would silently pass unvalidated input into the SQL template.
+     */
+    @Test
+    void unknownParamNotRegisteredForReportIsRejected() throws IOException {
+        Response<RunReportsResponse> response = fineractClient().createService(RunReportsApi.class)
+                .runReportGetData("Client Listing", Map.of("R_officeId", "1", "R_unregisteredParamXyz", "anything")).execute();
+        assertThat(response.code()).isEqualTo(403);
     }
 }


### PR DESCRIPTION
## Description

These changes use prepared statements for stretchy reports and sanitise input to the runreports endpoint. The sanitisation uses the format type of each report parameter and only allows e.g numeric input for a numeric parameter. Similarly for date and string parameters, the input is sanitised to only allow the corresponding type of input. The change helps reporting to check for valid and invalid inputs including non-numeric input to numeric parameters, attempts to inject SQL like SLEEP and UNION ALL through input parameters. Integration tests are added to ensure the reports work for valid input and reject invalid input.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
