### PR TITLE
FINERACT-2421: Allow using Mysql / Mariadb db clients for development (devRun/bootRun)

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -183,11 +183,18 @@ project.ext.pgPassword='postgres'
 
 configurations {
     driver
+    bootRunDriver {
+        canBeConsumed = false
+        canBeResolved = true
+    }
 }
 dependencies {
     driver 'org.mariadb.jdbc:mariadb-java-client'
     driver 'org.postgresql:postgresql'
     driver 'com.mysql:mysql-connector-j'
+
+    bootRunDriver 'org.mariadb.jdbc:mariadb-java-client'
+    bootRunDriver 'com.mysql:mysql-connector-j'
 }
 
 tasks.register('copyDatabaseDriverPlugins', Copy) {
@@ -280,6 +287,7 @@ tasks.named('licenseMain') {
 }
 
 bootRun {
+    classpath += configurations.bootRunDriver
     jvmArgs = [
             "-Dspring.output.ansi.enabled=ALWAYS"
     ]


### PR DESCRIPTION
## Description

With this PR, for development purposes (devRun and bootRun gradle tasks), MySQL and MariaDB drivers are loaded and allowed to be used. (By default, these drivers do not meet the license requirements of ASL.)

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
