### PR TITLE
FINERACT-2421: Github Actions CI guard on private repositories

### DIFF
--- a/.github/workflows/full-build-ci.yml
+++ b/.github/workflows/full-build-ci.yml
@@ -21,7 +21,30 @@ permissions:
   contents: read
 
 jobs:
+  private-repository-ci-disabled:
+    if: >-
+      ${{
+        github.event.repository.private == true &&
+        github.event_name != 'workflow_dispatch' &&
+        vars.ENABLE_PRIVATE_REPOSITORY_CI != 'true'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Private repository CI disabled
+        run: |
+          echo "GitHub Actions CI is not enabled by default for private repositories to avoid unwanted costs."
+          echo "GitHub Actions is only free on public repositories."
+          echo "To enable automatic CI runs for this private repository, set the repository variable ENABLE_PRIVATE_REPOSITORY_CI to true."
+          echo "Manual workflow_dispatch runs are still allowed."
+
   build-core:
+    if: >-
+      ${{
+        github.event.repository.private == false ||
+        github.event_name == 'workflow_dispatch' ||
+        vars.ENABLE_PRIVATE_REPOSITORY_CI == 'true'
+      }}
     uses: ./.github/workflows/build-core.yml
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}


### PR DESCRIPTION
## Description

Adding a CI guard for private repositories to avoid unwanted costs:
- Manually job execution still allowed
- Guard can be overridden by setting `ENABLE_PRIVATE_REPOSITORY_CI=true` repository variable

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
