### PR TITLE
FINERACT-2421: Bump setup-gradle to v6.2.0 for asf infra allowlist compliance

### DIFF
--- a/.github/actions/setup-and-build-fineract/action.yml
+++ b/.github/actions/setup-and-build-fineract/action.yml
@@ -19,7 +19,7 @@ runs:
         distribution: 'zulu'
 
     - name: Setup Gradle and Validate Wrapper
-      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         validate-wrappers: true
         cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/build-cucumber.yml
+++ b/.github/workflows/build-cucumber.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,7 +45,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Extract workspace
         run: tar -xf fineract-workspace.tar
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22

--- a/.github/workflows/build-e2e-tests.yml
+++ b/.github/workflows/build-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Make scripts executable
         run: chmod +x scripts/split-features.sh

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -53,7 +53,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -53,7 +53,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -53,7 +53,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/build-progressive-loan.yml
+++ b/.github/workflows/build-progressive-loan.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/build-quality-checks.yml
+++ b/.github/workflows/build-quality-checks.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 
@@ -77,7 +77,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 
@@ -119,7 +119,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 
@@ -161,7 +161,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 
@@ -203,7 +203,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/liquibase-only-postgresql.yml
+++ b/.github/workflows/liquibase-only-postgresql.yml
@@ -45,7 +45,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
 

--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -42,7 +42,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Get Git Hashes
         run: |

--- a/.github/workflows/regression-safety-db-changes.yml
+++ b/.github/workflows/regression-safety-db-changes.yml
@@ -124,7 +124,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Wait for PostgreSQL
         run: |

--- a/.github/workflows/run-integration-test-sequentially-postgresql.yml
+++ b/.github/workflows/run-integration-test-sequentially-postgresql.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Extract workspace
         run: tar -xf fineract-workspace.tar
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
       - name: Verify PostgreSQL connection

--- a/.github/workflows/smoke-messaging.yml
+++ b/.github/workflows/smoke-messaging.yml
@@ -45,7 +45,7 @@ jobs:
         run: tar -xf fineract-workspace.tar
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Extract workspace
         run: tar -xf fineract-workspace.tar
       - name: Setup Gradle and Validate Wrapper
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
       - name: Sonar


### PR DESCRIPTION
See the latest commit: https://github.com/apache/infrastructure-actions/commit/25ab499ef9c241b64a56860245e57c195baddec6 which has removed expired github actions used in fineract

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
