### PR TITLE
FINERACT-2633: DB connection handling improvements

### DIFF
--- a/fineract-cob/src/main/java/org/apache/fineract/cob/listener/AbstractLoanItemListener.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/listener/AbstractLoanItemListener.java
@@ -18,8 +18,6 @@
  */
 package org.apache.fineract.cob.listener;
 
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,8 +34,6 @@ import org.springframework.batch.core.annotation.OnSkipInWrite;
 import org.springframework.batch.core.annotation.OnWriteError;
 import org.springframework.batch.item.Chunk;
 import org.springframework.lang.NonNull;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
@@ -45,18 +41,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 public abstract class AbstractLoanItemListener<S extends AbstractPersistableCustom<Long>> {
 
     private final LockingService loanLockingService;
-    private final TransactionTemplate batchJdbcTransactionTemplate;
+    private final TransactionTemplate requiresNewTransactionJdbcTemplate;
 
     private void updateAccountLockWithError(List<Long> loanIds, String msg, Throwable e) {
-        batchJdbcTransactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-        batchJdbcTransactionTemplate.execute(new TransactionCallbackWithoutResult() {
-
-            @Override
-            protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
-                String stacktrace = ThrowableSerialization.serialize(e);
-                for (Long loanId : loanIds) {
-                    loanLockingService.updateLockError(loanId, getLockOwner(), String.format(msg, loanId), stacktrace);
-                }
+        requiresNewTransactionJdbcTemplate.executeWithoutResult(status -> {
+            String stacktrace = ThrowableSerialization.serialize(e);
+            for (Long loanId : loanIds) {
+                loanLockingService.updateLockError(loanId, getLockOwner(), String.format(msg, loanId), stacktrace);
             }
         });
     }

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/listener/CobWorkerStepListener.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/listener/CobWorkerStepListener.java
@@ -73,7 +73,6 @@ public class CobWorkerStepListener implements StepExecutionListener {
                 if (status == null) {
                     status = RepeatStatus.FINISHED;
                 }
-                stepExecution.incrementCommitCount();
             } catch (Exception exception) {
                 throw new IllegalStateException("COB worker step listener failed for step " + stepExecution.getStepName(), exception);
             }

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/tasklet/ApplyCommonLockTasklet.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/tasklet/ApplyCommonLockTasklet.java
@@ -18,8 +18,6 @@
  */
 package org.apache.fineract.cob.tasklet;
 
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
-
 import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
@@ -51,10 +49,12 @@ import org.springframework.transaction.support.TransactionTemplate;
 public abstract class ApplyCommonLockTasklet implements Tasklet {
 
     private static final long NUMBER_OF_RETRIES = 3;
+    private static final String APPLY_LOCK_ATTEMPTS = "apply-lock-attempts";
+
     private final FineractProperties fineractProperties;
     private final LockingService loanLockingService;
     private final RetrieveIdService retrieveIdService;
-    private final TransactionTemplate batchJdbcTransactionTemplate;
+    private final TransactionTemplate requiresNewTransactionJdbcTemplate;
 
     public abstract String getCOBParameter();
 
@@ -65,7 +65,6 @@ public abstract class ApplyCommonLockTasklet implements Tasklet {
     public RepeatStatus execute(@NonNull StepContribution contribution, @NonNull ChunkContext chunkContext)
             throws LockCannotBeAppliedException {
         ExecutionContext executionContext = contribution.getStepExecution().getExecutionContext();
-        long numberOfExecutions = contribution.getStepExecution().getCommitCount();
         COBParameter loanCOBParameter = COBParameterConverter.convert(executionContext.get(getCOBParameter()));
         boolean isCatchUp = CatchUpFlagResolver.resolve(contribution.getStepExecution());
         List<Long> loanIds;
@@ -86,7 +85,9 @@ public abstract class ApplyCommonLockTasklet implements Tasklet {
         try {
             applyLocks(toBeProcessedLoanIds);
         } catch (Exception e) {
-            if (numberOfExecutions > NUMBER_OF_RETRIES) {
+            long numberOfAttempts = executionContext.getLong(getApplyLockAttemptsKey(), 0) + 1;
+            executionContext.putLong(getApplyLockAttemptsKey(), numberOfAttempts);
+            if (numberOfAttempts > NUMBER_OF_RETRIES) {
                 String message = "There was an error applying lock to loan accounts.";
                 log.error("{}", message, e);
                 throw new LockCannotBeAppliedException(message, e);
@@ -95,12 +96,12 @@ public abstract class ApplyCommonLockTasklet implements Tasklet {
             }
         }
 
+        executionContext.remove(getApplyLockAttemptsKey());
         return RepeatStatus.FINISHED;
     }
 
     private void applyLocks(List<Long> toBeProcessedLoanIds) {
-        batchJdbcTransactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-        batchJdbcTransactionTemplate.execute(new TransactionCallbackWithoutResult() {
+        requiresNewTransactionJdbcTemplate.execute(new TransactionCallbackWithoutResult() {
 
             @Override
             protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
@@ -112,5 +113,9 @@ public abstract class ApplyCommonLockTasklet implements Tasklet {
 
     private int getInClauseParameterSizeLimit() {
         return fineractProperties.getQuery().getInClauseParameterSizeLimit();
+    }
+
+    private String getApplyLockAttemptsKey() {
+        return getCOBParameter() + "." + APPLY_LOCK_ATTEMPTS;
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/BusinessEventNotifierServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/BusinessEventNotifierServiceImpl.java
@@ -40,8 +40,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionExecution;
 import org.springframework.transaction.TransactionExecutionListener;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -90,7 +88,6 @@ public class BusinessEventNotifierServiceImpl implements BusinessEventNotifierSe
     }
 
     @Override
-    @Transactional(propagation = Propagation.SUPPORTS)
     public void notifyPostBusinessEvent(BusinessEvent<?> businessEvent) {
         throwExceptionIfBulkEvent(businessEvent);
         boolean isExternalEvent = !(businessEvent instanceof NoExternalEvent);

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.event.business.service;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
 import org.apache.fineract.infrastructure.event.external.repository.ExternalEventConfigurationRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Default implementation for {@link ExternalBusinessEventConfigurationService}, configured by
@@ -32,6 +33,7 @@ public class ExternalBusinessEventConfigurationServiceImpl implements ExternalBu
     private final ExternalEventConfigurationRepository eventConfigurationRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public boolean isExternalEventConfiguredForPosting(BusinessEvent<?> businessEvent) {
         if (businessEvent == null) {
             return false;

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/TransactionHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/business/service/TransactionHelper.java
@@ -19,15 +19,12 @@
 package org.apache.fineract.infrastructure.event.business.service;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
-@Transactional(propagation = Propagation.SUPPORTS)
 public class TransactionHelper {
 
     boolean hasTransaction() {
-        return TransactionAspectSupport.currentTransactionStatus().hasTransaction();
+        return TransactionSynchronizationManager.isActualTransactionActive();
     }
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/external/repository/ExternalEventConfigurationRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/event/external/repository/ExternalEventConfigurationRepository.java
@@ -19,7 +19,17 @@
 package org.apache.fineract.infrastructure.event.external.repository;
 
 import org.apache.fineract.infrastructure.event.external.repository.domain.ExternalEventConfiguration;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+@CacheConfig(cacheNames = ExternalEventConfigurationRepository.EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME)
 public interface ExternalEventConfigurationRepository
-        extends JpaRepository<ExternalEventConfiguration, String>, CustomExternalEventConfigurationRepository {}
+        extends JpaRepository<ExternalEventConfiguration, String>, CustomExternalEventConfigurationRepository {
+
+    String EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME = "externalEventConfigurationByType";
+
+    @Override
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat(#externalEventType)")
+    ExternalEventConfiguration findExternalEventConfigurationByTypeWithNotFoundDetection(String externalEventType);
+}

--- a/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/domain/ApplicationCurrencyRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/domain/ApplicationCurrencyRepository.java
@@ -37,14 +37,14 @@ public interface ApplicationCurrencyRepository
 
     String FIND_CURRENCY_DETAILS = "SELECT new org.apache.fineract.organisation.monetary.data.CurrencyData(ac.code, ac.name, ac.decimalPlaces, ac.inMultiplesOf, ac.displaySymbol, ac.nameCode) FROM ApplicationCurrency ac ";
 
-    @Cacheable(key = "'entity_' + #currencyCode")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('entity_' + #currencyCode)")
     ApplicationCurrency findOneByCode(String currencyCode);
 
-    @Cacheable(key = "'data_' + #currencyCode")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('data_' + #currencyCode)")
     @Query(FIND_CURRENCY_DETAILS + " WHERE ac.code = :code")
     CurrencyData findCurrencyDataByCode(@Param("code") String currencyCode);
 
-    @Cacheable
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('allSorted_' + #sort)")
     @Query(FIND_CURRENCY_DETAILS)
     List<CurrencyData> findAllSorted(Sort sort);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/ChunkProcessingLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/ChunkProcessingLoanItemListener.java
@@ -27,8 +27,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Slf4j
 public class ChunkProcessingLoanItemListener extends AbstractLoanItemListener<Loan> {
 
-    public ChunkProcessingLoanItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(lockingService, batchJdbcTransactionTemplate);
+    public ChunkProcessingLoanItemListener(LockingService lockingService, TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(lockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/InlineCOBLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/InlineCOBLoanItemListener.java
@@ -25,8 +25,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 public class InlineCOBLoanItemListener extends AbstractLoanItemListener<Loan> {
 
-    public InlineCOBLoanItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(lockingService, batchJdbcTransactionTemplate);
+    public InlineCOBLoanItemListener(LockingService lockingService, TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(lockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/listener/WorkingCapitalChunkProcessingLoanItemListener.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/listener/WorkingCapitalChunkProcessingLoanItemListener.java
@@ -33,8 +33,8 @@ public class WorkingCapitalChunkProcessingLoanItemListener extends AbstractLoanI
 
     public WorkingCapitalChunkProcessingLoanItemListener(
             @Qualifier("workingCapitalLoanLockingService") LockingService workingCapitalLoanAccountLockLockingService,
-            @Qualifier("batchJdbcTransactionTemplate") TransactionTemplate batchJdbcTransactionTemplate) {
-        super(workingCapitalLoanAccountLockLockingService, batchJdbcTransactionTemplate);
+            @Qualifier("requiresNewTransactionJdbcTemplate") TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(workingCapitalLoanAccountLockLockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyLoanLockTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/ApplyLoanLockTasklet.java
@@ -31,8 +31,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class ApplyLoanLockTasklet extends ApplyCommonLockTasklet {
 
     public ApplyLoanLockTasklet(FineractProperties fineractProperties, LockingService loanLockingService,
-            RetrieveIdService retrieveIdService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
+            RetrieveIdService retrieveIdService, TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(fineractProperties, loanLockingService, retrieveIdService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanCOBWorkerConfiguration.java
@@ -60,11 +60,11 @@ public class LoanCOBWorkerConfiguration {
     @Autowired
     private PlatformTransactionManager transactionManager;
     @Autowired
-    @Qualifier("batchJdbcTransactionManager")
-    private PlatformTransactionManager batchJdbcTransactionManager;
+    @Qualifier("jdbcTransactionManager")
+    private PlatformTransactionManager jdbcTransactionManager;
     @Autowired
-    @Qualifier("batchJdbcTransactionTemplate")
-    private TransactionTemplate batchJdbcTransactionTemplate;
+    @Qualifier("requiresNewTransactionJdbcTemplate")
+    private TransactionTemplate requiresNewTransactionJdbcTemplate;
     @Autowired
     private RemotePartitioningWorkerStepBuilderFactory stepBuilderFactory;
 
@@ -141,20 +141,12 @@ public class LoanCOBWorkerConfiguration {
 
     @Bean
     public ChunkProcessingLoanItemListener loanItemListener() {
-        return new ChunkProcessingLoanItemListener(loanLockingService, batchJdbcTransactionTemplate);
+        return new ChunkProcessingLoanItemListener(loanLockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Bean
     public ApplyLoanLockTasklet applyLock() {
-        return new ApplyLoanLockTasklet(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
-    }
-
-    @Bean
-    @StepScope
-    public Step applyLockStep(
-            @org.springframework.beans.factory.annotation.Value("#{stepExecutionContext['partition']}") String partitionName) {
-        return new org.springframework.batch.core.step.builder.StepBuilder("Apply lock - Step:" + partitionName, jobRepository)
-                .tasklet(applyLock(), batchJdbcTransactionManager).build();
+        return new ApplyLoanLockTasklet(fineractProperties, loanLockingService, retrieveIdService, requiresNewTransactionJdbcTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanInlineCOBConfig.java
@@ -63,8 +63,8 @@ public class LoanInlineCOBConfig {
     @Autowired
     private COBBusinessStepService cobBusinessStepService;
     @Autowired
-    @Qualifier("batchJdbcTransactionTemplate")
-    private TransactionTemplate batchJdbcTransactionTemplate;
+    @Qualifier("requiresNewTransactionJdbcTemplate")
+    private TransactionTemplate requiresNewTransactionJdbcTemplate;
     @Autowired
     private CustomJobParameterRepository customJobParameterRepository;
     @Autowired
@@ -129,7 +129,7 @@ public class LoanInlineCOBConfig {
 
     @Bean
     public InlineCOBLoanItemListener inlineCobLoanItemListener() {
-        return new InlineCOBLoanItemListener(loanLockingService, batchJdbcTransactionTemplate);
+        return new InlineCOBLoanItemListener(loanLockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/WorkingCapitalLoanInlineCOBConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/WorkingCapitalLoanInlineCOBConfig.java
@@ -61,8 +61,8 @@ public class WorkingCapitalLoanInlineCOBConfig {
     private final PlatformTransactionManager transactionManager;
     private final PropertyService propertyService;
     private final COBBusinessStepService cobBusinessStepService;
-    @Qualifier("batchJdbcTransactionTemplate")
-    private final TransactionTemplate batchJdbcTransactionTemplate;
+    @Qualifier("requiresNewTransactionJdbcTemplate")
+    private final TransactionTemplate requiresNewTransactionJdbcTemplate;
     private final CustomJobParameterRepository customJobParameterRepository;
     private final CustomJobParameterResolver customJobParameterResolver;
     @Qualifier("workingCapitalLoanLockingService")
@@ -132,7 +132,7 @@ public class WorkingCapitalLoanInlineCOBConfig {
 
     @Bean
     public InlineWorkingCapitalLoanCOBWorkerItemListener inlineWorkingCapitalLoanCobLoanItemListener() {
-        return new InlineWorkingCapitalLoanCOBWorkerItemListener(loanLockingService, batchJdbcTransactionTemplate);
+        return new InlineWorkingCapitalLoanCOBWorkerItemListener(loanLockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineCommonLockableCOBExecutorService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineCommonLockableCOBExecutorService.java
@@ -18,8 +18,6 @@
  */
 package org.apache.fineract.cob.service;
 
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
-
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -68,11 +66,8 @@ import org.springframework.batch.core.configuration.JobLocator;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.NoSuchJobException;
-import org.springframework.lang.NonNull;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
@@ -85,7 +80,7 @@ public abstract class InlineCommonLockableCOBExecutorService<T extends AccountLo
     private final JobLauncher jobLauncher;
     private final JobLocator jobLocator;
     private final JobExplorer jobExplorer;
-    private final TransactionTemplate transactionTemplate;
+    private final TransactionTemplate requiresNewTransactionTemplate;
     private final CustomJobParameterRepository customJobParameterRepository;
     private final PlatformSecurityContext context;
     private final RetrieveIdService retrieveIdService;
@@ -216,23 +211,18 @@ public abstract class InlineCommonLockableCOBExecutorService<T extends AccountLo
     }
 
     private void lockLoanAccounts(List<Long> loanIds, LocalDate businessDate) {
-        transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-
-            @Override
-            protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
-                List<T> loanAccountLocks = getLoanAccountLocks(loanIds, businessDate);
-                loanAccountLocks.forEach(loanAccountLock -> {
-                    try {
-                        loanAccountLock.setNewLockOwner(LockOwner.LOAN_INLINE_COB_PROCESSING);
-                        loanAccountLockRepository.saveAndFlush(loanAccountLock);
-                    } catch (Exception e) {
-                        log.error("Error updating lock on loan account. Locked loan ID: {}", loanAccountLock.getLoanId(), e);
-                        throw new AccountLockCannotBeOverruledException(
-                                "Error updating lock on loan account. Locked loan ID: %s".formatted(loanAccountLock.getLoanId()), e);
-                    }
-                });
-            }
+        requiresNewTransactionTemplate.executeWithoutResult(status -> {
+            List<T> loanAccountLocks = getLoanAccountLocks(loanIds, businessDate);
+            loanAccountLocks.forEach(loanAccountLock -> {
+                try {
+                    loanAccountLock.setNewLockOwner(LockOwner.LOAN_INLINE_COB_PROCESSING);
+                    loanAccountLockRepository.saveAndFlush(loanAccountLock);
+                } catch (Exception e) {
+                    log.error("Error updating lock on loan account. Locked loan ID: {}", loanAccountLock.getLoanId(), e);
+                    throw new AccountLockCannotBeOverruledException(
+                            "Error updating lock on loan account. Locked loan ID: %s".formatted(loanAccountLock.getLoanId()), e);
+                }
+            });
         });
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineLoanCOBExecutorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineLoanCOBExecutorServiceImpl.java
@@ -30,6 +30,7 @@ import org.apache.fineract.infrastructure.security.service.PlatformSecurityConte
 import org.springframework.batch.core.configuration.JobLocator;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -41,9 +42,10 @@ public class InlineLoanCOBExecutorServiceImpl extends InlineCommonLockableCOBExe
 
     public InlineLoanCOBExecutorServiceImpl(LoanAccountLockRepository loanAccountLockRepository,
             InlineLoanCOBExecutionDataParser dataParser, JobLauncher jobLauncher, JobLocator jobLocator, JobExplorer jobExplorer,
-            TransactionTemplate transactionTemplate, CustomJobParameterRepository customJobParameterRepository,
-            PlatformSecurityContext context, RetrieveLoanIdService retrieveIdService, FineractProperties fineractProperties) {
-        super(loanAccountLockRepository, dataParser, jobLauncher, jobLocator, jobExplorer, transactionTemplate,
+            @Qualifier("requiresNewTransactionTemplate") TransactionTemplate requiresNewTransactionTemplate,
+            CustomJobParameterRepository customJobParameterRepository, PlatformSecurityContext context,
+            RetrieveLoanIdService retrieveIdService, FineractProperties fineractProperties) {
+        super(loanAccountLockRepository, dataParser, jobLauncher, jobLocator, jobExplorer, requiresNewTransactionTemplate,
                 customJobParameterRepository, context, retrieveIdService, fineractProperties);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineWorkingCapitalLoanCOBExecutorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/InlineWorkingCapitalLoanCOBExecutorServiceImpl.java
@@ -31,6 +31,7 @@ import org.apache.fineract.infrastructure.security.service.PlatformSecurityConte
 import org.springframework.batch.core.configuration.JobLocator;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -42,9 +43,10 @@ public class InlineWorkingCapitalLoanCOBExecutorServiceImpl extends InlineCommon
 
     public InlineWorkingCapitalLoanCOBExecutorServiceImpl(WorkingCapitalAccountLockRepository loanAccountLockRepository,
             InlineLoanCOBExecutionDataParser dataParser, JobLauncher jobLauncher, JobLocator jobLocator, JobExplorer jobExplorer,
-            TransactionTemplate transactionTemplate, CustomJobParameterRepository customJobParameterRepository,
-            PlatformSecurityContext context, WorkingCapitalLoanRetrieveIdService retrieveIdService, FineractProperties fineractProperties) {
-        super(loanAccountLockRepository, dataParser, jobLauncher, jobLocator, jobExplorer, transactionTemplate,
+            @Qualifier("requiresNewTransactionTemplate") TransactionTemplate requiresNewTransactionTemplate,
+            CustomJobParameterRepository customJobParameterRepository, PlatformSecurityContext context,
+            WorkingCapitalLoanRetrieveIdService retrieveIdService, FineractProperties fineractProperties) {
+        super(loanAccountLockRepository, dataParser, jobLauncher, jobLocator, jobExplorer, requiresNewTransactionTemplate,
                 customJobParameterRepository, context, retrieveIdService, fineractProperties);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcTransactionConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/JdbcTransactionConfig.java
@@ -19,6 +19,8 @@
 
 package org.apache.fineract.infrastructure.core.config;
 
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
+
 import java.util.List;
 import org.apache.fineract.infrastructure.core.persistence.ExtendedDataSourceTransactionManager;
 import org.apache.fineract.infrastructure.core.persistence.TransactionLifecycleCallback;
@@ -46,21 +48,11 @@ public class JdbcTransactionConfig {
         return transactionManager;
     }
 
-    @Bean
-    public PlatformTransactionManager batchJdbcTransactionManager(FineractProperties fineractProperties, RoutingDataSource dataSource,
-            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers, List<TransactionLifecycleCallback> callbacks) {
-        boolean readOnly = fineractProperties.getMode().isReadOnlyMode();
-        ExtendedDataSourceTransactionManager transactionManager = new ExtendedDataSourceTransactionManager(readOnly);
-        transactionManager.setDataSource(dataSource);
-        transactionManager.setLifecycleCallbacks(callbacks);
-        transactionManager.setValidateExistingTransaction(true);
-        transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize(transactionManager));
-        return transactionManager;
-    }
-
-    @Bean
-    public TransactionTemplate batchJdbcTransactionTemplate(
-            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager batchJdbcTransactionManager) {
-        return new TransactionTemplate(batchJdbcTransactionManager);
+    @Bean("requiresNewTransactionJdbcTemplate")
+    public TransactionTemplate requiresNewTransactionJdbcTemplate(
+            @Qualifier("jdbcTransactionManager") PlatformTransactionManager jdbcTransactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(jdbcTransactionManager);
+        transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
+        return transactionTemplate;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/cache/CacheConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/cache/CacheConfig.java
@@ -19,6 +19,8 @@
 
 package org.apache.fineract.infrastructure.core.config.cache;
 
+import static org.apache.fineract.infrastructure.event.external.repository.ExternalEventConfigurationRepository.EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME;
+
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
@@ -60,7 +62,7 @@ public class CacheConfig {
         SpecifiedCacheSupportingCacheManager cacheManager = new SpecifiedCacheSupportingCacheManager();
         cacheManager.setNoOpCacheManager(new NoOpCacheManager());
         cacheManager.setDelegateCacheManager(ehCacheManager);
-        cacheManager.setSupportedCaches(CONFIG_BY_NAME_CACHE_NAME);
+        cacheManager.setSupportedCaches(CONFIG_BY_NAME_CACHE_NAME, EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME);
         return new TransactionBoundCacheManager(cacheManager);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JpaTransactionConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JpaTransactionConfig.java
@@ -19,6 +19,8 @@
 
 package org.apache.fineract.infrastructure.core.config.jpa;
 
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
+
 import java.util.List;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
@@ -50,5 +52,12 @@ public class JpaTransactionConfig {
     @Primary
     public TransactionTemplate jpaTransactionTemplate(PlatformTransactionManager transactionManager) {
         return new TransactionTemplate(transactionManager);
+    }
+
+    @Bean("requiresNewTransactionTemplate")
+    public TransactionTemplate requiresNewTransactionTemplate(PlatformTransactionManager transactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
+        return transactionTemplate;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/ScheduledJobRunnerConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/ScheduledJobRunnerConfig.java
@@ -51,7 +51,7 @@ public class ScheduledJobRunnerConfig {
 
     @Bean
     public JobRepository jobRepository(RoutingDataSource routingDataSource,
-            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager transactionManager,
+            @Qualifier("jdbcTransactionManager") PlatformTransactionManager transactionManager,
             Jackson2ExecutionContextStringSerializer executionContextSerializer, DataFieldMaxValueIncrementerFactory incrementerFactory)
             throws Exception {
         JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
@@ -66,7 +66,7 @@ public class ScheduledJobRunnerConfig {
 
     @Bean
     public JobExplorer jobExplorer(RoutingDataSource routingDataSource,
-            @Qualifier("batchJdbcTransactionManager") PlatformTransactionManager transactionManager,
+            @Qualifier("jdbcTransactionManager") PlatformTransactionManager transactionManager,
             Jackson2ExecutionContextStringSerializer executionContextSerializer) throws Exception {
         JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
         jobExplorerFactoryBean.setDataSource(routingDataSource);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/StuckJobExecutorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/service/StuckJobExecutorServiceImpl.java
@@ -18,17 +18,14 @@
  */
 package org.apache.fineract.infrastructure.jobs.service;
 
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.jobs.data.partitionedjobs.PartitionedJob;
 import org.apache.fineract.infrastructure.jobs.domain.JobExecutionRepository;
 import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
@@ -37,7 +34,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class StuckJobExecutorServiceImpl implements StuckJobExecutorService {
 
     private final JobExecutionRepository jobExecutionRepository;
-    private final TransactionTemplate transactionTemplate;
+    @Qualifier("requiresNewTransactionJdbcTemplate")
+    private final TransactionTemplate requiresNewTransactionJdbcTemplate;
     private final JobOperator jobOperator;
 
     @Override
@@ -86,18 +84,16 @@ public class StuckJobExecutorServiceImpl implements StuckJobExecutorService {
     private void handleStuckPartitionedJob(Long stuckJobId, String partitionerStepName) {
         try {
             waitUntilAllPartitionsFinished(stuckJobId, partitionerStepName);
-            transactionTemplate.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
-            transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-
-                @Override
-                protected void doInTransactionWithoutResult(TransactionStatus status) {
-                    jobExecutionRepository.updateJobStatusToFailed(stuckJobId, partitionerStepName);
-                }
-            });
+            updateJobStatusToFailedInNewTransaction(stuckJobId, partitionerStepName);
             jobOperator.restart(stuckJobId);
         } catch (Exception e) {
             throw new RuntimeException("Exception while handling a stuck job", e);
         }
+    }
+
+    private void updateJobStatusToFailedInNewTransaction(Long stuckJobId, String partitionerStepName) {
+        requiresNewTransactionJdbcTemplate
+                .executeWithoutResult(status -> jobExecutionRepository.updateJobStatusToFailed(stuckJobId, partitionerStepName));
     }
 
     private void waitUntilAllPartitionsFinished(Long stuckJobId, String partitionerStepName) throws InterruptedException {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/domain/CalendarInstanceRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/calendar/domain/CalendarInstanceRepository.java
@@ -38,10 +38,10 @@ import org.springframework.stereotype.Repository;
 @CacheConfig(cacheNames = "calendarInstances")
 public interface CalendarInstanceRepository extends JpaRepository<CalendarInstance, Long>, JpaSpecificationExecutor<CalendarInstance> {
 
-    @Cacheable(key = "'calId_' + #calendarId + '_entityId_' + #entityId + '_entityTypeId_' + #entityTypeId")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('calId_' + #calendarId + '_entityId_' + #entityId + '_entityTypeId_' + #entityTypeId)")
     CalendarInstance findByCalendarIdAndEntityIdAndEntityTypeId(Long calendarId, Long entityId, Integer entityTypeId);
 
-    @Cacheable(key = "'entityId_' + #entityId + '_entityTypeId_' + #entityTypeId")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('entityId_' + #entityId + '_entityTypeId_' + #entityTypeId)")
     Collection<CalendarInstance> findByEntityIdAndEntityTypeId(Long entityId, Integer entityTypeId);
 
     /**
@@ -53,18 +53,18 @@ public interface CalendarInstanceRepository extends JpaRepository<CalendarInstan
      *            {@link CalendarType}
      * @return
      */
-    @Cacheable(key = "'entityId_' + #entityId + '_entityTypeId_' + #entityTypeId + '_calendarTypeId_' + #calendarTypeId")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('entityId_' + #entityId + '_entityTypeId_' + #entityTypeId + '_calendarTypeId_' + #calendarTypeId)")
     CalendarInstance findByEntityIdAndEntityTypeIdAndCalendarTypeId(Long entityId, Integer entityTypeId, Integer calendarTypeId);
 
-    @Cacheable(key = "'findCalendarInstanceByEntityId_entityId_' + #entityId + '_entityTypeId_' + #entityTypeId")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('findCalendarInstanceByEntityId_entityId_' + #entityId + '_entityTypeId_' + #entityTypeId)")
     @Query("select ci from CalendarInstance ci where ci.entityId = :entityId and ci.entityTypeId = :entityTypeId")
     CalendarInstance findCalendarInstanceByEntityId(@Param("entityId") Long entityId, @Param("entityTypeId") Integer entityTypeId);
 
-    @Cacheable(key = "'calendarId_' + #calendarId + '_entityTypeId_' + #entityTypeId")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('calendarId_' + #calendarId + '_entityTypeId_' + #entityTypeId)")
     Collection<CalendarInstance> findByCalendarIdAndEntityTypeId(Long calendarId, Integer entityTypeId);
 
     /** Should use in clause, can I do it without creating a new class? **/
-    @Cacheable(key = "'groupId_' + #groupId + '_clientId_' + #clientId + '_statuses_' + T(org.springframework.util.StringUtils).collectionToCommaDelimitedString(#loanStatuses)")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('groupId_' + #groupId + '_clientId_' + #clientId + '_statuses_' + T(org.springframework.util.StringUtils).collectionToCommaDelimitedString(#loanStatuses))")
     @Query("select ci from CalendarInstance ci where ci.entityId in (select loan.id from Loan loan where loan.client.id = :clientId and loan.group.id = :groupId and loan.loanStatus in :loanStatuses) and ci.entityTypeId = 3")
     List<CalendarInstance> findCalendarInstancesForLoansByGroupIdAndClientIdAndStatuses(@Param("groupId") Long groupId,
             @Param("clientId") Long clientId, @Param("loanStatuses") Collection<LoanStatus> loanStatuses);
@@ -72,7 +72,7 @@ public interface CalendarInstanceRepository extends JpaRepository<CalendarInstan
     /**
      * EntityType = 3 is for loan
      */
-    @Cacheable(key = "'countLoans_calendarId_' + #calendarId + '_statuses_' + T(org.springframework.util.StringUtils).collectionToCommaDelimitedString(#loanStatuses)")
+    @Cacheable(key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat('countLoans_calendarId_' + #calendarId + '_statuses_' + T(org.springframework.util.StringUtils).collectionToCommaDelimitedString(#loanStatuses))")
     @Query("SELECT COUNT(ci.id) FROM CalendarInstance ci, Loan loan WHERE loan.id = ci.entityId AND ci.entityTypeId = 3 AND ci.calendar.id = :calendarId AND loan.loanStatus IN :loanStatuses ")
     Integer countOfLoansSyncedWithCalendar(@Param("calendarId") Long calendarId,
             @Param("loanStatuses") Collection<LoanStatus> loanStatuses);

--- a/fineract-provider/src/test/java/org/apache/fineract/TestConfiguration.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/TestConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
@@ -83,7 +84,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableWebSecurity
 @EnableConfigurationProperties({ FineractProperties.class, LiquibaseProperties.class })
-@ComponentScan(basePackages = "org.apache.fineract")
+@ComponentScan(basePackages = "org.apache.fineract", excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org\\.apache\\.fineract\\..*\\$TestConfig"))
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @PropertySource("classpath:application-test.properties")

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/listener/LoanItemListenerStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/listener/LoanItemListenerStepDefinitions.java
@@ -37,7 +37,6 @@ import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.mockito.Mockito;
 import org.springframework.batch.item.Chunk;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 public class LoanItemListenerStepDefinitions implements En {
@@ -68,7 +67,6 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onReadError result should match", () -> {
-            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
             verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
             verify(loanLockingService, Mockito.times(1)).updateLockError(eq(1L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
                     eq("Loan (id: 1) reading is failed"), anyString());
@@ -90,7 +88,6 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onProcessError result should match", () -> {
-            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
             verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
             verify(loanLockingService, Mockito.times(1)).updateLockError(eq(2L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
                     eq("Loan (id: 2) processing is failed"), anyString());
@@ -112,7 +109,6 @@ public class LoanItemListenerStepDefinitions implements En {
         });
 
         Then("LoanItemListener.onWriteError result should match", () -> {
-            verify(batchJdbcTransactionTemplate, Mockito.times(1)).setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
             verify(batchJdbcTransactionTemplate, Mockito.times(1)).execute(any());
             verify(loanLockingService, Mockito.times(1)).updateLockError(eq(3L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING),
                     eq("Loan (id: 3) writing is failed"), anyString());

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/loan/ApplyLoanLockTaskletStepDefinitions.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/loan/ApplyLoanLockTaskletStepDefinitions.java
@@ -52,16 +52,17 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 public class ApplyLoanLockTaskletStepDefinitions implements En {
 
-    ArgumentCaptor<List> valueCaptor = ArgumentCaptor.forClass(List.class);
-    ArgumentCaptor<LockOwner> lockOwnerValueCaptor = ArgumentCaptor.forClass(LockOwner.class);
+    @SuppressWarnings("unchecked")
+    private final ArgumentCaptor<List<Long>> valueCaptor = ArgumentCaptor.forClass(List.class);
+    private final ArgumentCaptor<LockOwner> lockOwnerValueCaptor = ArgumentCaptor.forClass(LockOwner.class);
     private LockingService loanLockingService = mock(LockingService.class);
     private FineractProperties fineractProperties = mock(FineractProperties.class);
     private FineractProperties.FineractQueryProperties fineractQueryProperties = mock(FineractProperties.FineractQueryProperties.class);
     private RetrieveIdService retrieveIdService = mock(RetrieveIdService.class);
-    private TransactionTemplate transactionTemplate = spy(TransactionTemplate.class);
+    private TransactionTemplate requiresNewTransactionJdbcTemplate = spy(new TransactionTemplate(mock(PlatformTransactionManager.class)));
 
     private ApplyLoanLockTasklet applyLoanLockTasklet = new ApplyLoanLockTasklet(fineractProperties, loanLockingService, retrieveIdService,
-            transactionTemplate);
+            requiresNewTransactionJdbcTemplate);
     private RepeatStatus resultItem;
     private StepContribution stepContribution;
 
@@ -95,7 +96,7 @@ public class ApplyLoanLockTaskletStepDefinitions implements En {
                 Long lock1 = 1L;
                 Long lock3 = 3L;
                 List<Long> accountLocks = List.of(lock1, lock3);
-                stepContribution.getStepExecution().setCommitCount(4);
+                executionContext.putLong(LoanCOBConstant.COB_PARAMETER + ".apply-lock-attempts", 4);
                 lenient().when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
                 lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
@@ -108,8 +109,6 @@ public class ApplyLoanLockTaskletStepDefinitions implements En {
                 lenient().when(fineractQueryProperties.getInClauseParameterSizeLimit()).thenReturn(65000);
                 lenient().when(loanLockingService.findLockIdsByLoanIdIn(Mockito.anyList())).thenReturn(accountLocks);
             }
-            transactionTemplate.setTransactionManager(mock(PlatformTransactionManager.class));
-
         });
 
         When("ApplyLoanLockTasklet.execute method executed", () -> {

--- a/fineract-provider/src/test/java/org/apache/fineract/cob/service/InlineLoanCOBExecutorServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/cob/service/InlineLoanCOBExecutorServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -88,7 +89,7 @@ class InlineLoanCOBExecutorServiceImplTest {
         businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
         ThreadLocalContextUtil.setBusinessDates(businessDates);
 
-        when(transactionTemplate.execute(any())).thenThrow(new AccountLockCannotBeOverruledException(""));
+        doThrow(new AccountLockCannotBeOverruledException("")).when(transactionTemplate).executeWithoutResult(any());
         when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
         when(fineractProperties.getApi()).thenReturn(fineractApiProperties);
         when(dataParser.parseExecution(any())).thenReturn(List.of(1L));
@@ -112,7 +113,7 @@ class InlineLoanCOBExecutorServiceImplTest {
         businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
         ThreadLocalContextUtil.setBusinessDates(businessDates);
 
-        when(transactionTemplate.execute(any())).thenThrow(new AccountLockCannotBeOverruledException(""));
+        doThrow(new AccountLockCannotBeOverruledException("")).when(transactionTemplate).executeWithoutResult(any());
         when(fineractProperties.getQuery()).thenReturn(fineractQueryProperties);
         when(fineractProperties.getApi()).thenReturn(fineractApiProperties);
         when(dataParser.parseExecution(any())).thenReturn(List.of(1L, 2L, 3L));

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationServiceImplTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.event.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.lang.reflect.Method;
+import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
+import org.apache.fineract.infrastructure.event.external.repository.ExternalEventConfigurationRepository;
+import org.apache.fineract.infrastructure.event.external.repository.domain.ExternalEventConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalBusinessEventConfigurationServiceImplTest {
+
+    @Mock
+    private ExternalEventConfigurationRepository eventConfigurationRepository;
+
+    @InjectMocks
+    private ExternalBusinessEventConfigurationServiceImpl underTest;
+
+    @Test
+    void shouldReturnFalseForNullEventWithoutTouchingTheDatabase() {
+        assertThat(underTest.isExternalEventConfiguredForPosting(null)).isFalse();
+        verifyNoInteractions(eventConfigurationRepository);
+    }
+
+    @Test
+    void shouldReturnConfiguredEnabledFlag() {
+        BusinessEvent<?> event = mock(BusinessEvent.class);
+        given(event.getType()).willReturn("LoanApprovedBusinessEvent");
+        ExternalEventConfiguration configuration = mock(ExternalEventConfiguration.class);
+        given(configuration.isEnabled()).willReturn(true);
+        given(eventConfigurationRepository.findExternalEventConfigurationByTypeWithNotFoundDetection("LoanApprovedBusinessEvent"))
+                .willReturn(configuration);
+
+        assertThat(underTest.isExternalEventConfiguredForPosting(event)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenConfigurationIsDisabled() {
+        BusinessEvent<?> event = mock(BusinessEvent.class);
+        given(event.getType()).willReturn("LoanApprovedBusinessEvent");
+        ExternalEventConfiguration configuration = mock(ExternalEventConfiguration.class);
+        given(configuration.isEnabled()).willReturn(false);
+        given(eventConfigurationRepository.findExternalEventConfigurationByTypeWithNotFoundDetection("LoanApprovedBusinessEvent"))
+                .willReturn(configuration);
+
+        assertThat(underTest.isExternalEventConfiguredForPosting(event)).isFalse();
+    }
+
+    /**
+     * The configuration read is the path that previously leaked a connection. It must run inside a real, committing
+     * (read-only) transaction so the connection is acquired, the query runs and the connection is released immediately,
+     * rather than being held idle-in-transaction.
+     */
+    @Test
+    void configurationLookupMustRunInAReadOnlyTransaction() throws NoSuchMethodException {
+        Method method = ExternalBusinessEventConfigurationServiceImpl.class.getMethod("isExternalEventConfiguredForPosting",
+                BusinessEvent.class);
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).as("isExternalEventConfiguredForPosting must be @Transactional").isNotNull();
+        assertThat(transactional.readOnly()).as("the configuration read must be marked read-only").isTrue();
+    }
+
+    /**
+     * Guards against re-introducing the leak: {@code notifyPostBusinessEvent} must NOT carry a
+     * {@code @Transactional(SUPPORTS)} annotation, which established a synchronization scope that held a connection for
+     * the whole request.
+     */
+    @Test
+    void notifyPostBusinessEventMustNotBeTransactional() throws NoSuchMethodException {
+        Method method = BusinessEventNotifierServiceImpl.class.getMethod("notifyPostBusinessEvent", BusinessEvent.class);
+
+        assertThat(method.getAnnotation(Transactional.class)).as("notifyPostBusinessEvent must not be @Transactional(SUPPORTS)").isNull();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationTransactionBoundaryTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/ExternalBusinessEventConfigurationTransactionBoundaryTest.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.event.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.event.business.domain.BusinessEvent;
+import org.apache.fineract.infrastructure.event.external.repository.ExternalEventConfigurationRepository;
+import org.apache.fineract.infrastructure.event.external.repository.domain.ExternalEventConfiguration;
+import org.apache.fineract.infrastructure.event.external.service.ExternalEventService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ExternalBusinessEventConfigurationTransactionBoundaryTest.TestConfig.class)
+@SuppressWarnings("unchecked")
+class ExternalBusinessEventConfigurationTransactionBoundaryTest {
+
+    @Autowired
+    private BusinessEventNotifierServiceImpl businessEventNotifierService;
+
+    @Autowired
+    private TransactionBoundaryProbe transactionBoundaryProbe;
+
+    @Autowired
+    private ProbeTransactionManager transactionManager;
+
+    @AfterEach
+    void tearDown() {
+        transactionBoundaryProbe.releasePostEvent();
+    }
+
+    @Test
+    void configurationLookupTransactionMustCloseBeforeDownstreamEventPostingBlocks() throws Exception {
+        BusinessEvent<?> businessEvent = mock(BusinessEvent.class);
+        given(businessEvent.getType()).willReturn("LoanApprovedBusinessEvent");
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = executor.submit(() -> businessEventNotifierService.notifyPostBusinessEvent(businessEvent));
+        try {
+            assertThat(transactionBoundaryProbe.awaitPostEvent()).as("postEvent should be reached").isTrue();
+
+            assertThat(transactionBoundaryProbe.isTransactionActiveDuringConfigurationLookup())
+                    .as("configuration lookup should run inside a real transaction").isTrue();
+            assertThat(transactionBoundaryProbe.isTransactionActiveAtPostEventEntry())
+                    .as("configuration lookup transaction must be closed before downstream posting starts").isFalse();
+            assertThat(transactionManager.getBeginCount()).as("configuration lookup should start one transaction").isEqualTo(1);
+            assertThat(transactionManager.getCommitCount()).as("configuration lookup transaction should already be committed").isEqualTo(1);
+            assertThat(transactionManager.getRollbackCount()).as("configuration lookup should not roll back").isZero();
+
+            transactionBoundaryProbe.releasePostEvent();
+            future.get(5, TimeUnit.SECONDS);
+        } finally {
+            transactionBoundaryProbe.releasePostEvent();
+            executor.shutdownNow();
+        }
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    static class TestConfig {
+
+        @Bean
+        ProbeTransactionManager transactionManager() {
+            return new ProbeTransactionManager();
+        }
+
+        @Bean
+        TransactionBoundaryProbe transactionBoundaryProbe() {
+            return new TransactionBoundaryProbe();
+        }
+
+        @Bean
+        ExternalEventConfigurationRepository externalEventConfigurationRepository(TransactionBoundaryProbe transactionBoundaryProbe) {
+            ExternalEventConfigurationRepository repository = mock(ExternalEventConfigurationRepository.class);
+            given(repository.findExternalEventConfigurationByTypeWithNotFoundDetection(anyString())).willAnswer(invocation -> {
+                transactionBoundaryProbe.recordConfigurationLookupTransactionState();
+                return new ExternalEventConfiguration(invocation.getArgument(0), true);
+            });
+            return repository;
+        }
+
+        @Bean
+        ExternalBusinessEventConfigurationService externalBusinessEventConfigurationService(
+                ExternalEventConfigurationRepository externalEventConfigurationRepository) {
+            return new ExternalBusinessEventConfigurationServiceImpl(externalEventConfigurationRepository);
+        }
+
+        @Bean
+        FineractProperties fineractProperties() {
+            FineractProperties fineractProperties = new FineractProperties();
+            FineractProperties.FineractEventsProperties eventsProperties = new FineractProperties.FineractEventsProperties();
+            FineractProperties.FineractExternalEventsProperties externalEventsProperties = new FineractProperties.FineractExternalEventsProperties();
+            externalEventsProperties.setEnabled(true);
+            eventsProperties.setExternal(externalEventsProperties);
+            fineractProperties.setEvents(eventsProperties);
+            return fineractProperties;
+        }
+
+        @Bean
+        TransactionHelper transactionHelper() {
+            return new TransactionHelper();
+        }
+
+        @Bean
+        BusinessEventNotifierServiceImpl businessEventNotifierService(FineractProperties fineractProperties,
+                TransactionHelper transactionHelper, ExternalBusinessEventConfigurationService externalBusinessEventConfigurationService,
+                TransactionBoundaryProbe transactionBoundaryProbe) {
+            ExternalEventService externalEventService = mock(ExternalEventService.class);
+            doAnswer(invocation -> {
+                transactionBoundaryProbe.recordPostEventEntryTransactionState();
+                assertThat(transactionBoundaryProbe.awaitReleasePostEvent()).as("postEvent should be released").isTrue();
+                return null;
+            }).when(externalEventService).postEvent(any(BusinessEvent.class));
+            return new BusinessEventNotifierServiceImpl(externalEventService, fineractProperties, transactionHelper,
+                    externalBusinessEventConfigurationService);
+        }
+    }
+
+    static final class TransactionBoundaryProbe {
+
+        private final CountDownLatch postEventEntered = new CountDownLatch(1);
+        private final CountDownLatch releasePostEvent = new CountDownLatch(1);
+        private final AtomicBoolean transactionActiveDuringConfigurationLookup = new AtomicBoolean();
+        private final AtomicBoolean transactionActiveAtPostEventEntry = new AtomicBoolean();
+
+        void recordConfigurationLookupTransactionState() {
+            transactionActiveDuringConfigurationLookup.set(TransactionSynchronizationManager.isActualTransactionActive());
+        }
+
+        void recordPostEventEntryTransactionState() {
+            transactionActiveAtPostEventEntry.set(TransactionSynchronizationManager.isActualTransactionActive());
+            postEventEntered.countDown();
+        }
+
+        boolean awaitPostEvent() throws InterruptedException {
+            return postEventEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        boolean awaitReleasePostEvent() throws InterruptedException {
+            return releasePostEvent.await(5, TimeUnit.SECONDS);
+        }
+
+        void releasePostEvent() {
+            releasePostEvent.countDown();
+        }
+
+        boolean isTransactionActiveDuringConfigurationLookup() {
+            return transactionActiveDuringConfigurationLookup.get();
+        }
+
+        boolean isTransactionActiveAtPostEventEntry() {
+            return transactionActiveAtPostEventEntry.get();
+        }
+    }
+
+    static final class ProbeTransactionManager extends AbstractPlatformTransactionManager {
+
+        private final AtomicInteger beginCount = new AtomicInteger();
+        private final AtomicInteger commitCount = new AtomicInteger();
+        private final AtomicInteger rollbackCount = new AtomicInteger();
+
+        @Override
+        protected Object doGetTransaction() {
+            return new Object();
+        }
+
+        @Override
+        protected void doBegin(Object transaction, TransactionDefinition definition) {
+            beginCount.incrementAndGet();
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus status) {
+            commitCount.incrementAndGet();
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus status) {
+            rollbackCount.incrementAndGet();
+        }
+
+        int getBeginCount() {
+            return beginCount.get();
+        }
+
+        int getCommitCount() {
+            return commitCount.get();
+        }
+
+        int getRollbackCount() {
+            return rollbackCount.get();
+        }
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/TransactionHelperTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/business/service/TransactionHelperTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.event.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Guards the connection-leak fix: {@link TransactionHelper#hasTransaction()} must reflect whether an <em>actual</em>
+ * (connection-backed) transaction is active, so that {@code notifyPostBusinessEvent} only defers events to commit when
+ * a real transaction exists. The previous implementation relied on {@code TransactionAspectSupport} together with a
+ * {@code @Transactional(SUPPORTS)} proxy, which established a synchronization scope that held a DB connection
+ * idle-in-transaction for the whole request.
+ */
+class TransactionHelperTest {
+
+    private final TransactionHelper underTest = new TransactionHelper();
+
+    @AfterEach
+    void tearDown() {
+        // Make sure the thread-bound flag never leaks into other tests.
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.setActualTransactionActive(false);
+        }
+    }
+
+    @Test
+    void shouldReportNoTransactionWhenNoActualTransactionIsActive() {
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+
+        assertThat(underTest.hasTransaction()).isFalse();
+    }
+
+    @Test
+    void shouldReportTransactionWhenAnActualTransactionIsActive() {
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+
+        assertThat(underTest.hasTransaction()).isTrue();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/repository/ExternalEventConfigurationRepositoryCacheTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/event/external/repository/ExternalEventConfigurationRepositoryCacheTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.event.external.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.apache.fineract.infrastructure.core.config.cache.TransactionBoundCacheManager;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+class ExternalEventConfigurationRepositoryCacheTest {
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void shouldUseTenantScopedCacheKey() throws NoSuchMethodException {
+        Method method = ExternalEventConfigurationRepository.class.getMethod("findExternalEventConfigurationByTypeWithNotFoundDetection",
+                String.class);
+        Cacheable cacheable = method.getAnnotation(Cacheable.class);
+
+        assertThat(cacheable.key()).isEqualTo(
+                "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat(#externalEventType)");
+    }
+
+    @Test
+    void shouldClearExternalEventConfigurationCacheOnTransactionLifecycleCallbacks() {
+        CacheManager delegate = new ConcurrentMapCacheManager(ExternalEventConfigurationRepository.EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME);
+        TransactionBoundCacheManager underTest = new TransactionBoundCacheManager(delegate);
+        Cache cache = underTest.getCache(ExternalEventConfigurationRepository.EXTERNAL_EVENT_CONFIGURATION_CACHE_NAME);
+
+        cache.put("aKey", true);
+        assertThat(cache.get("aKey", Boolean.class)).isTrue();
+
+        underTest.afterBegin();
+        assertThat(cache.get("aKey")).isNull();
+
+        cache.put("aKey", true);
+        underTest.afterCompletion();
+        assertThat(cache.get("aKey")).isNull();
+    }
+}

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/ApplyWorkingCapitalLoanLockTasklet.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/ApplyWorkingCapitalLoanLockTasklet.java
@@ -30,8 +30,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class ApplyWorkingCapitalLoanLockTasklet extends ApplyCommonLockTasklet {
 
     public ApplyWorkingCapitalLoanLockTasklet(FineractProperties fineractProperties, LockingService loanLockingService,
-            RetrieveIdService retrieveIdService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(fineractProperties, loanLockingService, retrieveIdService, batchJdbcTransactionTemplate);
+            RetrieveIdService retrieveIdService, TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(fineractProperties, loanLockingService, retrieveIdService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemListener.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/InlineWorkingCapitalLoanCOBWorkerItemListener.java
@@ -26,8 +26,9 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 public class InlineWorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<WorkingCapitalLoan> {
 
-    public InlineWorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(lockingService, batchJdbcTransactionTemplate);
+    public InlineWorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService,
+            TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(lockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
@@ -60,10 +60,10 @@ public class WorkingCapitalLoanCOBWorkerConfiguration {
     private final MessageChannel inboundRequests;
     private final PropertyService propertyService;
     private final PlatformTransactionManager transactionManager;
-    @Qualifier("batchJdbcTransactionManager")
-    private final PlatformTransactionManager batchJdbcTransactionManager;
-    @Qualifier("batchJdbcTransactionTemplate")
-    private final TransactionTemplate batchJdbcTransactionTemplate;
+    @Qualifier("jdbcTransactionManager")
+    private final PlatformTransactionManager jdbcTransactionManager;
+    @Qualifier("requiresNewTransactionJdbcTemplate")
+    private final TransactionTemplate requiresNewTransactionJdbcTemplate;
     @Qualifier("workingCapitalLoanLockingService")
     private final LockingService wpcLoanLockingService;
     private final FineractProperties fineractProperties;
@@ -122,21 +122,12 @@ public class WorkingCapitalLoanCOBWorkerConfiguration {
 
     @Bean
     public WorkingCapitalLoanCOBWorkerItemListener workingCapitalLoanItemListener() {
-        return new WorkingCapitalLoanCOBWorkerItemListener(wpcLoanLockingService, batchJdbcTransactionTemplate);
+        return new WorkingCapitalLoanCOBWorkerItemListener(wpcLoanLockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Bean
     public ApplyWorkingCapitalLoanLockTasklet applyWorkingCapitalLoanLock() {
         return new ApplyWorkingCapitalLoanLockTasklet(fineractProperties, wpcLoanLockingService, retrieveIdService,
-                batchJdbcTransactionTemplate);
+                requiresNewTransactionJdbcTemplate);
     }
-
-    @Bean
-    @StepScope
-    public Step applyWorkingCapitalLoanLockStep(
-            @org.springframework.beans.factory.annotation.Value("#{stepExecutionContext['partition']}") String partitionName) {
-        return new org.springframework.batch.core.step.builder.StepBuilder("Apply WC lock - Step:" + partitionName, jobRepository)
-                .tasklet(applyWorkingCapitalLoanLock(), batchJdbcTransactionManager).build();
-    }
-
 }

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerConfiguration.java
@@ -36,7 +36,6 @@ import org.apache.fineract.infrastructure.springbatch.PropertyService;
 import org.apache.fineract.portfolio.workingcapitalloan.domain.WorkingCapitalLoan;
 import org.apache.fineract.portfolio.workingcapitalloan.repository.WorkingCapitalLoanRepository;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.SimpleStepBuilder;
 import org.springframework.batch.integration.partition.RemotePartitioningWorkerStepBuilderFactory;

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemListener.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanCOBWorkerItemListener.java
@@ -26,8 +26,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 public class WorkingCapitalLoanCOBWorkerItemListener extends AbstractLoanItemListener<Loan> {
 
-    public WorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService, TransactionTemplate batchJdbcTransactionTemplate) {
-        super(lockingService, batchJdbcTransactionTemplate);
+    public WorkingCapitalLoanCOBWorkerItemListener(LockingService lockingService, TransactionTemplate requiresNewTransactionJdbcTemplate) {
+        super(lockingService, requiresNewTransactionJdbcTemplate);
     }
 
     @Override


### PR DESCRIPTION
## Description

**1. Enable / Rework External Event Caching**

**What changed:** Added @Cacheable to external event configuration lookup and enabled the cache in the supported cache manager list.

**Why:** Avoid repeated m_external_event_configuration DB reads on every event and reduce the chance of connection pressure in the event path.

**Files:**
- ExternalEventConfigurationRepository.java
- CacheConfig.java
- ExternalEventConfigurationRepositoryCacheTest.java
**4. Make Cache Keys Tenant-Aware**

**What changed:** Added tenant identifier to cache keys using the same pattern as `ChargeReadPlatformServiceImpl.retrieveAllCharges`.

**Why**: Fineract is multi-tenant; cache entries must not be shared across tenants.

**Files:**
- ExternalEventConfigurationRepository.java
- ApplicationCurrencyRepository.java
- CalendarInstanceRepository.java

**5. Remove SUPPORTS Transaction Scope From Event Notification**

**What changed:** Removed @Transactional(propagation = SUPPORTS) from business event notification and moved the external event config read into a real read-only transaction.

**Why:** SUPPORTS can create a synchronization scope without a real transaction, which was the suspected source of idle-in-transaction connection retention.

**Files:**
- BusinessEventNotifierServiceImpl.java
-ExternalBusinessEventConfigurationServiceImpl.java
-TransactionHelper.java

**6. Rework Transaction Detection**

**What changed:** TransactionHelper.hasTransaction() now uses TransactionSynchronizationManager.isActualTransactionActive() instead of TransactionAspectSupport.currentTransactionStatus().

**Why:** It checks for an actual active transaction without requiring the helper itself to be wrapped in a transactional proxy/scope.

Files:
- TransactionHelper.java
- TransactionHelperTest.java

**7. Rework JDBC/JPA Transaction Template Beans**

**What changed:** Added explicit requiresNewTransactionTemplate for JPA and requiresNewTransactionJdbcTemplate for JDBC. Removed the separate batch JDBC transaction manager/template usage.

**Why:** Avoid mutating shared TransactionTemplate beans at runtime and keep JDBC/JPA transaction boundaries explicit.

**Files:**
- JdbcTransactionConfig.java
- JpaTransactionConfig.java
- ScheduledJobRunnerConfig.java
- StuckJobExecutorServiceImpl.java

**8. Remove Runtime Mutation Of Shared TransactionTemplates**

**What changed:** Replaced transactionTemplate.setPropagationBehavior(REQUIRES_NEW) call sites with injected preconfigured REQUIRES_NEW templates.

**Why:** Shared singleton templates are mutable; changing propagation before execution is fragile and can affect later calls unexpectedly.

**Files:**
- AbstractLoanItemListener.java
- ApplyCommonLockTasklet.java
- InlineCommonLockableCOBExecutorService.java
- StuckJobExecutorServiceImpl.java

**9. Rework COB Locking / Retry Behavior** 

**What changed:** COB lock tasklet retry accounting moved away from manually incremented StepExecution.commitCount; lock retry attempts are tracked in ExecutionContext.

**Why:** commitCount is Spring Batch-owned state and manually incrementing it can corrupt/misrepresent chunk/step execution metadata.

**Files:**
- CobWorkerStepListener.java
- ApplyCommonLockTasklet.java
- ApplyLoanLockTaskletStepDefinitions.java

**11. Rewire COB Worker / Inline COB To Correct Templates**

**What changed:** COB worker configs and listeners now inject requiresNewTransactionJdbcTemplate where lock updates use JDBC. Inline COB lock override uses requiresNewTransactionTemplate where JPA repositories are used.

**Why:** Avoid mixing transaction managers and avoid opening the wrong transaction type for JDBC vs JPA operations.

**Files:**
- LoanCOBWorkerConfiguration.java
- LoanInlineCOBConfig.java
- WorkingCapitalLoanInlineCOBConfig.java
- WorkingCapitalLoanCOBWorkerConfiguration.java

**12. Event Transaction Boundary Tests**

**What changed:** Added tests around external event configuration behavior and transaction boundary detection.

**Why:** Guard against regression where event config checks accidentally run in a problematic transaction synchronization scope again.

**Files:**
- ExternalBusinessEventConfigurationServiceImplTest.java
- ExternalBusinessEventConfigurationTransactionBoundaryTest.java
- TransactionHelperTest.java

**10. E2E Diagnostics Tags**

**What changed:** Added @ConnectionPoolDiagnostics to selected E2E feature files.
**Why:** Enable connection pool diagnostics during high-risk COB/loan repayment/re-aging flows.

**Files:**
- 0_COB.feature
- LoanReAging-Part1.feature
- LoanRepayment-Part4.feature
- LoanRepaymentSchedule.feature

**11. COB Test Updates** 

What changed: Updated tests to stop expecting runtime mutation of TransactionTemplate, and to match new executeWithoutResult/retry behavior.
Why: Tests now assert the new safer transaction-template usage instead of the old mutation pattern.

**Files:**
- LoanItemListenerStepDefinitions.java
- ApplyLoanLockTaskletStepDefinitions.java
- InlineLoanCOBExecutorServiceImplTest.java

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
