### PR TITLE
FINERACT-2637: simpler build commands

### DIFF
--- a/.github/actions/setup-and-build-fineract/action.yml
+++ b/.github/actions/setup-and-build-fineract/action.yml
@@ -27,17 +27,17 @@ runs:
     - name: Build Avro Java SDK
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon :fineract-avro-schemas:buildJavaSdk -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew :fineract-avro-schemas:buildJavaSdk
 
     - name: Compile Fineract Provider
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon :fineract-provider:compileJava -x test -x cucumber -x doc -x buildJavaSdk -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew :fineract-provider:compileJava
 
     - name: Generate Fineract Git Properties
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon :fineract-provider:generateGitProperties -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew :fineract-provider:generateGitProperties
 
     - name: Verify generated git.properties
       shell: bash
@@ -47,14 +47,14 @@ runs:
     - name: Build Fineract Client Java SDK
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon :fineract-client:buildJavaSdk -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew :fineract-client:buildJavaSdk
 
     - name: Build Fineract Client Feign Java SDK
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon :fineract-client-feign:buildJavaSdk -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew :fineract-client-feign:buildJavaSdk
 
     - name: Build Fineract
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ./gradlew --no-daemon build -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+      run: ./gradlew build -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat

--- a/.github/workflows/build-quality-checks.yml
+++ b/.github/workflows/build-quality-checks.yml
@@ -40,7 +40,7 @@ jobs:
           validate-wrappers: true
 
       - name: Generate Javadocs
-        run: ./gradlew --no-daemon javadoc -x test -x cucumber -x doc -x buildJavaSdk
+        run: ./gradlew javadoc
 
       - name: Archive Javadoc reports
         if: failure()
@@ -82,7 +82,7 @@ jobs:
           validate-wrappers: true
 
       - name: Run Checkstyle
-        run: ./gradlew --no-daemon checkstyleMain checkstyleTest checkstyleJmh -x test -x cucumber -x doc -x javadoc -x javadocJar -x buildJavaSdk
+        run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
 
       - name: Archive Checkstyle reports
         if: failure()
@@ -124,7 +124,7 @@ jobs:
           validate-wrappers: true
 
       - name: Run RAT
-        run: ./gradlew --no-daemon rat -x test -x cucumber -x doc -x javadoc -x javadocJar -x buildJavaSdk
+        run: ./gradlew rat
 
       - name: Archive RAT reports
         if: failure()
@@ -166,7 +166,7 @@ jobs:
           validate-wrappers: true
 
       - name: Run SpotBugs
-        run: ./gradlew --no-daemon spotbugsMain spotbugsTest -x test -x cucumber -x doc -x javadoc -x javadocJar -x buildJavaSdk
+        run: ./gradlew spotbugsMain spotbugsTest
 
       - name: Archive SpotBugs reports
         if: failure()
@@ -208,4 +208,4 @@ jobs:
           validate-wrappers: true
 
       - name: Run Spotless
-        run: ./gradlew --no-daemon spotlessCheck -x test -x cucumber -x doc -x javadoc -x javadocJar -x buildJavaSdk
+        run: ./gradlew spotlessCheck


### PR DESCRIPTION
## Description
    
Let's simplify our build commands. The Gradle daemon will save on Java startup times. Gradle should handle caching so we shouldn't need to many explicit "-x" exclusions. The shorter commands are easier to read, maintain, and reproduce apart from GitHub Actions (e.g. during local dev/test). If we need to add some -x exclusions back, we can, but ideally we get Gradle to do that kind of fiddly work for us.

Guidance from Ádám Sághy:

> our gradle task dependencies should be rather reviewed first why any of the excluded tasks been triggered (hence depended) for the target task

FINERACT-2637

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).