### PR TITLE
FINERACT-405: Standardize mobile number validation across Client and Staff

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -80,6 +80,8 @@ public class FineractProperties {
 
     private FineractNotificationProperties notification;
 
+    private FineractPhoneProperties phone;
+
     private FineractLoanProperties loan;
 
     private FineractSamplingProperties sampling;
@@ -493,6 +495,13 @@ public class FineractProperties {
     public static class UserNotificationSystemProperties {
 
         private boolean enabled;
+    }
+
+    @Getter
+    @Setter
+    public static class FineractPhoneProperties {
+
+        private String regex = "^\\+?[0-9]{7,15}$";
     }
 
     @Getter

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/PhoneNumberValidationService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/PhoneNumberValidationService.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.validation;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PhoneNumberValidationService {
+
+    private final FineractProperties fineractProperties;
+
+    public boolean isValid(String phoneNumber) {
+        if (phoneNumber == null) {
+            return true;
+        }
+
+        return phoneNumber.matches(fineractProperties.getPhone().getRegex());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/PhoneNumberValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/PhoneNumberValidator.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+
+@Component
+@RequiredArgsConstructor
+public class PhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
+
+    private final PhoneNumberValidationService phoneNumberValidationService;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+
+        return phoneNumberValidationService.isValid(value);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/ValidPhoneNumber.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/validation/ValidPhoneNumber.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.core.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PhoneNumberValidator.class)
+public @interface ValidPhoneNumber {
+
+    String message() default "{org.apache.fineract.organisation.staff.mobile-no.invalid}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
@@ -20,13 +20,13 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.fineract.infrastructure.core.validation.ValidPhoneNumber;
 import org.hibernate.validator.constraints.Length;
 
 @Builder
@@ -56,7 +56,7 @@ public class StaffCreateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
-    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
+    @ValidPhoneNumber
     private String mobileNo;
     @Builder.Default
     @JsonProperty("isActive")

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
@@ -20,7 +20,6 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Hidden;
-import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -28,6 +27,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
+import org.apache.fineract.infrastructure.core.validation.ValidPhoneNumber;
 import org.apache.fineract.organisation.staff.validation.StaffForceStatus;
 import org.hibernate.validator.constraints.Length;
 
@@ -62,7 +62,7 @@ public class StaffUpdateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
-    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
+    @ValidPhoneNumber
     private String mobileNo;
     @JsonProperty("isActive")
     private Boolean isActive;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.configuration.service.ConfigurationReadPlatformService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
@@ -50,13 +51,15 @@ public final class ClientDataValidator {
 
     private final FromJsonHelper fromApiJsonHelper;
     private final ConfigurationReadPlatformService configurationReadPlatformService;
-    private static final String MOBILE_NUMBER_REGEX = "^\\+?[0-9]{7,15}$";
+    private final FineractProperties fineractProperties;
 
     @Autowired
     public ClientDataValidator(final FromJsonHelper fromApiJsonHelper,
-            final ConfigurationReadPlatformService configurationReadPlatformService) {
+                               final ConfigurationReadPlatformService configurationReadPlatformService,
+                               final FineractProperties fineractProperties) {
         this.fromApiJsonHelper = fromApiJsonHelper;
         this.configurationReadPlatformService = configurationReadPlatformService;
+        this.fineractProperties = fineractProperties;
     }
 
     public void validateForCreate(final String json) {
@@ -165,7 +168,7 @@ public final class ClientDataValidator {
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mobileNoParamName, element)) {
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
-                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
+                    .matchesRegularExpression(fineractProperties.getPhone().getRegex()).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);
@@ -451,7 +454,7 @@ public final class ClientDataValidator {
             atLeastOneParameterPassedForUpdate = true;
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
-                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
+                    .matchesRegularExpression(fineractProperties.getPhone().getRegex()).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.fineract.infrastructure.configuration.data.GlobalConfigurationPropertyData;
 import org.apache.fineract.infrastructure.configuration.service.ConfigurationReadPlatformService;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.portfolio.client.api.ClientApiConstants;
@@ -44,6 +45,9 @@ class ClientDataValidatorTest {
     @Mock
     private ConfigurationReadPlatformService configurationReadPlatformService;
 
+    @Mock
+    private FineractProperties fineractProperties;
+
     private ClientDataValidator validator;
 
     @BeforeEach
@@ -51,7 +55,12 @@ class ClientDataValidatorTest {
         FromJsonHelper fromApiJsonHelper = new FromJsonHelper();
         when(configurationReadPlatformService.retrieveGlobalConfiguration(anyString()))
                 .thenReturn(new GlobalConfigurationPropertyData().setEnabled(false));
-        validator = new ClientDataValidator(fromApiJsonHelper, configurationReadPlatformService);
+
+        FineractProperties.FineractPhoneProperties phoneProperties = new FineractProperties.FineractPhoneProperties();
+        phoneProperties.setRegex("^\\+?[0-9]{7,15}$");
+        when(fineractProperties.getPhone()).thenReturn(phoneProperties);
+
+        validator = new ClientDataValidator(fromApiJsonHelper, configurationReadPlatformService, fineractProperties);
     }
 
     private static String validMinimalCreateJson(String dateFormat) {


### PR DESCRIPTION
## Description

This PR replaces the hardcoded mobile number validation regex with a configurable property-based validation approach.

## Changes
-Added phone validation configuration under FineractProperties
-Introduced PhoneNumberValidationService to provide a shared validation rule
-Added custom @ValidPhoneNumber constraint and PhoneNumberValidator
-Updated StaffCreateRequest and StaffUpdateRequest to use the new validator
-Updated ClientDataValidator to use the same configurable validation rule
-Removed the hardcoded phone number regex constant
-Added/updated tests for client mobile number validation


