### PR TITLE
FINERACT-2421: Transaction summary report fix due duplicates

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/Reporting.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/Reporting.feature
@@ -183,8 +183,8 @@ Feature: Reporting
     And Admin creates a new office
     And Admin creates a client with random data in the last created office
     And Admin creates a fully customized loan with the following data:
-      | LoanProduct                                                                                | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
-      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | 01 February 2026      | 100         | 7                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                | MONTHS                  | 1             | MONTHS                   | 6                 | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+      | LoanProduct                                              | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | 01 February 2026  | 100            | 7                      | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
     And Admin successfully approves the loan on "01 February 2026" with "100" amount and expected disbursement date on "01 February 2026"
     And Admin successfully disburse the loan on "01 February 2026" with "100" EUR transaction amount
     And Admin adds buy down fee with "AUTOPAY" payment type to the loan on "01 February 2026" with "50" EUR transaction amount
@@ -288,3 +288,165 @@ Feature: Reporting
     Then Transaction Summary Report with Asset Owner for date "01 January 2025" column "Originator_External_Ids" has non-empty value for all rows
     And Transaction Summary Report with Asset Owner for date "01 January 2025" column "From_asset_owner_id" has empty value for all rows
     And Transaction Summary Report with Asset Owner for date "01 January 2025" column "Asset_owner_id" has empty value for all rows
+
+  @TestRailId:C83086
+  Scenario: Verify Transaction Summary Report with Asset Owner - UC01: Buydown fee amortization with multiple buydown fees should not duplicate
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a new office
+    And Admin creates a client with random data in the last created office
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                                              | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | 01 January 2026   | 100            | 12                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 100               | DAYS                  | 25             | DAYS                   | 4                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "01 January 2026" with "100" amount and expected disbursement date on "01 January 2026"
+    And Admin successfully disburse the loan on "01 January 2026" with "100" EUR transaction amount
+    And Admin sets the business date to "02 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds buy down fee with "AUTOPAY" payment type to the loan on "02 January 2026" with "50" EUR transaction amount
+    And Admin sets the business date to "03 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds buy down fee with "AUTOPAY" payment type to the loan on "03 January 2026" with "25" EUR transaction amount
+    And Admin sets the business date to "04 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin sets the business date to "05 January 2026"
+    And Admin runs inline COB job for Loan
+    Then Transaction Summary Report with Asset Owner for date "02 January 2026" has the following data:
+      | TransactionDate | Product                                                  | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.03               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Interest                 |                      | 50.0               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.51               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "03 January 2026" has the following data:
+      | TransactionDate | Product                                                  | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.04               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Interest                 |                      | 25.0               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.76               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "04 January 2026" has the following data:
+      | TransactionDate | Product                                                  | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.03               |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.76               |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+
+  @TestRailId:C83087
+  Scenario: Verify Transaction Summary Report with Asset Owner - UC02: Buydown fee amortization with FEE_INCOME allocation type should not duplicate
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a new office
+    And Admin creates a client with random data in the last created office
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                                                         | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | 01 January 2026   | 100            | 12                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 100               | DAYS                  | 25             | DAYS                   | 4                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "01 January 2026" with "100" amount and expected disbursement date on "01 January 2026"
+    And Admin successfully disburse the loan on "01 January 2026" with "100" EUR transaction amount
+    And Admin sets the business date to "02 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds buy down fee with "AUTOPAY" payment type to the loan on "02 January 2026" with "50" EUR transaction amount
+    And Admin sets the business date to "03 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds buy down fee with "AUTOPAY" payment type to the loan on "03 January 2026" with "25" EUR transaction amount
+    And Admin sets the business date to "04 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin sets the business date to "05 January 2026"
+    And Admin runs inline COB job for Loan
+    Then Transaction Summary Report with Asset Owner for date "02 January 2026" has the following data:
+      | TransactionDate | Product                                                             | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.03               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Fees                     |                      | 50.0               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.51               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "03 January 2026" has the following data:
+      | TransactionDate | Product                                                             | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.04               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Fees                     |                      | 25.0               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.76               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "04 January 2026" has the following data:
+      | TransactionDate | Product                                                             | TransactionType_Name      | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Apply Charges             |                  |            | 0        | Interest                 |                      | 0.03               |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Fees                     |                      | 0.76               |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_BUYDOWN_FEES_FEE_INCOME | Buy Down Fee Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+
+  @TestRailId:C83088
+  Scenario: Verify Transaction Summary Report with Asset Owner - UC03: Capitalized income amortization with multiple capitalized income transactions should not duplicate
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a new office
+    And Admin creates a client with random data in the last created office
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct                                                    | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | 01 January 2026   | 100            | 0                      | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 100               | DAYS                  | 25             | DAYS                   | 4                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "01 January 2026" with "100" amount and expected disbursement date on "01 January 2026"
+    And Admin successfully disburse the loan on "01 January 2026" with "25" EUR transaction amount
+    And Admin sets the business date to "02 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds capitalized income with "AUTOPAY" payment type to the loan on "02 January 2026" with "50" EUR transaction amount
+    And Admin sets the business date to "03 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin adds capitalized income with "AUTOPAY" payment type to the loan on "03 January 2026" with "25" EUR transaction amount
+    And Admin sets the business date to "04 January 2026"
+    And Admin runs inline COB job for Loan
+    And Admin sets the business date to "05 January 2026"
+    And Admin runs inline COB job for Loan
+    Then Transaction Summary Report with Asset Owner for date "02 January 2026" has the following data:
+      | TransactionDate | Product                                                        | TransactionType_Name            | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Principal                |                      | 50.0               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Interest                 |                      | 0.51               |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-02      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "03 January 2026" has the following data:
+      | TransactionDate | Product                                                        | TransactionType_Name            | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Interest                 |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Principal                |                      | 25.0               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income              | AUTOPAY          |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Interest                 |                      | 0.76               |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-03      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |
+    Then Transaction Summary Report with Asset Owner for date "04 January 2026" has the following data:
+      | TransactionDate | Product                                                        | TransactionType_Name            | PaymentType_Name | chargetype | Reversed | Allocation_Type          | Chargeoff_ReasonCode | Transaction_Amount |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Fees                     |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Interest                 |                      | 0.76               |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Penalty                  |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Principal                |                      | 0.0                |
+      | 2026-01-04      | LP2_PROGRESSIVE_ADVANCED_PAYMENT_ALLOCATION_CAPITALIZED_INCOME | Capitalized Income Amortization |                  |            | 0        | Unallocated Credit (UNC) |                      | 0.0                |

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -254,4 +254,5 @@
     <include file="parts/0233_backfill_repayment_start_date_type_on_loan.xml" relativeToChangelogFile="true" />
     <include file="parts/0234_add_missing_processing_result_enum_values.xml" relativeToChangelogFile="true" />
     <include file="parts/0235_transaction_summary_reports_buydown_fee_allocation.xml" relativeToChangelogFile="true" />
