### PR TITLE
FINERACT-2298: Move standing instruction history read security to Sec…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/SecurityConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/SecurityConfig.java
@@ -413,6 +413,9 @@ public class SecurityConfig {
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.DELETE, "/api/*/loan-collateral-management/*"))
                     .hasAnyAuthority(ALL_FUNCTIONS, ALL_FUNCTIONS_WRITE, "DELETE_LOAN_COLLATERAL_PRODUCT")
 
+                    .requestMatchers(API_MATCHER.matcher(HttpMethod.GET, "/api/*/standinginstructionrunhistory"))
+                    .hasAnyAuthority(ALL_FUNCTIONS, ALL_FUNCTIONS_READ, "READ_STANDINGINSTRUCTION")
+
                     .requestMatchers(API_MATCHER.matcher(HttpMethod.POST, "/api/*/twofactor/validate")).fullyAuthenticated()
                     .requestMatchers(API_MATCHER.matcher("/api/*/twofactor")).fullyAuthenticated()
                     .requestMatchers(API_MATCHER.matcher("/api/**"))

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionHistoryApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionHistoryApiResource.java
@@ -36,25 +36,23 @@ import org.apache.fineract.infrastructure.core.api.DateParam;
 import org.apache.fineract.infrastructure.core.data.DateFormat;
 import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.infrastructure.core.service.SearchParameters;
-import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
 import org.apache.fineract.portfolio.account.data.StandingInstructionDTO;
 import org.apache.fineract.portfolio.account.data.StandingInstructionHistoryData;
-import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadPlatformService;
+import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadService;
 import org.springframework.stereotype.Component;
 
 @Path("/v1/standinginstructionrunhistory")
 @Component
+@Produces({ MediaType.APPLICATION_JSON })
 @Tag(name = "Standing Instructions History", description = "The list capability of history can support pagination and sorting.")
 @RequiredArgsConstructor
 public class StandingInstructionHistoryApiResource {
 
-    private final PlatformSecurityContext context;
-    private final StandingInstructionHistoryReadPlatformService standingInstructionHistoryReadPlatformService;
+    private final StandingInstructionHistoryReadService standingInstructionHistoryReadService;
     private final SqlValidator sqlValidator;
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Standing Instructions Logged History", operationId = "retrieveAllStandingInstructionHistory", description = "The list capability of history can support pagination and sorting \n\n"
             + "Example Requests :\n" + "\n" + "standinginstructionrunhistory\n" + "\n"
             + "standinginstructionrunhistory?orderBy=name&sortOrder=DESC\n" + "\n" + "standinginstructionrunhistory?offset=10&limit=50")
