### PR TITLE
FINERACT-2627: Use Collection.isEmpty() instead of size() comparison …

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
@@ -174,7 +174,7 @@ public class LoanRepositoryWrapper {
     @Transactional(readOnly = true)
     public List<Loan> findByClientIdAndGroupId(@Param("clientId") Long clientId, @Param("groupId") Long groupId) {
         List<Loan> loans = this.repository.findByClientIdAndGroupId(clientId, groupId);
-        if (loans != null && loans.size() > 0) {
+        if (loans != null && !loans.isEmpty()) {
             for (Loan loan : loans) {
                 loan.initializeLoanOfficerHistory();
             }
@@ -186,7 +186,7 @@ public class LoanRepositoryWrapper {
     @Transactional(readOnly = true)
     public List<Loan> findLoanByClientId(@Param("clientId") Long clientId) {
         List<Loan> loans = this.repository.findLoanByClientId(clientId);
-        if (loans != null && loans.size() > 0) {
+        if (loans != null && !loans.isEmpty()) {
             for (Loan loan : loans) {
                 loan.initializeTransactions();
                 loan.initializeLoanOfficerHistory();
@@ -207,7 +207,7 @@ public class LoanRepositoryWrapper {
         List<List<Long>> partitions = Lists.partition(ids.stream().toList(), fineractProperties.getQuery().getInClauseParameterSizeLimit());
         partitions
                 .forEach(partition -> loans.addAll(this.repository.findByIdsAndLoanStatusAndLoanType(partition, loanStatuses, loanTypes)));
-        if (loans.size() > 0) {
+        if (!loans.isEmpty()) {
             for (Loan loan : loans) {
                 loan.initializeLazyCollections();
             }
@@ -224,7 +224,7 @@ public class LoanRepositoryWrapper {
     public List<Loan> findByClientOfficeIdsAndLoanStatus(@Param("officeIds") Collection<Long> officeIds,
             @Param("loanStatuses") Collection<LoanStatus> loanStatuses) {
         List<Loan> loans = this.repository.findByClientOfficeIdsAndLoanStatus(officeIds, loanStatuses);
-        if (loans != null && loans.size() > 0) {
+        if (loans != null && !loans.isEmpty()) {
             for (Loan loan : loans) {
                 loan.initializeRepaymentSchedule();
             }
@@ -236,7 +236,7 @@ public class LoanRepositoryWrapper {
     public List<Loan> findByGroupOfficeIdsAndLoanStatus(@Param("officeIds") Collection<Long> officeIds,
             @Param("loanStatuses") Collection<LoanStatus> loanStatuses) {
         List<Loan> loans = this.repository.findByGroupOfficeIdsAndLoanStatus(officeIds, loanStatuses);
-        if (loans != null && loans.size() > 0) {
+        if (loans != null && !loans.isEmpty()) {
             for (Loan loan : loans) {
                 loan.initializeRepaymentSchedule();
             }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanStatusChangeHistoryListener.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanStatusChangeHistoryListener.java
@@ -53,7 +53,7 @@ public class LoanStatusChangeHistoryListener {
     @PostConstruct
     public void addListeners() {
         loanStatuses.addAll(getLoanStatuses(fineractProperties.getLoan().getStatusChangeHistoryStatuses()));
-        if (loanStatuses.size() > 0) {
+        if (!loanStatuses.isEmpty()) {
             businessEventNotifierService.addPostBusinessEventListener(LoanStatusChangedBusinessEvent.class,
                     new LoanStatusChangedListener());
         }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProduct.java
@@ -396,14 +396,14 @@ public class LoanProduct extends AbstractPersistableCustom<Long> {
     }
 
     public void validateLoanProductPreSave() {
-        if (this.paymentAllocationRules != null && paymentAllocationRules.size() > 0
+        if (this.paymentAllocationRules != null && !paymentAllocationRules.isEmpty()
                 && !transactionProcessingStrategyCode.equals("advanced-payment-allocation-strategy")) {
             throw new LoanProductGeneralRuleException(
                     "payment_allocation.must.not.be.provided.when.allocation.strategy.is.not.advanced-payment-strategy",
                     "In case '" + transactionProcessingStrategyCode + "' payment strategy, payment_allocation must not be provided");
         }
 
-        if (this.creditAllocationRules != null && creditAllocationRules.size() > 0
+        if (this.creditAllocationRules != null && !creditAllocationRules.isEmpty()
                 && !transactionProcessingStrategyCode.equals("advanced-payment-allocation-strategy")) {
             throw new LoanProductGeneralRuleException(
                     "creditAllocation.must.not.be.provided.when.allocation.strategy.is.not.advanced-payment-strategy",


### PR DESCRIPTION
## Description

Replaces 5 occurrences of `loans.size() > 0` with `!loans.isEmpty()` in
`LoanRepositoryWrapper` (fineract-loan module), as flagged by SonarCloud rule
java:S1155 ("Collection.isEmpty() should be used to test for emptiness").

The change is behavior-preserving — `!collection.isEmpty()` is equivalent to
`collection.size() > 0` — and is a readability/consistency cleanup only.
No API, schema, or functional behavior changes. Covered by existing tests.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2627

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).