+    <include file="parts/0236_transaction_summary_reports_fix_for_cap_income_amortization_duplicates.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0236_transaction_summary_reports_fix_for_cap_income_amortization_duplicates.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0236_transaction_summary_reports_fix_for_cap_income_amortization_duplicates.xml
@@ -1,0 +1,2710 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="0236-fix-cap-income-amortization-duplicates" context="postgresql">
+        <update tableName="stretchy_report">
+            <column name="report_sql"><![CDATA[
+WITH loan_originators AS (SELECT mlom.loan_id,
+             STRING_AGG(DISTINCT mlo.external_id, ', ' ORDER BY mlo.external_id) AS originator_external_ids
+      FROM m_loan_originator_mapping mlom
+               JOIN m_loan_originator mlo ON mlo.id = mlom.originator_id
+      GROUP BY mlom.loan_id),
+     slt_except_charge_adj_and_accrual AS (SELECT '${endDate}' AS transactiondate,
+          t.id,
+          l.name,
+          d.payment_type_id,
+          CASE
+              WHEN d.payment_type_id IS NULL AND t.classification_cv_id IS NOT NULL
+                  THEN (SELECT code_value FROM m_code_value WHERE id = t.classification_cv_id)
+              ELSE NULL END AS classification_name,
+          t.transaction_type_enum,
+          t.amount,
+          t.overpayment_portion_derived,
+          t.principal_portion_derived,
+          t.interest_portion_derived,
+          t.fee_charges_portion_derived,
+          t.penalty_charges_portion_derived,
+          e.status,
+          e.settlement_date,
+          e.owner_id,
+          m.charged_off_on_date,
+          t.transaction_date,
+          m.charge_off_reason_cv_id,
+          lo.originator_external_ids
+   FROM m_loan_transaction t
+            JOIN m_loan m ON m.id = t.loan_id
+            JOIN m_product_loan l ON l.id = m.product_id
+            LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+            LEFT JOIN m_external_asset_owner_transfer e
+                      ON e.loan_id = t.loan_id AND
+     e.settlement_date < '${endDate}' AND
+     e.effective_date_to >= '${endDate}'
+            LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+   WHERE t.submitted_on_date = '${endDate}'
+     AND t.transaction_type_enum not in (10, 26, 32, 34, 36, 39, 42, 43)
+     AND (t.office_id = ${officeId})),
+     slt_charge_adj AS (SELECT '${endDate}' AS transactiondate,
+           t.id,
+           l.name,
+           t.transaction_type_enum,
+           d.payment_type_id,
+           t.overpayment_portion_derived,
+           t.principal_portion_derived,
+           t.interest_portion_derived,
+           t.fee_charges_portion_derived,
+           t.penalty_charges_portion_derived,
+           t.amount,
+           e.status,
+           e.settlement_date,
+           e.owner_id,
+           m.charged_off_on_date,
+           t.transaction_date,
+           m.charge_off_reason_cv_id,
+           lo.originator_external_ids
+    FROM m_loan_transaction t
+             JOIN m_loan m ON m.id = t.loan_id
+             JOIN m_product_loan l ON l.id = m.product_id
+             LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+             LEFT JOIN m_external_asset_owner_transfer e
+   ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+      e.effective_date_to >= '${endDate}'
+             LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+    WHERE t.submitted_on_date = '${endDate}'
+      AND t.transaction_type_enum = 26
+      AND (t.office_id = ${officeId})),
+     rlt_except_charge_adj_and_accrual AS (SELECT '${endDate}' AS transactiondate,
+          t.id,
+          l.name,
+          t.transaction_type_enum,
+          d.payment_type_id,
+          CASE
+              WHEN d.payment_type_id IS NULL AND t.classification_cv_id IS NOT NULL
+                  THEN (SELECT code_value FROM m_code_value WHERE id = t.classification_cv_id)
+              ELSE NULL END AS classification_name,
+          t.overpayment_portion_derived,
+          t.principal_portion_derived,
+          t.interest_portion_derived,
+          t.fee_charges_portion_derived,
+          t.penalty_charges_portion_derived,
+          t.amount,
+          e.status,
+          e.settlement_date,
+          e.owner_id,
+          m.charged_off_on_date,
+          t.transaction_date,
+          m.charge_off_reason_cv_id,
+          lo.originator_external_ids
+   FROM m_loan_transaction t
+            JOIN m_loan m ON m.id = t.loan_id
+            JOIN m_product_loan l ON l.id = m.product_id
+            LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+            LEFT JOIN m_external_asset_owner_transfer e
+                      ON e.loan_id = t.loan_id AND
+     e.settlement_date < '${endDate}' AND
+     e.effective_date_to >= '${endDate}'
+            LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+   WHERE t.reversed_on_date = '${endDate}'
+     AND t.transaction_type_enum not in (10, 26, 32, 34, 36, 39, 42, 43)
+     AND (t.office_id = ${officeId})),
+     rlt_charge_adj AS (SELECT '${endDate}' AS transactiondate,
+           t.id,
+           l.name,
+           t.transaction_type_enum,
+           d.payment_type_id,
+           t.overpayment_portion_derived,
+           t.principal_portion_derived,
+           t.interest_portion_derived,
+           t.fee_charges_portion_derived,
+           t.penalty_charges_portion_derived,
+           t.amount,
+           e.status,
+           e.settlement_date,
+           e.owner_id,
+           m.charged_off_on_date,
+           t.transaction_date,
+           m.charge_off_reason_cv_id,
+           lo.originator_external_ids
+    FROM m_loan_transaction t
+             JOIN m_loan m ON m.id = t.loan_id
+             JOIN m_product_loan l ON l.id = m.product_id
+             LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+             LEFT JOIN m_external_asset_owner_transfer e
+   ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+      e.effective_date_to >= '${endDate}'
+             LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+    WHERE t.reversed_on_date = '${endDate}'
+      AND t.transaction_type_enum = 26
+      AND (t.office_id = ${officeId})),
+     slt_cap_income_amortization AS (SELECT '${endDate}' AS transactiondate,
+    t.id,
+    l.name,
+    t.transaction_type_enum,
+    d.payment_type_id,
+    CASE
+        WHEN d.payment_type_id IS NULL AND bt.classification_cv_id IS NOT NULL
+            THEN (SELECT code_value FROM m_code_value WHERE id = bt.classification_cv_id)
+        ELSE NULL END AS classification_name,
+    CASE
+        WHEN t.overpayment_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS overpayment_portion_derived,
+    CASE
+        WHEN t.principal_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS principal_portion_derived,
+    CASE
+        WHEN t.interest_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS interest_portion_derived,
+    CASE
+        WHEN t.fee_charges_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS fee_charges_portion_derived,
+    CASE
+        WHEN t.penalty_charges_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS penalty_charges_portion_derived,
+    map.amount,
+    e.status,
+    e.settlement_date,
+    e.owner_id,
+    m.charged_off_on_date,
+    t.transaction_date,
+    m.charge_off_reason_cv_id,
+    lo.originator_external_ids
+                 FROM m_loan_transaction t
+      JOIN m_loan m ON m.id = t.loan_id
+      JOIN m_product_loan l ON l.id = m.product_id
+      LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+      JOIN m_loan_amortization_allocation_mapping map
+           ON map.amortization_loan_transaction_id = t.id
+      JOIN m_loan_transaction bt ON bt.id = map.base_loan_transaction_id
+      LEFT JOIN m_external_asset_owner_transfer e ON e.loan_id = t.loan_id AND
+             e.settlement_date <
+             '${endDate}' AND
+             e.effective_date_to >=
+             '${endDate}'
+      LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+                 WHERE t.submitted_on_date = '${endDate}'
+                   AND t.is_reversed = false
+                   AND t.transaction_type_enum IN (36, 39, 42, 43)
+                   AND (t.office_id = ${officeId})),
+     rlt_cap_income_amortization AS (SELECT '${endDate}' AS transactiondate,
+    t.id,
+    l.name,
+    t.transaction_type_enum,
+    d.payment_type_id,
+    CASE
+        WHEN d.payment_type_id IS NULL AND bt.classification_cv_id IS NOT NULL
+            THEN (SELECT code_value FROM m_code_value WHERE id = bt.classification_cv_id)
+        ELSE NULL END AS classification_name,
+    CASE
+        WHEN t.overpayment_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS overpayment_portion_derived,
+    CASE
+        WHEN t.principal_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS principal_portion_derived,
+    CASE
+        WHEN t.interest_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS interest_portion_derived,
+    CASE
+        WHEN t.fee_charges_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS fee_charges_portion_derived,
+    CASE
+        WHEN t.penalty_charges_portion_derived IS NOT NULL
+            THEN map.amount
+        ELSE NULL END AS penalty_charges_portion_derived,
+    map.amount,
+    e.status,
+    e.settlement_date,
+    e.owner_id,
+    m.charged_off_on_date,
+    t.transaction_date,
+    m.charge_off_reason_cv_id,
+    lo.originator_external_ids
+                 FROM m_loan_transaction t
+      JOIN m_loan m ON m.id = t.loan_id
+      JOIN m_product_loan l ON l.id = m.product_id
+      LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+      JOIN m_loan_amortization_allocation_mapping map
+           ON map.amortization_loan_transaction_id = t.id
+      JOIN m_loan_transaction bt ON bt.id = map.base_loan_transaction_id
+      LEFT JOIN m_external_asset_owner_transfer e ON e.loan_id = t.loan_id AND
+             e.settlement_date <
+             '${endDate}' AND
+             e.effective_date_to >=
+             '${endDate}'
+      LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+                 WHERE t.reversed_on_date = '${endDate}'
+                   AND t.is_reversed = true
+                   AND t.transaction_type_enum IN (36, 39, 42, 43)
+                   AND (t.office_id = ${officeId})),
+     active_external_asset_owner_transfers AS (SELECT '${endDate}' AS transactiondate,
+              t.id,
+              p.name,
+              t.owner_id,
+              t.previous_owner_id,
+              dt.principal_outstanding_derived,
+              dt.interest_outstanding_derived,
+              dt.fee_charges_outstanding_derived,
+              dt.penalty_charges_outstanding_derived,
+              dt.total_overpaid_derived,
+              l.charged_off_on_date,
+              t.settlement_date,
+              l.charge_off_reason_cv_id,
+              lo.originator_external_ids
+       FROM m_external_asset_owner_transfer t
+                JOIN m_loan l ON l.id = t.loan_id
+                JOIN m_client c ON c.id = l.client_id
+                JOIN m_product_loan p ON p.id = l.product_id
+                JOIN m_external_asset_owner_transfer_details dt
+                     ON dt.asset_owner_transfer_id = t.id
+                LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+       WHERE t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE')
+         AND c.office_id = ${officeId}
+         AND t.settlement_date = '${endDate}'),
+     buyback_external_asset_owner_transfers AS (SELECT '${endDate}' AS transactiondate,
+               t.id,
+               p.name,
+               dt.principal_outstanding_derived,
+               dt.interest_outstanding_derived,
+               dt.fee_charges_outstanding_derived,
+               dt.penalty_charges_outstanding_derived,
+               dt.total_overpaid_derived,
+               l.charged_off_on_date,
+               t.settlement_date,
+               l.charge_off_reason_cv_id,
+               t.owner_id,
+               lo.originator_external_ids
+        FROM m_external_asset_owner_transfer t
+                 JOIN m_loan l ON l.id = t.loan_id
+                 JOIN m_client c ON c.id = l.client_id
+                 JOIN m_product_loan p ON p.id = l.product_id
+                 JOIN m_external_asset_owner_transfer_details dt
+                      ON dt.asset_owner_transfer_id = t.id
+                 LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+        WHERE t.status in ('BUYBACK', 'BUYBACK_INTERMEDIATE')
+          AND c.office_id = ${officeId}
+          AND t.settlement_date = '${endDate}')
+SELECT '${endDate}' AS TransactionDate,
+       a.product AS Product,
+       CASE
+           WHEN a.transaction_type = 9999 THEN 'Asset Transfer'
+           WHEN a.transaction_type = 99999 THEN 'Asset Buyback'
+           ELSE (SELECT enum_message_property
+                 FROM r_enum_value
+                 WHERE enum_name = 'transaction_type_enum'
+                   AND enum_id = a.transaction_type) END AS TransactionType_Name,
+       COALESCE((SELECT value FROM m_payment_type WHERE id = a.payment_type_id),
+                a.classification_name) AS PaymentType_Name,
+       a.chargetype AS chargetype,
+       a.reversal_indicator AS Reversed,
+       a.Allocation_Type AS Allocation_Type,
+       (SELECT code_value FROM m_code_value WHERE id = a.charge_off_reason_id) AS Chargeoff_ReasonCode,
+       CASE
+           WHEN a.transaction_type = 9999 THEN sum(a.amount) * + 1
+           WHEN a.transaction_type = 99999 THEN sum(a.amount) * - 1
+           WHEN a.transaction_type IN (2, 23, 21, 22, 24, 4, 5, 8, 6, 27, 9, 26, 28, 31, 33, 34, 37, 39, 41, 43) AND
+                a.reversal_indicator = false THEN sum(a.amount) * -1
+           WHEN a.transaction_type IN (2, 23, 21, 22, 24, 4, 5, 8, 6, 27, 9, 26, 28, 31, 33, 34, 37, 39, 41, 43) AND
+                a.reversal_indicator = true THEN sum(a.amount) * + 1
+           WHEN a.transaction_type IN (1, 10, 25, 20, 35, 36, 40, 42) AND a.reversal_indicator = false THEN sum(a.amount) * + 1
+           WHEN a.transaction_type IN (1, 10, 25, 20, 35, 36, 40, 42) AND a.reversal_indicator = true
+               THEN sum(a.amount) * -1 END AS Transaction_Amount,
+       (SELECT external_id
+        FROM m_external_asset_owner
+        WHERE id = a.asset_owner_id) AS Asset_owner_id,
+       (SELECT external_id
+        FROM m_external_asset_owner
+        WHERE id = a.from_asset_owner_id) AS From_asset_owner_id,
+       a.originator_external_ids
+FROM (SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE
+                 WHEN t.transaction_type_enum in (1) THEN (CASE
+   WHEN t.amount is null THEN 0
+   WHEN t.overpayment_portion_derived is null THEN t.amount
+   WHEN t.overpayment_portion_derived is not null
+       THEN t.amount - t.overpayment_portion_derived
+   ELSE t.amount END)
+                 ELSE (CASE
+       WHEN t.principal_portion_derived is null THEN 0
+       ELSE t.principal_portion_derived end) END amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = false
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = true
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum in (10, 34)
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE
+                 WHEN t.transaction_type_enum in (1) THEN (CASE
+   WHEN t.amount is null THEN 0
+   WHEN t.overpayment_portion_derived is null THEN t.amount
+   WHEN t.overpayment_portion_derived is not null
+       THEN t.amount - t.overpayment_portion_derived
+   ELSE t.amount END)
+                 ELSE (CASE
+       WHEN t.principal_portion_derived is null THEN 0
+       ELSE t.principal_portion_derived end) END amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = false
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = true
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+ THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+ THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+ THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null::bigint AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_type,
+             t.principal_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.principal_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_type,
+             t.interest_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.interest_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_type,
+             t.fee_charges_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.fee_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_type,
+             t.penalty_charges_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.penalty_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_type,
+             t.total_overpaid_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.total_overpaid_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_type,
+             t.principal_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.principal_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_type,
+             t.interest_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.interest_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_type,
+             t.fee_charges_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.fee_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_type,
+             t.penalty_charges_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.penalty_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_type,
+             t.total_overpaid_derived * -1 AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+ THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.total_overpaid_derived > 0) a
+GROUP BY a.transactiondate, a.product, a.transaction_type, a.payment_type_id, a.classification_name, a.chargetype,
+         a.reversal_indicator, a.Allocation_Type, a.asset_owner_id, a.charge_off_reason_id, a.from_asset_owner_id,
+         a.originator_external_ids
+ORDER BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+
+                                    ]]>
+            </column>
+            <where>report_name='Transaction Summary Report with Asset Owner'</where>
+        </update>
+    </changeSet>
+    <changeSet author="fineract" id="0236-fix-cap-income-amortization-duplicates-mysql" context="mysql">
+        <update tableName="stretchy_report">
+            <column name="report_sql"><![CDATA[
+
+WITH loan_originators AS (SELECT mlom.loan_id,
+              GROUP_CONCAT(DISTINCT mlo.external_id, ', ' ORDER BY mlo.external_id) AS originator_external_ids
+       FROM m_loan_originator_mapping mlom
+                JOIN m_loan_originator mlo ON mlo.id = mlom.originator_id
+       GROUP BY mlom.loan_id),
+     slt_except_charge_adj_and_accrual AS (SELECT '${endDate}' AS transactiondate,
+            t.id,
+            l.name,
+            d.payment_type_id,
+            CASE
+                WHEN d.payment_type_id IS NULL AND t.classification_cv_id IS NOT NULL
+                    THEN (SELECT code_value FROM m_code_value WHERE id = t.classification_cv_id)
+                ELSE NULL END AS classification_name,
+            t.transaction_type_enum,
+            t.amount,
+            t.overpayment_portion_derived,
+            t.principal_portion_derived,
+            t.interest_portion_derived,
+            t.fee_charges_portion_derived,
+            t.penalty_charges_portion_derived,
+            e.status,
+            e.settlement_date,
+            e.owner_id,
+            m.charged_off_on_date,
+            t.transaction_date,
+            m.charge_off_reason_cv_id,
+            lo.originator_external_ids
+     FROM m_loan_transaction t
+              JOIN m_loan m ON m.id = t.loan_id
+              JOIN m_product_loan l ON l.id = m.product_id
+              LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+              LEFT JOIN m_external_asset_owner_transfer e
+                        ON e.loan_id = t.loan_id AND
+        e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+              LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+     WHERE t.submitted_on_date = '${endDate}'
+       AND t.transaction_type_enum not in (10, 26, 32, 34, 36, 39, 42, 43)
+       AND (t.office_id = ${officeId})),
+     slt_charge_adj AS (SELECT '${endDate}' AS transactiondate,
+            t.id,
+            l.name,
+            t.transaction_type_enum,
+            d.payment_type_id,
+            t.overpayment_portion_derived,
+            t.principal_portion_derived,
+            t.interest_portion_derived,
+            t.fee_charges_portion_derived,
+            t.penalty_charges_portion_derived,
+            t.amount,
+            e.status,
+            e.settlement_date,
+            e.owner_id,
+            m.charged_off_on_date,
+            t.transaction_date,
+            m.charge_off_reason_cv_id,
+            lo.originator_external_ids
+     FROM m_loan_transaction t
+              JOIN m_loan m ON m.id = t.loan_id
+              JOIN m_product_loan l ON l.id = m.product_id
+              LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+              LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+              LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+     WHERE t.submitted_on_date = '${endDate}'
+       AND t.transaction_type_enum = 26
+       AND (t.office_id = ${officeId})),
+     rlt_except_charge_adj_and_accrual AS (SELECT '${endDate}' AS transactiondate,
+            t.id,
+            l.name,
+            t.transaction_type_enum,
+            d.payment_type_id,
+            CASE
+                WHEN d.payment_type_id IS NULL AND t.classification_cv_id IS NOT NULL
+                    THEN (SELECT code_value FROM m_code_value WHERE id = t.classification_cv_id)
+                ELSE NULL END AS classification_name,
+            t.overpayment_portion_derived,
+            t.principal_portion_derived,
+            t.interest_portion_derived,
+            t.fee_charges_portion_derived,
+            t.penalty_charges_portion_derived,
+            t.amount,
+            e.status,
+            e.settlement_date,
+            e.owner_id,
+            m.charged_off_on_date,
+            t.transaction_date,
+            m.charge_off_reason_cv_id,
+            lo.originator_external_ids
+     FROM m_loan_transaction t
+              JOIN m_loan m ON m.id = t.loan_id
+              JOIN m_product_loan l ON l.id = m.product_id
+              LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+              LEFT JOIN m_external_asset_owner_transfer e
+                        ON e.loan_id = t.loan_id AND
+        e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+              LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+     WHERE t.reversed_on_date = '${endDate}'
+       AND t.transaction_type_enum not in (10, 26, 32, 34, 36, 39, 42, 43)
+       AND (t.office_id = ${officeId})),
+     rlt_charge_adj AS (SELECT '${endDate}' AS transactiondate,
+            t.id,
+            l.name,
+            t.transaction_type_enum,
+            d.payment_type_id,
+            t.overpayment_portion_derived,
+            t.principal_portion_derived,
+            t.interest_portion_derived,
+            t.fee_charges_portion_derived,
+            t.penalty_charges_portion_derived,
+            t.amount,
+            e.status,
+            e.settlement_date,
+            e.owner_id,
+            m.charged_off_on_date,
+            t.transaction_date,
+            m.charge_off_reason_cv_id,
+            lo.originator_external_ids
+     FROM m_loan_transaction t
+              JOIN m_loan m ON m.id = t.loan_id
+              JOIN m_product_loan l ON l.id = m.product_id
+              LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+              LEFT JOIN m_external_asset_owner_transfer e
+     ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+        e.effective_date_to >= '${endDate}'
+              LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+     WHERE t.reversed_on_date = '${endDate}'
+       AND t.transaction_type_enum = 26
+       AND (t.office_id = ${officeId})),
+     slt_cap_income_amortization AS (SELECT '${endDate}' AS transactiondate,
+      t.id,
+      l.name,
+      t.transaction_type_enum,
+      d.payment_type_id,
+      CASE
+          WHEN d.payment_type_id IS NULL AND bt.classification_cv_id IS NOT NULL
+              THEN (SELECT code_value FROM m_code_value WHERE id = bt.classification_cv_id)
+          ELSE NULL END AS classification_name,
+      CASE
+          WHEN t.overpayment_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS overpayment_portion_derived,
+      CASE
+          WHEN t.principal_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS principal_portion_derived,
+      CASE
+          WHEN t.interest_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS interest_portion_derived,
+      CASE
+          WHEN t.fee_charges_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS fee_charges_portion_derived,
+      CASE
+          WHEN t.penalty_charges_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS penalty_charges_portion_derived,
+      map.amount,
+      e.status,
+      e.settlement_date,
+      e.owner_id,
+      m.charged_off_on_date,
+      t.transaction_date,
+      m.charge_off_reason_cv_id,
+      lo.originator_external_ids
+                  FROM m_loan_transaction t
+        JOIN m_loan m ON m.id = t.loan_id
+        JOIN m_product_loan l ON l.id = m.product_id
+        LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+        JOIN m_loan_amortization_allocation_mapping map
+             ON map.amortization_loan_transaction_id = t.id
+        JOIN m_loan_transaction bt ON bt.id = map.base_loan_transaction_id
+        LEFT JOIN m_external_asset_owner_transfer e ON e.loan_id = t.loan_id AND
+                 e.settlement_date <
+                 '${endDate}' AND
+                 e.effective_date_to >=
+                 '${endDate}'
+        LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+                  WHERE t.submitted_on_date = '${endDate}'
+                    AND t.is_reversed = false
+                    AND t.transaction_type_enum IN (36, 39, 42, 43)
+                    AND (t.office_id = ${officeId})),
+     rlt_cap_income_amortization AS (SELECT '${endDate}' AS transactiondate,
+      t.id,
+      l.name,
+      t.transaction_type_enum,
+      d.payment_type_id,
+      CASE
+          WHEN d.payment_type_id IS NULL AND bt.classification_cv_id IS NOT NULL
+              THEN (SELECT code_value FROM m_code_value WHERE id = bt.classification_cv_id)
+          ELSE NULL END AS classification_name,
+      CASE
+          WHEN t.overpayment_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS overpayment_portion_derived,
+      CASE
+          WHEN t.principal_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS principal_portion_derived,
+      CASE
+          WHEN t.interest_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS interest_portion_derived,
+      CASE
+          WHEN t.fee_charges_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS fee_charges_portion_derived,
+      CASE
+          WHEN t.penalty_charges_portion_derived IS NOT NULL
+              THEN map.amount
+          ELSE NULL END AS penalty_charges_portion_derived,
+      map.amount,
+      e.status,
+      e.settlement_date,
+      e.owner_id,
+      m.charged_off_on_date,
+      t.transaction_date,
+      m.charge_off_reason_cv_id,
+      lo.originator_external_ids
+                  FROM m_loan_transaction t
+        JOIN m_loan m ON m.id = t.loan_id
+        JOIN m_product_loan l ON l.id = m.product_id
+        LEFT JOIN m_payment_detail d ON d.id = t.payment_detail_id
+        JOIN m_loan_amortization_allocation_mapping map
+             ON map.amortization_loan_transaction_id = t.id
+        JOIN m_loan_transaction bt ON bt.id = map.base_loan_transaction_id
+        LEFT JOIN m_external_asset_owner_transfer e ON e.loan_id = t.loan_id AND
+                 e.settlement_date <
+                 '${endDate}' AND
+                 e.effective_date_to >=
+                 '${endDate}'
+        LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+                  WHERE t.reversed_on_date = '${endDate}'
+                    AND t.is_reversed = true
+                    AND t.transaction_type_enum IN (36, 39, 42, 43)
+                    AND (t.office_id = ${officeId})),
+     active_external_asset_owner_transfers AS (SELECT '${endDate}' AS transactiondate,
+                t.id,
+                p.name,
+                t.owner_id,
+                t.previous_owner_id,
+                dt.principal_outstanding_derived,
+                dt.interest_outstanding_derived,
+                dt.fee_charges_outstanding_derived,
+                dt.penalty_charges_outstanding_derived,
+                dt.total_overpaid_derived,
+                l.charged_off_on_date,
+                t.settlement_date,
+                l.charge_off_reason_cv_id,
+                lo.originator_external_ids
+         FROM m_external_asset_owner_transfer t
+                  JOIN m_loan l ON l.id = t.loan_id
+                  JOIN m_client c ON c.id = l.client_id
+                  JOIN m_product_loan p ON p.id = l.product_id
+                  JOIN m_external_asset_owner_transfer_details dt
+                       ON dt.asset_owner_transfer_id = t.id
+                  LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+         WHERE t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE')
+           AND c.office_id = ${officeId}
+           AND t.settlement_date = '${endDate}'),
+     buyback_external_asset_owner_transfers AS (SELECT '${endDate}' AS transactiondate,
+                 t.id,
+                 p.name,
+                 dt.principal_outstanding_derived,
+                 dt.interest_outstanding_derived,
+                 dt.fee_charges_outstanding_derived,
+                 dt.penalty_charges_outstanding_derived,
+                 dt.total_overpaid_derived,
+                 l.charged_off_on_date,
+                 t.settlement_date,
+                 l.charge_off_reason_cv_id,
+                 t.owner_id,
+                 lo.originator_external_ids
+          FROM m_external_asset_owner_transfer t
+                   JOIN m_loan l ON l.id = t.loan_id
+                   JOIN m_client c ON c.id = l.client_id
+                   JOIN m_product_loan p ON p.id = l.product_id
+                   JOIN m_external_asset_owner_transfer_details dt
+                        ON dt.asset_owner_transfer_id = t.id
+                   LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+          WHERE t.status in ('BUYBACK', 'BUYBACK_INTERMEDIATE')
+            AND c.office_id = ${officeId}
+            AND t.settlement_date = '${endDate}')
+SELECT '${endDate}' AS TransactionDate,
+       a.product AS Product,
+       CASE
+           WHEN a.transaction_type = 9999 THEN 'Asset Transfer'
+           WHEN a.transaction_type = 99999 THEN 'Asset Buyback'
+           ELSE (SELECT enum_message_property
+                 FROM r_enum_value
+                 WHERE enum_name = 'transaction_type_enum'
+                   AND enum_id = a.transaction_type) END AS TransactionType_Name,
+       COALESCE((SELECT value FROM m_payment_type WHERE id = a.payment_type_id),
+                a.classification_name) AS PaymentType_Name,
+       a.chargetype AS chargetype,
+       a.reversal_indicator AS Reversed,
+       a.Allocation_Type AS Allocation_Type,
+       (SELECT code_value FROM m_code_value WHERE id = a.charge_off_reason_id) AS Chargeoff_ReasonCode,
+       CASE
+           WHEN a.transaction_type = 9999 THEN sum(a.amount) * + 1
+           WHEN a.transaction_type = 99999 THEN sum(a.amount) * - 1
+           WHEN a.transaction_type IN (2, 23, 21, 22, 24, 4, 5, 8, 6, 27, 9, 26, 28, 31, 33, 34, 37, 39, 41, 43) AND
+                a.reversal_indicator = false THEN sum(a.amount) * -1
+           WHEN a.transaction_type IN (2, 23, 21, 22, 24, 4, 5, 8, 6, 27, 9, 26, 28, 31, 33, 34, 37, 39, 41, 43) AND
+                a.reversal_indicator = true THEN sum(a.amount) * + 1
+           WHEN a.transaction_type IN (1, 10, 25, 20, 35, 36, 40, 42) AND a.reversal_indicator = false THEN sum(a.amount) * + 1
+           WHEN a.transaction_type IN (1, 10, 25, 20, 35, 36, 40, 42) AND a.reversal_indicator = true
+               THEN sum(a.amount) * -1 END AS Transaction_Amount,
+       (SELECT external_id
+        FROM m_external_asset_owner
+        WHERE id = a.asset_owner_id) AS Asset_owner_id,
+       (SELECT external_id
+        FROM m_external_asset_owner
+        WHERE id = a.from_asset_owner_id) AS From_asset_owner_id,
+       a.originator_external_ids AS Originator_External_Ids
+FROM (SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE
+                 WHEN t.transaction_type_enum in (1) THEN (CASE
+      WHEN t.amount is null THEN 0
+      WHEN t.overpayment_portion_derived is null THEN t.amount
+      WHEN t.overpayment_portion_derived is not null
+          THEN t.amount - t.overpayment_portion_derived
+      ELSE t.amount END)
+                 ELSE (CASE
+        WHEN t.principal_portion_derived is null THEN 0
+        ELSE t.principal_portion_derived end) END amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.transaction_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_cap_income_amortization AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = false
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = true
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.submitted_on_date = '${endDate}'
+        AND t.transaction_type_enum in (10, 34)
+        AND t.is_reversed = false
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM slt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE
+                 WHEN t.transaction_type_enum in (1) THEN (CASE
+      WHEN t.amount is null THEN 0
+      WHEN t.overpayment_portion_derived is null THEN t.amount
+      WHEN t.overpayment_portion_derived is not null
+          THEN t.amount - t.overpayment_portion_derived
+      ELSE t.amount END)
+                 ELSE (CASE
+        WHEN t.principal_portion_derived is null THEN 0
+        ELSE t.principal_portion_derived end) END amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             t.classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_except_charge_adj_and_accrual AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = false
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             mc.name AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE WHEN pd.amount is null THEN 0 ELSE pd.amount END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               JOIN m_loan_charge_paid_by pd ON pd.loan_transaction_id = t.id
+               JOIN m_loan_charge c ON c.id = pd.loan_charge_id
+               JOIN m_charge mc ON mc.id = c.charge_id AND mc.is_penalty = true
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             l.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN e.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND e.settlement_date < '${endDate}'
+  THEN e.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (m.charged_off_on_date <= t.transaction_date)
+  THEN m.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             lo.originator_external_ids
+      FROM m_loan_transaction t
+               JOIN m_loan m ON m.id = t.loan_id
+               JOIN m_product_loan l ON l.id = m.product_id
+               LEFT JOIN m_external_asset_owner_transfer e
+      ON e.loan_id = t.loan_id AND e.settlement_date < '${endDate}' AND
+         e.effective_date_to >= '${endDate}'
+               LEFT JOIN loan_originators lo ON lo.loan_id = t.loan_id
+      WHERE t.reversed_on_date = '${endDate}'
+        AND t.transaction_type_enum = 10
+        AND t.is_reversed = true
+        AND (t.office_id = ${officeId})
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Fees' AS Allocation_Type,
+             CASE WHEN t.fee_charges_portion_derived is null THEN 0 ELSE t.fee_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Penalty' AS Allocation_Type,
+             CASE
+                 WHEN t.penalty_charges_portion_derived is null THEN 0
+                 ELSE t.penalty_charges_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Interest' AS Allocation_Type,
+             CASE WHEN t.interest_portion_derived is null THEN 0 ELSE t.interest_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Principal' AS Allocation_Type,
+             CASE WHEN t.principal_portion_derived is null THEN 0 ELSE t.principal_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             t.transaction_type_enum AS transaction_type,
+             t.payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             true AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_Type,
+             CASE WHEN t.overpayment_portion_derived is null THEN 0 ELSE t.overpayment_portion_derived END AS amount,
+             CASE
+                 WHEN t.status in ('ACTIVE', 'ACTIVE_INTERMEDIATE') AND t.settlement_date < '${endDate}'
+  THEN t.owner_id END AS asset_owner_id,
+             CASE
+                 WHEN t.transaction_type_enum = 27 OR (t.charged_off_on_date <= t.transaction_date)
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             null AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM rlt_charge_adj AS t
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_type,
+             t.principal_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.principal_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_type,
+             t.interest_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.interest_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_type,
+             t.fee_charges_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.fee_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_type,
+             t.penalty_charges_outstanding_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.penalty_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT t.transactiondate,
+             t.id,
+             t.name AS product,
+             9999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_type,
+             t.total_overpaid_derived AS amount,
+             t.owner_id AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.previous_owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM active_external_asset_owner_transfers AS t
+      WHERE t.total_overpaid_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Principal' AS Allocation_type,
+             t.principal_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.principal_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Interest' AS Allocation_type,
+             t.interest_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.interest_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Fees' AS Allocation_type,
+             t.fee_charges_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.fee_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Penalty' AS Allocation_type,
+             t.penalty_charges_outstanding_derived AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.penalty_charges_outstanding_derived > 0
+      UNION ALL
+      SELECT '${endDate}' AS transactiondate,
+             t.id,
+             t.name AS product,
+             99999 AS transaction_type,
+             null AS payment_type_id,
+             null AS classification_name,
+             '' AS chargetype,
+             false AS reversal_indicator,
+             'Unallocated Credit (UNC)' AS Allocation_type,
+             t.total_overpaid_derived * -1 AS amount,
+             null AS asset_owner_id,
+             CASE
+                 WHEN t.charged_off_on_date <= t.settlement_date
+  THEN t.charge_off_reason_cv_id END AS charge_off_reason_id,
+             t.owner_id AS from_asset_owner_id,
+             t.originator_external_ids
+      FROM buyback_external_asset_owner_transfers AS t
+      WHERE t.total_overpaid_derived > 0) a
+GROUP BY a.transactiondate, a.product, a.transaction_type, a.payment_type_id, a.classification_name, a.chargetype,
+         a.reversal_indicator, a.Allocation_Type, a.asset_owner_id, a.charge_off_reason_id, a.from_asset_owner_id,
+         a.originator_external_ids
+ORDER BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+
+                                    ]]>
+            </column>
+            <where>report_name='Transaction Summary Report with Asset Owner'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description

Fix the transaction summary report SQL for the case when a cap income/buydown fee amortization is mapped to multiple cap income/buydown fee and the mapping cause the whole amortized amount to be duplicated.

[FINERACT-2421](https://issues.apache.org/jira/browse/FINERACT-2421)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
