### PR TITLE
FINERACT-2640: Extend FeignLoanHelper charge and disbursal methods

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -19,20 +19,30 @@
 package org.apache.fineract.integrationtests.client.feign;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.DeleteLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.integrationtests.client.FeignIntegrationTest;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignAccountHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessDateHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignChargesHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignClientHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignJournalEntryHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanHelper;
@@ -56,6 +66,7 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
     protected static FeignJournalEntryHelper journalHelper;
     protected static FeignBusinessDateHelper businessDateHelper;
     protected static FeignClientHelper clientHelper;
+    protected static FeignChargesHelper chargesHelper;
     protected static LoanTestAccounts accounts;
 
     @BeforeAll
@@ -67,6 +78,7 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         journalHelper = new FeignJournalEntryHelper(client);
         businessDateHelper = new FeignBusinessDateHelper(client);
         clientHelper = new FeignClientHelper(client);
+        chargesHelper = new FeignChargesHelper(client);
     }
 
     protected LoanTestAccounts getAccounts() {
@@ -112,11 +124,11 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         return loanHelper.applyForLoan(request);
     }
 
-    protected Long approveLoan(Long loanId, PostLoansLoanIdRequest request) {
+    protected PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
         return loanHelper.approveLoan(loanId, request);
     }
 
-    protected Long disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
+    protected PostLoansLoanIdResponse disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
         return loanHelper.disburseLoan(loanId, request);
     }
 
@@ -130,6 +142,60 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected void undoDisbursement(Long loanId) {
         loanHelper.undoDisbursement(loanId);
+    }
+
+    protected PostLoansLoanIdResponse disburseToSavings(Long loanId, PostLoansLoanIdRequest request) {
+        return loanHelper.disburseToSavings(loanId, request);
+    }
+
+    protected PostLoansLoanIdResponse rejectLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return loanHelper.rejectLoan(loanId, request);
+    }
+
+    protected PostLoansLoanIdResponse withdrawLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return loanHelper.withdrawLoan(loanId, request);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return loanHelper.closeLoan(loanId, request);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse forecloseLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return loanHelper.forecloseLoan(loanId, request);
+    }
+
+    protected PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, PostLoansLoanIdChargesRequest request) {
+        return loanHelper.addLoanCharge(loanId, request);
+    }
+
+    protected List<GetLoansLoanIdChargesChargeIdResponse> getLoanCharges(Long loanId) {
+        return loanHelper.getLoanCharges(loanId);
+    }
+
+    protected GetLoansLoanIdChargesChargeIdResponse getLoanCharge(Long loanId, Long loanChargeId) {
+        return loanHelper.getLoanCharge(loanId, loanChargeId);
+    }
+
+    protected DeleteLoansLoanIdChargesChargeIdResponse deleteLoanCharge(Long loanId, Long loanChargeId) {
+        return loanHelper.deleteLoanCharge(loanId, loanChargeId);
+    }
+
+    protected PostLoansLoanIdChargesChargeIdResponse waiveLoanCharge(Long loanId, Long loanChargeId,
+            PostLoansLoanIdChargesChargeIdRequest request) {
+        return loanHelper.waiveLoanCharge(loanId, loanChargeId, request);
+    }
+
+    protected PostLoansLoanIdChargesChargeIdResponse payLoanCharge(Long loanId, Long loanChargeId,
+            PostLoansLoanIdChargesChargeIdRequest request) {
+        return loanHelper.payLoanCharge(loanId, loanChargeId, request);
+    }
+
+    protected Long createLoanSpecifiedDueDateCharge(double amount) {
+        return chargesHelper.createLoanSpecifiedDueDateCharge(amount);
+    }
+
+    protected Long createLoanDisbursementCharge(double amount) {
+        return chargesHelper.createLoanDisbursementCharge(amount);
     }
 
     protected Long addRepayment(Long loanId, PostLoansLoanIdTransactionsRequest request) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
@@ -26,18 +26,33 @@ import java.util.List;
 import java.util.Map;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.CommandProcessingResult;
+import org.apache.fineract.client.models.DeleteLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.PostAddAndDeleteDisbursementDetailRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansOriginatorData;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansResponse;
+import org.apache.fineract.client.models.PutLoansAvailableDisbursementAmountRequest;
+import org.apache.fineract.client.models.PutLoansAvailableDisbursementAmountResponse;
+import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.integrationtests.common.Utils;
 
 public class FeignLoanHelper {
@@ -84,15 +99,48 @@ public class FeignLoanHelper {
         return response.getLoanId();
     }
 
-    public Long approveLoan(Long loanId, PostLoansLoanIdRequest request) {
-        PostLoansLoanIdResponse response = ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "approve")));
-        return response.getLoanId();
+    public PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "approve")));
     }
 
