### PR TITLE
FINERACT-2284: Enforce Charge Rounding using Money rounding rules

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeService.java
@@ -39,6 +39,7 @@ import org.apache.fineract.portfolio.charge.domain.Charge;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.charge.exception.LoanChargeCannotBeAddedException;
 import org.apache.fineract.portfolio.charge.exception.LoanChargeWithoutMandatoryFieldException;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
@@ -232,6 +233,8 @@ public class LoanChargeService {
         update(loanCharge, chargeAmt, loanCharge.getDueLocalDate(), amount, loan.fetchNumberOfInstallmentsAfterExceptions(),
                 totalChargeAmt);
 
+        validateChargeAmountNotZero(loanCharge);
+
         // NOTE: must add new loan charge to set of loan charges before
         // reprocessing the repayment schedule.
         if (loan.getLoanCharges() == null) {
@@ -384,6 +387,7 @@ public class LoanChargeService {
                 case PERCENT_OF_AMOUNT_AND_INTEREST:
                 case PERCENT_OF_INTEREST:
                 case PERCENT_OF_DISBURSEMENT_AMOUNT:
+
                     loanCharge.setPercentage(newValue);
                     loanCharge.setAmountPercentageAppliedTo(amount);
                     loanChargeAmount = BigDecimal.ZERO;
@@ -818,13 +822,18 @@ public class LoanChargeService {
                 case INVALID:
                 break;
                 case FLAT:
+                    BigDecimal roundedAmount;
                     if (loanCharge.isInstalmentFee()) {
                         if (numberOfRepayments == null) {
                             numberOfRepayments = loanCharge.getLoan().fetchNumberOfInstallmentsAfterExceptions();
                         }
-                        loanCharge.setAmount(amount.multiply(BigDecimal.valueOf(numberOfRepayments)));
+                        roundedAmount = Money
+                                .of(loanCharge.getLoan().getCurrency(), amount.multiply(BigDecimal.valueOf(numberOfRepayments)))
+                                .getAmount();
+                        loanCharge.setAmount(roundedAmount);
                     } else {
-                        loanCharge.setAmount(amount);
+                        roundedAmount = Money.of(loanCharge.getLoan().getCurrency(), amount).getAmount();
+                        loanCharge.setAmount(roundedAmount);
                     }
                 break;
                 case PERCENT_OF_AMOUNT:
@@ -996,6 +1005,15 @@ public class LoanChargeService {
     private boolean doesLoanChargePaidByContainLoanCharge(Set<LoanChargePaidBy> loanChargePaidBys, LoanCharge loanCharge) {
         return loanChargePaidBys.stream() //
                 .anyMatch(loanChargePaidBy -> loanChargePaidBy.getLoanCharge().equals(loanCharge));
+    }
+
+    private void validateChargeAmountNotZero(final LoanCharge loanCharge) {
+        if (loanCharge.getAmount() != null && BigDecimal.ZERO.compareTo(loanCharge.getAmount()) == 0) {
+            final String defaultUserMessage = "This charge cannot be added because the calculated amount becomes zero after rounding.";
+
+            throw new LoanChargeCannotBeAddedException("loanCharge", "amount.rounded.to.zero", defaultUserMessage,
+                    loanCharge.getLoan().getId(), loanCharge.name());
+        }
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientCharge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/domain/ClientCharge.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
@@ -34,7 +33,6 @@ import org.apache.fineract.organisation.monetary.domain.OrganisationCurrency;
 import org.apache.fineract.portfolio.charge.domain.Charge;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
-import org.apache.fineract.portfolio.client.api.ClientApiConstants;
 
 @Entity
 @Table(name = "m_client_charge")
@@ -94,12 +92,8 @@ public class ClientCharge extends AbstractPersistableCustom<Long> {
         //
     }
 
-    public static ClientCharge createNew(final Client client, final Charge charge, final JsonCommand command) {
-        BigDecimal amount = command.bigDecimalValueOfParameterNamed(ClientApiConstants.amountParamName);
-        final LocalDate dueDate = command.localDateValueOfParameterNamed(ClientApiConstants.dueAsOfDateParamName);
+    public static ClientCharge createNew(final Client client, final Charge charge, final BigDecimal amount, final LocalDate dueDate) {
         final boolean status = true;
-        // Derive from charge definition if not passed in as a parameter
-        amount = (amount == null) ? charge.getAmount() : amount;
         return new ClientCharge(client, charge, amount, dueDate, status);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientChargeWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientChargeWritePlatformServiceImpl.java
@@ -42,6 +42,9 @@ import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityEx
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
+import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
+import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.apache.fineract.portfolio.charge.domain.Charge;
@@ -78,6 +81,7 @@ public class ClientChargeWritePlatformServiceImpl implements ClientChargeWritePl
     private final ClientTransactionRepository clientTransactionRepository;
     private final PaymentDetailWritePlatformService paymentDetailWritePlatformService;
     private final JournalEntryWritePlatformService journalEntryWritePlatformService;
+    private final ApplicationCurrencyRepositoryWrapper applicationCurrencyRepositoryWrapper;
 
     @Override
     public CommandProcessingResult addCharge(Long clientId, JsonCommand command) {
@@ -95,7 +99,10 @@ public class ClientChargeWritePlatformServiceImpl implements ClientChargeWritePl
                 throw new ChargeCannotBeAppliedToException("client", errorMessage, charge.getId());
             }
 
-            final ClientCharge clientCharge = ClientCharge.createNew(client, charge, command);
+            Money roundedAmount = calculateRoundedChargeAmount(charge, command);
+            validateChargeAmountNotZero(roundedAmount);
+            final LocalDate date = command.localDateValueOfParameterNamed(ClientApiConstants.dueAsOfDateParamName);
+            final ClientCharge clientCharge = ClientCharge.createNew(client, charge, roundedAmount.getAmount(), date);
             final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat());
             final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
             final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
@@ -426,6 +433,25 @@ public class ClientChargeWritePlatformServiceImpl implements ClientChargeWritePl
         log.error("Error occured.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.client.charges.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource: " + realCause.getMessage());
+    }
+
+    private Money calculateRoundedChargeAmount(final Charge charge, final JsonCommand command) {
+        BigDecimal amount = command.bigDecimalValueOfParameterNamed(ClientApiConstants.amountParamName);
+        amount = (amount == null) ? charge.getAmount() : amount;
+
+        ApplicationCurrency currency = this.applicationCurrencyRepositoryWrapper.findOneWithNotFoundDetection(charge.getCurrencyCode());
+
+        CurrencyData currencyData = currency.toData();
+        return Money.of(currencyData, amount);
+    }
+
+    private void validateChargeAmountNotZero(Money amount) {
+        if (amount.isZero()) {
+            List<ApiParameterError> errors = new ArrayList<>();
+            errors.add(ApiParameterError.parameterError("error.msg.client.charge.amount.rounded.to.zero",
+                    "This charge cannot be added because the calculated amount becomes zero after rounding.", "amount"));
+            throw new PlatformApiDataValidationException(errors);
+        }
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -87,6 +87,7 @@ import org.apache.fineract.portfolio.account.domain.StandingInstructionStatus;
 import org.apache.fineract.portfolio.account.service.AccountAssociationsReadPlatformService;
 import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
 import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargeRepositoryWrapper;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 import org.apache.fineract.portfolio.client.domain.Client;
@@ -1237,6 +1238,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         }
         final SavingsAccountCharge savingsAccountCharge = SavingsAccountCharge.createNewFromJson(savingsAccount, chargeDefinition, command);
 
+        validateChargeAmountNotZero(savingsAccountCharge, dataValidationErrors);
+
         if (chargeDefinition.isEnableFreeWithdrawal()) {
             savingsAccountCharge.setFreeWithdrawalCount(0);
         }
@@ -2078,6 +2081,20 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private void validateReasonForHold(String reasonForBlock) {
         if (StringUtils.isBlank(reasonForBlock)) {
             throw new PlatformDataIntegrityException("Reason For Block is Mandatory", "error.msg.reason.for.block.mandatory");
+        }
+    }
+
+    private void validateChargeAmountNotZero(final SavingsAccountCharge savingsAccountCharge,
+            final List<ApiParameterError> dataValidationErrors) {
+        if (!ChargeCalculationType.fromInt(savingsAccountCharge.getCharge().getChargeCalculation()).isFlat()) {
+            return;
+        }
+
+        if (savingsAccountCharge.getAmount(savingsAccountCharge.savingsAccount().getCurrency()).isZero()) {
+            final String defaultUserMessage = "This charge cannot be added because the calculated amount becomes zero after rounding.";
+
+            dataValidationErrors
+                    .add(ApiParameterError.parameterError("error.msg.savings.charge.amount.rounded.to.zero", defaultUserMessage, "amount"));
         }
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/domain/ShareAccountCharge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/domain/ShareAccountCharge.java
@@ -374,7 +374,7 @@ public class ShareAccountCharge extends AbstractPersistableCustom<Long> {
     }
 
     public BigDecimal deriveChargeAmount(BigDecimal transactionAmount, final MonetaryCurrency currency) {
-        BigDecimal toReturnAmount = amountOrPercentage;
+        BigDecimal toReturnAmount;
         if (ChargeCalculationType.fromInt(this.chargeCalculation) == ChargeCalculationType.PERCENT_OF_AMOUNT) {
             toReturnAmount = Money.of(currency, percentageOf(transactionAmount, this.percentage)).getAmount();
             this.amountPercentageAppliedTo = transactionAmount;
@@ -384,7 +384,8 @@ public class ShareAccountCharge extends AbstractPersistableCustom<Long> {
             this.amountWaived = null;
             this.amountWrittenOff = null;
         } else {
-            this.amount = this.amountOrPercentage;
+            this.amount = Money.of(currency, this.amountOrPercentage).getAmount();
+            toReturnAmount = this.amount;
             this.amountOutstanding = calculateOutstanding();
             this.amountWaived = null;
             this.amountWrittenOff = null;
@@ -393,7 +394,7 @@ public class ShareAccountCharge extends AbstractPersistableCustom<Long> {
     }
 
     public BigDecimal updateChargeDetailsForAdditionalSharesRequest(final BigDecimal transactionAmount, final MonetaryCurrency currency) {
-        BigDecimal toReturnAmount = amountOrPercentage;
+        BigDecimal toReturnAmount;
         if (ChargeCalculationType.fromInt(this.chargeCalculation) == ChargeCalculationType.PERCENT_OF_AMOUNT) {
             toReturnAmount = Money.of(currency, percentageOf(transactionAmount, this.percentage)).getAmount();
             this.amountPercentageAppliedTo = this.amountPercentageAppliedTo.add(transactionAmount);
@@ -402,7 +403,9 @@ public class ShareAccountCharge extends AbstractPersistableCustom<Long> {
             this.amountWaived = null;
             this.amountWrittenOff = null;
         } else {
-            this.amount = this.amount.add(this.amountOrPercentage);
+            BigDecimal roundedAmount = Money.of(currency, this.amountOrPercentage).getAmount();
+            toReturnAmount = roundedAmount;
+            this.amount = this.amount.add(roundedAmount);
             this.amountOutstanding = calculateOutstanding();
             this.amountWaived = null;
             this.amountWrittenOff = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/domain/ShareAccountTransaction.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/domain/ShareAccountTransaction.java
@@ -114,7 +114,7 @@ public class ShareAccountTransaction extends AbstractPersistableCustom<Long> {
         final BigDecimal unitPrice = null;
         final Integer status = PurchasedSharesStatusType.APPROVED.getValue();
         final Integer type = PurchasedSharesStatusType.CHARGE_PAYMENT.getValue();
-        BigDecimal amount = charge.percentageOrAmount();
+        BigDecimal amount = charge.amoutOutstanding();
         BigDecimal chargeAmount = null;
         BigDecimal amountPaid = null;
         return new ShareAccountTransaction(transactionDate, totalShares, unitPrice, status, type, amount, chargeAmount, amountPaid);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/serialization/ShareAccountDataSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/serialization/ShareAccountDataSerializer.java
@@ -242,9 +242,10 @@ public class ShareAccountDataSerializer {
         LocalDate currentDate = DateUtils.getBusinessLocalDate();
         for (ShareAccountCharge charge : charges) {
             if (charge.isActive() && charge.isShareAccountActivation()) {
-                charge.deriveChargeAmount(totalChargeAmount, account.getCurrency());
+                BigDecimal amount = charge.deriveChargeAmount(totalChargeAmount, account.getCurrency());
+                validateChargeAmountNotZero(amount);
                 ShareAccountTransaction chargeTransaction = ShareAccountTransaction.createChargeTransaction(currentDate, charge);
-                ShareAccountChargePaidBy paidBy = new ShareAccountChargePaidBy(chargeTransaction, charge, charge.percentageOrAmount());
+                ShareAccountChargePaidBy paidBy = new ShareAccountChargePaidBy(chargeTransaction, charge, amount);
                 chargeTransaction.addShareAccountChargePaidBy(paidBy);
                 account.addChargeTransaction(chargeTransaction);
             }
@@ -255,6 +256,7 @@ public class ShareAccountDataSerializer {
             for (ShareAccountCharge charge : charges) {
                 if (charge.isActive() && charge.isSharesPurchaseCharge()) {
                     BigDecimal amount = charge.deriveChargeAmount(pending.amount(), account.getCurrency());
+                    validateChargeAmountNotZero(amount);
                     ShareAccountChargePaidBy paidBy = new ShareAccountChargePaidBy(pending, charge, amount);
                     pending.addShareAccountChargePaidBy(paidBy);
                     totalChargeAmount = totalChargeAmount.add(amount);
@@ -1042,5 +1044,14 @@ public class ShareAccountDataSerializer {
         handleRedeemSharesChargeTransactions(account, transaction);
         actualChanges.put(ShareAccountApiConstants.requestedshares_paramname, transaction);
         return actualChanges;
+    }
+
+    private void validateChargeAmountNotZero(BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            List<ApiParameterError> errors = new ArrayList<>();
+            errors.add(ApiParameterError.parameterError("error.msg.share.charge.amount.rounded.to.zero",
+                    "This charge cannot be added because the calculated amount becomes zero after rounding.", "amount"));
+            throw new PlatformApiDataValidationException(errors);
+        }
     }
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountCharge.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountCharge.java
@@ -263,11 +263,12 @@ public class SavingsAccountCharge extends AbstractAuditableWithUTCDateTimeCustom
                 this.amountWrittenOff = null;
             break;
             case FLAT:
+                Money money = Money.of(this.savingsAccount().getCurrency(), chargeAmount);
                 this.percentage = null;
-                this.amount = chargeAmount;
+                this.amount = money.getAmount();
                 this.amountPercentageAppliedTo = null;
                 this.amountPaid = null;
-                this.amountOutstanding = chargeAmount;
+                this.amountOutstanding = money.getAmount();
                 this.amountWaived = null;
                 this.amountWrittenOff = null;
             break;

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.fineract.integrationtests.common.ClientHelper.addChargesForClient;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.restassured.response.Response;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.CurrencyConfigurationData;
+import org.apache.fineract.client.models.CurrencyUpdateRequest;
+import org.apache.fineract.client.models.GetClientsChargesPageItems;
+import org.apache.fineract.client.models.GetClientsClientIdChargesResponse;
+import org.apache.fineract.client.models.PostChargesResponse;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
+
+    private Long clientId;
+    private ChargesHelper chargesHelper;
+    private static final String DATE = "01 January 2026";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        enableRequiredCurrencies();
+        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        chargesHelper = new ChargesHelper();
+    }
+
+    @Test
+    public void shouldRoundUsdClientChargeTo_TwoDecimalPlaces() throws Exception {
+        PostChargesResponse chargesResponse = createFlatClientCharge(19.876, "USD");
+
+        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.876"));
+
+        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+
+        assertNotNull(charge);
+        BigDecimal actualChargeAmount = charge.getAmount();
+        BigDecimal expectedChargeAmount = new BigDecimal("19.88");
+        assertAmountEquals(expectedChargeAmount, actualChargeAmount);
+    }
+
+    @Test
+    public void shouldRoundJpyClientChargeTo_ZeroDecimalPlaces() throws Exception {
+        PostChargesResponse chargesResponse = createFlatClientCharge(19.8, "JPY");
+
+        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.8"));
+
+        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+
+        assertNotNull(charge);
+        BigDecimal actualChargeAmount = charge.getAmount();
+        BigDecimal expectedChargeAmount = new BigDecimal("20");
+        assertAmountEquals(expectedChargeAmount, actualChargeAmount);
+    }
+
+    @Test
+    public void shouldRoundUpJpyClientCharge_whenValueIsAboveHalfTo_ZeroDecimalPlaces() throws Exception {
+        PostChargesResponse chargesResponse = createFlatClientCharge(0.55, "JPY");
+
+        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("0.55"));
+
+        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+
+        assertNotNull(charge);
+        BigDecimal actualChargeAmount = charge.getAmount();
+        BigDecimal expectedChargeAmount = new BigDecimal("1");
+        assertAmountEquals(expectedChargeAmount, actualChargeAmount);
+    }
+
+    @Test
+    public void shouldFailToAddJpyClientCharge_whenRoundedToZero() throws Exception {
+        PostChargesResponse chargesResponse = createFlatClientCharge(0.5, "JPY");
+
+        Response response = applyChargeToClientRaw(clientId, chargesResponse.getResourceId(), new BigDecimal("0.5"));
+
+        assertEquals(400, response.statusCode());
+        String errorBody = response.asString();
+        assertTrue(errorBody.contains("error.msg.client.charge.amount.rounded.to.zero"));
+        assertFalse(hasAnyClientCharges(clientId), "Expected no client charge to be created when rounded amount becomes 0");
+    }
+
+    // -----------------------------
+    // HELPERS
+    // -----------------------------
+
+    private PostChargesResponse createFlatClientCharge(double amount, String currencyCode) {
+        String uniqueChargeName = "Client Charge Flat " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(3) // CLIENT
+                .chargeTimeType(2).chargeCalculationType(1) // FLAT
+                .amount(amount).currencyCode(currencyCode).locale("en").active(true).penalty(false));
+    }
+
+    private Integer applyChargeToClient(Long clientId, Long chargeId, BigDecimal amount) {
+        String request = """
+                {
+                  "chargeId": %d,
+                  "amount": %s,
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "dueDate": "%s"
+                }
+                """.formatted(chargeId, amount.toPlainString(), DATE);
+
+        return addChargesForClient(requestSpec, responseSpec, clientId.intValue(), request);
+    }
+
+    private Response applyChargeToClientRaw(Long clientId, Long chargeId, BigDecimal amount) {
+
+        String request = """
+                {
+                  "chargeId": %d,
+                  "amount": %s,
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "dueDate": "%s"
+                }
+                """.formatted(chargeId, amount.toPlainString(), DATE);
+
+        String url = "/fineract-provider/api/v1/clients/" + clientId + "/charges?" + Utils.TENANT_IDENTIFIER;
+
+        return given().spec(requestSpec).body(request).when().post(url);
+    }
+
+    private GetClientsChargesPageItems getClientCharge(Long clientId, Long chargeId) throws IOException {
+        return FineractClientHelper.getFineractClient().clientCharges.retrieveOneClientCharge(clientId, chargeId).execute().body();
+    }
+
+    private boolean hasAnyClientCharges(Long clientId) throws IOException {
+
+        GetClientsClientIdChargesResponse response = FineractClientHelper.getFineractClient().clientCharges
+                .retrieveAllClientCharges(clientId, "all", null, null, null).execute().body();
+
+        return response != null && response.getPageItems() != null && !response.getPageItems().isEmpty();
+    }
+
+    private void assertAmountEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual));
+    }
+
+    /**
+     * Currencies used by these tests must be explicitly enabled in the currency configuration. Otherwise, charge
+     * creation and persistence may succeed while retrieval APIs do not return the charges.
+     */
+    private void enableRequiredCurrencies() throws Exception {
+        CurrencyUpdateRequest request = new CurrencyUpdateRequest().currencies(List.of("USD", "JPY"));
+
+        FineractClientHelper.getFineractClient().currencies.updateCurrencies(request).execute();
+
+        CurrencyConfigurationData data = FineractClientHelper.getFineractClient().currencies.retrieveCurrencies().execute().body();
+
+        assertNotNull(data);
+        assertNotNull(data.getSelectedCurrencyOptions());
+        assertCurrencyEnabled(data, "USD");
+        assertCurrencyEnabled(data, "JPY");
+    }
+
+    private void assertCurrencyEnabled(CurrencyConfigurationData data, String currencyCode) {
+        assertTrue(data.getSelectedCurrencyOptions().stream().anyMatch(c -> currencyCode.equals(c.getCode())),
+                "Currency " + currencyCode + " should be enabled");
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeRoundingTest.java
@@ -1,0 +1,818 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.GetLoansLoanIdLoanChargeData;
+import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.PostChargesResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansDisbursementData;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
+
+    private Long clientId;
+
+    private static final String DATE = "01 January 2026";
+    private static final String LATER_DATE = "01 June 2026";
+
+    @BeforeEach
+    public void setup() {
+        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+    }
+
+    /** FLAT CHARGE **/
+    @Test
+    public void shouldApplyRoundingRules_forFlatCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createFlatCharge(19.8);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 19.8);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("19.8"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpFlatCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createFlatCharge(0.6);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.6);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.6"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddFlatCharge_whenAmountRoundsToZero() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createFlatCharge(0.5);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.5);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    /** PERCENTAGE OF AMOUNT CHARGE **/
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfAmountCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 3);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountCharge(2.5067);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 2.5067);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal principal = getLoanPrincipal(loanId);
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(principal.toPlainString(), "0.025067", 0, 3);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageOfAmountCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountCharge(0.006);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.006);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal principal = getLoanPrincipal(loanId);
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(principal.toPlainString(), "0.00006", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentageOfAmountCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountCharge(0.005);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.005);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    /** PERCENTAGE OF AMOUNT + INTEREST CHARGE **/
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfAmountPlusInterestCharge_beforeInterestAccrual() {
+        runAt(DATE, () -> {
+
+            Long productId = createLoanProduct(0, 1);
+
+            Long loanId = applyAndApproveLoan(productId, 10000.0, 1);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountPlusInterestCharge(2.536);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 2.536);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal principal = getLoanPrincipal(loanId);
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(principal.toPlainString(), "0.02536", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfAmountPlusInterestCharge_afterInterestAccrualViaCOB() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(10000.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            BigDecimal totalInterest = executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountPlusInterestCharge(2.536);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), LATER_DATE, 2.536);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal base = new BigDecimal("10000").add(totalInterest);
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(base.toPlainString(), "0.02536", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageOfAmountPlusInterestCharge_whenValueIsAboveHalf() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(100.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            BigDecimal totalInterest = executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountPlusInterestCharge(0.56);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), LATER_DATE, 0.56);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal base = new BigDecimal("100").add(totalInterest);
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(base.toPlainString(), "0.0056", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentageOfAmountPlusInterestCharge_whenRoundedToZero() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(100.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfAmountPlusInterestCharge(0.38);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.38);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    /** PERCENTAGE OF INTEREST **/
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfInterestCharge() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(10000.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            BigDecimal totalInterest = executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfInterestCharge(2.536);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), LATER_DATE, 2.536);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(totalInterest.toPlainString(), "0.02536", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageOfInterestCharge_whenValueIsAboveHalf() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(100.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            BigDecimal totalInterest = executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfInterestCharge(2.068);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), LATER_DATE, 2.068);
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge(totalInterest.toPlainString(), "0.02068", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentageOfInterestCharge_whenRoundedToZero() {
+        AtomicReference<Long> loanIdRef = new AtomicReference<>();
+
+        runAt(DATE, () -> {
+            loanIdRef.set(createAndDisburseProgressiveLoan(100.0, 0, 1));
+        });
+
+        runAt(LATER_DATE, () -> {
+
+            Long loanId = loanIdRef.get();
+
+            executeCobAndGetTotalInterest(loanId);
+
+            PostChargesResponse chargeResponse = createPercentageOfInterestCharge(1.68);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 1.68);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    /** PERCENTAGE OF TRANCHE DISBURSEMENT */
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfTrancheDisbursementCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfTrancheDisbursementCharge(0.5);
+            assertNotNull(chargeResponse.getResourceId());
+
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.5);
+
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            assertNotNull(charges);
+            assertEquals(2, charges.size());
+
+            List<BigDecimal> actualAmounts = extractAndSortAmounts(charges);
+            assertTrue(actualAmounts.stream().allMatch(amount -> amount.compareTo(BigDecimal.ZERO) > 0));
+
+            List<BigDecimal> expectedAmounts = calculateExpectedTrancheCharges(disbursements, "0.005", 0, 1);
+
+            assertFalse(expectedAmounts.isEmpty());
+            assertEquals(expectedAmounts.size(), actualAmounts.size());
+            assertBigDecimalListEquals(expectedAmounts, actualAmounts);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentageOfTrancheDisbursementCharge_whenAnyTrancheRoundsToZero() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfTrancheDisbursementCharge(0.09);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.09);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            assertTrue(charges == null || charges.isEmpty(), "Expected no charges since rounded amount becomes 0");
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    @Test
+    public void shouldFailToAddAnyCharges_whenAllRoundedChargesBecomeZero_forPercentageOfTrancheDisbursementCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfTrancheDisbursementCharge(0.04);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.04);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            assertTrue(charges == null || charges.isEmpty(), "Expected no charges since rounded amount becomes 0");
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    /** PERCENTAGE OF DISBURSEMENT */
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfDisbursementCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfDisbursementCharge(0.5);
+
+            assertNotNull(chargeResponse.getResourceId());
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.5);
+
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+
+            assertNotNull(charges);
+            assertEquals(1, charges.size());
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("615", "0.005", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageOfDisbursementCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfDisbursementCharge(0.09);
+            assertNotNull(chargeResponse.getResourceId());
+
+            addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.09);
+
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+
+            assertNotNull(charges);
+            assertEquals(1, charges.size());
+
+            BigDecimal actualChargeAmount = getLoanChargeAmount(loanId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("615", "0.0009", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentageOfDisbursementCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+
+            Long productId = createMultiDisbursementLoanProduct(0, 1);
+
+            List<PostLoansDisbursementData> disbursements = List.of(
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 January 2026").principal(new BigDecimal("615")),
+                    new PostLoansDisbursementData().expectedDisbursementDate("01 February 2026").principal(new BigDecimal("385")));
+
+            Long loanId = applyAndApproveMultiTrancheLoan(productId, disbursements);
+
+            PostChargesResponse chargeResponse = createPercentageOfDisbursementCharge(0.04);
+            assertNotNull(chargeResponse.getResourceId());
+
+            PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.04);
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+
+            assertEquals(403, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+
+            assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
+        });
+    }
+
+    // -----------------------------
+    // HELPERS
+    // -----------------------------
+
+    private Long createLoanProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return loanProductHelper
+                .createLoanProduct(baseLoanProductRequest().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf))
+                .getResourceId();
+    }
+
+    private Long createMultiDisbursementLoanProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return loanProductHelper
+                .createLoanProduct(
+                        baseLoanProductRequestMultiRepayment().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf))
+                .getResourceId();
+    }
+
+    private PostLoanProductsRequest baseLoanProductRequest() {
+        return new PostLoanProductsRequest().name("LP-" + UUID.randomUUID()).shortName(randomShortName()).currencyCode("USD").locale("en")
+                .dateFormat("dd MMMM yyyy").principal(10000.00).numberOfRepayments(1).repaymentEvery(1).repaymentFrequencyType(1L)
+                .interestRatePerPeriod(1.0).interestRateFrequencyType(1).amortizationType(1).interestType(0)
+                .interestCalculationPeriodType(1).transactionProcessingStrategyCode("mifos-standard-strategy").accountingRule(1)
+                .isInterestRecalculationEnabled(false).daysInYearType(1).daysInMonthType(1);
+    }
+
+    private String randomShortName() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        return "L" + chars.charAt(ThreadLocalRandom.current().nextInt(chars.length()))
+                + chars.charAt(ThreadLocalRandom.current().nextInt(chars.length()))
+                + chars.charAt(ThreadLocalRandom.current().nextInt(chars.length()));
+    }
+
+    private PostLoanProductsRequest baseLoanProductRequestMultiRepayment() {
+        return baseLoanProductRequest().interestCalculationPeriodType(0).multiDisburseLoan(true).maxTrancheCount(2)
+                .outstandingLoanBalance(0.0).disallowExpectedDisbursements(false);
+    }
+
+    private Long applyAndApproveLoan(Long productId, double principal, int repayments) {
+        PostLoansResponse response = loanTransactionHelper.applyLoan(applyLoanRequest(clientId, productId, DATE, principal, repayments));
+        Long loanId = response.getLoanId();
+        BigDecimal approvedPrincipal = getLoanPrincipal(loanId);
+        assertNotNull(approvedPrincipal);
+        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(approvedPrincipal.doubleValue(), DATE));
+        return loanId;
+    }
+
+    private BigDecimal getLoanPrincipal(Long loanId) {
+        return loanTransactionHelper.getLoanDetails(loanId).getPrincipal();
+    }
+
+    private Long applyAndApproveMultiTrancheLoan(Long productId, List<PostLoansDisbursementData> disbursements) {
+        double totalPrincipal = disbursements.stream().map(PostLoansDisbursementData::getPrincipal).mapToDouble(BigDecimal::doubleValue)
+                .sum();
+
+        PostLoansRequest request = applyLoanRequest(clientId, productId, DATE, totalPrincipal, disbursements.size());
+        request.interestCalculationPeriodType(0).setDisbursementData(disbursements);
+        PostLoansResponse response = loanTransactionHelper.applyLoan(request);
+        Long loanId = response.getLoanId();
+        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(totalPrincipal, DATE));
+        return loanId;
+    }
+
+    private PostChargesResponse createFlatCharge(double amount) {
+        String uniqueChargeName = "Loan Flat Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2)
+                .chargeCalculationType(1).amount(amount).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageOfAmountCharge(double percentage) {
+        String uniqueChargeName = "Loan Percentage of Amount Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper
+                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(2)
+                        .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageOfAmountPlusInterestCharge(double percentage) {
+        String uniqueChargeName = "Loan Percentage of Amount Plus Interest Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper
+                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(3)
+                        .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageOfInterestCharge(double percentage) {
+        String uniqueChargeName = "Loan Percentage of Interest Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper
+                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(4)
+                        .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageOfTrancheDisbursementCharge(double percentage) {
+        String uniqueChargeName = "Loan Tranche Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper
+                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(12).chargeCalculationType(5)
+                        .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageOfDisbursementCharge(double percentage) {
+        String uniqueChargeName = "Loan Disbursement Charge" + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper
+                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(1).chargeCalculationType(2)
+                        .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    protected PostLoansLoanIdChargesRequest buildLoanChargeRequest(Long chargeId, String dueDate, Double amount) {
+        return new PostLoansLoanIdChargesRequest().chargeId(chargeId).amount(amount).dueDate(dueDate).dateFormat("dd MMMM yyyy")
+                .locale("en");
+    }
+
+    @Override
+    protected PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, Long chargeId, String dueDate, Double amount) {
+        PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeId, dueDate, amount);
+        return loanTransactionHelper.addLoanCharge(loanId, request);
+    }
+
+    private BigDecimal getLoanChargeAmount(Long loanId, Long chargeId) {
+        List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+        assertNotNull(charges);
+        GetLoansLoanIdLoanChargeData charge = charges.stream().filter(c -> Objects.equals(c.getChargeId(), chargeId)).findFirst()
+                .orElseThrow(() -> new AssertionError("Loan charge not found: " + chargeId));
+
+        BigDecimal amount = charge.getAmount();
+        assertNotNull(amount);
+        return amount;
+    }
+
+    private BigDecimal calculateExpectedPercentageCharge(String baseAmount, String percentageAsDecimal, int digitsAfterDecimal,
+            int inMultiplesOf) {
+        BigDecimal base = new BigDecimal(baseAmount);
+        BigDecimal percentage = new BigDecimal(percentageAsDecimal);
+        BigDecimal rawCharge = base.multiply(percentage);
+        return applyRoundingRules(rawCharge, digitsAfterDecimal, inMultiplesOf);
+    }
+
+    private List<GetLoansLoanIdLoanChargeData> getLoanCharges(Long loanId) {
+        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        return loanDetails.getCharges();
+    }
+
+    private List<BigDecimal> extractAndSortAmounts(List<GetLoansLoanIdLoanChargeData> charges) {
+        return charges.stream().map(GetLoansLoanIdLoanChargeData::getAmount).sorted().toList();
+    }
+
+    private BigDecimal applyRoundingRules(BigDecimal amount, int digitsAfterDecimal, int inMultiplesOf) {
+        BigDecimal scaled;
+
+        if (digitsAfterDecimal == 0) {
+            BigDecimal fractionPart = amount.remainder(BigDecimal.ONE);
+
+            if (fractionPart.compareTo(new BigDecimal("0.5")) <= 0) {
+                scaled = amount.setScale(0, RoundingMode.DOWN);
+            } else {
+                scaled = amount.setScale(0, RoundingMode.UP);
+            }
+        } else {
+            scaled = amount.setScale(digitsAfterDecimal, RoundingMode.HALF_UP);
+        }
+
+        if (digitsAfterDecimal == 0 && inMultiplesOf > 0) {
+            BigDecimal divisor = new BigDecimal(inMultiplesOf);
+            BigDecimal remainder = scaled.remainder(divisor);
+
+            if (remainder.compareTo(BigDecimal.ZERO) != 0) {
+                scaled = scaled.add(divisor.subtract(remainder));
+            }
+        }
+        return scaled;
+    }
+
+    private List<BigDecimal> calculateExpectedTrancheCharges(List<PostLoansDisbursementData> disbursements, String percentageAsDecimal,
+            int digitsAfterDecimal, int inMultiplesOf) {
+        BigDecimal percentage = new BigDecimal(percentageAsDecimal);
+        List<BigDecimal> expectedAmounts = new ArrayList<>();
+        for (PostLoansDisbursementData disbursement : disbursements) {
+            BigDecimal rawCharge = disbursement.getPrincipal().multiply(percentage);
+            BigDecimal rounded = applyRoundingRules(rawCharge, digitsAfterDecimal, inMultiplesOf);
+            if (rounded.compareTo(BigDecimal.ZERO) != 0) {
+                expectedAmounts.add(rounded);
+            }
+        }
+        Collections.sort(expectedAmounts);
+        return expectedAmounts;
+    }
+
+    private void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual));
+    }
+
+    private void assertBigDecimalListEquals(List<BigDecimal> expected, List<BigDecimal> actual) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(0, expected.get(i).compareTo(actual.get(i)));
+        }
+    }
+
+    /// AMOUNT + INTEREST
+    private Long createAndDisburseProgressiveLoan(double principal, int digitsAfterDecimal, int inMultiplesOf) {
+        PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+                create4IProgressive().numberOfRepayments(12).interestRatePerPeriod(1.0).isInterestRecalculationEnabled(false)
+                        .currencyCode("USD").digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf));
+
+        PostLoansRequest request = applyLoanRequest(clientId, loanProduct.getResourceId(), DATE, principal, 12);
+
+        request.setInterestRatePerPeriod(new BigDecimal("1.0"));
+        request.setInterestRateFrequencyType(1);
+        request.setTransactionProcessingStrategyCode("advanced-payment-allocation-strategy");
+
+        Long loanId = loanTransactionHelper.applyLoan(request).getLoanId();
+
+        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(principal, DATE));
+
+        loanTransactionHelper.disburseLoan(loanId, DATE, principal);
+
+        return loanId;
+    }
+
+    private BigDecimal executeCobAndGetTotalInterest(Long loanId) {
+        inlineLoanCOBHelper.executeInlineCOB(loanId);
+
+        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+
+        BigDecimal totalInterest = loanDetails.getRepaymentSchedule().getPeriods().stream()
+                .map(p -> p.getInterestDue() == null ? BigDecimal.ZERO : p.getInterestDue()).reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        assertTrue(totalInterest.compareTo(BigDecimal.ZERO) > 0);
+
+        return totalInterest;
+    }
+
+    private void assertNoChargesPersisted(Long loanId, Long chargeId) {
+        List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+
+        boolean chargeExists = charges != null && charges.stream().anyMatch(c -> Objects.equals(c.getChargeId(), chargeId));
+
+        assertFalse(chargeExists, "Expected charge not to persist since rounded amount becomes 0");
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsAccountChargeRoundingTest.java
@@ -1,0 +1,351 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.GetSavingsAccountsSavingsAccountIdChargesResponse;
+import org.apache.fineract.client.models.GetSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdResponse;
+import org.apache.fineract.client.models.PostChargesResponse;
+import org.apache.fineract.client.models.PostSavingsAccountTransactionsRequest;
+import org.apache.fineract.client.models.PostSavingsAccountTransactionsResponse;
+import org.apache.fineract.client.models.PostSavingsAccountsSavingsAccountIdChargesRequest;
+import org.apache.fineract.client.models.PostSavingsAccountsSavingsAccountIdChargesResponse;
+import org.apache.fineract.client.models.PostSavingsProductsRequest;
+import org.apache.fineract.client.models.SavingsAccountData;
+import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.savings.base.BaseSavingsIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class SavingsAccountChargeRoundingTest extends BaseSavingsIntegrationTest {
+
+    private Long clientId;
+    private ChargesHelper chargesHelper;
+    private static final String DATE = "01 January 2026";
+
+    @BeforeEach
+    public void setup() {
+        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        chargesHelper = new ChargesHelper();
+    }
+
+    /** FLAT CHARGE **/
+    @Test
+    public void shouldApplyRoundingRules_forFlatCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createFlatCharge(19.8);
+            assertNotNull(charge.getResourceId());
+
+            Long savingsChargeId = addFlatCharge(savingsId, charge.getResourceId(), 19.8, DATE);
+
+            BigDecimal actualChargeAmount = getSavingsChargeAmount(savingsId, savingsChargeId);
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("19.8"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpFlatCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createFlatCharge(0.6);
+            assertNotNull(charge.getResourceId());
+
+            Long savingsChargeId = addFlatCharge(savingsId, charge.getResourceId(), 0.6, DATE);
+
+            BigDecimal actualChargeAmount = getSavingsChargeAmount(savingsId, savingsChargeId);
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.6"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddFlatCharge_whenAmountRoundsToZero() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createFlatCharge(0.4);
+            assertNotNull(charge.getResourceId());
+
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> addFlatCharge(savingsId, charge.getResourceId(), 0.4, DATE));
+
+            assertEquals(400, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.savings.charge.amount.rounded.to.zero"));
+            assertNoChargesPersisted(savingsId, charge.getResourceId());
+        });
+    }
+
+    @Test
+    public void shouldApplyRoundingRules_forPercentageOfWithdrawalCharge() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createPercentageWithdrawalCharge(2.5);
+
+            addPercentageWithdrawalCharge(savingsId, charge.getResourceId(), 2.5);
+
+            deposit(savingsId, DATE, BigDecimal.valueOf(1000));
+
+            withdraw(savingsId, DATE, BigDecimal.valueOf(615));
+
+            SavingsAccountData accountData = getSavingsAccount(savingsId);
+
+            BigDecimal actualChargeFees = getActualChargeAmount(accountData);
+            assertNotNull(actualChargeFees);
+
+            BigDecimal actualBalance = getActualBalance(accountData);
+            assertNotNull(actualBalance);
+
+            BigDecimal expectedChargeFees = calculateExpectedPercentageCharge("615", "0.025", 0, 1);
+
+            BigDecimal expectedBalance = calculateExpectedBalance("1000", "615", expectedChargeFees);
+
+            assertBigDecimalEquals(expectedChargeFees, actualChargeFees);
+            assertBigDecimalEquals(expectedBalance, actualBalance);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageOfWithdrawalCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createPercentageWithdrawalCharge(2.5);
+
+            addPercentageWithdrawalCharge(savingsId, charge.getResourceId(), 2.5);
+
+            deposit(savingsId, DATE, BigDecimal.valueOf(1000));
+
+            withdraw(savingsId, DATE, BigDecimal.valueOf(24));
+
+            SavingsAccountData accountData = getSavingsAccount(savingsId);
+
+            BigDecimal actualChargeFees = getActualChargeAmount(accountData);
+            assertNotNull(actualChargeFees);
+
+            BigDecimal actualBalance = getActualBalance(accountData);
+            assertNotNull(actualBalance);
+
+            BigDecimal expectedChargeFees = calculateExpectedPercentageCharge("24", "0.025", 0, 1);
+
+            BigDecimal expectedBalance = calculateExpectedBalance("1000", "24", expectedChargeFees);
+
+            assertBigDecimalEquals(expectedChargeFees, actualChargeFees);
+            assertBigDecimalEquals(expectedBalance, actualBalance);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeFees);
+        });
+    }
+
+    @Test
+    public void shouldIgnorePercentageOfWithdrawalCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+
+            Long productId = createSavingsProduct(0, 1);
+            Long savingsId = createAndActivateSavingsAccount(productId, DATE);
+
+            PostChargesResponse charge = createPercentageWithdrawalCharge(2.5);
+
+            addPercentageWithdrawalCharge(savingsId, charge.getResourceId(), 2.5);
+
+            deposit(savingsId, DATE, BigDecimal.valueOf(1000));
+
+            withdraw(savingsId, DATE, BigDecimal.valueOf(20));
+
+            SavingsAccountData accountData = getSavingsAccount(savingsId);
+
+            BigDecimal actualChargeFees = getActualChargeAmount(accountData);
+            assertNull(actualChargeFees);
+
+            BigDecimal actualBalance = getActualBalance(accountData);
+            assertNotNull(actualBalance);
+
+            assertBigDecimalEquals(new BigDecimal("980"), actualBalance);
+        });
+    }
+
+    // -----------------------------
+    // HELPERS
+    // -----------------------------
+
+    private Long createSavingsProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return createProduct(baseSavingsProduct(digitsAfterDecimal, inMultiplesOf)).getResourceId();
+    }
+
+    private PostSavingsProductsRequest baseSavingsProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return dailyInterestPostingProduct().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf).currencyCode("USD");
+    }
+
+    private Long createAndActivateSavingsAccount(Long productId, String date) {
+        Long savingsId = applySavingsAccount(applySavingsRequest(clientId, productId, date)).getSavingsId();
+        approveSavingsAccount(savingsId, date);
+        activateSavingsAccount(savingsId, date);
+        return savingsId;
+    }
+
+    private PostChargesResponse createFlatCharge(double amount) {
+        String uniqueChargeName = "Savings Account Flat Charge " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(2) // SAVINGS
+                .chargeTimeType(2) // SPECIFIED DUE DATE
+                .chargeCalculationType(1) // FLAT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPercentageWithdrawalCharge(double percentage) {
+        String uniqueChargeName = "Savings Account Withdrawal Charge " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(2) // SAVINGS
+                .chargeTimeType(5) // WITHDRAWAL
+                .chargeCalculationType(2) // % OF AMOUNT
+                .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
+    }
+
+    private Long addFlatCharge(Long savingsId, Long chargeId, double amount, String date) {
+        PostSavingsAccountsSavingsAccountIdChargesRequest request = new PostSavingsAccountsSavingsAccountIdChargesRequest()
+                .chargeId(chargeId).amount((float) amount).dateFormat(DATETIME_PATTERN).locale("en").dueDate(date);
+
+        PostSavingsAccountsSavingsAccountIdChargesResponse response = ok(
+                fineractClient().savingsAccountCharges.addSavingsAccountCharge(savingsId, request));
+
+        return response.getResourceId();
+    }
+
+    private void addPercentageWithdrawalCharge(Long savingsId, Long chargeId, double amount) {
+        PostSavingsAccountsSavingsAccountIdChargesRequest request = new PostSavingsAccountsSavingsAccountIdChargesRequest()
+                .chargeId(chargeId).amount((float) amount).locale("en");
+
+        ok(fineractClient().savingsAccountCharges.addSavingsAccountCharge(savingsId, request));
+    }
+
+    private PostSavingsAccountTransactionsResponse withdraw(Long savingsId, String date, BigDecimal amount) {
+        PostSavingsAccountTransactionsRequest request = new PostSavingsAccountTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                .locale("en").paymentTypeId(1).transactionAmount(amount).transactionDate(date);
+
+        return ok(fineractClient().savingsTransactions.createSavingsAccountTransaction(savingsId, request, "withdrawal"));
+    }
+
+    private GetSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdResponse getSavingsAccountCharge(Long savingsId,
+            Long savingsAccountChargeId) {
+        return ok(fineractClient().savingsAccountCharges.retrieveSavingsAccountCharge(savingsId, savingsAccountChargeId));
+    }
+
+    private BigDecimal applyRoundingRules(BigDecimal amount, int digitsAfterDecimal, int inMultiplesOf) {
+        BigDecimal scaled;
+
+        if (digitsAfterDecimal == 0) {
+            BigDecimal fractionPart = amount.remainder(BigDecimal.ONE);
+
+            if (fractionPart.compareTo(new BigDecimal("0.5")) <= 0) {
+                scaled = amount.setScale(0, RoundingMode.DOWN);
+            } else {
+                scaled = amount.setScale(0, RoundingMode.UP);
+            }
+        } else {
+            scaled = amount.setScale(digitsAfterDecimal, RoundingMode.HALF_UP);
+        }
+
+        if (digitsAfterDecimal == 0 && inMultiplesOf > 0) {
+            BigDecimal divisor = new BigDecimal(inMultiplesOf);
+            BigDecimal remainder = scaled.remainder(divisor);
+
+            if (remainder.compareTo(BigDecimal.ZERO) != 0) {
+                scaled = scaled.add(divisor.subtract(remainder));
+            }
+        }
+        return scaled;
+    }
+
+    private BigDecimal getSavingsChargeAmount(Long savingsId, Long savingsChargeId) {
+
+        var chargeData = getSavingsAccountCharge(savingsId, savingsChargeId);
+
+        assertNotNull(chargeData);
+        assertNotNull(chargeData.getAmount());
+
+        return BigDecimal.valueOf(chargeData.getAmount().doubleValue());
+    }
+
+    private void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual));
+    }
+
+    private BigDecimal getActualChargeAmount(SavingsAccountData accountData) {
+        assertNotNull(accountData.getSummary());
+        return accountData.getSummary().getTotalWithdrawalFees();
+    }
+
+    private BigDecimal getActualBalance(SavingsAccountData accountData) {
+        assertNotNull(accountData.getSummary());
+        return accountData.getSummary().getAccountBalance();
+    }
+
+    private BigDecimal calculateExpectedPercentageCharge(String baseAmount, String percentageAsDecimal, int digitsAfterDecimal,
+            int inMultiplesOf) {
+        BigDecimal base = new BigDecimal(baseAmount);
+        BigDecimal percentage = new BigDecimal(percentageAsDecimal);
+        BigDecimal rawCharge = base.multiply(percentage);
+        return applyRoundingRules(rawCharge, digitsAfterDecimal, inMultiplesOf);
+    }
+
+    private BigDecimal calculateExpectedBalance(String deposit, String withdraw, BigDecimal expectedChargeFees) {
+        return new BigDecimal(deposit).subtract(new BigDecimal(withdraw)).subtract(expectedChargeFees);
+    }
+
+    private List<GetSavingsAccountsSavingsAccountIdChargesResponse> getSavingsCharges(Long savingsId) {
+        return ok(fineractClient().savingsAccountCharges.retrieveAllSavingsAccountCharges(savingsId, "all"));
+    }
+
+    private void assertNoChargesPersisted(Long savingsId, Long chargeId) {
+        var charges = getSavingsCharges(savingsId);
+        boolean chargeExists = charges.stream().anyMatch(c -> chargeId.equals(c.getChargeId()));
+        assertFalse(chargeExists, "Expected charge not to persist since rounded amount becomes 0");
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ShareAccountChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ShareAccountChargeRoundingTest.java
@@ -1,0 +1,665 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.accounting.journalentry.domain.JournalEntryType;
+import org.apache.fineract.accounting.journalentry.service.AccountingProcessorHelper;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.AccountChargesRequest;
+import org.apache.fineract.client.models.AccountRequest;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.GetAccountsCharges;
+import org.apache.fineract.client.models.GetAccountsPurchasedShares;
+import org.apache.fineract.client.models.GetAccountsTypeAccountIdResponse;
+import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
+import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.PostAccountsTypeAccountIdRequest;
+import org.apache.fineract.client.models.PostChargesResponse;
+import org.apache.fineract.client.models.PostProductsTypeRequest;
+import org.apache.fineract.client.models.PostSavingsProductsRequest;
+import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignAccountHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignJournalEntryHelper;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareAccountTransactionHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareProductHelper;
+import org.apache.fineract.integrationtests.common.shares.ShareProductTransactionHelper;
+import org.apache.fineract.integrationtests.savings.base.BaseSavingsIntegrationTest;
+import org.apache.fineract.portfolio.shareaccounts.domain.ShareAccountStatusType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ShareAccountChargeRoundingTest extends BaseSavingsIntegrationTest {
+
+    private Long clientId;
+    private ChargesHelper chargesHelper;
+    private static final String DATE = "01 January 2026";
+    private static final String LATER_DATE = "01 June 2026";
+
+    @BeforeEach
+    public void setup() {
+        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        chargesHelper = new ChargesHelper();
+    }
+
+    /** ACTIVATION CHARGE - FLAT **/
+    @Test
+    public void shouldApplyRoundingRules_forFlatActivationCharge() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createActivationFeeFlatCharge(19.8);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 19.8, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("19.8"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpFlatActivationCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createActivationFeeFlatCharge(0.55);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.55, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.55"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddFlatActivationCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createActivationFeeFlatCharge(0.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.5, DATE));
+
+            assertEquals(400, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.share.charge.amount.rounded.to.zero"));
+        });
+    }
+
+    @Test
+    void verifyActivationChargeRoundedCorrectlyWithAccountingEnabled() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createActivationFeeFlatCharge(19.8);
+
+            Long shareProductId = createShareProductWithAccountingRule2(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 19.8, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("19.8"), 0, 1);
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+
+            GetAccountsTypeAccountIdResponse accountData = ok(
+                    fineractClient().shareAccounts.retrieveOneShareAccount(shareAccountId, "share"));
+            assertShareAccountActive(accountData);
+
+            // Find the charge payment transaction
+            GetAccountsPurchasedShares chargeTransaction = getChargePaymentTransaction(accountData);
+
+            // Verify accounting journal entries
+            GetJournalEntriesTransactionIdResponse journalResponse = getJournalEntriesForShareTransaction(chargeTransaction.getId());
+            assertNotNull(journalResponse);
+            assertEquals(2L, journalResponse.getTotalFilteredRecords());
+
+            List<JournalEntryTransactionItem> entries = journalResponse.getPageItems();
+            assertNotNull(entries);
+            assertEquals(2, entries.size());
+
+            JournalEntryTransactionItem debit = getDebitEntry(entries);
+            JournalEntryTransactionItem credit = getCreditEntry(entries);
+
+            assertActivationChargeAccounting(debit, credit, expectedChargeAmount);
+        });
+    }
+
+    /** PURCHASE CHARGE - FLAT **/
+    @Test
+    public void shouldApplyRoundingRules_forFlatPurchaseCharge() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 3);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeeFlatCharge(19.8);
+
+            Long shareProductId = createShareProduct(0, 3);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 19.8, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("19.8"), 0, 3);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpFlatPurchaseCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeeFlatCharge(0.51);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.51, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.51"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddFlatPurchaseCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeeFlatCharge(0.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.5, DATE));
+
+            assertEquals(400, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.share.charge.amount.rounded.to.zero"));
+        });
+    }
+
+    /** PURCHASE CHARGE - PERCENTAGE **/
+    @Test
+    public void shouldApplyRoundingRules_forPercentagePurchaseCharge() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeePercentCharge(2.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 2.5, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("100", "0.025", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentagePurchaseCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeePercentCharge(0.51);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.51, DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("100", "0.0051", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldFailToAddPercentagePurchaseCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createPurchaseFeePercentCharge(0.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.5, DATE));
+
+            assertEquals(400, exception.getResponse().code());
+            assertTrue(exception.getMessage().contains("error.msg.share.charge.amount.rounded.to.zero"));
+        });
+    }
+
+    /** REDEEM CHARGE - FLAT **/
+    @Test
+    public void shouldApplyRoundingRules_forFlatRedeemCharge() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeeFlatCharge(10.7);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 10.7, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("10.7"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpFlatRedeemCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeeFlatCharge(0.6);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.6, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.6"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldIgnoreFlatRedeemCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeeFlatCharge(0.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 0.5, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = applyRoundingRules(new BigDecimal("0.5"), 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ZERO, expectedChargeAmount);
+        });
+    }
+
+    /** REDEEM CHARGE - PERCENT **/
+    @Test
+    public void shouldApplyRoundingRules_forPercentageRedeemCharge() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeePercentCharge(5.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 5.5, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("50", "0.055", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldRoundUpPercentageRedeemCharge_whenValueIsAboveHalf() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeePercentCharge(1.5);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 1.5, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("50", "0.015", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ONE, actualChargeAmount);
+        });
+    }
+
+    @Test
+    public void shouldIgnorePercentageRedeemCharge_whenRoundedToZero() {
+        runAt(DATE, () -> {
+            Long savingsProductId = createSavingsProduct(0, 1);
+            Long savingsAccountId = createAndActivateSavingsAccount(savingsProductId, DATE);
+
+            PostChargesResponse chargeResponse = createRedeemFeePercentCharge(1);
+
+            Long shareProductId = createShareProduct(0, 1);
+            Long shareAccountId = applyShareAccount(clientId, shareProductId, savingsAccountId, chargeResponse.getResourceId(), 1, DATE);
+            approveShareAccount(shareAccountId);
+            activateShareAccount(shareAccountId, DATE);
+            redeemShares(shareAccountId, 50, LATER_DATE);
+
+            BigDecimal actualChargeAmount = getShareChargeAmount(shareAccountId, chargeResponse.getResourceId());
+
+            BigDecimal expectedChargeAmount = calculateExpectedPercentageCharge("50", "0.01", 0, 1);
+
+            assertBigDecimalEquals(expectedChargeAmount, actualChargeAmount);
+            assertBigDecimalEquals(BigDecimal.ZERO, expectedChargeAmount);
+        });
+    }
+
+    // -----------------------------
+    // HELPERS
+    // -----------------------------
+
+    private Long createSavingsProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return createProduct(baseSavingsProduct(digitsAfterDecimal, inMultiplesOf)).getResourceId();
+    }
+
+    private PostSavingsProductsRequest baseSavingsProduct(int digitsAfterDecimal, int inMultiplesOf) {
+        return dailyInterestPostingProduct().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf).currencyCode("USD");
+    }
+
+    private Long createAndActivateSavingsAccount(Long productId, String date) {
+        Long savingsId = applySavingsAccount(applySavingsRequest(clientId, productId, date)).getSavingsId();
+        approveSavingsAccount(savingsId, date);
+        activateSavingsAccount(savingsId, date);
+        return savingsId;
+    }
+
+    private PostChargesResponse createActivationFeeFlatCharge(double amount) {
+        String uniqueChargeName = "Share Account Activation Fee Flat " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(4) // SHARE
+                .chargeTimeType(13) // ACTIVATION
+                .chargeCalculationType(1) // FLAT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPurchaseFeeFlatCharge(double amount) {
+        String uniqueChargeName = "Share Account Purchase Fee Flat " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(4) // SHARE
+                .chargeTimeType(14) // PURCHASE
+                .chargeCalculationType(1) // FLAT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private PostChargesResponse createPurchaseFeePercentCharge(double amount) {
+        String uniqueChargeName = "Share Account Purchase Fee Percent " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(4) // SHARE
+                .chargeTimeType(14) // PURCHASE
+                .chargeCalculationType(2) // PERCENT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private PostChargesResponse createRedeemFeeFlatCharge(double amount) {
+        String uniqueChargeName = "Share Account Redeem Fee Flat " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(4) // SHARE
+                .chargeTimeType(15) // REDEEM
+                .chargeCalculationType(1) // FLAT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private PostChargesResponse createRedeemFeePercentCharge(double amount) {
+        String uniqueChargeName = "Share Account Redeem Fee Percent " + UUID.randomUUID().toString().replace("-", "");
+        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(4) // SHARE
+                .chargeTimeType(15) // REDEEM
+                .chargeCalculationType(2) // PERCENT
+                .amount(amount).currencyCode("USD").locale("en").active(true).penalty(false));
+    }
+
+    private Long createShareProduct(int digitsAfterDecimal, int inMultiplesOf) {
+
+        PostProductsTypeRequest request = new PostProductsTypeRequest().name("Share Product " + UUID.randomUUID()).shortName("SP")
+                .description("Description").currencyCode("USD").digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf)
+                .locale("en").totalShares(1000).unitPrice(1).nominalShares(20).allowDividendCalculationForInactiveClients(true)
+                .accountingRule(1);
+
+        return ok(fineractClient().shareProducts.createShareProduct("share", request)).getResourceId();
+    }
+
+    private Long createShareProductWithAccountingRule2(int digitsAfterDecimal, int inMultiplesOf) {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        FineractFeignClient feignClient = FineractFeignClientHelper.getFineractFeignClient();
+        FeignAccountHelper accountHelper = new FeignAccountHelper(feignClient);
+
+        Account shareReference = accountHelper.createAssetAccount("Share Reference " + suffix);
+        Account shareSuspense = accountHelper.createLiabilityAccount("Share Suspense " + suffix);
+        Account feeIncome = accountHelper.createIncomeAccount("Share Fee Income " + suffix);
+        Account shareEquity = accountHelper.createEquityAccount("Share Equity " + suffix);
+
+        Account[] accounts = { shareReference, shareSuspense, shareEquity, feeIncome };
+
+        String shareProductJson = new ShareProductHelper().withCashBasedAccounting(accounts).withDigitsAfterDecimal(digitsAfterDecimal)
+                .withInMultiplesOf(inMultiplesOf).build();
+
+        return ShareProductTransactionHelper.createShareProduct(shareProductJson, requestSpec, responseSpec).longValue();
+    }
+
+    private Long applyShareAccount(Long clientId, Long productId, Long savingsAccountId, Long chargeId, double chargeAmount, String date) {
+        AccountChargesRequest charge = new AccountChargesRequest().chargeId(chargeId).amount(new BigDecimal(chargeAmount));
+
+        AccountRequest request = new AccountRequest().clientId(clientId).productId(productId).submittedDate(date).locale("en")
+                .dateFormat(DATETIME_PATTERN).savingsAccountId(savingsAccountId).requestedShares(100L).applicationDate(date)
+                .charges(List.of(charge));
+
+        return ok(fineractClient().shareAccounts.createShareAccount("share", request)).getResourceId();
+    }
+
+    private void approveShareAccount(Long shareAccountId) {
+        ok(fineractClient().shareAccounts.handleCommandsShareAccount("share", shareAccountId, new PostAccountsTypeAccountIdRequest(),
+                "approve"));
+    }
+
+    private void activateShareAccount(Long shareAccountId, String activationDate) {
+        Map<String, Object> activateMap = new HashMap<>();
+        activateMap.put("dateFormat", "dd MMMM yyyy");
+        activateMap.put("activatedDate", activationDate);
+        activateMap.put("locale", "en");
+
+        String activateJson = new Gson().toJson(activateMap);
+
+        ShareAccountTransactionHelper.postCommand("activate", shareAccountId.intValue(), activateJson, requestSpec, responseSpec);
+    }
+
+    private void redeemShares(Long shareAccountId, long shares, String requestedDate) {
+        Map<String, Object> redeemMap = new HashMap<>();
+        redeemMap.put("requestedDate", requestedDate);
+        redeemMap.put("dateFormat", "dd MMMM yyyy");
+        redeemMap.put("locale", "en");
+        redeemMap.put("requestedShares", String.valueOf(shares));
+
+        String redeemJson = new Gson().toJson(redeemMap);
+
+        ShareAccountTransactionHelper.postCommand("redeemshares", shareAccountId.intValue(), redeemJson, requestSpec, responseSpec);
+    }
+
+    private GetAccountsTypeAccountIdResponse getShareAccount(Long shareAccountId) {
+        return ok(fineractClient().shareAccounts.retrieveOneShareAccount(shareAccountId, "share"));
+    }
+
+    private BigDecimal getShareChargeAmount(Long shareAccountId, Long chargeId) {
+        GetAccountsTypeAccountIdResponse response = getShareAccount(shareAccountId);
+
+        Set<GetAccountsCharges> charges = response.getCharges();
+        assertNotNull(charges);
+
+        GetAccountsCharges charge = charges.stream().filter(c -> Objects.equals(c.getChargeId(), chargeId)).findFirst()
+                .orElseThrow(() -> new AssertionError("Share charge not found: " + chargeId));
+
+        BigDecimal amount = BigDecimal.valueOf(charge.getAmount());
+        assertNotNull(amount);
+
+        return amount;
+    }
+
+    private BigDecimal applyRoundingRules(BigDecimal amount, int digitsAfterDecimal, int inMultiplesOf) {
+        BigDecimal scaled;
+
+        if (digitsAfterDecimal == 0) {
+            BigDecimal fractionPart = amount.remainder(BigDecimal.ONE);
+
+            if (fractionPart.compareTo(new BigDecimal("0.5")) <= 0) {
+                scaled = amount.setScale(0, RoundingMode.DOWN);
+            } else {
+                scaled = amount.setScale(0, RoundingMode.UP);
+            }
+        } else {
+            scaled = amount.setScale(digitsAfterDecimal, RoundingMode.HALF_UP);
+        }
+
+        if (digitsAfterDecimal == 0 && inMultiplesOf > 0) {
+            BigDecimal divisor = new BigDecimal(inMultiplesOf);
+            BigDecimal remainder = scaled.remainder(divisor);
+
+            if (remainder.compareTo(BigDecimal.ZERO) != 0) {
+                scaled = scaled.add(divisor.subtract(remainder));
+            }
+        }
+        return scaled;
+    }
+
+    private BigDecimal calculateExpectedPercentageCharge(String baseAmount, String percentageAsDecimal, int digitsAfterDecimal,
+            int inMultiplesOf) {
+        BigDecimal base = new BigDecimal(baseAmount);
+        BigDecimal percentage = new BigDecimal(percentageAsDecimal);
+        BigDecimal rawCharge = base.multiply(percentage);
+        return applyRoundingRules(rawCharge, digitsAfterDecimal, inMultiplesOf);
+    }
+
+    private void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual));
+    }
+
+    private void assertShareAccountActive(GetAccountsTypeAccountIdResponse accountData) {
+        assertNotNull(accountData);
+        assertNotNull(accountData.getStatus());
+        assertEquals((long) ShareAccountStatusType.ACTIVE.getValue(), accountData.getStatus().getId());
+        assertEquals(ShareAccountStatusType.ACTIVE.getCode(), accountData.getStatus().getCode());
+        assertEquals(Boolean.TRUE, accountData.getStatus().getActive());
+    }
+
+    private GetAccountsPurchasedShares getChargePaymentTransaction(GetAccountsTypeAccountIdResponse accountData) {
+        assertNotNull(accountData.getPurchasedShares());
+        return accountData.getPurchasedShares().stream().filter(tx -> {
+            assertNotNull(tx.getType());
+            return "charge.payment".equals(tx.getType().getCode());
+        }).findFirst().orElseThrow(() -> new AssertionError("Charge payment transaction not found"));
+    }
+
+    private GetJournalEntriesTransactionIdResponse getJournalEntriesForShareTransaction(Long id) {
+        String transactionId = AccountingProcessorHelper.SHARE_TRANSACTION_IDENTIFIER + id;
+        FineractFeignClient feignClient = FineractFeignClientHelper.getFineractFeignClient();
+        FeignJournalEntryHelper feignJournalEntryHelper = new FeignJournalEntryHelper(feignClient);
+        return feignJournalEntryHelper.getJournalEntriesByTransactionId(transactionId);
+    }
+
+    private JournalEntryTransactionItem getDebitEntry(List<JournalEntryTransactionItem> entries) {
+        return entries.stream().filter(e -> {
+            assertNotNull(e.getEntryType());
+            return JournalEntryType.DEBIT.getCode().equals(e.getEntryType().getCode());
+        }).findFirst().orElseThrow(() -> new AssertionError("Debit entry not found"));
+    }
+
+    private JournalEntryTransactionItem getCreditEntry(List<JournalEntryTransactionItem> entries) {
+        return entries.stream().filter(e -> {
+            assertNotNull(e.getEntryType());
+            return JournalEntryType.CREDIT.getCode().equals(e.getEntryType().getCode());
+        }).findFirst().orElseThrow(() -> new AssertionError("Credit entry not found"));
+    }
+
+    private void assertActivationChargeAccounting(JournalEntryTransactionItem debit, JournalEntryTransactionItem credit,
+            BigDecimal expectedChargeAmount) {
+        assertNotNull(debit.getAmount());
+        assertBigDecimalEquals(expectedChargeAmount, BigDecimal.valueOf(debit.getAmount()));
+        assertNotNull(credit.getAmount());
+        assertBigDecimalEquals(expectedChargeAmount, BigDecimal.valueOf(credit.getAmount()));
+
+        assertNotNull(debit.getGlAccountName());
+        assertTrue(debit.getGlAccountName().startsWith("Share Reference"));
+        assertNotNull(credit.getGlAccountName());
+        assertTrue(credit.getGlAccountName().startsWith("Share Fee Income"));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
@@ -44,6 +44,10 @@ public class FeignAccountHelper {
         return createAccount(name, "2", "LIABILITY");
     }
 
+    public Account createEquityAccount(String name) {
+        return createAccount(name, "3", "EQUITY");
+    }
+
     public Account createIncomeAccount(String name) {
         return createAccount(name, "4", "INCOME");
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/shares/ShareProductHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/shares/ShareProductHelper.java
@@ -39,10 +39,10 @@ public class ShareProductHelper {
     private static final String NONE = "1";
     private static final String CASH_BASED = "2";
     private static final String LOCALE = "en_GB";
-    private static final String DIGITS_AFTER_DECIMAL = "4";
-    private static final String IN_MULTIPLES_OF = "0";
     private static final String USD = "USD";
 
+    private String digitsAfterDecimal = "4";
+    private String inMultiplesOf = "0";
     private String productName = Utils.uniqueRandomStringGenerator("SHARE_PRODUCT_", 6);
     private String shortName = Utils.uniqueRandomStringGenerator("", 4);
     private String description = Utils.randomStringGenerator("", 20);
@@ -76,8 +76,8 @@ public class ShareProductHelper {
         map.put("description", this.description);
         map.put("currencyCode", this.currencyCode);
         map.put("locale", LOCALE);
-        map.put("digitsAfterDecimal", DIGITS_AFTER_DECIMAL);
-        map.put("inMultiplesOf", IN_MULTIPLES_OF);
+        map.put("digitsAfterDecimal", this.digitsAfterDecimal);
+        map.put("inMultiplesOf", this.inMultiplesOf);
         map.put("totalShares", this.totalShares);
         map.put("sharesIssued", this.sharesIssued);
         map.put("unitPrice", this.unitPrice);
@@ -146,6 +146,16 @@ public class ShareProductHelper {
         return this;
     }
 
+    public ShareProductHelper withDigitsAfterDecimal(int digitsAfterDecimal) {
+        this.digitsAfterDecimal = String.valueOf(digitsAfterDecimal);
+        return this;
+    }
+
+    public ShareProductHelper withInMultiplesOf(int inMultiplesOf) {
+        this.inMultiplesOf = String.valueOf(inMultiplesOf);
+        return this;
+    }
+
     @SuppressWarnings("unchecked")
     // TODO: Rewrite to use fineract-client instead!
     // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
@@ -165,10 +175,10 @@ public class ShareProductHelper {
         Assertions.assertEquals(this.currencyCode, currencyCode);
 
         String digitsAfterDecimal = String.valueOf(currency.get("decimalPlaces"));
-        Assertions.assertEquals(DIGITS_AFTER_DECIMAL, digitsAfterDecimal);
+        Assertions.assertEquals(this.digitsAfterDecimal, digitsAfterDecimal);
 
         String inMultiplesOf = String.valueOf(currency.get("inMultiplesOf"));
-        Assertions.assertEquals(IN_MULTIPLES_OF, inMultiplesOf);
+        Assertions.assertEquals(this.inMultiplesOf, inMultiplesOf);
 
         String totalShares = String.valueOf(shareProductData.get("totalShares"));
         Assertions.assertEquals(this.totalShares, totalShares);


### PR DESCRIPTION
## Description

## FINERACT-2284: Enforce charge rounding using Money rounding rules

This PR fixes charge amount handling across Fineract by ensuring that charge values are rounded using the application's configured currency rules before they are persisted or processed.

Previously, several charge flows stored or processed raw `BigDecimal` values directly. As a result, charge amounts could bypass currency rounding settings such as:

* `digitsAfterDecimal`
* `inMultiplesOf`

This led to inconsistent behavior between charge calculations and other monetary operations that already rely on `Money`.

This PR standardizes charge amount handling by using `Money` for charge rounding across all supported charge types:

* Loan Charges
* Savings Account Charges
* Share Account Charges
* Client Charges

In addition, if a charge amount rounds to zero after applying currency rules, the charge is no longer persisted or created.

## Functional Changes

### Loan Charges

* Applied currency rounding when enforcing minimum and maximum charge caps.
* Ensured installment fee calculations and charge updates persist rounded values.
* Prevented zero-value loan charges from being persisted.

### Savings Account Charges

* Applied currency rounding through `Money`.
* Prevented persistence of flat charges whose final rounded value is zero.

### Share Account Charges

* Applied currency rounding when deriving charge amounts.
* Applied currency rounding when updating charge amounts for additional share transactions.
* Prevented creation of charge transactions for charges whose rounded value is zero.
* Prevented zero-value activation, purchase, and redemption charge transactions from being generated.

### Client Charges

* Applied currency rounding before charge creation.
* Prevented persistence of client charges whose rounded value becomes zero after rounding.

## API Documentation

Updated Swagger/OpenAPI schemas where required to improve request model documentation and examples.

## Why This Change

Fineract already provides currency-specific monetary rules through `Money`, including support for:

* Currency precision (`digitsAfterDecimal`)
* Rounding increments (`inMultiplesOf`)

Charges should follow the same monetary rules as all other financial amounts.

By enforcing rounding consistently:

* Charge calculations become predictable.
* Persisted charge values match configured currency behavior.
* Zero-value charges generated by rounding are avoided.
* Charge processing remains consistent across all portfolio modules.

## Test Coverage

Added integration test coverage for all supported charge types:

* `LoanChargeRoundingTest`
* `SavingsAccountChargeRoundingTest`
* `ShareAccountChargeRoundingTest`
* `ClientChargeRoundingTest`

The tests verify:

* Charge amounts respect configured currency rounding rules.
* `inMultiplesOf` and `digitsAfterDecimal` rounding is enforced.
* Rounded values are persisted correctly.
* Charges that round to zero are not created or persisted.

## Verification

Executed the complete charge rounding integration test suite successfully.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
