### PR TITLE
FINERACT-1788: Split notification queries by read status

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/notification/data/NotificationData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/notification/data/NotificationData.java
@@ -46,7 +46,7 @@ public class NotificationData implements Serializable {
     private Set<Long> userIds;
 
     public NotificationData(final Long id, final String objectType, final Long objectId, final Long actorId, final String action,
-            final String content, final boolean isSystemGenerated, final LocalDateTime createdAt) {
+            final String content, final boolean isSystemGenerated, final boolean isRead, final LocalDateTime createdAt) {
         this.id = id;
         this.objectType = objectType;
         this.objectId = objectId;
@@ -54,6 +54,7 @@ public class NotificationData implements Serializable {
         this.action = action;
         this.content = content;
         this.isSystemGenerated = isSystemGenerated;
+        this.isRead = isRead;
         this.createdAt = createdAt == null ? null : createdAt.toString();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/domain/NotificationMapperRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/domain/NotificationMapperRepository.java
@@ -47,14 +47,18 @@ public interface NotificationMapperRepository extends JpaRepository<Notification
             """)
     void markUnreadNotificationsAsRead(@Param("appUserId") Long appUserId);
 
-    // 1. Method for fetching ALL notifications (No read status filter)
     @Query(value = """
             select new org.apache.fineract.notification.data.NotificationData(
-                n.id, n.objectType, n.objectIdentifier, n.actorId, n.action,
-                n.notificationContent, n.isSystemGenerated, nm.createdAt
+                nm.notification.id,
+                nm.notification.objectType,
+                nm.notification.objectIdentifier,
+                nm.notification.actorId,
+                nm.notification.action,
+                nm.notification.notificationContent,
+                nm.notification.isSystemGenerated,
+                nm.createdAt
             )
             from NotificationMapper nm
-            join nm.notification n
             where nm.userId.id = :appUserId
             """, countQuery = """
             select count(nm)
@@ -63,22 +67,25 @@ public interface NotificationMapperRepository extends JpaRepository<Notification
             """)
     Page<NotificationData> findNotificationDataByUserId(@Param("appUserId") Long appUserId, Pageable pageable);
 
-    // 2. Method for fetching with a SPECIFIC read status (e.g., Unread only)
     @Query(value = """
             select new org.apache.fineract.notification.data.NotificationData(
-                n.id, n.objectType, n.objectIdentifier, n.actorId, n.action,
-                n.notificationContent, n.isSystemGenerated, nm.createdAt
+                nm.notification.id,
+                nm.notification.objectType,
+                nm.notification.objectIdentifier,
+                nm.notification.actorId,
+                nm.notification.action,
+                nm.notification.notificationContent,
+                nm.notification.isSystemGenerated,
+                nm.createdAt
             )
             from NotificationMapper nm
-            join nm.notification n
             where nm.userId.id = :appUserId
-            and nm.isRead = :isRead
+            and nm.isRead = false
             """, countQuery = """
             select count(nm)
             from NotificationMapper nm
             where nm.userId.id = :appUserId
-            and nm.isRead = :isRead
+            and nm.isRead = false
             """)
-    Page<NotificationData> findNotificationDataByUserIdAndReadStatus(@Param("appUserId") Long appUserId, @Param("isRead") Boolean isRead,
-            Pageable pageable);
+    Page<NotificationData> findUnreadNotificationDataByUserId(@Param("appUserId") Long appUserId, Pageable pageable);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/domain/NotificationMapperRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/domain/NotificationMapperRepository.java
@@ -56,6 +56,7 @@ public interface NotificationMapperRepository extends JpaRepository<Notification
                 nm.notification.action,
                 nm.notification.notificationContent,
                 nm.notification.isSystemGenerated,
+                nm.isRead,
                 nm.createdAt
             )
             from NotificationMapper nm
@@ -76,6 +77,7 @@ public interface NotificationMapperRepository extends JpaRepository<Notification
                 nm.notification.action,
                 nm.notification.notificationContent,
                 nm.notification.isSystemGenerated,
+                nm.isRead,
                 nm.createdAt
             )
             from NotificationMapper nm

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/service/NotificationReadPlatformServiceImpl.java
@@ -96,7 +96,7 @@ public class NotificationReadPlatformServiceImpl implements NotificationReadPlat
         final Long appUserId = context.authenticatedUser().getId();
         final Pageable pageable = toPageable(searchParameters);
         final org.springframework.data.domain.Page<NotificationData> springPage = this.notificationMapperRepository
-                .findNotificationDataByUserIdAndReadStatus(appUserId, false, pageable);
+                .findUnreadNotificationDataByUserId(appUserId, pageable);
         return toFineractPage(springPage);
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/NotificationApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/NotificationApiTest.java
@@ -108,4 +108,36 @@ public class NotificationApiTest {
         Assertions.assertEquals(clientId.longValue(), firstNotification.getObjectId());
         Assertions.assertEquals(CLIENT_OBJECT_TYPE, firstNotification.getObjectType());
     }
+
+    @Test
+    public void testNotificationReadStatusFiltering() {
+        // given
+        PostClientsRequest clientRequest = ClientHelper.defaultClientCreationRequest();
+        Integer clientId = ClientHelper.createClient(requestSpec, responseSpec, clientRequest);
+        Assertions.assertNotNull(clientId);
+
+        newUserNotificationHelper.waitUntilNotificationsAreAvailable();
+
+        // verify the new notification is unread
+        GetNotificationsResponse unreadResponse = newUserNotificationHelper.getUnreadNotifications();
+        Assertions.assertNotNull(unreadResponse);
+        Assertions.assertEquals(1, unreadResponse.getPageItems().size());
+        Assertions.assertFalse(unreadResponse.getPageItems().get(0).getIsRead());
+
+        // mark the notification as read
+        newUserNotificationHelper.markNotificationsAsRead();
+
+        // verify it is removed from the unread result
+        GetNotificationsResponse unreadAfterUpdate = newUserNotificationHelper.getUnreadNotifications();
+        Assertions.assertNotNull(unreadAfterUpdate);
+        Assertions.assertTrue(unreadAfterUpdate.getPageItems().isEmpty());
+
+        GetNotificationsResponse allNotifications = newUserNotificationHelper.getNotifications();
+        Assertions.assertNotNull(allNotifications);
+        Assertions.assertEquals(1, allNotifications.getPageItems().size());
+
+        GetNotification notification = allNotifications.getPageItems().get(0);
+        Assertions.assertTrue(notification.getIsRead());
+        Assertions.assertEquals(clientId.longValue(), notification.getObjectId());
+    }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignNotificationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignNotificationHelper.java
@@ -34,7 +34,19 @@ public class FeignNotificationHelper {
     }
 
     public GetNotificationsResponse getNotifications() {
-        return ok(() -> fineractClient.notification().getAllNotifications(null, null, null, null, null));
+        return ok(() -> fineractClient.notification().getAllNotifications(null, null, null, null, true));
+    }
+
+    public GetNotificationsResponse getNotifications(Boolean isRead) {
+        return ok(() -> fineractClient.notification().getAllNotifications(null, null, null, null, isRead));
+    }
+
+    public GetNotificationsResponse getUnreadNotifications() {
+        return ok(() -> fineractClient.notification().getAllNotifications(null, null, null, null, false));
+    }
+
+    public void markNotificationsAsRead() {
+        fineractClient.notification().update4();
     }
 
     public boolean areNotificationsAvailable() {


### PR DESCRIPTION
## Description

Splits the notification retrieval query into two explicit repository methods:

* One method retrieves all notifications for the authenticated user.
* One method retrieves only unread notifications.

This removes the nullable `isRead` parameter and avoids the EclipseLink parameter-binding issue when `null` is passed. The notification read service now calls the appropriate repository method for each use case.

## Testing

* `.\gradlew.bat :fineract-provider:compileJava`
* `.\gradlew.bat :fineract-provider:compileTestJava`
* `.\gradlew.bat spotlessApply`
* `.\gradlew.bat :integration-tests:test --tests "*NotificationApiTest*" --no-parallel --max-workers=1`
* `git diff --check`
* `git diff --cached --check`

All completed successfully.
