### PR TITLE
FINERACT-2515: Remove obsolete IDE-generated TODO comments

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/calendar/service/CalendarUtils.java
@@ -222,10 +222,8 @@ public final class CalendarUtils {
 
             return rrule.getRecur();
         } catch (final ParseException e) {
-            // TODO Auto-generated catch block
             log.error("Problem occurred in getICalRecur function", e);
         } catch (final ValidationException e) {
-            // TODO Auto-generated catch block
             log.error("Problem occurred in getICalRecur function", e);
         }
 

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/group/domain/GroupRole.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/group/domain/GroupRole.java
@@ -48,7 +48,7 @@ public class GroupRole extends AbstractPersistableCustom<Long> {
     private CodeValue role;
 
     public GroupRole() {
-        // TODO Auto-generated constructor stub
+
     }
 
     public static final GroupRole createGroupRole(final Group group, final Client client, final CodeValue role) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesPropertiesReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesPropertiesReadPlatformServiceImpl.java
@@ -158,7 +158,6 @@ public class ExternalServicesPropertiesReadPlatformServiceImpl implements Extern
 
     @Override
     public SMTPCredentialsData getSMTPCredentials() {
-        // TODO Auto-generated method stub
         final ResultSetExtractor<SMTPCredentialsData> resultSetExtractor = new SMTPCredentialsDataExtractor();
         final String sql = "SELECT esp.name, esp.value FROM c_external_service_properties esp inner join c_external_service es on esp.external_service_id = es.id where es.name = '"
                 + ExternalServicesConstants.SMTP_SERVICE_NAME + "'";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/exception/InvalidClientStateTransitionException.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/exception/InvalidClientStateTransitionException.java
@@ -29,7 +29,6 @@ public class InvalidClientStateTransitionException extends AbstractPlatformDomai
     public InvalidClientStateTransitionException(final String action, final String postFix, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
         super("error.msg.client." + action + "." + postFix, defaultUserMessage, defaultUserMessageArgs);
-        // TODO Auto-generated constructor stub
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientFamilyMembersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientFamilyMembersWritePlatformServiceImpl.java
@@ -224,7 +224,6 @@ public class ClientFamilyMembersWritePlatformServiceImpl implements ClientFamily
                     date = LocalDate.parse(member.get("dateOfBirth").getAsString(), formatter);
                     dateOfBirth = date;
                 } catch (DateTimeParseException e) {
-                    // TODO Auto-generated catch block
                     LOG.error("Problem occurred in addClientFamilyMember function", e);
                 }
 


### PR DESCRIPTION
## Description

Removes auto-generated TODO stub comments left behind by IDEs across multiple modules. These comments were inserted automatically during code generation and add no value — the implementations they reference are already complete.

### Changes 

- **CalendarUtils.java** — Removed `// TODO Auto-generated catch block` from two catch blocks. Both blocks already have proper error logging via `log.error()`.

- **GroupRole.java** — Removed `// TODO Auto-generated constructor stub` from the no-arg constructor. The constructor body is intentionally empty as required by JPA.

- **ExternalServicesPropertiesReadPlatformServiceImpl.java** — Removed `// TODO Auto-generated method stub` from `getSMTPCredentials()`. The method is fully implemented.

- **InvalidClientStateTransitionException.java** — Removed `// TODO Auto-generated constructor stub`. The constructor delegates correctly to `super()` and is complete.

- **ClientFamilyMembersWritePlatformServiceImpl.java** — Removed `// TODO Auto-generated catch block` from a catch block that already logs the exception properly.

No logic has been added, removed, or modified. This is a cleanup-only change.
