### PR TITLE
FINERACT-2642: string param AS header interpolation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -58,6 +58,7 @@ import org.apache.fineract.infrastructure.dataqueries.data.ResultsetRowData;
 import org.apache.fineract.infrastructure.dataqueries.domain.ReportType;
 import org.apache.fineract.infrastructure.dataqueries.exception.ReportNotFoundException;
 import org.apache.fineract.infrastructure.report.service.ReportParameterTypeResolver;
+import org.apache.fineract.infrastructure.security.exception.InputValidationException;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
 import org.apache.fineract.infrastructure.security.utils.LogParameterEscapeUtil;
@@ -164,8 +165,8 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         return value;
     }
 
-    private PreparedQuery buildPreparedQuery(final String name, final Map<String, String> queryParams, final String sql) {
-        final Map<String, String> paramFormatTypes = this.reportParameterTypeResolver.loadParamFormatTypes(name);
+    private PreparedQuery buildPreparedQuery(final String name, final Map<String, String> queryParams, final String sql,
+            final Map<String, String> paramFormatTypes) {
         final List<Object> paramValues = new ArrayList<>();
         final Matcher matcher = PLACEHOLDER_PATTERN.matcher(sql);
         final StringBuilder preparedSql = new StringBuilder();
@@ -205,6 +206,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
      */
     private PreparedQuery getSQLtoRun(final String name, final String type, final Map<String, String> queryParams) {
 
+        final Map<String, String> paramFormatTypes = this.reportParameterTypeResolver.loadParamFormatTypes(name);
         String sql = getSql(name, type);
 
         // Step 1 — resolve server-controlled placeholders as plain strings (not user input)
@@ -221,14 +223,20 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         sql = Pattern.compile(Pattern.quote("CURRENT_DATE"), Pattern.CASE_INSENSITIVE).matcher(sql)
                 .replaceAll(Matcher.quoteReplacement(sqlGenerator.currentBusinessDate()));
 
-        // Step 2.5a — resolve display-literal placeholders: '${param}' AS alias
-        // These are not filter values so direct substitution is safe.
+        // Step 2.5a — display-literal substitution for date/number params only
+        // Substitute as plain string to preserve varchar return type expected by callers
         for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-            if (entry.getKey().startsWith("${")) {
-                String paramName = entry.getKey().substring(2, entry.getKey().length() - 1);
-                // Replace display-literal pattern: '${param}' followed by AS
-                sql = sql.replaceAll("'" + Pattern.quote("${" + paramName + "}") + "'(\\s+AS\\s+)",
-                        "'" + Matcher.quoteReplacement(entry.getValue()) + "'$1");
+            String paramName = entry.getKey().startsWith("${") ? entry.getKey().substring(2, entry.getKey().length() - 1) : entry.getKey();
+            String formatType = paramFormatTypes.get(paramName);
+            String displayPattern = "'\\$\\{" + Pattern.quote(paramName) + "\\}'(\\s+AS\\s+)";
+            if (sql.matches("(?s).*" + displayPattern + ".*")) {
+                if (formatType == null || (!formatType.equalsIgnoreCase("number") && !formatType.equalsIgnoreCase("integer")
+                        && !formatType.equalsIgnoreCase("date"))) {
+                    throw new InputValidationException("Parameter '%s' of type '%s' cannot be used in display-literal position"
+                            .formatted(paramName, formatType != null ? formatType : "unregistered"));
+                }
+                // Substitute as string literal — preserves varchar return type
+                sql = sql.replaceAll(displayPattern, "'" + Matcher.quoteReplacement(entry.getValue()) + "'$1");
             }
         }
 
@@ -247,7 +255,7 @@ public class ReadReportingServiceImpl implements ReadReportingService {
             normalisedParams.put(key, entry.getValue());
         }
 
-        return buildPreparedQuery(name, normalisedParams, sql);
+        return buildPreparedQuery(name, normalisedParams, sql, paramFormatTypes);
     }
 
     private String getSql(final String name, final String type) {
@@ -592,13 +600,14 @@ public class ReadReportingServiceImpl implements ReadReportingService {
      * are bound as {@code ?} variables — never concatenated into the SQL string.
      */
     private PreparedQuery sqlToRunForSmsEmailCampaign(final String name, final String type, final Map<String, String> queryParams) {
+        final Map<String, String> paramFormatTypes = this.reportParameterTypeResolver.loadParamFormatTypes(name);
         String sql = getSql(name, type);
 
         sql = sql.replaceAll("'(\\$\\{[^}]+\\})'", "$1");
         sql = sql.replaceAll("\"(\\$\\{[^}]+\\})\"", "$1");
         sql = sql.replaceAll("\"(-?\\d+)\"", "$1");
 
-        return buildPreparedQuery(name, queryParams, sql);
+        return buildPreparedQuery(name, queryParams, sql, paramFormatTypes);
     }
 
     @Override


### PR DESCRIPTION
## Description

Besides the use of reporting params in report_sql in WHERE clause expressions, there are a couple of standard reports using the pattern ${param} AS header to configure the headers in the tabular output of the SELECT query. Currently no report has string parameters, but if such report is added, then it bypasses the prepared statement execution and needs to be handled safely. This PR implements type checking to only allow date/numeric params for this pattern.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
