### PR TITLE
FINERACT-405: Add client and staff mobile number validation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -55,6 +56,7 @@ public class StaffCreateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
+    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
     private String mobileNo;
     @Builder.Default
     @JsonProperty("isActive")

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -61,6 +62,7 @@ public class StaffUpdateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
+    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
     private String mobileNo;
     @JsonProperty("isActive")
     private Boolean isActive;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
@@ -50,6 +50,7 @@ public final class ClientDataValidator {
 
     private final FromJsonHelper fromApiJsonHelper;
     private final ConfigurationReadPlatformService configurationReadPlatformService;
+    private static final String MOBILE_NUMBER_REGEX = "^\\+?[0-9]{7,15}$";
 
     @Autowired
     public ClientDataValidator(final FromJsonHelper fromApiJsonHelper,
@@ -164,7 +165,7 @@ public final class ClientDataValidator {
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mobileNoParamName, element)) {
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
-                    .notExceedingLengthOf(50);
+                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);
@@ -449,7 +450,8 @@ public final class ClientDataValidator {
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mobileNoParamName, element)) {
             atLeastOneParameterPassedForUpdate = true;
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
-            baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).notExceedingLengthOf(50);
+            baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
+                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
@@ -129,4 +129,76 @@ class ClientDataValidatorTest {
 
         assertDoesNotThrow(() -> validator.validateForUpdate(json));
     }
+
+    @Test
+    void validateForCreate_withInvalidMobileNumber_throwsPlatformApiDataValidationException() {
+        String json = """
+                {
+                  "officeId": 1,
+                  "firstname": "John",
+                  "lastname": "Doe",
+                  "active": false,
+                  "legalFormId": 1,
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "mobileNo": "phone123"
+                }
+                """;
+
+        PlatformApiDataValidationException ex = assertThrows(PlatformApiDataValidationException.class,
+                () -> validator.validateForCreate(json));
+
+        assertTrue(ex.getErrors().stream().anyMatch(e -> ClientApiConstants.mobileNoParamName.equals(e.getParameterName())));
+    }
+
+    @Test
+    void validateForCreate_withValidMobileNumber_doesNotThrow() {
+        String json = """
+                {
+                  "officeId": 1,
+                  "firstname": "John",
+                  "lastname": "Doe",
+                  "active": false,
+                  "legalFormId": 1,
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "mobileNo": "+919876543210"
+                }
+                """;
+
+        assertDoesNotThrow(() -> validator.validateForCreate(json));
+    }
+
+    @Test
+    void validateForUpdate_withInvalidMobileNumber_throwsPlatformApiDataValidationException() {
+        String json = """
+                {
+                  "firstname": "Jane",
+                  "lastname": "Doe",
+                  "locale": "en",
+                  "dateFormat": "yyyy-MM-dd",
+                  "mobileNo": "phone123"
+                }
+                """;
+
+        PlatformApiDataValidationException ex = assertThrows(PlatformApiDataValidationException.class,
+                () -> validator.validateForUpdate(json));
+
+        assertTrue(ex.getErrors().stream().anyMatch(e -> ClientApiConstants.mobileNoParamName.equals(e.getParameterName())));
+    }
+
+    @Test
+    void validateForUpdate_withValidMobileNumber_doesNotThrow() {
+        String json = """
+                {
+                  "firstname": "Jane",
+                  "lastname": "Doe",
+                  "locale": "en",
+                  "dateFormat": "yyyy-MM-dd",
+                  "mobileNo": "+14155552671"
+                }
+                """;
+
+        assertDoesNotThrow(() -> validator.validateForUpdate(json));
+    }
 }

--- a/fineract-validation/src/main/resources/ValidationMessages.properties
+++ b/fineract-validation/src/main/resources/ValidationMessages.properties
@@ -23,6 +23,7 @@ org.apache.fineract.validation.local-date=Wrong local date fields.
 org.apache.fineract.validation.locale=The parameter `locale` has an invalid language value: `${validatedValue}`.
 org.apache.fineract.validation.date-format=The parameter `dateFormat` is not a valid Java date/time pattern: `${validatedValue}`. Use e.g. dd MMMM yyyy or yyyy-MM-dd.
 org.apache.fineract.validation.enum=The parameter has an invalid enum value: `${validatedValue}`.
+org.apache.fineract.organisation.staff.mobile-no.invalid=The parameter 'mobileNo' must contain only digits with an optional leading '+' and be between 7 and 15 digits long
 
 ## Business Date
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/StaffTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/StaffTest.java
@@ -172,8 +172,7 @@ public class StaffTest {
         final String firstname = Utils.uniqueRandomStringGenerator("michael_", 10);
         final String lastname = Utils.uniqueRandomStringGenerator("Doe_", 10);
         final String externalId = UUID.randomUUID().toString();
-        final String mobileNo = Utils.uniqueRandomStringGenerator("num_", 10);
-
+        final String mobileNo = "+14155552671";
         map.put("firstname", firstname);
         map.put("lastname", lastname);
         map.put("externalId", externalId);


### PR DESCRIPTION
## Description

This PR adds backend validation for client and staff mobile numbers.

## Changes
-Added mobile number validation for client create and update operations.
-Added mobile number validation for staff create and update requests using Jakarta Bean Validation.
-Added validation message for invalid staff mobile numbers.
-Added unit tests covering valid and invalid client mobile number scenarios.

##Notes
This PR focuses on backend validation only. It does not implement default country code handling or phone number normalization.
