### PR TITLE
FINERACT-2630: Use Collection.isEmpty() instead of size() comparison in fineract-savings

### DIFF
--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -1638,7 +1638,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public void validateAccountBalanceDoesNotViolateOverdraft(final List<SavingsAccountTransaction> savingsAccountTransaction,
             final BigDecimal amountPaid) {
-        if (savingsAccountTransaction != null && savingsAccountTransaction.size() > 0) {
+        if (savingsAccountTransaction != null && !savingsAccountTransaction.isEmpty()) {
             SavingsAccountTransaction savingsAccountTransactionFirst = savingsAccountTransaction.get(0);
             if (!this.allowOverdraft) {
                 if (savingsAccountTransactionFirst.getRunningBalance(this.currency).minus(amountPaid).isLessThanZero()) {
@@ -2821,7 +2821,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             }
         }
         final List<SavingsAccountTransaction> savingsAccountTransactions = retrieveListOfTransactions();
-        if (savingsAccountTransactions.size() > 0) {
+        if (!savingsAccountTransactions.isEmpty()) {
             final SavingsAccountTransaction accountTransaction = savingsAccountTransactions.get(savingsAccountTransactions.size() - 1);
             if (accountTransaction.isAfter(closedDate)) {
                 baseDataValidator.reset().parameter(SavingsApiConstants.closedOnDateParamName).value(closedDate)
@@ -3780,7 +3780,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     public LocalDate retrieveLastTransactionDate() {
         final List<SavingsAccountTransaction> transactionsSortedByDate = retrieveListOfTransactions();
         SavingsAccountTransaction lastTransaction = null;
-        if (transactionsSortedByDate.size() > 0) {
+        if (!transactionsSortedByDate.isEmpty()) {
             lastTransaction = transactionsSortedByDate.get(transactionsSortedByDate.size() - 1);
         }
         LocalDate lastransactionDate = null;
@@ -3793,7 +3793,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     public LocalDate retrieveLastTransactionDateWithPivotConfig() {
         final List<SavingsAccountTransaction> transactionsSortedByDate = retrieveSortedTransactions();
         SavingsAccountTransaction lastTransaction = null;
-        if (transactionsSortedByDate.size() > 0) {
+        if (!transactionsSortedByDate.isEmpty()) {
             lastTransaction = transactionsSortedByDate.get(transactionsSortedByDate.size() - 1);
         }
         LocalDate lastransactionDate = null;

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountRepositoryWrapper.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountRepositoryWrapper.java
@@ -155,7 +155,7 @@ public class SavingsAccountRepositoryWrapper {
     }
 
     private void loadLazyCollections(final List<SavingsAccount> accounts) {
-        if (accounts != null && accounts.size() > 0) {
+        if (accounts != null && !accounts.isEmpty()) {
             for (SavingsAccount account : accounts) {
                 account.loadLazyCollections();
             }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPoster.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularInterestPoster.java
@@ -139,7 +139,7 @@ public class SavingsSchedularInterestPoster {
             }
         }
 
-        if (paramsForGLInsertion != null && paramsForGLInsertion.size() > 0) {
+        if (paramsForGLInsertion != null && !paramsForGLInsertion.isEmpty()) {
             this.jdbcTemplate.batchUpdate(queryForJGLUpdate, paramsForGLInsertion);
         }
     }


### PR DESCRIPTION
## Description

Replaces 6 occurrences of `Collection.size() > 0` emptiness checks with `!Collection.isEmpty()` across the `fineract-savings` module (`SavingsAccount`, `SavingsAccountRepositoryWrapper`, `SavingsSchedularInterestPoster`), as flagged by SonarCloud rule java:S1155 ("Collection.isEmpty() should be used to test for emptiness"). This mirrors the cleanup done for the `fineract-loan` module in FINERACT-2627.

The change is behavior-preserving — `!collection.isEmpty()` is equivalent to `collection.size() > 0` — and is a readability/consistency cleanup only. No API, schema, or functional behavior changes. `JsonArray` checks and index-bound `size()` usages were intentionally left untouched. Covered by existing tests.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2630

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).