### PR TITLE
FINERACT-2633: Rework datasource connection handling

### DIFF
--- a/fineract-cob/src/main/java/org/apache/fineract/cob/domain/AbstractLockingService.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/domain/AbstractLockingService.java
@@ -20,26 +20,35 @@ package org.apache.fineract.cob.domain;
 
 import java.sql.PreparedStatement;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-@RequiredArgsConstructor
 @Slf4j
-public abstract class AbstractLockingService<T extends AccountLock> implements LockingService<T> {
+public abstract class AbstractLockingService implements LockingService {
 
     private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final FineractProperties fineractProperties;
-    private final AccountLockRepository<T> loanAccountLockRepository;
 
-    protected abstract String getBatchLoanLockUpgrade();
+    protected AbstractLockingService(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+        this.fineractProperties = fineractProperties;
+    }
+
+    protected abstract String getTableName();
 
     protected abstract String getBatchLoanLockInsert();
+
+    protected abstract String getBatchLoanLockUpgrade();
 
     @Override
     public void upgradeLock(List<Long> accountsToLock, LockOwner lockOwner) {
@@ -51,21 +60,21 @@ public abstract class AbstractLockingService<T extends AccountLock> implements L
     }
 
     @Override
-    public List<T> findAllByLoanIdIn(List<Long> loanIds) {
-        return loanAccountLockRepository.findAllByLoanIdIn(loanIds);
+    public List<Long> findLockIdsByLoanIdIn(List<Long> loanIds) {
+        if (loanIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT loan_id FROM " + getTableName() + " WHERE loan_id IN (:ids)";
+        return namedParameterJdbcTemplate.queryForList(sql, Map.of("ids", loanIds), Long.class);
     }
 
     @Override
-    public T findByLoanIdAndLockOwner(Long loanId, LockOwner lockOwner) {
-        return loanAccountLockRepository.findByLoanIdAndLockOwner(loanId, lockOwner).orElseGet(() -> {
-            log.warn("There is no lock for loan account with id: {}", loanId);
-            return null;
-        });
-    }
-
-    @Override
-    public List<T> findAllByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner) {
-        return loanAccountLockRepository.findAllByLoanIdInAndLockOwner(loanIds, lockOwner);
+    public List<Long> findLockIdsByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner) {
+        if (loanIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT loan_id FROM " + getTableName() + " WHERE loan_id IN (:ids) AND lock_owner = :owner";
+        return namedParameterJdbcTemplate.queryForList(sql, Map.of("ids", loanIds, "owner", lockOwner.name()), Long.class);
     }
 
     @Override
@@ -82,7 +91,20 @@ public abstract class AbstractLockingService<T extends AccountLock> implements L
 
     @Override
     public void deleteByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner) {
-        loanAccountLockRepository.deleteByLoanIdInAndLockOwner(loanIds, lockOwner);
+        if (loanIds.isEmpty()) {
+            return;
+        }
+        String sql = "DELETE FROM " + getTableName() + " WHERE loan_id IN (:ids) AND lock_owner = :owner";
+        namedParameterJdbcTemplate.update(sql, Map.of("ids", loanIds, "owner", lockOwner.name()));
+    }
+
+    @Override
+    public void updateLockError(Long loanId, LockOwner lockOwner, String error, String stacktrace) {
+        String sql = "UPDATE " + getTableName() + " SET error = ?, stacktrace = ? WHERE loan_id = ? AND lock_owner = ?";
+        int updated = jdbcTemplate.update(sql, error, stacktrace, loanId, lockOwner.name());
+        if (updated == 0) {
+            log.warn("No lock found to update error for loan id: {} with owner: {}", loanId, lockOwner);
+        }
     }
 
     private int getInClauseParameterSizeLimit() {

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/domain/LockingService.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/domain/LockingService.java
@@ -20,17 +20,17 @@ package org.apache.fineract.cob.domain;
 
 import java.util.List;
 
-public interface LockingService<T extends AccountLock> {
+public interface LockingService {
 
     void upgradeLock(List<Long> accountsToLock, LockOwner lockOwner);
 
     void deleteByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner);
 
-    List<T> findAllByLoanIdIn(List<Long> loanIds);
+    List<Long> findLockIdsByLoanIdIn(List<Long> loanIds);
 
-    T findByLoanIdAndLockOwner(Long loanId, LockOwner lockOwner);
-
-    List<T> findAllByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner);
+    List<Long> findLockIdsByLoanIdInAndLockOwner(List<Long> loanIds, LockOwner lockOwner);
 
     void applyLock(List<Long> loanIds, LockOwner lockOwner);
+
+    void updateLockError(Long loanId, LockOwner lockOwner, String error, String stacktrace);
 }

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/listener/AbstractLoanItemListener.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/listener/AbstractLoanItemListener.java
@@ -23,7 +23,6 @@ import static org.springframework.transaction.TransactionDefinition.PROPAGATION_
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.cob.domain.AccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.exceptions.LockedReadException;
@@ -43,23 +42,20 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractLoanItemListener<T extends AccountLock, S extends AbstractPersistableCustom<Long>> {
+public abstract class AbstractLoanItemListener<S extends AbstractPersistableCustom<Long>> {
 
-    private final LockingService<T> loanLockingService;
-
-    private final TransactionTemplate transactionTemplate;
+    private final LockingService loanLockingService;
+    private final TransactionTemplate batchJdbcTransactionTemplate;
 
     private void updateAccountLockWithError(List<Long> loanIds, String msg, Throwable e) {
-        transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+        batchJdbcTransactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
+        batchJdbcTransactionTemplate.execute(new TransactionCallbackWithoutResult() {
 
             @Override
             protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+                String stacktrace = ThrowableSerialization.serialize(e);
                 for (Long loanId : loanIds) {
-                    T loanAccountLock = loanLockingService.findByLoanIdAndLockOwner(loanId, getLockOwner());
-                    if (loanAccountLock != null) {
-                        loanAccountLock.setError(String.format(msg, loanId), ThrowableSerialization.serialize(e));
-                    }
+                    loanLockingService.updateLockError(loanId, getLockOwner(), String.format(msg, loanId), stacktrace);
                 }
             }
         });
@@ -85,7 +81,6 @@ public abstract class AbstractLoanItemListener<T extends AccountLock, S extends 
     public void onWriteError(Exception e, @NonNull Chunk<? extends S> items) {
         List<Long> loanIds = items.getItems().stream().map(AbstractPersistableCustom::getId).toList();
         log.warn("Error was triggered during writing of Loans (ids={}) due to: {}", loanIds, ThrowableSerialization.serialize(e));
-
         updateAccountLockWithError(loanIds, "Loan (id: %d) writing is failed", e);
     }
 

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/service/BeforeStepLockingItemReaderHelper.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/service/BeforeStepLockingItemReaderHelper.java
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.fineract.cob.COBConstant;
 import org.apache.fineract.cob.converter.COBParameterConverter;
 import org.apache.fineract.cob.data.COBParameter;
-import org.apache.fineract.cob.domain.AccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.resolver.CatchUpFlagResolver;
@@ -36,10 +35,10 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.NonNull;
 
 @RequiredArgsConstructor
-public class BeforeStepLockingItemReaderHelper<T extends AccountLock> {
+public class BeforeStepLockingItemReaderHelper {
 
     private final RetrieveIdService retrieveIdService;
-    private final LockingService<T> loanLockingService;
+    private final LockingService loanLockingService;
 
     @SuppressWarnings({ "unchecked" })
     public LinkedBlockingQueue<Long> filterRemainingData(@NonNull StepExecution stepExecution) {
@@ -54,16 +53,12 @@ public class BeforeStepLockingItemReaderHelper<T extends AccountLock> {
         } else {
             loanIds = retrieveIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter, isCatchUp);
             if (!loanIds.isEmpty()) {
-                List<Long> lockedByCOBChunkProcessingAccountIds = getLoanIdsLockedWithChunkProcessingLock(loanIds);
+                List<Long> lockedByCOBChunkProcessingAccountIds = loanLockingService.findLockIdsByLoanIdInAndLockOwner(loanIds,
+                        LockOwner.LOAN_COB_CHUNK_PROCESSING);
+                loanIds = new ArrayList<>(loanIds);
                 loanIds.retainAll(lockedByCOBChunkProcessingAccountIds);
             }
         }
         return new LinkedBlockingQueue<>(loanIds);
-    }
-
-    private List<Long> getLoanIdsLockedWithChunkProcessingLock(List<Long> loanIds) {
-        List<T> accountLocks = new ArrayList<>(
-                loanLockingService.findAllByLoanIdInAndLockOwner(loanIds, LockOwner.LOAN_COB_CHUNK_PROCESSING));
-        return accountLocks.stream().map(T::getId).toList();
     }
 }

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/tasklet/ApplyCommonLockTasklet.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/tasklet/ApplyCommonLockTasklet.java
@@ -30,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.converter.COBParameterConverter;
 import org.apache.fineract.cob.data.COBParameter;
-import org.apache.fineract.cob.domain.AccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.exceptions.LockCannotBeAppliedException;
@@ -49,13 +48,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class ApplyCommonLockTasklet<T extends AccountLock> implements Tasklet {
+public abstract class ApplyCommonLockTasklet implements Tasklet {
 
     private static final long NUMBER_OF_RETRIES = 3;
     private final FineractProperties fineractProperties;
-    private final LockingService<T> loanLockingService;
+    private final LockingService loanLockingService;
     private final RetrieveIdService retrieveIdService;
-    private final TransactionTemplate transactionTemplate;
+    private final TransactionTemplate batchJdbcTransactionTemplate;
 
     public abstract String getCOBParameter();
 
@@ -79,13 +78,11 @@ public abstract class ApplyCommonLockTasklet<T extends AccountLock> implements T
                     retrieveIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter, isCatchUp));
         }
         List<List<Long>> loanIdPartitions = Lists.partition(loanIds, getInClauseParameterSizeLimit());
-        List<T> accountLocks = new ArrayList<>();
-        loanIdPartitions.forEach(loanIdPartition -> accountLocks.addAll(loanLockingService.findAllByLoanIdIn(loanIdPartition)));
+        List<Long> alreadyLockedIds = new ArrayList<>();
+        loanIdPartitions.forEach(partition -> alreadyLockedIds.addAll(loanLockingService.findLockIdsByLoanIdIn(partition)));
 
         List<Long> toBeProcessedLoanIds = new ArrayList<>(loanIds);
-        List<Long> alreadyLockedAccountIds = accountLocks.stream().map(AccountLock::getId).toList();
-
-        toBeProcessedLoanIds.removeAll(alreadyLockedAccountIds);
+        toBeProcessedLoanIds.removeAll(alreadyLockedIds);
         try {
             applyLocks(toBeProcessedLoanIds);
         } catch (Exception e) {
@@ -102,8 +99,8 @@ public abstract class ApplyCommonLockTasklet<T extends AccountLock> implements T
     }
 
     private void applyLocks(List<Long> toBeProcessedLoanIds) {
-        transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+        batchJdbcTransactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
+        batchJdbcTransactionTemplate.execute(new TransactionCallbackWithoutResult() {
 
             @Override
             protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {

--- a/fineract-command-jdbc/src/main/java/org/apache/fineract/command/jdbc/store/JdbcCommandStore.java
+++ b/fineract-command-jdbc/src/main/java/org/apache/fineract/command/jdbc/store/JdbcCommandStore.java
@@ -97,18 +97,31 @@ public class JdbcCommandStore implements CommandStore {
     @Override
     @Retry(name = "commandStore", fallbackMethod = "fallback")
     public void store(Command<?> command, Object response, CommandState state) {
+        final long startedAt = System.nanoTime();
         final var commandEntity = isNull(response) ? mapper.map(command) : mapper.map(command, response);
 
         if (state != null) {
             commandEntity.setState(state);
         }
 
-        repository.save(commandEntity);
+        log.debug("Storing command idempotencyKey={}, state={}, payloadType={}, thread={}", command.getIdempotencyKey(),
+                commandEntity.getState(), payloadType(command), Thread.currentThread().getName());
 
-        command.setCommandId(commandEntity.getId());
+        try {
+            repository.save(commandEntity);
+            command.setCommandId(commandEntity.getId());
+            log.debug("Stored command id={}, idempotencyKey={}, state={}, elapsedMs={}", commandEntity.getId(), command.getIdempotencyKey(),
+                    commandEntity.getState(), elapsedMillis(startedAt));
+        } catch (RuntimeException e) {
+            log.warn("Command store save failed idempotencyKey={}, state={}, payloadType={}, elapsedMs={}; retry/fallback may follow",
+                    command.getIdempotencyKey(), commandEntity.getState(), payloadType(command), elapsedMillis(startedAt), e);
+            throw e;
+        }
     }
 
     void fallback(Command<?> command, Object response, CommandState state, Throwable t) throws Exception {
+        log.warn("Command store fallback idempotencyKey={}, state={}, payloadType={}, deadLetterQueueEnabled={}",
+                command.getIdempotencyKey(), state, payloadType(command), properties.getFileDeadLetterQueueEnabled(), t);
         if (Boolean.TRUE.equals(properties.getFileDeadLetterQueueEnabled())) {
             write(command);
         }
@@ -136,5 +149,13 @@ public class JdbcCommandStore implements CommandStore {
                                 + Optional.ofNullable(command.getIdempotencyKey()).orElseGet(() -> UUID.randomUUID().toString()) + ".json")
                 .toFile();
         FileUtils.write(file, objectMapper.writeValueAsString(command), UTF_8);
+    }
+
+    private static long elapsedMillis(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000L;
+    }
+
+    private static String payloadType(Command<?> command) {
+        return Optional.ofNullable(command.getPayload()).map(Object::getClass).map(Class::getName).orElse("null");
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/batch/service/BatchApiServiceImpl.java
@@ -155,7 +155,7 @@ public class BatchApiServiceImpl implements BatchApiService {
                 TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
                 transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ);
                 if (transactionManager instanceof ExtendedJpaTransactionManager extendedJpaTransactionManager) {
-                    transactionTemplate.setReadOnly(extendedJpaTransactionManager.isReadOnlyConnection());
+                    transactionTemplate.setReadOnly(extendedJpaTransactionManager.isReadOnly());
                 }
                 transactionConfigurator.accept(transactionTemplate);
                 return transactionTemplate.execute(status -> {

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -126,6 +126,7 @@ public class FineractProperties {
 
         private int minPoolSize;
         private int maxPoolSize;
+        private long leakDetectionThreshold;
 
         public boolean isMinPoolSizeSet() {
             return minPoolSize != -1;
@@ -133,6 +134,10 @@ public class FineractProperties {
 
         public boolean isMaxPoolSizeSet() {
             return maxPoolSize != -1;
+        }
+
+        public boolean isLeakDetectionThresholdSet() {
+            return leakDetectionThreshold > 0;
         }
     }
 

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/domain/FineractPlatformTenantConnection.java
@@ -19,8 +19,6 @@
 package org.apache.fineract.infrastructure.core.domain;
 
 import java.io.Serializable;
-import java.sql.Connection;
-import javax.sql.DataSource;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -126,13 +124,18 @@ public class FineractPlatformTenantConnection implements Serializable {
         return sb.toString();
     }
 
-    public static String toProtocol(DataSource dataSource) {
-        try (Connection connection = dataSource.getConnection()) {
-            String url = connection.getMetaData().getURL();
-            return url.substring(0, url.indexOf("://"));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    public static String resolveProtocol(String driver) {
+        if ("org.postgresql.Driver".equals(driver)) {
+            return "jdbc:postgresql";
         }
+        if ("com.mysql.cj.jdbc.Driver".equals(driver)) {
+            return "jdbc:mysql";
+        }
+        if ("org.mariadb.jdbc.Driver".equals(driver)) {
+            return "jdbc:mariadb";
+        }
+
+        throw new IllegalStateException("Unsupported JDBC driver: " + driver);
     }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/persistence/ExtendedDataSourceTransactionManager.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/persistence/ExtendedDataSourceTransactionManager.java
@@ -18,81 +18,55 @@
  */
 package org.apache.fineract.infrastructure.core.persistence;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.FlushModeType;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import lombok.Getter;
-import org.springframework.jdbc.datasource.JdbcTransactionObjectSupport;
-import org.springframework.orm.jpa.EntityManagerHolder;
-import org.springframework.orm.jpa.JpaTransactionManager;
+import org.jspecify.annotations.NonNull;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.DefaultTransactionStatus;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-public class ExtendedJpaTransactionManager extends JpaTransactionManager {
+public class ExtendedDataSourceTransactionManager extends DataSourceTransactionManager {
 
     private final List<TransactionLifecycleCallback> lifecycleCallbacks = new CopyOnWriteArrayList<>();
 
     @Getter
     private final boolean readOnly;
 
-    public ExtendedJpaTransactionManager(boolean readOnly) {
+    public ExtendedDataSourceTransactionManager(boolean readOnly) {
         this.readOnly = readOnly;
     }
 
     @Override
-    protected void doBegin(Object transaction, TransactionDefinition definition) {
+    protected void doBegin(@NonNull Object transaction, @NonNull TransactionDefinition definition) {
         super.doBegin(transaction, definition);
 
-        if (definition.isReadOnly() || isReadOnlyTx(transaction) || isReadOnly()) {
-            EntityManager entityManager = getCurrentEntityManager();
-            if (entityManager != null) {
-                entityManager.setFlushMode(FlushModeType.COMMIT);
-            }
+        if (isReadOnly()) {
+            setEnforceReadOnly(true);
         }
 
         invokeLifecycleCallbacks(TransactionLifecycleCallback::afterBegin);
     }
 
     @Override
-    protected void doCommit(DefaultTransactionStatus status) {
-        if (isReadOnlyTx(status.getTransaction()) || isReadOnly()) {
-            EntityManager entityManager = getCurrentEntityManager();
-            if (entityManager != null) {
-                entityManager.clear();
-            }
-        }
-
+    protected void doCommit(@NonNull DefaultTransactionStatus status) {
         super.doCommit(status);
         invokeLifecycleCallbacks(TransactionLifecycleCallback::afterCommit);
     }
 
     @Override
-    protected void doCleanupAfterCompletion(Object transaction) {
+    protected void doCleanupAfterCompletion(@NonNull Object transaction) {
         super.doCleanupAfterCompletion(transaction);
         invokeLifecycleCallbacks(TransactionLifecycleCallback::afterCompletion);
     }
 
-    private boolean isReadOnlyTx(Object transaction) {
-        JdbcTransactionObjectSupport txObject = (JdbcTransactionObjectSupport) transaction;
-        return txObject.isReadOnly();
-    }
-
-    private EntityManager getCurrentEntityManager() {
-        EntityManagerHolder holder = (EntityManagerHolder) TransactionSynchronizationManager.getResource(obtainEntityManagerFactory());
-        if (holder != null) {
-            return holder.getEntityManager();
-        }
-        return null;
-    }
-
     private void invokeLifecycleCallbacks(Consumer<TransactionLifecycleCallback> f) {
-        lifecycleCallbacks.forEach(f::accept);
+        lifecycleCallbacks.forEach(f);
     }
 
     public void setLifecycleCallbacks(List<TransactionLifecycleCallback> lifecycleCallbacks) {
         this.lifecycleCallbacks.addAll(lifecycleCallbacks);
     }
+
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DataSourcePerTenantServiceFactory.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DataSourcePerTenantServiceFactory.java
@@ -18,8 +18,8 @@
  */
 package org.apache.fineract.infrastructure.core.service.database;
 
+import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.resolveProtocol;
 import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.toJdbcUrl;
-import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.toProtocol;
 
 import com.zaxxer.hikari.HikariConfig;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -34,7 +34,6 @@ import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
 import org.apache.fineract.infrastructure.core.service.database.metrics.TenantConnectionPoolMetricsTrackerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -48,7 +47,6 @@ public class DataSourcePerTenantServiceFactory {
 
     private final HikariConfig hikariConfig;
     private final FineractProperties fineractProperties;
-    private final ApplicationContext context;
     @Qualifier("hikariTenantDataSource")
     private final DataSource tenantDataSource;
     private final HikariDataSourceFactory hikariDataSourceFactory;
@@ -62,7 +60,7 @@ public class DataSourcePerTenantServiceFactory {
             throw new IllegalArgumentException(
                     "Invalid master password on tenant connection %d.".formatted(tenantConnection.getConnectionId()));
         }
-        String protocol = toProtocol(tenantDataSource);
+        String protocol = resolveProtocol(hikariConfig.getDriverClassName());
         // Default properties for Writing
         String schemaServer = tenantConnection.getSchemaServer();
         String schemaPort = tenantConnection.getSchemaServerPort();
@@ -95,6 +93,7 @@ public class DataSourcePerTenantServiceFactory {
         config.setDriverClassName(hikariConfig.getDriverClassName());
         config.setConnectionTestQuery(hikariConfig.getConnectionTestQuery());
         config.setAutoCommit(hikariConfig.isAutoCommit());
+        config.setLeakDetectionThreshold(getLeakDetectionThreshold());
 
         // https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management
         config.setRegisterMbeans(true);
@@ -106,6 +105,11 @@ public class DataSourcePerTenantServiceFactory {
         // is also in src/main/resources/META-INF/spring/hikariDataSource.xml
         // for the all Tenants DB -->
         config.setDataSourceProperties(hikariConfig.getDataSourceProperties());
+
+        if (config.getLeakDetectionThreshold() > 0) {
+            log.warn("Tenant datasource {} leak detection enabled at {}ms; Hikari will log borrower stack traces for long-held connections",
+                    config.getPoolName(), config.getLeakDetectionThreshold());
+        }
 
         return hikariDataSourceFactory.create(config);
     }
@@ -130,6 +134,14 @@ public class DataSourcePerTenantServiceFactory {
         } else {
             return tenantConnection.getInitialSize();
         }
+    }
+
+    private long getLeakDetectionThreshold() {
+        FineractProperties.FineractConfigProperties configOverride = fineractProperties.getTenant().getConfig();
+        if (configOverride.isLeakDetectionThresholdSet()) {
+            return configOverride.getLeakDetectionThreshold();
+        }
+        return hikariConfig.getLeakDetectionThreshold();
     }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantDataSourceFactory.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantDataSourceFactory.java
@@ -18,9 +18,10 @@
  */
 package org.apache.fineract.infrastructure.core.service.migration;
 
+import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.resolveProtocol;
 import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.toJdbcUrl;
-import static org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection.toProtocol;
 
+import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
@@ -36,13 +37,15 @@ public class TenantDataSourceFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(TenantDataSourceFactory.class);
 
+    private final HikariConfig hikariConfig;
     private final HikariDataSource tenantDataSource;
 
     private final DatabasePasswordEncryptor databasePasswordEncryptor;
 
     @Autowired
-    public TenantDataSourceFactory(@Qualifier("hikariTenantDataSource") HikariDataSource tenantDataSource,
+    public TenantDataSourceFactory(HikariConfig hikariConfig, @Qualifier("hikariTenantDataSource") HikariDataSource tenantDataSource,
             DatabasePasswordEncryptor databasePasswordEncryptor) {
+        this.hikariConfig = hikariConfig;
         this.tenantDataSource = tenantDataSource;
         this.databasePasswordEncryptor = databasePasswordEncryptor;
     }
@@ -62,7 +65,7 @@ public class TenantDataSourceFactory {
         }
         dataSource.setUsername(tenantConnection.getSchemaUsername());
         dataSource.setPassword(databasePasswordEncryptor.decrypt(tenantConnection.getSchemaPassword()));
-        String protocol = toProtocol(tenantDataSource);
+        String protocol = resolveProtocol(hikariConfig.getDriverClassName());
         String tenantJdbcUrl = toJdbcUrl(protocol, tenantConnection.getSchemaServer(), tenantConnection.getSchemaServerPort(),
                 tenantConnection.getSchemaName(), tenantConnection.getSchemaConnectionParameters());
         LOG.debug("JDBC URL for tenant {} is {}", tenant.getTenantIdentifier(), tenantJdbcUrl);

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/utils/ColumnValidator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/security/utils/ColumnValidator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -48,23 +49,28 @@ public class ColumnValidator {
     private final JdbcTemplate jdbcTemplate;
 
     private void validateColumn(Map<String, Set<String>> tableColumnMap) {
-        Connection connection = null;
+        DataSource dataSource = Objects.requireNonNull(this.jdbcTemplate.getDataSource());
+        Connection connection = DataSourceUtils.getConnection(dataSource);
 
         try {
-            connection = Objects.requireNonNull(this.jdbcTemplate.getDataSource()).getConnection();
             DatabaseMetaData dbMetaData = connection.getMetaData();
+
             for (Map.Entry<String, Set<String>> entry : tableColumnMap.entrySet()) {
                 Set<String> columns = entry.getValue();
-                ResultSet resultSet = dbMetaData.getColumns(null, null, entry.getKey(), null);
-                Set<String> tableColumns = getTableColumns(resultSet);
-                if (!columns.isEmpty() && tableColumns.isEmpty()) {
-                    throw new PlatformApiDataValidationException("error.msg.invalid.table.column", "Invalid table or column name detected",
-                            entry.getKey(), columns);
-                }
-                for (String requestedColumn : columns) {
-                    if (!tableColumns.contains(requestedColumn)) {
-                        throw new PlatformApiDataValidationException("error.msg.invalid.table.column", "Invalid table column name detected",
-                                entry.getKey(), requestedColumn);
+
+                try (ResultSet resultSet = dbMetaData.getColumns(null, null, entry.getKey(), null)) {
+                    Set<String> tableColumns = getTableColumns(resultSet);
+
+                    if (!columns.isEmpty() && tableColumns.isEmpty()) {
+                        throw new PlatformApiDataValidationException("error.msg.invalid.table.column",
+                                "Invalid table or column name detected", entry.getKey(), columns);
+                    }
+
+                    for (String requestedColumn : columns) {
+                        if (!tableColumns.contains(requestedColumn)) {
+                            throw new PlatformApiDataValidationException("error.msg.invalid.table.column",
+                                    "Invalid table column name detected", entry.getKey(), requestedColumn);
+                        }
                     }
                 }
             }
@@ -72,10 +78,7 @@ public class ColumnValidator {
             throw new PlatformApiDataValidationException("error.msg.database.access.error",
                     "Database access error during column validation", e.getMessage(), e);
         } finally {
-            if (connection != null) {
-                DataSourceUtils.releaseConnection(connection, jdbcTemplate.getDataSource());
-            }
-            connection = null;
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
     }
 

--- a/fineract-core/src/test/java/org/apache/fineract/batch/service/BatchApiServiceImplTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/batch/service/BatchApiServiceImplTest.java
@@ -244,7 +244,7 @@ class BatchApiServiceImplTest {
                 null);
 
         // Mock getTransaction to return our status when the read-only flag matches
-        when(extendedJpaTransactionManager.isReadOnlyConnection()).thenReturn(isReadOnly);
+        when(extendedJpaTransactionManager.isReadOnly()).thenReturn(isReadOnly);
         when(extendedJpaTransactionManager
                 .getTransaction(argThat(definition -> definition != null && definition.isReadOnly() == isReadOnly)))
                 .thenReturn(transactionStatus);

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/hook/ConnectionPoolDiagnosticsHook.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/hook/ConnectionPoolDiagnosticsHook.java
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.test.stepdef.hook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.test.api.ApiProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class ConnectionPoolDiagnosticsHook {
+
+    private static final Pattern PROMETHEUS_SAMPLE = Pattern
+            .compile("^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\\{[^}]*})?\\s+([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?)$");
+    private static final String TENANT_PREFIX = "fineract_tenants_";
+    private static final String TENANT_HIKARI = "_hikaricp_connections";
+    private static final String MASTER_HIKARI = "hikaricp_connections";
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
+
+    @Autowired
+    private ApiProperties apiProperties;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    private final AtomicReference<ConnectionPoolMetrics> latest = new AtomicReference<>();
+    private ScheduledExecutorService executor;
+    private ScheduledFuture<?> samplingTask;
+    private ConnectionPoolMetrics baseline;
+    private ConnectionPoolPeaks peaks;
+
+    @Before(value = "@ConnectionPoolDiagnostics", order = 1000)
+    public void startConnectionPoolDiagnostics(Scenario scenario) {
+        baseline = fetchMetrics();
+        // Fail fast if Prometheus is not reachable or the tenant pool metrics are absent.
+        // This hook is opt-in via the @ConnectionPoolDiagnostics tag, so it should only
+        // be applied to scenarios running against a fully provisioned environment where
+        // the actuator endpoint is guaranteed to be available.
+        assertThat(baseline.hasTenantMetrics()).as("No tenant Hikari metrics were found at %s", prometheusUri()).isTrue();
+
+        peaks = new ConnectionPoolPeaks(baseline);
+        latest.set(baseline);
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "connection-pool-diagnostics");
+            thread.setDaemon(true);
+            return thread;
+        });
+        samplingTask = executor.scheduleAtFixedRate(this::sampleMetrics, 0, POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
+
+        logSnapshot(scenario, "Connection pool diagnostics baseline", baseline);
+    }
+
+    @After(value = "@ConnectionPoolDiagnostics", order = 1000)
+    public void stopConnectionPoolDiagnostics(Scenario scenario) {
+        if (samplingTask != null) {
+            samplingTask.cancel(true);
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+
+        int recoveryTimeoutSeconds = Integer.getInteger("fineract-test.connection-pool.recovery-timeout-seconds", 30);
+        await().atMost(Duration.ofSeconds(recoveryTimeoutSeconds)).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+            ConnectionPoolMetrics current = fetchMetrics();
+            latest.set(current);
+            assertThat(current.tenantPending()).as("Tenant Hikari pending connections after scenario").isZero();
+            assertThat(current.masterPending()).as("Master Hikari pending connections after scenario").isZero();
+            assertThat(current.tenantActive()).as("Tenant Hikari active connections after scenario")
+                    .isLessThanOrEqualTo(baseline.tenantActive());
+        });
+
+        ConnectionPoolMetrics current = latest.get();
+        logSnapshot(scenario, "Connection pool diagnostics final", current);
+        scenario.log("Connection pool diagnostics peaks: " + peaks);
+
+        assertThat(current.tenantTimeouts()).as("Tenant Hikari connection timeouts increased").isEqualTo(baseline.tenantTimeouts());
+        assertThat(current.masterTimeouts()).as("Master Hikari connection timeouts increased").isEqualTo(baseline.masterTimeouts());
+    }
+
+    private void sampleMetrics() {
+        try {
+            ConnectionPoolMetrics metrics = fetchMetrics();
+            latest.set(metrics);
+            peaks.record(metrics);
+        } catch (Exception e) {
+            log.warn("Unable to sample Hikari connection pool metrics", e);
+        }
+    }
+
+    private ConnectionPoolMetrics fetchMetrics() {
+        URI uri = prometheusUri();
+        if ("https".equalsIgnoreCase(uri.getScheme())) {
+            return ConnectionPoolMetrics.parse(fetchMetricsWithCurl(uri));
+        }
+
+        HttpRequest request = HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(10)).GET().build();
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).as("Prometheus actuator endpoint status").isEqualTo(200);
+            return ConnectionPoolMetrics.parse(response.body());
+        } catch (IOException e) {
+            throw new AssertionError("Unable to fetch Prometheus metrics from " + uri, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while fetching Prometheus metrics from " + uri, e);
+        }
+    }
+
+    private String fetchMetricsWithCurl(URI uri) {
+        // -k disables certificate verification; acceptable here because test environments
+        // typically use self-signed certificates on the HTTPS endpoint.
+        ProcessBuilder processBuilder = new ProcessBuilder("curl", "-k", "--fail", "--silent", "--show-error", "--max-time", "10",
+                uri.toString());
+        try {
+            Process process = processBuilder.start();
+            String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+            int exitCode = process.waitFor();
+            assertThat(exitCode).as("Prometheus actuator curl exit code. stderr: %s", stderr).isZero();
+            return stdout;
+        } catch (IOException e) {
+            throw new AssertionError("Unable to fetch Prometheus metrics from " + uri + " using curl", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while fetching Prometheus metrics from " + uri + " using curl", e);
+        }
+    }
+
+    private URI prometheusUri() {
+        String baseUrl = apiProperties.getBaseUrl();
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return URI.create(baseUrl + "/fineract-provider/actuator/prometheus");
+    }
+
+    private void logSnapshot(Scenario scenario, String label, ConnectionPoolMetrics metrics) {
+        String message = "%s: tenant(active=%s, pending=%s, timeouts=%s, total=%s, idle=%s, max=%s), master(active=%s, pending=%s, timeouts=%s, total=%s, idle=%s, max=%s)"
+                .formatted(label, metrics.tenantActive(), metrics.tenantPending(), metrics.tenantTimeouts(), metrics.tenantTotal(),
+                        metrics.tenantIdle(), metrics.tenantMax(), metrics.masterActive(), metrics.masterPending(),
+                        metrics.masterTimeouts(), metrics.masterTotal(), metrics.masterIdle(), metrics.masterMax());
+        scenario.log(message);
+        log.info(message);
+    }
+
+    @RequiredArgsConstructor
+    private static final class ConnectionPoolMetrics {
+
+        private final Map<String, Double> metrics;
+
+        static ConnectionPoolMetrics parse(String prometheusBody) {
+            Map<String, Double> metrics = new HashMap<>();
+            prometheusBody.lines().filter(line -> !line.isBlank() && !line.startsWith("#")).forEach(line -> {
+                Matcher matcher = PROMETHEUS_SAMPLE.matcher(line);
+                if (matcher.matches()) {
+                    // Labels are stripped from the key; merge by summing so that multiple samples
+                    // for the same metric name with different label sets (e.g. multiple Hikari
+                    // pools sharing a metric name) are accumulated rather than overwritten.
+                    metrics.merge(matcher.group(1), Double.parseDouble(matcher.group(2)), Double::sum);
+                }
+            });
+            return new ConnectionPoolMetrics(metrics);
+        }
+
+        boolean hasTenantMetrics() {
+            return metrics.keySet().stream().anyMatch(name -> name.startsWith(TENANT_PREFIX) && name.contains(TENANT_HIKARI));
+        }
+
+        long tenantActive() {
+            return tenantSum("_active");
+        }
+
+        long tenantPending() {
+            return tenantSum("_pending");
+        }
+
+        long tenantTimeouts() {
+            return tenantSum("_timeout_total");
+        }
+
+        long tenantTotal() {
+            return tenantSum("");
+        }
+
+        long tenantIdle() {
+            return tenantSum("_idle");
+        }
+
+        long tenantMax() {
+            return tenantSum("_max");
+        }
+
+        long masterActive() {
+            return metric(MASTER_HIKARI + "_active");
+        }
+
+        long masterPending() {
+            return metric(MASTER_HIKARI + "_pending");
+        }
+
+        long masterTimeouts() {
+            return metric(MASTER_HIKARI + "_timeout_total");
+        }
+
+        long masterTotal() {
+            return metric(MASTER_HIKARI);
+        }
+
+        long masterIdle() {
+            return metric(MASTER_HIKARI + "_idle");
+        }
+
+        long masterMax() {
+            return metric(MASTER_HIKARI + "_max");
+        }
+
+        private long tenantSum(String suffix) {
+            return Math.round(metrics.entrySet().stream()
+                    .filter(entry -> entry.getKey().startsWith(TENANT_PREFIX) && entry.getKey().endsWith(TENANT_HIKARI + suffix))
+                    .mapToDouble(Map.Entry::getValue).sum());
+        }
+
+        private long metric(String name) {
+            return Math.round(metrics.getOrDefault(name, 0D));
+        }
+    }
+
+    @Getter
+    @ToString
+    private static final class ConnectionPoolPeaks {
+
+        private long maxTenantActive;
+        private long maxTenantPending;
+        private long maxMasterActive;
+        private long maxMasterPending;
+
+        private ConnectionPoolPeaks(ConnectionPoolMetrics baseline) {
+            record(baseline);
+        }
+
+        private void record(ConnectionPoolMetrics metrics) {
+            maxTenantActive = Math.max(maxTenantActive, metrics.tenantActive());
+            maxTenantPending = Math.max(maxTenantPending, metrics.tenantPending());
+            maxMasterActive = Math.max(maxMasterActive, metrics.masterActive());
+            maxMasterPending = Math.max(maxMasterPending, metrics.masterPending());
+        }
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/ChunkProcessingLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/ChunkProcessingLoanItemListener.java
@@ -19,17 +19,16 @@
 package org.apache.fineract.cob.listener;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
-public class ChunkProcessingLoanItemListener extends AbstractLoanItemListener<LoanAccountLock, Loan> {
+public class ChunkProcessingLoanItemListener extends AbstractLoanItemListener<Loan> {
 
-    public ChunkProcessingLoanItemListener(LockingService<LoanAccountLock> lockingService, TransactionTemplate transactionTemplate) {
-        super(lockingService, transactionTemplate);
+    public ChunkProcessingLoanItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(lockingService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/InlineCOBLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/InlineCOBLoanItemListener.java
@@ -18,16 +18,15 @@
  */
 package org.apache.fineract.cob.listener;
 
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.springframework.transaction.support.TransactionTemplate;
 
-public class InlineCOBLoanItemListener extends AbstractLoanItemListener<LoanAccountLock, Loan> {
+public class InlineCOBLoanItemListener extends AbstractLoanItemListener<Loan> {
 
-    public InlineCOBLoanItemListener(LockingService<LoanAccountLock> lockingService, TransactionTemplate transactionTemplate) {
-        super(lockingService, transactionTemplate);
+    public InlineCOBLoanItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(lockingService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/WorkingCapitalChunkProcessingLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/WorkingCapitalChunkProcessingLoanItemListener.java
@@ -21,21 +21,20 @@ package org.apache.fineract.cob.listener;
 import org.apache.fineract.cob.conditions.BatchWorkerCondition;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
 @Conditional(BatchWorkerCondition.class)
-public class WorkingCapitalChunkProcessingLoanItemListener
-        extends AbstractLoanItemListener<WorkingCapitalLoanAccountLock, WorkingCapitalLoan> {
+public class WorkingCapitalChunkProcessingLoanItemListener extends AbstractLoanItemListener<WorkingCapitalLoan> {
 
     public WorkingCapitalChunkProcessingLoanItemListener(
-            LockingService<WorkingCapitalLoanAccountLock> workingCapitalLoanAccountLockLockingService,
-            TransactionTemplate transactionTemplate) {
-        super(workingCapitalLoanAccountLockLockingService, transactionTemplate);
+            @Qualifier("workingCapitalLoanLockingService") LockingService workingCapitalLoanAccountLockLockingService,
+            @Qualifier("batchJdbcTransactionTemplate") TransactionTemplate batchJdbcTransactionTemplate) {
+        super(workingCapitalLoanAccountLockLockingService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/AbstractLoanItemWriter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/AbstractLoanItemWriter.java
@@ -21,7 +21,6 @@ package org.apache.fineract.cob.loan;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
@@ -34,7 +33,7 @@ import org.springframework.lang.NonNull;
 @RequiredArgsConstructor
 public abstract class AbstractLoanItemWriter extends RepositoryItemWriter<Loan> {
 
-    private final LockingService<LoanAccountLock> loanLockingService;
+    private final LockingService loanLockingService;
 
     @Override
     public void write(@NonNull Chunk<? extends Loan> items) throws Exception {

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyLoanLockTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyLoanLockTasklet.java
@@ -20,7 +20,6 @@ package org.apache.fineract.cob.loan;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.COBConstant;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.service.RetrieveIdService;
@@ -29,11 +28,11 @@ import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
-public class ApplyLoanLockTasklet extends ApplyCommonLockTasklet<LoanAccountLock> {
+public class ApplyLoanLockTasklet extends ApplyCommonLockTasklet {
 
-    public ApplyLoanLockTasklet(FineractProperties fineractProperties, LockingService<LoanAccountLock> loanLockingService,
-            RetrieveIdService retrieveIdService, TransactionTemplate transactionTemplate) {
-        super(fineractProperties, loanLockingService, retrieveIdService, transactionTemplate);
+    public ApplyLoanLockTasklet(FineractProperties fineractProperties, LockingService loanLockingService,
+            RetrieveIdService retrieveIdService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/InlineCOBLoanItemWriter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/InlineCOBLoanItemWriter.java
@@ -18,13 +18,12 @@
  */
 package org.apache.fineract.cob.loan;
 
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 
 public class InlineCOBLoanItemWriter extends AbstractLoanItemWriter {
 
-    public InlineCOBLoanItemWriter(LockingService<LoanAccountLock> loanLockingService) {
+    public InlineCOBLoanItemWriter(LockingService loanLockingService) {
         super(loanLockingService);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
@@ -22,7 +22,6 @@ import org.apache.fineract.cob.COBBusinessStepService;
 import org.apache.fineract.cob.common.InitialisationTasklet;
 import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.conditions.BatchWorkerCondition;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.listener.ChunkProcessingLoanItemListener;
 import org.apache.fineract.cob.listener.CobWorkerStepListener;
@@ -41,6 +40,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.SimpleStepBuilder;
 import org.springframework.batch.integration.partition.RemotePartitioningWorkerStepBuilderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -60,6 +60,12 @@ public class LoanCOBWorkerConfiguration {
     @Autowired
     private PlatformTransactionManager transactionManager;
     @Autowired
+    @Qualifier("batchJdbcTransactionManager")
+    private PlatformTransactionManager batchJdbcTransactionManager;
+    @Autowired
+    @Qualifier("batchJdbcTransactionTemplate")
+    private TransactionTemplate batchJdbcTransactionTemplate;
+    @Autowired
     private RemotePartitioningWorkerStepBuilderFactory stepBuilderFactory;
 
     @Autowired
@@ -73,14 +79,13 @@ public class LoanCOBWorkerConfiguration {
     @Autowired
     private AppUserRepositoryWrapper userRepository;
     @Autowired
-    private TransactionTemplate transactionTemplate;
-    @Autowired
     private RetrieveLoanIdService retrieveIdService;
 
     @Autowired
     private FineractProperties fineractProperties;
     @Autowired
-    private LockingService<LoanAccountLock> loanLockingService;
+    @Qualifier("retrieveLoanLockingService")
+    private LockingService loanLockingService;
 
     @Autowired
     private ProgressiveLoanModelProcessingService progressiveLoanModelProcessingService;
@@ -136,12 +141,20 @@ public class LoanCOBWorkerConfiguration {
 
     @Bean
     public ChunkProcessingLoanItemListener loanItemListener() {
-        return new ChunkProcessingLoanItemListener(loanLockingService, transactionTemplate);
+        return new ChunkProcessingLoanItemListener(loanLockingService, batchJdbcTransactionTemplate);
     }
 
     @Bean
     public ApplyLoanLockTasklet applyLock() {
-        return new ApplyLoanLockTasklet(fineractProperties, loanLockingService, retrieveIdService, transactionTemplate);
+        return new ApplyLoanLockTasklet(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public Step applyLockStep(
+            @org.springframework.beans.factory.annotation.Value("#{stepExecutionContext['partition']}") String partitionName) {
+        return new org.springframework.batch.core.step.builder.StepBuilder("Apply lock - Step:" + partitionName, jobRepository)
+                .tasklet(applyLock(), batchJdbcTransactionManager).build();
     }
 
     @Bean
@@ -152,7 +165,7 @@ public class LoanCOBWorkerConfiguration {
     @Bean
     @StepScope
     public LoanItemReader cobWorkerItemReader() {
-        return new LoanItemReader(loanRepository, new BeforeStepLockingItemReaderHelper<>(retrieveIdService, loanLockingService));
+        return new LoanItemReader(loanRepository, new BeforeStepLockingItemReaderHelper(retrieveIdService, loanLockingService));
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
@@ -22,7 +22,6 @@ import org.apache.fineract.cob.COBBusinessStepService;
 import org.apache.fineract.cob.common.CustomJobParameterResolver;
 import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.conditions.LoanCOBEnabledCondition;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.listener.InlineCOBLoanItemListener;
 import org.apache.fineract.infrastructure.jobs.domain.CustomJobParameterRepository;
@@ -41,6 +40,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.integration.config.annotation.EnableBatchIntegration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -63,13 +63,15 @@ public class LoanInlineCOBConfig {
     @Autowired
     private COBBusinessStepService cobBusinessStepService;
     @Autowired
-    private TransactionTemplate transactionTemplate;
+    @Qualifier("batchJdbcTransactionTemplate")
+    private TransactionTemplate batchJdbcTransactionTemplate;
     @Autowired
     private CustomJobParameterRepository customJobParameterRepository;
     @Autowired
     private CustomJobParameterResolver customJobParameterResolver;
     @Autowired
-    private LockingService<LoanAccountLock> loanLockingService;
+    @Qualifier("retrieveLoanLockingService")
+    private LockingService loanLockingService;
     @Autowired
     private ProgressiveLoanModelProcessingService progressiveLoanModelProcessingService;
 
@@ -127,7 +129,7 @@ public class LoanInlineCOBConfig {
 
     @Bean
     public InlineCOBLoanItemListener inlineCobLoanItemListener() {
-        return new InlineCOBLoanItemListener(loanLockingService, transactionTemplate);
+        return new InlineCOBLoanItemListener(loanLockingService, batchJdbcTransactionTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemReader.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemReader.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.cob.loan;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.service.BeforeStepLockingItemReaderHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
@@ -30,10 +29,9 @@ import org.springframework.lang.NonNull;
 @Slf4j
 public class LoanItemReader extends AbstractLoanItemReader<Loan> {
 
-    private final BeforeStepLockingItemReaderHelper<LoanAccountLock> beforeStepLockingItemReaderHelper;
+    private final BeforeStepLockingItemReaderHelper beforeStepLockingItemReaderHelper;
 
-    public LoanItemReader(LoanRepository loanRepository,
-            BeforeStepLockingItemReaderHelper<LoanAccountLock> beforeStepLockingItemReaderHelper) {
+    public LoanItemReader(LoanRepository loanRepository, BeforeStepLockingItemReaderHelper beforeStepLockingItemReaderHelper) {
         super(loanRepository);
         this.beforeStepLockingItemReaderHelper = beforeStepLockingItemReaderHelper;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemWriter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanItemWriter.java
@@ -18,13 +18,12 @@
  */
 package org.apache.fineract.cob.loan;
 
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 
 public class LoanItemWriter extends AbstractLoanItemWriter {
 
-    public LoanItemWriter(LockingService<LoanAccountLock> loanLockingService) {
+    public LoanItemWriter(LockingService loanLockingService) {
         super(loanLockingService);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingConfiguration.java
@@ -18,8 +18,6 @@
  */
 package org.apache.fineract.cob.loan;
 
-import org.apache.fineract.cob.domain.LoanAccountLock;
-import org.apache.fineract.cob.domain.LoanAccountLockRepository;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,12 +33,10 @@ public class LoanLockingConfiguration {
     private JdbcTemplate jdbcTemplate;
     @Autowired
     private FineractProperties fineractProperties;
-    @Autowired
-    private LoanAccountLockRepository loanAccountLockRepository;
 
     @Bean
-    @ConditionalOnMissingBean
-    public LockingService<LoanAccountLock> retrieveLoanLockingService() {
-        return new LoanLockingServiceImpl(jdbcTemplate, fineractProperties, loanAccountLockRepository);
+    @ConditionalOnMissingBean(name = "retrieveLoanLockingService")
+    public LockingService retrieveLoanLockingService() {
+        return new LoanLockingServiceImpl(jdbcTemplate, fineractProperties);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingServiceImpl.java
@@ -20,13 +20,13 @@ package org.apache.fineract.cob.loan;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.AbstractLockingService;
-import org.apache.fineract.cob.domain.LoanAccountLock;
-import org.apache.fineract.cob.domain.LoanAccountLockRepository;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Slf4j
-public class LoanLockingServiceImpl extends AbstractLockingService<LoanAccountLock> {
+public class LoanLockingServiceImpl extends AbstractLockingService {
+
+    private static final String TABLE_NAME = "m_loan_account_locks";
 
     private static final String BATCH_LOAN_LOCK_INSERT = """
                 INSERT INTO m_loan_account_locks (loan_id, version, lock_owner, lock_placed_on, lock_placed_on_cob_business_date) VALUES (?,?,?,?,?)
@@ -36,9 +36,13 @@ public class LoanLockingServiceImpl extends AbstractLockingService<LoanAccountLo
                 UPDATE m_loan_account_locks SET version= version + 1, lock_owner = ?, lock_placed_on = ? WHERE loan_id = ?
             """;
 
-    public LoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties,
-            LoanAccountLockRepository loanAccountLockRepository) {
-        super(jdbcTemplate, fineractProperties, loanAccountLockRepository);
+    public LoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
+        super(jdbcTemplate, fineractProperties);
+    }
+
+    @Override
+    protected String getTableName() {
+        return TABLE_NAME;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/WorkingCapitalLoanInlineCOBConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/WorkingCapitalLoanInlineCOBConfig.java
@@ -25,7 +25,6 @@ import org.apache.fineract.cob.common.CustomJobParameterResolver;
 import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.conditions.LoanCOBEnabledCondition;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.workingcapitalloan.InlineWorkingCapitalLoanCOBWorkerItemListener;
 import org.apache.fineract.cob.workingcapitalloan.InlineWorkingCapitalLoanCOBWorkerItemWriter;
 import org.apache.fineract.cob.workingcapitalloan.WorkingCapitalLoanCOBConstant;
@@ -45,6 +44,7 @@ import org.springframework.batch.core.listener.ExecutionContextPromotionListener
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.integration.config.annotation.EnableBatchIntegration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -61,10 +61,12 @@ public class WorkingCapitalLoanInlineCOBConfig {
     private final PlatformTransactionManager transactionManager;
     private final PropertyService propertyService;
     private final COBBusinessStepService cobBusinessStepService;
-    private final TransactionTemplate transactionTemplate;
+    @Qualifier("batchJdbcTransactionTemplate")
+    private final TransactionTemplate batchJdbcTransactionTemplate;
     private final CustomJobParameterRepository customJobParameterRepository;
     private final CustomJobParameterResolver customJobParameterResolver;
-    private final LockingService<WorkingCapitalLoanAccountLock> loanLockingService;
+    @Qualifier("workingCapitalLoanLockingService")
+    private final LockingService loanLockingService;
     private final WorkingCapitalLoanRepository loanRepository;
 
     @Bean
@@ -130,7 +132,7 @@ public class WorkingCapitalLoanInlineCOBConfig {
 
     @Bean
     public InlineWorkingCapitalLoanCOBWorkerItemListener inlineWorkingCapitalLoanCobLoanItemListener() {
-        return new InlineWorkingCapitalLoanCOBWorkerItemListener(loanLockingService, transactionTemplate);
+        return new InlineWorkingCapitalLoanCOBWorkerItemListener(loanLockingService, batchJdbcTransactionTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/HikariCpConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/HikariCpConfig.java
@@ -32,8 +32,7 @@ public class HikariCpConfig {
     // TODO: we can get rid of this config class by defining "spring.hikariTenantDataSource.hikari.*" in
     // "application.properties" and enabling auto-configuration
 
-    // initMethod is triggering lazy initialization of Hikari pool
-    @Bean(initMethod = "getConnection", destroyMethod = "close")
+    @Bean(destroyMethod = "close")
     @ConfigurationProperties(prefix = "spring.datasource.hikari")
     public HikariDataSource hikariTenantDataSource() {
         return new HikariDataSource();

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcConfig.java
@@ -28,7 +28,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 @Profile("!liquibase-only")
 @Configuration
-@EnableJdbcRepositories(basePackages = { "org.apache.fineract.**.domain" })
+@EnableJdbcRepositories(basePackages = { "org.apache.fineract.command.jdbc.store.domain",
+        "org.apache.fineract.infrastructure.documentmanagement.domain",
+        "org.apache.fineract.mix.domain" }, jdbcOperationsRef = "namedParameterJdbcTemplate", transactionManagerRef = "jdbcTransactionManager")
 public class JdbcConfig {
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcTransactionConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcTransactionConfig.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.config;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.core.persistence.ExtendedDataSourceTransactionManager;
+import org.apache.fineract.infrastructure.core.persistence.TransactionLifecycleCallback;
+import org.apache.fineract.infrastructure.core.service.database.RoutingDataSource;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration(proxyBeanMethods = false)
+public class JdbcTransactionConfig {
+
+    @Bean
+    public PlatformTransactionManager jdbcTransactionManager(FineractProperties fineractProperties, RoutingDataSource dataSource,
+            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers, List<TransactionLifecycleCallback> callbacks) {
+        boolean readOnly = fineractProperties.getMode().isReadOnlyMode();
+        ExtendedDataSourceTransactionManager transactionManager = new ExtendedDataSourceTransactionManager(readOnly);
+        transactionManager.setDataSource(dataSource);
+        transactionManager.setLifecycleCallbacks(callbacks);
+        transactionManager.setValidateExistingTransaction(true);
+        transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize(transactionManager));
+        return transactionManager;
+    }
+
+    @Bean
+    public PlatformTransactionManager batchJdbcTransactionManager(FineractProperties fineractProperties, RoutingDataSource dataSource,
+            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers, List<TransactionLifecycleCallback> callbacks) {
+        boolean readOnly = fineractProperties.getMode().isReadOnlyMode();
+        ExtendedDataSourceTransactionManager transactionManager = new ExtendedDataSourceTransactionManager(readOnly);
+        transactionManager.setDataSource(dataSource);
+        transactionManager.setLifecycleCallbacks(callbacks);
+        transactionManager.setValidateExistingTransaction(true);
+        transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize(transactionManager));
+        return transactionManager;
+    }
+
+    @Bean
+    public TransactionTemplate batchJdbcTransactionTemplate(
+            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager batchJdbcTransactionManager) {
+        return new TransactionTemplate(batchJdbcTransactionManager);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JPAConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JPAConfig.java
@@ -38,8 +38,10 @@ import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.AuditorAware;
@@ -52,13 +54,15 @@ import org.springframework.orm.jpa.persistenceunit.PersistenceUnitManager;
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitPostProcessor;
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
 import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.jta.JtaTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = { "org.apache.fineract.**.domain", "org.apache.fineract.**.repository" })
+@EnableJpaRepositories(basePackages = { "org.apache.fineract.**.domain",
+        "org.apache.fineract.**.repository" }, excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = {
+                "org\\.apache\\.fineract\\.command\\.jdbc\\.store\\.domain\\..*",
+                "org\\.apache\\.fineract\\.infrastructure\\.documentmanagement\\.domain\\..*Repository",
+                "org\\.apache\\.fineract\\.mix\\.domain\\..*Repository" }))
 @EnableConfigurationProperties(JpaProperties.class)
 @Import(JpaAuditingHandlerRegistrar.class)
 public class JPAConfig extends JpaBaseConfiguration {
@@ -128,10 +132,4 @@ public class JPAConfig extends JpaBaseConfiguration {
         return new AuditorAwareImpl();
     }
 
-    @Bean
-    public TransactionTemplate txTemplate(PlatformTransactionManager transactionManager) {
-        TransactionTemplate tt = new TransactionTemplate();
-        tt.setTransactionManager(transactionManager);
-        return tt;
-    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JpaTransactionConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JpaTransactionConfig.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.config.jpa;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
+import org.apache.fineract.infrastructure.core.persistence.TransactionLifecycleCallback;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration(proxyBeanMethods = false)
+public class JpaTransactionConfig {
+
+    @Bean(name = { "transactionManager", "jpaTransactionManager" })
+    @Primary
+    public PlatformTransactionManager jpaTransactionManager(FineractProperties fineractProperties,
+            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers, List<TransactionLifecycleCallback> callbacks) {
+        boolean readOnly = fineractProperties.getMode().isReadOnlyMode();
+        ExtendedJpaTransactionManager transactionManager = new ExtendedJpaTransactionManager(readOnly);
+        transactionManager.setLifecycleCallbacks(callbacks);
+        transactionManager.setValidateExistingTransaction(true);
+        transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize(transactionManager));
+        return transactionManager;
+    }
+
+    @Bean(name = { "transactionTemplate", "txTemplate", "jpaTransactionTemplate" })
+    @Primary
+    public TransactionTemplate jpaTransactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/ExtendedSpringLiquibase.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/ExtendedSpringLiquibase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.infrastructure.core.service.migration;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import liquibase.Liquibase;
 import liquibase.exception.DatabaseException;
@@ -27,7 +28,7 @@ import liquibase.integration.spring.SpringLiquibase;
 public class ExtendedSpringLiquibase extends SpringLiquibase {
 
     public void changeLogSync() throws LiquibaseException {
-        try (Liquibase liquibase = createLiquibase(getDataSource().getConnection())) {
+        try (Connection connection = getDataSource().getConnection(); Liquibase liquibase = createLiquibase(connection)) {
             liquibase.changeLogSync(getContexts());
         } catch (SQLException e) {
             throw new DatabaseException(e);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantPasswordEncryptionTask.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantPasswordEncryptionTask.java
@@ -19,10 +19,9 @@
 package org.apache.fineract.infrastructure.core.service.migration;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.sql.SQLException;
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
@@ -44,37 +43,64 @@ public class TenantPasswordEncryptionTask implements CustomTaskChange, Applicati
 
     private static DatabasePasswordEncryptor databasePasswordEncryptor;
 
-    // NOTE: workaround for double execution bug; see: https://github.com/liquibase/liquibase/issues/3945
-    private Map<String, Boolean> done = new ConcurrentHashMap<>();
+    private static final String SELECT_UNENCRYPTED_PASSWORDS = """
+            SELECT id, schema_password
+            FROM tenant_server_connections
+            WHERE master_password_hash IS NULL
+               OR master_password_hash = ''
+            """;
+
+    private static final String UPDATE_PASSWORD = """
+            UPDATE tenant_server_connections
+            SET schema_password = ?,
+                master_password_hash = ?
+            WHERE id = ?
+              AND (master_password_hash IS NULL OR master_password_hash = '')
+            """;
 
     @Override
     public void execute(Database database) throws CustomChangeException {
-        JdbcConnection dbConn = (JdbcConnection) database.getConnection(); // autocommit is false
-        try (Statement selectStatement = dbConn.createStatement(); Statement updateStatement = dbConn.createStatement()) {
+        if (databasePasswordEncryptor == null) {
+            throw new CustomChangeException("DatabasePasswordEncryptor is not initialized");
+        }
 
-            try (ResultSet rs = selectStatement.executeQuery("SELECT id, schema_password FROM tenant_server_connections")) {
+        try {
+            liquibase.database.DatabaseConnection connection = database.getConnection();
+
+            if (!(connection instanceof JdbcConnection dbConn)) {
+                throw new CustomChangeException(
+                        "Expected Liquibase JdbcConnection but got " + (connection == null ? "null" : connection.getClass().getName()));
+            }
+
+            try (PreparedStatement selectStatement = dbConn.prepareStatement(SELECT_UNENCRYPTED_PASSWORDS);
+                    PreparedStatement updateStatement = dbConn.prepareStatement(UPDATE_PASSWORD);
+                    ResultSet rs = selectStatement.executeQuery()) {
+
+                String masterPasswordHash = databasePasswordEncryptor.getMasterPasswordHash();
+
                 while (rs.next()) {
-                    String id = rs.getString("id");
-                    if (!Boolean.TRUE.equals(done.get(id))) {
-                        String schemaPassword = rs.getString("schema_password");
-                        String encryptedPassword = TenantPasswordEncryptionTask.databasePasswordEncryptor.encrypt(schemaPassword);
+                    long id = rs.getLong("id");
+                    String schemaPassword = rs.getString("schema_password");
+                    String encryptedPassword = databasePasswordEncryptor.encrypt(schemaPassword);
 
-                        String updateSql = String.format(
-                                "update tenant_server_connections set schema_password = '%s', master_password_hash = '%s' where id = %s",
-                                encryptedPassword, TenantPasswordEncryptionTask.databasePasswordEncryptor.getMasterPasswordHash(), id);
-                        updateStatement.execute(updateSql);
-                        done.put(id, true);
-                    }
+                    updateStatement.setString(1, encryptedPassword);
+                    updateStatement.setString(2, masterPasswordHash);
+                    updateStatement.setLong(3, id);
+                    updateStatement.executeUpdate();
                 }
             }
+        } catch (CustomChangeException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CustomChangeException("Failed to encrypt tenant database passwords", e);
         } catch (Exception e) {
-            throw new CustomChangeException(e);
+            throw new CustomChangeException("Unexpected error while encrypting tenant database passwords", e);
         }
     }
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Tenant database passwords encrypted";
     }
 
     @Override
@@ -89,7 +115,13 @@ public class TenantPasswordEncryptionTask implements CustomTaskChange, Applicati
 
     @Override
     public ValidationErrors validate(Database database) {
-        return null;
+        ValidationErrors validationErrors = new ValidationErrors();
+
+        if (databasePasswordEncryptor == null) {
+            validationErrors.addError("DatabasePasswordEncryptor is not initialized");
+        }
+
+        return validationErrors;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantReadOnlyPasswordEncryptionTask.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/migration/TenantReadOnlyPasswordEncryptionTask.java
@@ -19,12 +19,12 @@
 package org.apache.fineract.infrastructure.core.service.migration;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.sql.SQLException;
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.CustomChangeException;
 import liquibase.exception.SetupException;
@@ -44,40 +44,66 @@ public class TenantReadOnlyPasswordEncryptionTask implements CustomTaskChange, A
 
     private static DatabasePasswordEncryptor databasePasswordEncryptor;
 
-    // NOTE: workaround for double execution bug; see: https://github.com/liquibase/liquibase/issues/3945
-    private Map<String, Boolean> done = new ConcurrentHashMap<>();
+    private static final String SELECT_READ_ONLY_PASSWORDS = """
+            SELECT id, readonly_schema_password
+            FROM tenant_server_connections
+            WHERE readonly_schema_password IS NOT NULL
+              AND readonly_schema_password <> ''
+              AND (master_password_hash IS NULL OR master_password_hash = '')
+            """;
+
+    private static final String UPDATE_READ_ONLY_PASSWORD = """
+            UPDATE tenant_server_connections
+            SET readonly_schema_password = ?,
+                master_password_hash = ?
+            WHERE id = ?
+              AND readonly_schema_password IS NOT NULL
+              AND readonly_schema_password <> ''
+            """;
 
     @Override
     public void execute(Database database) throws CustomChangeException {
-        JdbcConnection dbConn = (JdbcConnection) database.getConnection(); // autocommit is false
-        try (Statement selectStatement = dbConn.createStatement(); Statement updateStatement = dbConn.createStatement()) {
+        if (databasePasswordEncryptor == null) {
+            throw new CustomChangeException("DatabasePasswordEncryptor is not initialized");
+        }
 
-            try (ResultSet rs = selectStatement.executeQuery(
-                    "SELECT id, readonly_schema_password FROM tenant_server_connections WHERE readonly_schema_password IS NOT NULL")) {
+        try {
+            DatabaseConnection connection = database.getConnection();
+
+            if (!(connection instanceof JdbcConnection dbConn)) {
+                throw new CustomChangeException(
+                        "Expected Liquibase JdbcConnection but got " + (connection == null ? "null" : connection.getClass().getName()));
+            }
+
+            try (PreparedStatement selectStatement = dbConn.prepareStatement(SELECT_READ_ONLY_PASSWORDS);
+                    PreparedStatement updateStatement = dbConn.prepareStatement(UPDATE_READ_ONLY_PASSWORD);
+                    ResultSet rs = selectStatement.executeQuery()) {
+
+                String masterPasswordHash = databasePasswordEncryptor.getMasterPasswordHash();
+
                 while (rs.next()) {
-                    String id = rs.getString("id");
-                    if (!Boolean.TRUE.equals(done.get(id))) {
-                        String readOnlySchemaPassword = rs.getString("readonly_schema_password");
-                        String encryptedPassword = TenantReadOnlyPasswordEncryptionTask.databasePasswordEncryptor
-                                .encrypt(readOnlySchemaPassword);
+                    long id = rs.getLong("id");
+                    String readOnlySchemaPassword = rs.getString("readonly_schema_password");
+                    String encryptedPassword = databasePasswordEncryptor.encrypt(readOnlySchemaPassword);
 
-                        String updateSql = String.format(
-                                "update tenant_server_connections set readonly_schema_password = '%s', master_password_hash = '%s' where id = %s",
-                                encryptedPassword, TenantReadOnlyPasswordEncryptionTask.databasePasswordEncryptor.getMasterPasswordHash(),
-                                id);
-                        updateStatement.execute(updateSql);
-                        done.put(id, true);
-                    }
+                    updateStatement.setString(1, encryptedPassword);
+                    updateStatement.setString(2, masterPasswordHash);
+                    updateStatement.setLong(3, id);
+                    updateStatement.executeUpdate();
                 }
             }
+        } catch (CustomChangeException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CustomChangeException("Failed to encrypt tenant read-only database passwords", e);
         } catch (Exception e) {
-            throw new CustomChangeException(e);
+            throw new CustomChangeException("Unexpected error while encrypting tenant read-only database passwords", e);
         }
     }
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Tenant read-only database passwords encrypted";
     }
 
     @Override
@@ -92,7 +118,13 @@ public class TenantReadOnlyPasswordEncryptionTask implements CustomTaskChange, A
 
     @Override
     public ValidationErrors validate(Database database) {
-        return null;
+        ValidationErrors validationErrors = new ValidationErrors();
+
+        if (databasePasswordEncryptor == null) {
+            validationErrors.addError("DatabasePasswordEncryptor is not initialized");
+        }
+
+        return validationErrors;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/ScheduledJobRunnerConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/ScheduledJobRunnerConfig.java
@@ -18,9 +18,6 @@
  */
 package org.apache.fineract.infrastructure.jobs;
 
-import java.util.List;
-import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
-import org.apache.fineract.infrastructure.core.persistence.TransactionLifecycleCallback;
 import org.apache.fineract.infrastructure.core.service.database.RoutingDataSource;
 import org.apache.fineract.infrastructure.jobs.config.FineractDataFieldMaxValueIncrementerFactory;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -31,8 +28,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.item.database.support.DataFieldMaxValueIncrementerFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -40,16 +36,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration(proxyBeanMethods = false)
 @EnableBatchProcessing
 public class ScheduledJobRunnerConfig {
-
-    @Bean
-    public PlatformTransactionManager transactionManager(ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers,
-            List<TransactionLifecycleCallback> callbacks) {
-        ExtendedJpaTransactionManager transactionManager = new ExtendedJpaTransactionManager();
-        transactionManager.setLifecycleCallbacks(callbacks);
-        transactionManager.setValidateExistingTransaction(true);
-        transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize(transactionManager));
-        return transactionManager;
-    }
 
     @Bean
     public Jackson2ExecutionContextStringSerializer executionContextSerializer() {
@@ -64,7 +50,8 @@ public class ScheduledJobRunnerConfig {
     }
 
     @Bean
-    public JobRepository jobRepository(RoutingDataSource routingDataSource, PlatformTransactionManager transactionManager,
+    public JobRepository jobRepository(RoutingDataSource routingDataSource,
+            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager transactionManager,
             Jackson2ExecutionContextStringSerializer executionContextSerializer, DataFieldMaxValueIncrementerFactory incrementerFactory)
             throws Exception {
         JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
@@ -78,7 +65,8 @@ public class ScheduledJobRunnerConfig {
     }
 
     @Bean
-    public JobExplorer jobExplorer(RoutingDataSource routingDataSource, PlatformTransactionManager transactionManager,
+    public JobExplorer jobExplorer(RoutingDataSource routingDataSource,
+            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager transactionManager,
             Jackson2ExecutionContextStringSerializer executionContextSerializer) throws Exception {
         JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
         jobExplorerFactoryBean.setDataSource(routingDataSource);

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -62,6 +62,7 @@ fineract.tenant.read-only-name=${FINERACT_DEFAULT_TENANTDB_RO_NAME:}
 
 fineract.tenant.config.min-pool-size=${FINERACT_CONFIG_MIN_POOL_SIZE:-1}
 fineract.tenant.config.max-pool-size=${FINERACT_CONFIG_MAX_POOL_SIZE:-1}
+fineract.tenant.config.leak-detection-threshold=${FINERACT_CONFIG_LEAK_DETECTION_THRESHOLD:0}
 fineract.tenant.config.rounding-mode=${FINERACT_CONFIG_ROUNDING_MODE:6}
 
 fineract.mode.read-enabled=${FINERACT_MODE_READ_ENABLED:true}
@@ -354,7 +355,7 @@ management.otlp.metrics.export.enabled=${FINERACT_MANAGEMENT_OLTP_ENABLED:false}
 management.otlp.metrics.export.url=${FINERACT_MANAGEMENT_OLTP_METRICS_EXPORT_URL:http://tempo:4318/v1/traces}
 management.otlp.metrics.export.aggregationTemporality=${FINERACT_MANAGEMENT_OLTP_METRICS_EXPORT_AGGREGATION_TEMPORALITY:cumulative}
 
-management.prometheus.metrics.export.enabled=${FINERACT_MANAGEMENT_PROMETHEUS_ENABLED:false}
+management.prometheus.metrics.export.enabled=${FINERACT_MANAGEMENT_PROMETHEUS_ENABLED:true}
 # TODO: show pushgateway example
 # management.prometheus.metrics.export.pushgateway.enabled=false
 
@@ -409,6 +410,7 @@ spring.datasource.hikari.minimumIdle=${FINERACT_HIKARI_MINIMUM_IDLE:3}
 spring.datasource.hikari.maximumPoolSize=${FINERACT_HIKARI_MAXIMUM_POOL_SIZE:10}
 spring.datasource.hikari.idleTimeout=${FINERACT_HIKARI_IDLE_TIMEOUT:60000}
 spring.datasource.hikari.connectionTimeout=${FINERACT_HIKARI_CONNECTION_TIMEOUT:20000}
+spring.datasource.hikari.leakDetectionThreshold=${FINERACT_HIKARI_LEAK_DETECTION_THRESHOLD:0}
 spring.datasource.hikari.connectionTestquery=${FINERACT_HIKARI_TEST_QUERY:SELECT 1}
 spring.datasource.hikari.autoCommit=${FINERACT_HIKARI_AUTO_COMMIT:true}
 spring.datasource.hikari.transactionIsolation=${FINERACT_HIKARI_TRANSACTION_ISOLATION:TRANSACTION_REPEATABLE_READ}

--- a/fineract-provider/src/test/java/org/apache/fineract/TestConfiguration.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/TestConfiguration.java
@@ -22,6 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 
+import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.util.List;
 import liquibase.change.custom.CustomTaskChange;
@@ -40,7 +41,6 @@ import org.apache.fineract.infrastructure.core.service.migration.TenantDatabaseS
 import org.apache.fineract.infrastructure.core.service.migration.TenantDatabaseUpgradeService;
 import org.apache.fineract.infrastructure.core.service.tenant.TenantDetailsService;
 import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
-import org.apache.fineract.infrastructure.jobs.ScheduledJobRunnerConfig;
 import org.apache.fineract.infrastructure.jobs.service.JobRegisterService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -64,7 +64,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
@@ -84,16 +83,15 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableWebSecurity
 @EnableConfigurationProperties({ FineractProperties.class, LiquibaseProperties.class })
-@ComponentScan(basePackages = "org.apache.fineract", excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = ScheduledJobRunnerConfig.class) })
+@ComponentScan(basePackages = "org.apache.fineract")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @PropertySource("classpath:application-test.properties")
 public class TestConfiguration {
 
     @Bean
-    public TenantDataSourceFactory tenantDataSourceFactory(DatabasePasswordEncryptor databasePasswordEncryptor) {
-        return new TenantDataSourceFactory(null, databasePasswordEncryptor) {
+    public TenantDataSourceFactory tenantDataSourceFactory(HikariConfig hikariConfig, DatabasePasswordEncryptor databasePasswordEncryptor) {
+        return new TenantDataSourceFactory(hikariConfig, null, databasePasswordEncryptor) {
 
             @Override
             public HikariDataSource create(FineractPlatformTenant tenant) {

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/listener/LoanItemListenerStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/listener/LoanItemListenerStepDefinitions.java
@@ -18,19 +18,16 @@
  */
 package org.apache.fineract.cob.listener;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.cucumber.java8.En;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.List;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.exceptions.LockedReadException;
@@ -45,23 +42,20 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 public class LoanItemListenerStepDefinitions implements En {
 
-    private LockingService loanLockingService = mock(LockingService.class);
-    private TransactionTemplate transactionTemplate = spy(TransactionTemplate.class);
+    private final LockingService loanLockingService = mock(LockingService.class);
+    private final TransactionTemplate batchJdbcTransactionTemplate = spy(TransactionTemplate.class);
 
-    private ChunkProcessingLoanItemListener loanItemListener = new ChunkProcessingLoanItemListener(loanLockingService, transactionTemplate);
+    private final ChunkProcessingLoanItemListener loanItemListener = new ChunkProcessingLoanItemListener(loanLockingService,
+            batchJdbcTransactionTemplate);
 
     private Exception exception;
-
-    private LoanAccountLock loanAccountLock;
     private final Loan loan = mock(Loan.class);
 
     public LoanItemListenerStepDefinitions() {
         Given("/^The LoanItemListener.onReadError method (.*)$/", (String action) -> {
             ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
             exception = new LockedReadException(1L, new RuntimeException("fail"));
-            loanAccountLock = new LoanAccountLock(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-            when(loanLockingService.findByLoanIdAndLockOwner(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING)).thenReturn(loanAccountLock);
-            transactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
+            batchJdbcTransactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
             when(loan.getId()).thenReturn(1L);
         });
 
@@ -74,20 +68,17 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onReadError result should match", () -> {
-            verify(transactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-            verify(transactionTemplate, Mockito.times(1)).execute(any());
-            verify(loanLockingService, Mockito.times(1)).findByLoanIdAndLockOwner(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING);
-            assertEquals("Loan (id: 1) reading is failed", loanAccountLock.getError());
-            assertNotNull(loanAccountLock.getStacktrace());
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
+            verify(loanLockingService, Mockito.times(1)).updateLockError(eq(1L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
+                    eq("Loan (id: 1) reading is failed"), anyString());
         });
 
         Given("/^The LoanItemListener.onProcessError method (.*)$/", (String action) -> {
             ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
             exception = new LockedReadException(1L, new RuntimeException("fail"));
-            loanAccountLock = new LoanAccountLock(2L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-            when(loanLockingService.findByLoanIdAndLockOwner(2L, LockOwner.LOAN_COB_CHUNK_PROCESSING)).thenReturn(loanAccountLock);
             when(loan.getId()).thenReturn(2L);
-            transactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
+            batchJdbcTransactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
         });
 
         When("LoanItemListener.onProcessError method executed", () -> {
@@ -99,20 +90,17 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onProcessError result should match", () -> {
-            verify(transactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-            verify(transactionTemplate, Mockito.times(1)).execute(any());
-            verify(loanLockingService, Mockito.times(1)).findByLoanIdAndLockOwner(2L, LockOwner.LOAN_COB_CHUNK_PROCESSING);
-            assertEquals("Loan (id: 2) processing is failed", loanAccountLock.getError());
-            assertNotNull(loanAccountLock.getStacktrace());
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
+            verify(loanLockingService, Mockito.times(1)).updateLockError(eq(2L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
+                    eq("Loan (id: 2) processing is failed"), anyString());
         });
 
         Given("/^The LoanItemListener.onWriteError method (.*)$/", (String action) -> {
             ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
             exception = new LockedReadException(3L, new RuntimeException("fail"));
-            loanAccountLock = new LoanAccountLock(3L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-            when(loanLockingService.findByLoanIdAndLockOwner(3L, LockOwner.LOAN_COB_CHUNK_PROCESSING)).thenReturn(loanAccountLock);
             when(loan.getId()).thenReturn(3L);
-            transactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
+            batchJdbcTransactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
         });
 
         When("LoanItemListener.onWriteError method executed", () -> {
@@ -124,11 +112,10 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onWriteError result should match", () -> {
-            verify(transactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-            verify(transactionTemplate, Mockito.times(1)).execute(any());
-            verify(loanLockingService, Mockito.times(1)).findByLoanIdAndLockOwner(3L, LockOwner.LOAN_COB_CHUNK_PROCESSING);
-            assertEquals("Loan (id: 3) writing is failed", loanAccountLock.getError());
-            assertNotNull(loanAccountLock.getStacktrace());
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
+            verify(loanLockingService, Mockito.times(1)).updateLockError(eq(3L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
+                    eq("Loan (id: 3) writing is failed"), anyString());
         });
     }
 }

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/ApplyLoanLockTaskletStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/ApplyLoanLockTaskletStepDefinitions.java
@@ -32,7 +32,6 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.fineract.cob.data.COBParameter;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.exceptions.LockCannotBeAppliedException;
@@ -85,34 +84,29 @@ public class ApplyLoanLockTaskletStepDefinitions implements En {
             if ("error".equals(action)) {
                 lenient().when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
-                lenient().when(loanLockingService.findAllByLoanIdIn(Mockito.anyList())).thenThrow(new RuntimeException("fail"));
+                lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenThrow(new RuntimeException("fail"));
             } else if ("db-error-first-try".equals(action)) {
-                LoanAccountLock lock1 = new LoanAccountLock(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-                LoanAccountLock lock3 = new LoanAccountLock(3L, LockOwner.LOAN_INLINE_COB_PROCESSING,
-                        LocalDate.now(ZoneId.systemDefault()));
-                List<LoanAccountLock> accountLocks = List.of(lock1, lock3);
+                List<Long> accountLocks = List.of(1L, 3L);
                 lenient().when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
-                lenient().when(loanLockingService.findAllByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
+                lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
                 Mockito.doThrow(new RuntimeException("db error")).when(loanLockingService).applyLock(Mockito.anyList(), any());
             } else if ("db-error-not-recoverable".equals(action)) {
-                LoanAccountLock lock1 = new LoanAccountLock(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-                LoanAccountLock lock3 = new LoanAccountLock(3L, LockOwner.LOAN_INLINE_COB_PROCESSING,
-                        LocalDate.now(ZoneId.systemDefault()));
-                List<LoanAccountLock> accountLocks = List.of(lock1, lock3);
+                Long lock1 = 1L;
+                Long lock3 = 3L;
+                List<Long> accountLocks = List.of(lock1, lock3);
                 stepContribution.getStepExecution().setCommitCount(4);
                 lenient().when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
-                lenient().when(loanLockingService.findAllByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
+                lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
                 Mockito.doThrow(new RuntimeException("db error")).when(loanLockingService).applyLock(Mockito.anyList(), any());
             } else {
-                LoanAccountLock lock1 = new LoanAccountLock(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.now(ZoneId.systemDefault()));
-                LoanAccountLock lock3 = new LoanAccountLock(3L, LockOwner.LOAN_INLINE_COB_PROCESSING,
-                        LocalDate.now(ZoneId.systemDefault()));
-                List<LoanAccountLock> accountLocks = List.of(lock1, lock3);
+                Long lock1 = 1L;
+                Long lock3 = 3L;
+                List<Long> accountLocks = List.of(lock1, lock3);
                 lenient().when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
-                lenient().when(loanLockingService.findAllByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
+                lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
             }
             transactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
 

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderStepDefinitions.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.fineract.cob.common.CustomJobParameterResolver;
 import org.apache.fineract.cob.data.COBParameter;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.exceptions.LockedReadException;
@@ -61,7 +60,7 @@ public class LoanItemReaderStepDefinitions implements En {
     private LockingService lockingService = mock(LockingService.class);
 
     private LoanItemReader loanItemReader = new LoanItemReader(loanRepository,
-            new BeforeStepLockingItemReaderHelper<LoanAccountLock>(retrieveIdService, lockingService));
+            new BeforeStepLockingItemReaderHelper(retrieveIdService, lockingService));
 
     private Loan loan = mock(Loan.class);
 
@@ -96,15 +95,14 @@ public class LoanItemReaderStepDefinitions implements En {
             businessDates.put(BusinessDateType.BUSINESS_DATE, businessDate);
             businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
             ThreadLocalContextUtil.setBusinessDates(businessDates);
-            LoanAccountLock loanAccountLock = new LoanAccountLock(1L, LockOwner.LOAN_COB_CHUNK_PROCESSING, businessDate.minusDays(1));
-            LoanAccountLock loanAccountLockNegativeNumberTest = new LoanAccountLock(-1L, LockOwner.LOAN_COB_CHUNK_PROCESSING,
-                    businessDate.minusDays(1));
+            Long loanAccountLock = 1L;
+            Long loanAccountLockNegativeNumberTest = -1L;
             lenient().when(customJobParameterResolver.getCustomJobParameterSet(any())).thenReturn(Optional.empty());
-            lenient().when(lockingService.findAllByLoanIdInAndLockOwner(List.of(1L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
+            lenient().when(lockingService.findLockIdsByLoanIdInAndLockOwner(List.of(1L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
                     .thenReturn(List.of(loanAccountLock));
-            lenient().when(lockingService.findAllByLoanIdInAndLockOwner(List.of(1L, 2L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
+            lenient().when(lockingService.findLockIdsByLoanIdInAndLockOwner(List.of(1L, 2L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
                     .thenReturn(List.of(loanAccountLock));
-            lenient().when(lockingService.findAllByLoanIdInAndLockOwner(List.of(-1L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
+            lenient().when(lockingService.findLockIdsByLoanIdInAndLockOwner(List.of(-1L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
                     .thenReturn(List.of(loanAccountLockNegativeNumberTest));
 
             loanItemReader.beforeStep(stepExecution);

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/LoanItemReaderTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.fineract.cob.data.COBParameter;
-import org.apache.fineract.cob.domain.LoanAccountLock;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.cob.service.BeforeStepLockingItemReaderHelper;
@@ -64,7 +62,7 @@ class LoanItemReaderTest {
     private RetrieveIdService retrieveIdService;
 
     @Mock
-    private LockingService<LoanAccountLock> loanLockingService;
+    private LockingService loanLockingService;
 
     @Mock
     private StepExecution stepExecution;
@@ -87,7 +85,7 @@ class LoanItemReaderTest {
         // given
         ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "test", "UTC", null));
         LoanItemReader loanItemReader = new LoanItemReader(loanRepository,
-                new BeforeStepLockingItemReaderHelper<>(retrieveIdService, loanLockingService));
+                new BeforeStepLockingItemReaderHelper(retrieveIdService, loanLockingService));
         when(stepExecution.getExecutionContext()).thenReturn(executionContext);
         when(stepExecution.getJobExecution()).thenReturn(jobExecution);
         when(jobExecution.getExecutionContext()).thenReturn(executionContext);
@@ -95,9 +93,8 @@ class LoanItemReaderTest {
         when(executionContext.get(LoanCOBConstant.COB_PARAMETER)).thenReturn(loanCOBParameter);
         when(retrieveIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter, false))
                 .thenReturn(new ArrayList<>(List.of(1L, 2L, 3L, 4L, 5L)));
-        List<LoanAccountLock> accountLocks = Stream.of(1L, 2L, 3L, 4L, 5L)
-                .map(l -> new LoanAccountLock(l, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.of(2023, 7, 25))).toList();
-        when(loanLockingService.findAllByLoanIdInAndLockOwner(List.of(1L, 2L, 3L, 4L, 5L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
+        List<Long> accountLocks = Stream.of(1L, 2L, 3L, 4L, 5L).toList();
+        when(loanLockingService.findLockIdsByLoanIdInAndLockOwner(List.of(1L, 2L, 3L, 4L, 5L), LockOwner.LOAN_COB_CHUNK_PROCESSING))
                 .thenReturn(accountLocks);
         when(loanRepository.findById(anyLong())).thenReturn(Optional.of(loan));
 
@@ -117,7 +114,7 @@ class LoanItemReaderTest {
         // given
         ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "test", "UTC", null));
         LoanItemReader loanItemReader = new LoanItemReader(loanRepository,
-                new BeforeStepLockingItemReaderHelper<>(retrieveIdService, loanLockingService));
+                new BeforeStepLockingItemReaderHelper(retrieveIdService, loanLockingService));
         when(stepExecution.getExecutionContext()).thenReturn(executionContext);
         when(stepExecution.getJobExecution()).thenReturn(jobExecution);
         when(jobExecution.getExecutionContext()).thenReturn(executionContext);
@@ -140,7 +137,7 @@ class LoanItemReaderTest {
         // given
         ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "test", "test", "UTC", null));
         LoanItemReader loanItemReader = new LoanItemReader(loanRepository,
-                new BeforeStepLockingItemReaderHelper<>(retrieveIdService, loanLockingService));
+                new BeforeStepLockingItemReaderHelper(retrieveIdService, loanLockingService));
         when(stepExecution.getExecutionContext()).thenReturn(executionContext);
         when(stepExecution.getJobExecution()).thenReturn(jobExecution);
         when(jobExecution.getExecutionContext()).thenReturn(executionContext);
@@ -148,9 +145,8 @@ class LoanItemReaderTest {
         when(executionContext.get(LoanCOBConstant.COB_PARAMETER)).thenReturn(loanCOBParameter);
         when(retrieveIdService.retrieveAllNonClosedLoansByLastClosedBusinessDateAndMinAndMaxLoanId(loanCOBParameter, false))
                 .thenReturn(new ArrayList<>(IntStream.rangeClosed(1, 100).boxed().map(Long::valueOf).toList()));
-        List<LoanAccountLock> accountLocks = IntStream.rangeClosed(1, 100).boxed().map(Long::valueOf)
-                .map(l -> new LoanAccountLock(l, LockOwner.LOAN_COB_CHUNK_PROCESSING, LocalDate.of(2023, 7, 25))).toList();
-        when(loanLockingService.findAllByLoanIdInAndLockOwner(IntStream.rangeClosed(1, 100).boxed().map(Long::valueOf).toList(),
+        List<Long> accountLocks = IntStream.rangeClosed(1, 100).boxed().map(Long::valueOf).toList();
+        when(loanLockingService.findLockIdsByLoanIdInAndLockOwner(IntStream.rangeClosed(1, 100).boxed().map(Long::valueOf).toList(),
                 LockOwner.LOAN_COB_CHUNK_PROCESSING)).thenReturn(accountLocks);
         when(loanRepository.findById(anyLong())).thenReturn(Optional.of(loan));
 

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/core/DataSourcePerTenantServiceFactoryTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/core/DataSourcePerTenantServiceFactoryTest.java
@@ -81,6 +81,7 @@ public class DataSourcePerTenantServiceFactoryTest {
     public static final int MASTER_DB_MAX_ACTIVE = 5;
     public static final long MASTER_DB_VALIDATION_INTERVAL = 500L;
     public static final long MASTER_DB_INIT_FAIL_TIMEOUT = 0L;
+    public static final long MASTER_DB_LEAK_DETECTION_THRESHOLD = 20_000L;
 
     public static final String MASTER_DB_DRIVER_CLASS_NAME = "org.postgresql.Driver";
     public static final String MASTER_DB_CONN_TEST_QUERY = "SELECT 1";
@@ -159,12 +160,14 @@ public class DataSourcePerTenantServiceFactoryTest {
         given(tenantHikariConfig.getConnectionTestQuery()).willReturn(MASTER_DB_CONN_TEST_QUERY);
         given(tenantHikariConfig.getDataSourceProperties()).willReturn(mock(Properties.class));
         given(tenantHikariConfig.isAutoCommit()).willReturn(MASTER_DB_AUTO_COMMIT_ENABLED);
+        given(tenantHikariConfig.getLeakDetectionThreshold()).willReturn(0L);
 
         given(hikariDataSourceFactory.create(any())).willReturn(mock(HikariDataSource.class));
 
         FineractProperties.FineractConfigProperties configProperties = new FineractProperties.FineractConfigProperties();
         configProperties.setMinPoolSize(-1);
         configProperties.setMaxPoolSize(-1);
+        configProperties.setLeakDetectionThreshold(0L);
 
         FineractProperties.FineractTenantProperties tenantPropertiesMock = mock(FineractProperties.FineractTenantProperties.class);
         given(tenantPropertiesMock.getEncryption()).willReturn(MASTER_ENCRYPTION);
@@ -206,6 +209,7 @@ public class DataSourcePerTenantServiceFactoryTest {
         assertEquals(MASTER_DB_DRIVER_CLASS_NAME, hikariConfig.getDriverClassName());
         assertEquals(MASTER_DB_CONN_TEST_QUERY, hikariConfig.getConnectionTestQuery());
         assertEquals(MASTER_DB_AUTO_COMMIT_ENABLED, hikariConfig.isAutoCommit());
+        assertEquals(0L, hikariConfig.getLeakDetectionThreshold());
     }
 
     @Test
@@ -238,6 +242,44 @@ public class DataSourcePerTenantServiceFactoryTest {
         assertEquals(MASTER_DB_DRIVER_CLASS_NAME, hikariConfig.getDriverClassName());
         assertEquals(MASTER_DB_CONN_TEST_QUERY, hikariConfig.getConnectionTestQuery());
         assertEquals(MASTER_DB_AUTO_COMMIT_ENABLED, hikariConfig.isAutoCommit());
+    }
+
+    @Test
+    void testCreateNewDataSourceFor_ShouldUseMasterLeakDetectionThreshold_WhenConfiguredOnHikari() {
+        // given
+        FineractProperties.FineractModeProperties modeProperties = createModeProps(MASTER_DB_AUTO_COMMIT_ENABLED,
+                MASTER_DB_AUTO_COMMIT_ENABLED, MASTER_DB_AUTO_COMMIT_ENABLED, MASTER_DB_AUTO_COMMIT_ENABLED);
+        given(fineractProperties.getMode()).willReturn(modeProperties);
+        given(tenantHikariConfig.getLeakDetectionThreshold()).willReturn(MASTER_DB_LEAK_DETECTION_THRESHOLD);
+
+        // when
+        DataSource dataSource = underTest.createNewDataSourceFor(TENANT, defaultTenant.getConnection());
+
+        // then
+        assertNotNull(dataSource);
+        verify(hikariDataSourceFactory).create(hikariConfigCaptor.capture());
+        HikariConfig hikariConfig = hikariConfigCaptor.getValue();
+        assertEquals(MASTER_DB_LEAK_DETECTION_THRESHOLD, hikariConfig.getLeakDetectionThreshold());
+    }
+
+    @Test
+    void testCreateNewDataSourceFor_ShouldOverrideLeakDetectionThreshold_WhenConfigured() {
+        // given
+        FineractProperties.FineractModeProperties modeProperties = createModeProps(MASTER_DB_AUTO_COMMIT_ENABLED,
+                MASTER_DB_AUTO_COMMIT_ENABLED, MASTER_DB_AUTO_COMMIT_ENABLED, MASTER_DB_AUTO_COMMIT_ENABLED);
+        given(fineractProperties.getMode()).willReturn(modeProperties);
+
+        FineractProperties.FineractConfigProperties config = fineractProperties.getTenant().getConfig();
+        config.setLeakDetectionThreshold(MASTER_DB_LEAK_DETECTION_THRESHOLD);
+
+        // when
+        DataSource dataSource = underTest.createNewDataSourceFor(TENANT, defaultTenant.getConnection());
+
+        // then
+        assertNotNull(dataSource);
+        verify(hikariDataSourceFactory).create(hikariConfigCaptor.capture());
+        HikariConfig hikariConfig = hikariConfigCaptor.getValue();
+        assertEquals(MASTER_DB_LEAK_DETECTION_THRESHOLD, hikariConfig.getLeakDetectionThreshold());
     }
 
     @Test

--- a/fineract-savings/src/main/java/org/apache/fineract/cob/savings/domain/SavingsAccountLockRepository.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/cob/savings/domain/SavingsAccountLockRepository.java
@@ -16,10 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.cob.savings;
+package org.apache.fineract.cob.savings.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.fineract.cob.savings.SavingsAccountLock;
+import org.apache.fineract.cob.savings.SavingsLockOwner;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/AbstractWorkingCapitalLoanCOBWorkerItemWriter.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/AbstractWorkingCapitalLoanCOBWorkerItemWriter.java
@@ -23,7 +23,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.springframework.batch.item.Chunk;
@@ -33,9 +32,9 @@ import org.springframework.data.repository.CrudRepository;
 @Slf4j
 public abstract class AbstractWorkingCapitalLoanCOBWorkerItemWriter extends RepositoryItemWriter<WorkingCapitalLoan> {
 
-    private final LockingService<WorkingCapitalLoanAccountLock> loanLockingService;
+    private final LockingService loanLockingService;
 
-    public AbstractWorkingCapitalLoanCOBWorkerItemWriter(LockingService<WorkingCapitalLoanAccountLock> loanLockingService,
+    public AbstractWorkingCapitalLoanCOBWorkerItemWriter(LockingService loanLockingService,
             CrudRepository<WorkingCapitalLoan, Long> repository) {
         this.loanLockingService = loanLockingService;
         setRepository(repository);

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/ApplyWorkingCapitalLoanLockTasklet.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/ApplyWorkingCapitalLoanLockTasklet.java
@@ -21,19 +21,17 @@ package org.apache.fineract.cob.workingcapitalloan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.service.RetrieveIdService;
 import org.apache.fineract.cob.tasklet.ApplyCommonLockTasklet;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
-public class ApplyWorkingCapitalLoanLockTasklet extends ApplyCommonLockTasklet<WorkingCapitalLoanAccountLock> {
+public class ApplyWorkingCapitalLoanLockTasklet extends ApplyCommonLockTasklet {
 
-    public ApplyWorkingCapitalLoanLockTasklet(FineractProperties fineractProperties,
-            LockingService<WorkingCapitalLoanAccountLock> loanLockingService, RetrieveIdService retrieveIdService,
-            TransactionTemplate transactionTemplate) {
-        super(fineractProperties, loanLockingService, retrieveIdService, transactionTemplate);
+    public ApplyWorkingCapitalLoanLockTasklet(FineractProperties fineractProperties, LockingService loanLockingService,
+            RetrieveIdService retrieveIdService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemListener.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemListener.java
@@ -20,16 +20,14 @@ package org.apache.fineract.cob.workingcapitalloan;
 
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.listener.AbstractLoanItemListener;
-import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.springframework.transaction.support.TransactionTemplate;
 
-public class InlineWorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<WorkingCapitalLoanAccountLock, Loan> {
+public class InlineWorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<WorkingCapitalLoan> {
 
-    public InlineWorkingCapitalLoanCOBWorkerItemListener(LockingService<WorkingCapitalLoanAccountLock> lockingService,
-            TransactionTemplate transactionTemplate) {
-        super(lockingService, transactionTemplate);
+    public InlineWorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(lockingService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemWriter.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemWriter.java
@@ -21,14 +21,13 @@ package org.apache.fineract.cob.workingcapitalloan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.springframework.data.repository.CrudRepository;
 
 @Slf4j
 public class InlineWorkingCapitalLoanCOBWorkerItemWriter extends AbstractWorkingCapitalLoanCOBWorkerItemWriter {
 
-    public InlineWorkingCapitalLoanCOBWorkerItemWriter(LockingService<WorkingCapitalLoanAccountLock> loanLockingService,
+    public InlineWorkingCapitalLoanCOBWorkerItemWriter(LockingService loanLockingService,
             CrudRepository<WorkingCapitalLoan, Long> repository) {
         super(loanLockingService, repository);
     }

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
@@ -27,7 +27,6 @@ import org.apache.fineract.cob.common.InitialisationTasklet;
 import org.apache.fineract.cob.common.ResetContextTasklet;
 import org.apache.fineract.cob.conditions.BatchWorkerCondition;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.listener.CobWorkerStepListener;
 import org.apache.fineract.cob.loan.ContextAwareTaskDecorator;
 import org.apache.fineract.cob.service.BeforeStepLockingItemReaderHelper;
@@ -37,6 +36,8 @@ import org.apache.fineract.infrastructure.springbatch.PropertyService;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.apache.fineract.portfolio.workingcapitalloan.repository.WorkingCapitalLoanRepository;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.SimpleStepBuilder;
 import org.springframework.batch.integration.partition.RemotePartitioningWorkerStepBuilderFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -55,12 +56,17 @@ import org.springframework.transaction.support.TransactionTemplate;
 @RequiredArgsConstructor
 public class WorkingCapitalLoanCOBWorkerConfiguration {
 
+    private final JobRepository jobRepository;
     private final RemotePartitioningWorkerStepBuilderFactory stepBuilderFactory;
     private final MessageChannel inboundRequests;
     private final PropertyService propertyService;
     private final PlatformTransactionManager transactionManager;
-    private final TransactionTemplate transactionTemplate;
-    private final LockingService<WorkingCapitalLoanAccountLock> wpcLoanLockingService;
+    @Qualifier("batchJdbcTransactionManager")
+    private final PlatformTransactionManager batchJdbcTransactionManager;
+    @Qualifier("batchJdbcTransactionTemplate")
+    private final TransactionTemplate batchJdbcTransactionTemplate;
+    @Qualifier("workingCapitalLoanLockingService")
+    private final LockingService wpcLoanLockingService;
     private final FineractProperties fineractProperties;
     private final WorkingCapitalLoanRetrieveIdService retrieveIdService;
     private final WorkingCapitalLoanRepository workingCapitalLoanRepository;
@@ -75,7 +81,7 @@ public class WorkingCapitalLoanCOBWorkerConfiguration {
                 .get(WORKING_CAPITAL_LOAN_COB_WORKER_STEP).inputChannel(inboundRequests)
                 .<WorkingCapitalLoan, WorkingCapitalLoan>chunk(propertyService.getChunkSize(JobName.LOAN_COB.name()), transactionManager) //
                 .reader(new WorkingCapitalLoanCOBWorkerItemReader(workingCapitalLoanRepository,
-                        new BeforeStepLockingItemReaderHelper<>(retrieveIdService, wpcLoanLockingService))) //
+                        new BeforeStepLockingItemReaderHelper(retrieveIdService, wpcLoanLockingService))) //
                 .processor(new WorkingCapitalLoanCOBWorkerItemProcessor(cobBusinessStepService)) //
                 .writer(new WorkingCapitalLoanCOBWorkerItemWriter(wpcLoanLockingService, workingCapitalLoanRepository)) //
                 .faultTolerant() //
@@ -117,12 +123,21 @@ public class WorkingCapitalLoanCOBWorkerConfiguration {
 
     @Bean
     public WorkingCapitalLoanCOBWorkerItemListener workingCapitalLoanItemListener() {
-        return new WorkingCapitalLoanCOBWorkerItemListener(wpcLoanLockingService, transactionTemplate);
+        return new WorkingCapitalLoanCOBWorkerItemListener(wpcLoanLockingService, batchJdbcTransactionTemplate);
     }
 
     @Bean
     public ApplyWorkingCapitalLoanLockTasklet applyWorkingCapitalLoanLock() {
-        return new ApplyWorkingCapitalLoanLockTasklet(fineractProperties, wpcLoanLockingService, retrieveIdService, transactionTemplate);
+        return new ApplyWorkingCapitalLoanLockTasklet(fineractProperties, wpcLoanLockingService, retrieveIdService,
+                batchJdbcTransactionTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public Step applyWorkingCapitalLoanLockStep(
+            @org.springframework.beans.factory.annotation.Value("#{stepExecutionContext['partition']}") String partitionName) {
+        return new org.springframework.batch.core.step.builder.StepBuilder("Apply WC lock - Step:" + partitionName, jobRepository)
+                .tasklet(applyWorkingCapitalLoanLock(), batchJdbcTransactionManager).build();
     }
 
 }

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemListener.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemListener.java
@@ -20,16 +20,14 @@ package org.apache.fineract.cob.workingcapitalloan;
 
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.listener.AbstractLoanItemListener;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.springframework.transaction.support.TransactionTemplate;
 
-public class WorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<WorkingCapitalLoanAccountLock, Loan> {
+public class WorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<Loan> {
 
-    public WorkingCapitalLoanCOBWorkerItemListener(LockingService<WorkingCapitalLoanAccountLock> lockingService,
-            TransactionTemplate transactionTemplate) {
-        super(lockingService, transactionTemplate);
+    public WorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
+        super(lockingService, batchJdbcTransactionTemplate);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemReader.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemReader.java
@@ -23,7 +23,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.cob.exceptions.LockedReadException;
 import org.apache.fineract.cob.service.BeforeStepLockingItemReaderHelper;
 import org.apache.fineract.portfolio.loanaccount.exception.LoanNotFoundException;
@@ -40,7 +39,7 @@ import org.springframework.lang.Nullable;
 public class WorkingCapitalLoanCOBWorkerItemReader implements ItemReader<WorkingCapitalLoan> {
 
     private final WorkingCapitalLoanRepository repository;
-    private final BeforeStepLockingItemReaderHelper<WorkingCapitalLoanAccountLock> itemReaderHelper;
+    private final BeforeStepLockingItemReaderHelper itemReaderHelper;
 
     @Setter(AccessLevel.PROTECTED)
     private LinkedBlockingQueue<Long> remainingData;

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemWriter.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemWriter.java
@@ -21,15 +21,13 @@ package org.apache.fineract.cob.workingcapitalloan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.LockOwner;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.springframework.data.repository.CrudRepository;
 
 @Slf4j
 public class WorkingCapitalLoanCOBWorkerItemWriter extends AbstractWorkingCapitalLoanCOBWorkerItemWriter {
 
-    public WorkingCapitalLoanCOBWorkerItemWriter(LockingService<WorkingCapitalLoanAccountLock> loanLockingService,
-            CrudRepository<WorkingCapitalLoan, Long> repository) {
+    public WorkingCapitalLoanCOBWorkerItemWriter(LockingService loanLockingService, CrudRepository<WorkingCapitalLoan, Long> repository) {
         super(loanLockingService, repository);
     }
 

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingConfiguration.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingConfiguration.java
@@ -20,8 +20,6 @@ package org.apache.fineract.cob.workingcapitalloan;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.cob.domain.LockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalAccountLockRepository;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -34,11 +32,10 @@ public class WorkingCapitalLoanLockingConfiguration {
 
     private final JdbcTemplate jdbcTemplate;
     private final FineractProperties fineractProperties;
-    private final WorkingCapitalAccountLockRepository workingCapitalAccountLockRepository;
 
     @Bean
-    @ConditionalOnMissingBean
-    public LockingService<WorkingCapitalLoanAccountLock> workingCapitalLoanLockingService() {
-        return new WorkingCapitalLoanLockingServiceImpl(jdbcTemplate, fineractProperties, workingCapitalAccountLockRepository);
+    @ConditionalOnMissingBean(name = "workingCapitalLoanLockingService")
+    public LockingService workingCapitalLoanLockingService() {
+        return new WorkingCapitalLoanLockingServiceImpl(jdbcTemplate, fineractProperties);
     }
 }

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingServiceImpl.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingServiceImpl.java
@@ -20,13 +20,13 @@ package org.apache.fineract.cob.workingcapitalloan;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.AbstractLockingService;
-import org.apache.fineract.cob.domain.WorkingCapitalAccountLockRepository;
-import org.apache.fineract.cob.domain.WorkingCapitalLoanAccountLock;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Slf4j
-public class WorkingCapitalLoanLockingServiceImpl extends AbstractLockingService<WorkingCapitalLoanAccountLock> {
+public class WorkingCapitalLoanLockingServiceImpl extends AbstractLockingService {
+
+    private static final String TABLE_NAME = "m_wc_loan_account_locks";
 
     private static final String BATCH_LOAN_LOCK_INSERT = """
                 INSERT INTO m_wc_loan_account_locks (loan_id, version, lock_owner, lock_placed_on, lock_placed_on_cob_business_date) VALUES (?,?,?,?,?)
@@ -36,9 +36,13 @@ public class WorkingCapitalLoanLockingServiceImpl extends AbstractLockingService
                 UPDATE m_wc_loan_account_locks SET version= version + 1, lock_owner = ?, lock_placed_on = ? WHERE loan_id = ?
             """;
 
-    public WorkingCapitalLoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties,
-            WorkingCapitalAccountLockRepository loanAccountLockRepository) {
-        super(jdbcTemplate, fineractProperties, loanAccountLockRepository);
+    public WorkingCapitalLoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
+        super(jdbcTemplate, fineractProperties);
+    }
+
+    @Override
+    protected String getTableName() {
+        return TABLE_NAME;
     }
 
     @Override


### PR DESCRIPTION
## Description

Connection pool exhaustion issues were noticed.

Following optimizations were done:

- Close more aggressively datasource connections (where applicable)
- Reworked COB locking to rely on JDBC Repositories solely (no mixed JPA + JDBC connections around locking)
- Separate 3 kind of transaction managers:
  - JPA transaction manager (default)
  - JDBC transaction manager (used by new command framework)
  - Batch job JDBC transaction manager (used by Spring Batch for JDBC repository operations)
- Connection pool exhaustion diagnostics added 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
