### PR TITLE
FINERACT-2421: DataTableApi revert body parameter type from Object -> String

### DIFF
--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractMultipartEncoder.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractMultipartEncoder.java
@@ -50,7 +50,7 @@ public class FineractMultipartEncoder implements Encoder {
             encodeFileAsMultipart((File) object, template);
         } else if (object instanceof String && template.headers().containsKey("Content-Type")) {
             String contentType = template.headers().get("Content-Type").iterator().next();
-            if (contentType.startsWith("text/html") || contentType.startsWith("text/plain")) {
+            if (contentType.startsWith("text/html") || contentType.startsWith("text/plain") || contentType.startsWith("application/json")) {
                 byte[] bodyBytes = ((String) object).getBytes(StandardCharsets.UTF_8);
                 template.body(bodyBytes, StandardCharsets.UTF_8);
             } else {

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/datatable/DatatablesStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/datatable/DatatablesStepDef.java
@@ -23,6 +23,8 @@ import static org.apache.fineract.client.feign.util.FeignCalls.fail;
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -37,12 +39,14 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.fineract.client.feign.FeignException;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.feign.ObjectMapperFactory;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetDataTablesResponse;
 import org.apache.fineract.client.models.PostColumnHeaderData;
 import org.apache.fineract.client.models.PostDataTablesAppTableIdResponse;
 import org.apache.fineract.client.models.PostDataTablesRequest;
 import org.apache.fineract.client.models.PostDataTablesResponse;
+import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PostWorkingCapitalLoanProductsResponse;
 import org.apache.fineract.client.models.PostWorkingCapitalLoansResponse;
 import org.apache.fineract.client.models.PutDataTablesRequest;
@@ -63,6 +67,7 @@ public class DatatablesStepDef extends AbstractStepDef {
     public static final String DATATABLE_NAME = "DatatableId";
     public static final String DATATABLE_QUERY_RESPONSE = "DatatableQueryResponse";
     public static final String DATATABLE_ENTRY_ID = "DatatableEntryId";
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getShared();
 
     private final FineractFeignClient fineractClient;
     private final DatatableNameGenerator datatableNameGenerator;
@@ -97,6 +102,20 @@ public class DatatablesStepDef extends AbstractStepDef {
     public void whenMultirowDatatableCreated(final String entityTypeStr) {
         final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
         final List<PostColumnHeaderData> columns = createRandomDatatableColumnsRequest();
+        final PostDataTablesRequest request = createDatatableRequest(entityType, columns, true);
+
+        final PostDataTablesResponse response = ok(() -> fineractClient.dataTables().createDatatable(request, Map.of()));
+
+        testContext().set(CREATE_DATATABLE_RESULT_KEY, response);
+        testContext().set(DATATABLE_NAME, response.getResourceIdentifier());
+    }
+
+    @When("A multirow datatable for {string} is created with the following extra columns:")
+    public void whenMultirowDatatableCreatedWithFollowingExtraColumns(final String entityTypeStr, final DataTable dataTable) {
+        final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
+        final List<List<String>> rows = dataTable.asLists();
+        final List<List<String>> rowsWithoutHeader = rows.subList(1, rows.size());
+        final List<PostColumnHeaderData> columns = createDatatableColumnsRequest(rowsWithoutHeader);
         final PostDataTablesRequest request = createDatatableRequest(entityType, columns, true);
 
         final PostDataTablesResponse response = ok(() -> fineractClient.dataTables().createDatatable(request, Map.of()));
@@ -268,10 +287,19 @@ public class DatatablesStepDef extends AbstractStepDef {
 
     @When("A datatable entry is created for {string} with value {string} in column {string}")
     public void whenEntryCreatedForEntity(final String entityTypeStr, final String value, final String columnName) {
+        createDatatableEntry(entityTypeStr, columnName, value);
+    }
+
+    @When("A datatable entry is created for {string} with null in column {string}")
+    public void whenEntryCreatedWithNull(final String entityTypeStr, final String columnName) {
+        createDatatableEntry(entityTypeStr, columnName, "null");
+    }
+
+    private void createDatatableEntry(final String entityTypeStr, final String columnName, final String value) {
         final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
         final String datatableName = currentDatatable();
         final Long entityId = resolveEntityId(entityType);
-        final Map<String, Object> body = buildEntryBody(columnName, value);
+        final String body = buildEntryBodyJson(columnName, value);
         final PostDataTablesAppTableIdResponse response = ok(
                 () -> fineractClient.dataTables().createDatatableEntry(datatableName, entityId, body, Map.of()));
         testContext().set(DATATABLE_ENTRY_ID, response.getResourceId());
@@ -282,7 +310,7 @@ public class DatatablesStepDef extends AbstractStepDef {
         final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
         final String datatableName = currentDatatable();
         final Long entityId = resolveEntityId(entityType);
-        final Map<String, Object> body = buildEntryBody(columnName, value);
+        final String body = buildEntryBodyJson(columnName, value);
         try {
             fineractClient.dataTables().createDatatableEntry(datatableName, entityId, body, Map.of());
             throw new AssertionError(
@@ -304,12 +332,30 @@ public class DatatablesStepDef extends AbstractStepDef {
                 .isTrue();
     }
 
+    @Then("Fetching the datatable entry for {string} returns null in column {string}")
+    public void thenEntryHasNullValue(final String entityTypeStr, final String columnName) {
+        final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
+        final List<Map<?, ?>> rows = fetchEntryRows(entityType);
+        assertThat(rows).withFailMessage("No datatable rows found for entity %s", entityType).isNotEmpty();
+        assertThat(rows.getFirst().get(columnName))
+                .withFailMessage("Column [%s] expected null but was [%s]", columnName, rows.getFirst().get(columnName)).isNull();
+    }
+
     @When("The datatable entry for {string} is updated with value {string} in column {string}")
     public void whenEntryUpdated(final String entityTypeStr, final String value, final String columnName) {
         final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
         final String datatableName = currentDatatable();
         final Long entityId = resolveEntityId(entityType);
-        final Map<String, Object> body = buildEntryBody(columnName, value);
+        final String body = buildEntryBodyJson(columnName, value);
+        ok(() -> fineractClient.dataTables().updateDatatableEntryOnetoOne(datatableName, entityId, body, Map.of()));
+    }
+
+    @When("The datatable entry for {string} is updated with null in column {string}")
+    public void whenEntryUpdatedWithNull(final String entityTypeStr, final String columnName) {
+        final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
+        final String datatableName = currentDatatable();
+        final Long entityId = resolveEntityId(entityType);
+        final String body = buildEntryBodyJson(columnName, "null");
         ok(() -> fineractClient.dataTables().updateDatatableEntryOnetoOne(datatableName, entityId, body, Map.of()));
     }
 
@@ -330,13 +376,12 @@ public class DatatablesStepDef extends AbstractStepDef {
 
     @When("A multirow datatable entry is created for {string} with value {string} in column {string}")
     public void whenMultirowEntryCreated(final String entityTypeStr, final String value, final String columnName) {
-        final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
-        final String datatableName = currentDatatable();
-        final Long entityId = resolveEntityId(entityType);
-        final Map<String, Object> body = buildEntryBody(columnName, value);
-        final PostDataTablesAppTableIdResponse response = ok(
-                () -> fineractClient.dataTables().createDatatableEntry(datatableName, entityId, body, Map.of()));
-        testContext().set(DATATABLE_ENTRY_ID, response.getResourceId());
+        createDatatableEntry(entityTypeStr, columnName, value);
+    }
+
+    @When("A multirow datatable entry is created for {string} with null in column {string}")
+    public void whenMultirowEntryCreatedWithNull(final String entityTypeStr, final String columnName) {
+        createDatatableEntry(entityTypeStr, columnName, "null");
     }
 
     @Then("Fetching multirow datatable entries for {string} returns value {string} in column {string}")
@@ -348,13 +393,21 @@ public class DatatablesStepDef extends AbstractStepDef {
         assertThat(rows).anyMatch(row -> valuesMatch(row.get(columnName), expected));
     }
 
+    @Then("Fetching multirow datatable entries for {string} returns null in column {string}")
+    public void thenMultirowEntryHasNullValue(final String entityTypeStr, final String columnName) {
+        final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
+        final List<Map<?, ?>> rows = fetchEntryRows(entityType);
+        assertThat(rows).withFailMessage("No datatable rows found for entity %s", entityType).isNotEmpty();
+        assertThat(rows).anyMatch(row -> row.get(columnName) == null);
+    }
+
     @When("The multirow datatable entry for {string} is updated with value {string} in column {string} by entry id")
     public void whenMultirowEntryUpdatedById(final String entityTypeStr, final String value, final String columnName) {
         final DatatableEntityType entityType = DatatableEntityType.fromString(entityTypeStr);
         final String datatableName = currentDatatable();
         final Long entityId = resolveEntityId(entityType);
         final Long entryId = testContext().get(DATATABLE_ENTRY_ID);
-        final Map<String, Object> body = buildEntryBody(columnName, value);
+        final String body = buildEntryBodyJson(columnName, value);
         ok(() -> fineractClient.dataTables().updateDatatableEntryOneToMany(datatableName, entityId, entryId, body, Map.of()));
     }
 
@@ -474,8 +527,15 @@ public class DatatablesStepDef extends AbstractStepDef {
         return request;
     }
 
-    private Map<String, Object> buildEntryBody(final String columnName, final String value) {
-        return Map.of("locale", "en", columnName, parseValue(value));
+    private String buildEntryBodyJson(final String columnName, final String value) {
+        if ("null".equalsIgnoreCase(value)) {
+            return "{\"locale\":\"en\",\"" + columnName + "\":null}";
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(Map.of("locale", "en", columnName, parseValue(value)));
+        } catch (final JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize datatable entry body", e);
+        }
     }
 
     private Object parseValue(final String value) {
@@ -533,11 +593,20 @@ public class DatatablesStepDef extends AbstractStepDef {
 
     private Long resolveEntityId(final DatatableEntityType entityType) {
         return switch (entityType) {
+            case LOAN -> resolveLoanId();
             case WC_LOAN_PRODUCT -> resolveWcLoanProductId();
             case WC_LOAN -> resolveWcLoanId();
-            case LOAN, LOAN_PRODUCT ->
-                throw new UnsupportedOperationException("Entry steps are not implemented for " + entityType + " entity");
+            case LOAN_PRODUCT -> throw new UnsupportedOperationException("Entry steps are not implemented for " + entityType + " entity");
         };
+    }
+
+    private Long resolveLoanId() {
+        final PostLoansResponse response = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
+        assertThat(response)
+                .withFailMessage(
+                        "No loan found in test context. Use 'Admin creates a fully customized loan with the following data' step first.")
+                .isNotNull();
+        return response.getLoanId();
     }
 
     private Long resolveWcLoanProductId() {

--- a/fineract-e2e-tests-runner/src/test/resources/features/Datatables.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/Datatables.feature
@@ -52,3 +52,31 @@ Feature: Datatables
       | loan_id       | InvalidInput | validation.msg.invalid.integer.format    |
       | created_at    | InvalidInput | validation.msg.invalid.dateFormat.format |
       | invalidColumn | InvalidInput | validation.msg.validation.errors.exist   |
+
+  @TestRailId:C85156
+  Scenario: Datatable entry create with null value persists column via client JSON body
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct  | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy                            |
+      | LP1_DUE_DATE | 01 January 2026   | 1000           | 0                      | DECLINING_BALANCE | SAME_AS_REPAYMENT_PERIOD    | EQUAL_INSTALLMENTS | 1                 | MONTHS                | 1              | MONTHS                 | 1                  | 0                       | 0                      | 0                    | PENALTIES_FEES_INTEREST_PRINCIPAL_ORDER |
+    And A datatable for "Loan" is created with the following extra columns:
+      | Name   | Type   | Length | Unique | Indexed |
+      | amount | number | 10     | false  | false   |
+    And A datatable entry is created for "Loan" with null in column "amount"
+    Then Fetching the datatable entry for "Loan" returns null in column "amount"
+
+  @TestRailId:C85157
+  Scenario: Datatable entry update with null value clears column via client JSON body
+    When Admin sets the business date to "01 January 2026"
+    And Admin creates a client with random data
+    And Admin creates a fully customized loan with the following data:
+      | LoanProduct  | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy                            |
+      | LP1_DUE_DATE | 01 January 2026   | 1000           | 0                      | DECLINING_BALANCE | SAME_AS_REPAYMENT_PERIOD    | EQUAL_INSTALLMENTS | 1                 | MONTHS                | 1              | MONTHS                 | 1                  | 0                       | 0                      | 0                    | PENALTIES_FEES_INTEREST_PRINCIPAL_ORDER |
+    And A datatable for "Loan" is created with the following extra columns:
+      | Name   | Type   | Length | Unique | Indexed |
+      | amount | number | 10     | false  | false   |
+    And A datatable entry is created for "Loan" with value "100" in column "amount"
+    Then Fetching the datatable entry for "Loan" returns value "100" in column "amount"
+    When The datatable entry for "Loan" is updated with null in column "amount"
+    Then Fetching the datatable entry for "Loan" returns null in column "amount"

--- a/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDatatables.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapitalDatatables.feature
@@ -275,3 +275,21 @@ Feature: WorkingCapitalDatatables
     And A multirow datatable for "WC_Loan" is created
     And A multirow datatable entry is created for "WC_Loan" with value "55" in column "col"
     Then Fetching the multirow datatable entry by id for "WC_Loan" returns value "55" in column "col"
+
+  @TestRailId:C85158
+  Scenario: Single-row datatable entry create with null value persists column via client JSON body
+    When Admin creates a new Working Capital Loan Product
+    And A datatable for "WC_Loan_Product" is created with the following extra columns:
+      | Name   | Type   | Length | Unique | Indexed |
+      | amount | number | 10     | false  | false   |
+    And A datatable entry is created for "WC_Loan_Product" with null in column "amount"
+    Then Fetching the datatable entry for "WC_Loan_Product" returns null in column "amount"
+
+  @TestRailId:C85159
+  Scenario: Multi-row datatable entry create with null value persists column via client JSON body
+    When Admin creates a new Working Capital Loan Product
+    And A multirow datatable for "WC_Loan_Product" is created with the following extra columns:
+      | Name   | Type   | Length | Unique | Indexed |
+      | amount | number | 10     | false  | false   |
+    And A multirow datatable entry is created for "WC_Loan_Product" with null in column "amount"
+    Then Fetching multirow datatable entries for "WC_Loan_Product" returns null in column "amount"

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
@@ -346,7 +346,7 @@ public class DatatablesApiResource {
             Note that the default datatable UI functionality converts any field name containing spaces to underscores \
             when using the API. This means the field name "Business Description" is considered the same as \
             "Business_Description". So you shouldn't have both "versions" in any data table.""")
-    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = Object.class)), description = "{\n  \"BusinessDescription\": \"Livestock sales\",\n  \"Comment\": \"First comment made\",\n  \"Education_cv\": \"Primary\",\n  \"Gender_cd\": 6,\n  \"HighestRatePaid\": 8.5,\n  \"NextVisit\": \"01 October 2012\",\n  \"YearsinBusiness\": 5,\n  \"dateFormat\": \"dd MMMM yyyy\",\n  \"locale\": \"en\"\n}")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = String.class)), description = "{\n  \"BusinessDescription\": \"Livestock sales\",\n  \"Comment\": \"First comment made\",\n  \"Education_cv\": \"Primary\",\n  \"Gender_cd\": 6,\n  \"HighestRatePaid\": 8.5,\n  \"NextVisit\": \"01 October 2012\",\n  \"YearsinBusiness\": 5,\n  \"dateFormat\": \"dd MMMM yyyy\",\n  \"locale\": \"en\"\n}")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DatatablesApiResourceSwagger.PostDataTablesAppTableIdResponse.class)))
     public String createDatatableEntry(@PathParam("datatable") @Parameter(description = "datatable") final String datatable,
             @PathParam("apptableId") @Parameter(description = "apptableId") final Long apptableId,
@@ -367,7 +367,7 @@ public class DatatablesApiResource {
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Update Entry in Data Table (One to One)", description = "Updates the row (if it exists) of the data table.")
-    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = Object.class)))
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = String.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DatatablesApiResourceSwagger.PutDataTablesAppTableIdResponse.class)))
     public String updateDatatableEntryOnetoOne(@PathParam("datatable") @Parameter(description = "datatable") final String datatable,
             @PathParam("apptableId") @Parameter(description = "apptableId") final Long apptableId,
@@ -388,7 +388,7 @@ public class DatatablesApiResource {
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(summary = "Update Entry in Data Table (One to Many)", description = "Updates the row (if it exists) of the data table.")
-    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = Object.class)))
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = String.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DatatablesApiResourceSwagger.PutDataTablesAppTableIdDatatableIdResponse.class)))
     public String updateDatatableEntryOneToMany(@PathParam("datatable") @Parameter(description = "datatable") final String datatable,
             @PathParam("apptableId") @Parameter(description = "apptableId") final Long apptableId,


### PR DESCRIPTION
## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