-    public Long disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
-        PostLoansLoanIdResponse response = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "disburse")));
-        return response.getLoanId();
+    public PostLoansLoanIdResponse disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "disburse")));
+    }
+
+    public PostLoansLoanIdResponse disburseToSavings(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "disburseToSavings")));
+    }
+
+    public PostLoansLoanIdResponse rejectLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "reject")));
+    }
+
+    public PostLoansLoanIdResponse withdrawLoan(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "withdrawnByApplicant")));
+    }
+
+    public PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "close")));
+    }
+
+    public PostLoansLoanIdResponse closeAsRescheduled(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "closeAsRescheduled")));
+    }
+
+    public PostLoansLoanIdTransactionsResponse forecloseLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "foreclosure")));
+    }
+
+    public PostLoansLoanIdResponse assignLoanOfficer(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "assignLoanOfficer")));
+    }
+
+    public PostLoansLoanIdResponse unassignLoanOfficer(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "unassignLoanOfficer")));
+    }
+
+    public PostLoansLoanIdResponse recoverGuarantee(Long loanId, PostLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "recoverFromGuarantor")));
     }
 
     public GetLoansLoanIdResponse getLoanDetails(Long loanId) {
@@ -203,6 +251,82 @@ public class FeignLoanHelper {
 
     private PostLoansRequest buildSubmittedLoanRequest(Long clientId) {
         return buildSubmittedLoanRequest(clientId, createSimpleLoanProduct());
+    }
+
+    public PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, PostLoansLoanIdChargesRequest request) {
+        return ok(() -> fineractClient.loanCharges().executeLoanCharge(loanId, request, (String) null));
+    }
+
+    public List<GetLoansLoanIdChargesChargeIdResponse> getLoanCharges(Long loanId) {
+        return ok(() -> fineractClient.loanCharges().retrieveAllLoanCharges(loanId));
+    }
+
+    public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(Long loanId, Long loanChargeId) {
+        return ok(() -> fineractClient.loanCharges().retrieveLoanCharge(loanId, loanChargeId));
+    }
+
+    public PutLoansLoanIdChargesChargeIdResponse updateLoanCharge(Long loanId, Long loanChargeId,
+            PutLoansLoanIdChargesChargeIdRequest request) {
+        return ok(() -> fineractClient.loanCharges().updateLoanCharge(loanId, loanChargeId, request));
+    }
+
+    public DeleteLoansLoanIdChargesChargeIdResponse deleteLoanCharge(Long loanId, Long loanChargeId) {
+        return ok(() -> fineractClient.loanCharges().deleteLoanCharge(loanId, loanChargeId));
+    }
+
+    public GetLoansLoanIdChargesTemplateResponse getLoanChargeTemplate(Long loanId) {
+        return ok(() -> fineractClient.loanCharges().retrieveTemplateLoanCharge(loanId));
+    }
+
+    public PostLoansLoanIdChargesChargeIdResponse waiveLoanCharge(Long loanId, Long loanChargeId,
+            PostLoansLoanIdChargesChargeIdRequest request) {
+        return ok(() -> fineractClient.loanCharges().executeLoanChargeOnExistingCharge(loanId, loanChargeId, request, "waive"));
+    }
+
+    public PostLoansLoanIdChargesChargeIdResponse payLoanCharge(Long loanId, Long loanChargeId,
+            PostLoansLoanIdChargesChargeIdRequest request) {
+        return ok(() -> fineractClient.loanCharges().executeLoanChargeOnExistingCharge(loanId, loanChargeId, request, "pay"));
+    }
+
+    public PostLoansLoanIdChargesChargeIdResponse adjustLoanCharge(Long loanId, Long loanChargeId,
+            PostLoansLoanIdChargesChargeIdRequest request) {
+        return ok(() -> fineractClient.loanCharges().executeLoanChargeOnExistingCharge(loanId, loanChargeId, request, "adjustment"));
+    }
+
+    public Long addSpecifiedDueDateCharge(Long loanId, Long chargeId, double amount, String dueDate) {
+        PostLoansLoanIdChargesRequest request = new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .dueDate(dueDate)//
+                .locale("en")//
+                .dateFormat("dd MMMM yyyy");
+        return addLoanCharge(loanId, request).getResourceId();
+    }
+
+    public Long addDisbursementCharge(Long loanId, Long chargeId, double amount) {
+        PostLoansLoanIdChargesRequest request = new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale("en")//
+                .dateFormat("dd MMMM yyyy");
+        return addLoanCharge(loanId, request).getResourceId();
+    }
+
+    public CommandProcessingResult addAndDeleteDisbursementDetail(Long loanId, PostAddAndDeleteDisbursementDetailRequest request) {
+        return ok(() -> fineractClient.loanDisbursementDetails().addAndDeleteDisbursementDetail(loanId, request));
+    }
+
+    public String getDisbursementDetail(Long loanId, Long disbursementId) {
+        return ok(() -> fineractClient.loanDisbursementDetails().retriveDetail(loanId, disbursementId));
+    }
+
+    public CommandProcessingResult updateDisbursementDate(Long loanId, Long disbursementId, String body) {
+        return ok(() -> fineractClient.loanDisbursementDetails().updateDisbursementDate(loanId, disbursementId, body));
+    }
+
+    public PutLoansAvailableDisbursementAmountResponse modifyAvailableDisbursementAmount(Long loanId,
+            PutLoansAvailableDisbursementAmountRequest request) {
+        return ok(() -> fineractClient.loans().modifyLoanAvailableDisbursementAmount(loanId, request));
     }
 
     public Long createRescheduleRequest(PostCreateRescheduleLoansRequest request) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanRequestBuilders.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 import org.apache.fineract.client.models.AdvancedPaymentData;
 import org.apache.fineract.client.models.PaymentAllocationOrder;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
@@ -232,5 +234,88 @@ public final class LoanRequestBuilders {
                 .map(rule -> new PaymentAllocationOrder().paymentAllocationRule(rule).order(order.getAndIncrement())).toList();
         data.setPaymentAllocationOrder(orders);
         return data;
+    }
+
+    public static PostLoansLoanIdRequest rejectLoan(String rejectedOnDate) {
+        return new PostLoansLoanIdRequest()//
+                .rejectedOnDate(rejectedOnDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdRequest withdrawLoan(String withdrawnOnDate) {
+        return new PostLoansLoanIdRequest()//
+                .withdrawnOnDate(withdrawnOnDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdTransactionsRequest closeLoan(String transactionDate) {
+        return new PostLoansLoanIdTransactionsRequest()//
+                .transactionDate(transactionDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdTransactionsRequest forecloseLoan(String transactionDate) {
+        return new PostLoansLoanIdTransactionsRequest()//
+                .transactionDate(transactionDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdRequest assignLoanOfficer(Long toLoanOfficerId, String assignmentDate) {
+        return new PostLoansLoanIdRequest()//
+                .toLoanOfficerId(toLoanOfficerId)//
+                .assignmentDate(assignmentDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdRequest unassignLoanOfficer(String unassignedDate) {
+        return new PostLoansLoanIdRequest()//
+                .unassignedDate(unassignedDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdChargesRequest addLoanCharge(Long chargeId, double amount, String dueDate) {
+        return new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .dueDate(dueDate)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdChargesRequest addLoanCharge(Long chargeId, double amount) {
+        return new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN);
+    }
+
+    public static PostLoansLoanIdChargesChargeIdRequest waiveLoanCharge(double amount) {
+        PostLoansLoanIdChargesChargeIdRequest request = new PostLoansLoanIdChargesChargeIdRequest();
+        request.setAmount(amount);
+        request.setLocale(LoanTestData.LOCALE);
+        return request;
+    }
+
+    public static PostLoansLoanIdChargesChargeIdRequest payLoanCharge(double amount, String transactionDate) {
+        PostLoansLoanIdChargesChargeIdRequest request = new PostLoansLoanIdChargesChargeIdRequest();
+        request.setAmount(amount);
+        request.setTransactionDate(transactionDate);
+        request.setDateFormat(LoanTestData.DATETIME_PATTERN);
+        request.setLocale(LoanTestData.LOCALE);
+        return request;
+    }
+
+    public static PostLoansLoanIdChargesChargeIdRequest adjustLoanCharge(double amount) {
+        PostLoansLoanIdChargesChargeIdRequest request = new PostLoansLoanIdChargesChargeIdRequest();
+        request.setAmount(amount);
+        request.setLocale(LoanTestData.LOCALE);
+        return request;
     }
 }


### PR DESCRIPTION
## Description

Extends the RestAssured → Feign migration (PR 4 of the roadmap) to Loan Charge Management, Loan State Transitions, and Disbursement Details.

## Key Changes

**Added Loan Charge Management to `FeignLoanHelper`:** 11 pure-Feign methods covering the full charge lifecycle on a loan — `addLoanCharge`, `getLoanCharges`, `getLoanCharge`, `updateLoanCharge`, `deleteLoanCharge`, `getLoanChargeTemplate`, `waiveLoanCharge`, `payLoanCharge`, `adjustLoanCharge`, plus convenience overloads `addSpecifiedDueDateCharge` and `addDisbursementCharge`.

**Extended Loan State Transitions:** Added the remaining state-transition methods — `closeLoan`, `closeAsRescheduled`, `forecloseLoan`, `assignLoanOfficer`, `unassignLoanOfficer`, and `recoverGuarantee` — routing correctly between `LoansApi` (state commands) and `LoanTransactionsApi` (transactional commands).

**Added Disbursement Detail & Available Amount Methods:** `addAndDeleteDisbursementDetail`, `getDisbursementDetail`, `updateDisbursementDate`, and `modifyAvailableDisbursementAmount` covering multi-tranche disbursement workflows.

**Added Reschedule Methods:** `createRescheduleRequest`, `approveRescheduleRequest`, and the convenience composite `createAndApproveRescheduleRequest` via `RescheduleLoansApi`.

**Extended `LoanRequestBuilders`:** Static typed factories for all new operations — `rejectLoan`, `withdrawLoan`, `closeLoan`, `forecloseLoan`, `assignLoanOfficer`, `unassignLoanOfficer`, `addLoanCharge` (with and without due date), `waiveLoanCharge`, `payLoanCharge`, `adjustLoanCharge`.

**Updated `FeignLoanTestBase`:** Exposed delegate methods for all new `FeignLoanHelper` and `FeignChargesHelper` capabilities, keeping test classes thin and consistent with the base pattern.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).