@@ -75,8 +73,6 @@ public class StandingInstructionHistoryApiResource {
             @QueryParam("fromDate") @Parameter(description = "fromDate") final DateParam fromDateParam,
             @QueryParam("toDate") @Parameter(description = "toDate") final DateParam toDateParam) {
 
-        this.context.authenticatedUser().validateHasReadPermission(StandingInstructionApiConstants.STANDING_INSTRUCTION_RESOURCE_NAME);
-
         final DateFormat dateFormat = StringUtils.isBlank(rawDateFormat) ? null : new DateFormat(rawDateFormat);
 
         sqlValidator.validate(orderBy);
@@ -96,6 +92,6 @@ public class StandingInstructionHistoryApiResource {
         StandingInstructionDTO standingInstructionDTO = new StandingInstructionDTO(searchParameters, transferType, clientName, clientId,
                 fromAccount, fromAccountType, startDateRange, endDateRange);
 
-        return standingInstructionHistoryReadPlatformService.retrieveAll(standingInstructionDTO);
+        return standingInstructionHistoryReadService.retrieveAll(standingInstructionDTO);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionHistoryReadService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionHistoryReadService.java
@@ -22,7 +22,7 @@ import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.portfolio.account.data.StandingInstructionDTO;
 import org.apache.fineract.portfolio.account.data.StandingInstructionHistoryData;
 
-public interface StandingInstructionHistoryReadPlatformService {
+public interface StandingInstructionHistoryReadService {
 
     Page<StandingInstructionHistoryData> retrieveAll(StandingInstructionDTO standingInstructionDTO);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionHistoryReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionHistoryReadServiceImpl.java
@@ -43,7 +43,7 @@ import org.apache.fineract.portfolio.client.data.ClientData;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
-public class StandingInstructionHistoryReadPlatformServiceImpl implements StandingInstructionHistoryReadPlatformService {
+public class StandingInstructionHistoryReadServiceImpl implements StandingInstructionHistoryReadService {
 
     private final JdbcTemplate jdbcTemplate;
     private final DatabaseSpecificSQLGenerator sqlGenerator;
@@ -55,7 +55,7 @@ public class StandingInstructionHistoryReadPlatformServiceImpl implements Standi
     // pagination
     private final PaginationHelper paginationHelper;
 
-    public StandingInstructionHistoryReadPlatformServiceImpl(final JdbcTemplate jdbcTemplate, final ColumnValidator columnValidator,
+    public StandingInstructionHistoryReadServiceImpl(final JdbcTemplate jdbcTemplate, final ColumnValidator columnValidator,
             DatabaseSpecificSQLGenerator sqlGenerator, PaginationHelper paginationHelper) {
         this.jdbcTemplate = jdbcTemplate;
         this.sqlGenerator = sqlGenerator;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/starter/AccountConfiguration.java
@@ -42,8 +42,8 @@ import org.apache.fineract.portfolio.account.service.AccountTransfersWritePlatfo
 import org.apache.fineract.portfolio.account.service.AccountTransfersWritePlatformServiceImpl;
 import org.apache.fineract.portfolio.account.service.PortfolioAccountReadPlatformService;
 import org.apache.fineract.portfolio.account.service.PortfolioAccountReadPlatformServiceImpl;
-import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadPlatformService;
-import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadPlatformServiceImpl;
+import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadService;
+import org.apache.fineract.portfolio.account.service.StandingInstructionHistoryReadServiceImpl;
 import org.apache.fineract.portfolio.account.service.StandingInstructionReadPlatformService;
 import org.apache.fineract.portfolio.account.service.StandingInstructionReadPlatformServiceImpl;
 import org.apache.fineract.portfolio.account.service.StandingInstructionWritePlatformService;
@@ -107,10 +107,10 @@ public class AccountConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(StandingInstructionHistoryReadPlatformService.class)
-    public StandingInstructionHistoryReadPlatformService standingInstructionHistoryReadPlatformService(JdbcTemplate jdbcTemplate,
+    @ConditionalOnMissingBean(StandingInstructionHistoryReadService.class)
+    public StandingInstructionHistoryReadService standingInstructionHistoryReadService(JdbcTemplate jdbcTemplate,
             ColumnValidator columnValidator, DatabaseSpecificSQLGenerator sqlGenerator, PaginationHelper paginationHelper) {
-        return new StandingInstructionHistoryReadPlatformServiceImpl(jdbcTemplate, columnValidator, sqlGenerator, paginationHelper);
+        return new StandingInstructionHistoryReadServiceImpl(jdbcTemplate, columnValidator, sqlGenerator, paginationHelper);
     }
 
     @Bean


### PR DESCRIPTION
## Description

  JIRA: https://issues.apache.org/jira/browse/FINERACT-2298

  Aligns the Standing Instruction History read endpoint with the new
  command-processing conventions:

  - Moves authorization for ⁠ GET /standinginstructionrunhistory ⁠ out of the
    resource's programmatic ⁠ validateHasReadPermission ⁠ check and into
    ⁠ SecurityConfig ⁠ (⁠ READ_STANDINGINSTRUCTION ⁠); the resulting authority set
    is identical, so existing roles are unaffected.
  - Renames ⁠ StandingInstructionHistoryReadPlatformService ⁠ /
    ⁠ ...Impl ⁠ to ⁠ StandingInstructionHistoryReadService ⁠ / ⁠ ...Impl ⁠ to match the
    ⁠ *ReadService ⁠ naming used elsewhere, and updates the bean wiring in
    ⁠ AccountConfiguration ⁠ and the API resource accordingly.
  - Drops the now-unused ⁠ PlatformSecurityContext ⁠ dependency from the resource
    and hoists ⁠ @Produces(APPLICATION_JSON) ⁠ to the class level.

  No behavior change to the endpoint response or query logic.