### PR TITLE
FINERACT-2653: Fix provisioning category delete failing with mandatory categoryname error

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl.java
@@ -68,9 +68,10 @@ public class ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl implement
 
     @Override
     public CommandProcessingResult deleteProvisioningCateogry(JsonCommand command) {
-        this.fromApiJsonDeserializer.validateForCreate(command.json());
-        final ProvisioningCategory provisioningCategory = ProvisioningCategory.fromJson(command);
-        boolean isProvisioningCategoryInUse = isAnyLoanProductsAssociateWithThisProvisioningCategory(provisioningCategory.getId());
+        final Long categoryId = command.entityId();
+        final ProvisioningCategory provisioningCategory = this.provisioningCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new ProvisioningCategoryNotFoundException(categoryId));
+        boolean isProvisioningCategoryInUse = isAnyLoanProductsAssociateWithThisProvisioningCategory(categoryId);
         if (isProvisioningCategoryInUse) {
             throw new ProvisioningCategoryCannotBeDeletedException(
                     "error.msg.provisioningcategory.cannot.be.deleted.it.is.already.used.in.loanproduct",
@@ -78,7 +79,7 @@ public class ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl implement
         }
         this.provisioningCategoryRepository.delete(provisioningCategory);
         return new CommandProcessingResultBuilder() //
-                .withEntityId(provisioningCategory.getId()) //
+                .withEntityId(categoryId) //
                 .build();
     }
 
@@ -107,10 +108,20 @@ public class ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl implement
         }
     }
 
-    private boolean isAnyLoanProductsAssociateWithThisProvisioningCategory(final Long categoryID) {
-        final String sql = "select (CASE WHEN (exists (select 1 from m_loanproduct_provisioning_details lpd where lpd.category_id = ?)) = 1 THEN 'true' ELSE 'false' END)";
-        final String isLoansUsingCharge = this.jdbcTemplate.queryForObject(sql, String.class, new Object[] { categoryID });
-        return Boolean.valueOf(isLoansUsingCharge);
+    private boolean isAnyLoanProductsAssociateWithThisProvisioningCategory(final Long categoryId) {
+        // The category is in use when a provisioning criteria definition references it. The original code queried the
+        // non-existent m_loanproduct_provisioning_details table; the category_id column actually lives on
+        // m_provisioning_criteria_definition. EXISTS short-circuits at the first match instead of counting every row,
+        // and maps cleanly to Boolean across PostgreSQL (native bool) and MySQL/MariaDB (BIGINT 1/0).
+        final String sql = """
+                select exists (
+                    select 1
+                    from m_provisioning_criteria_definition
+                    where category_id = ?
+                )
+                """;
+        final Boolean exists = this.jdbcTemplate.queryForObject(sql, Boolean.class, categoryId);
+        return Boolean.TRUE.equals(exists);
     }
 
     /*

--- a/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCategoryWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCategoryWritePlatformServiceJpaRepositoryImplTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.provisioning.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCategory;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCategoryRepository;
+import org.apache.fineract.organisation.provisioning.exception.ProvisioningCategoryCannotBeDeletedException;
+import org.apache.fineract.organisation.provisioning.exception.ProvisioningCategoryNotFoundException;
+import org.apache.fineract.organisation.provisioning.serialization.ProvisioningCategoryDefinitionJsonDeserializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ProvisioningCategoryWritePlatformServiceJpaRepositoryImplTest {
+
+    @InjectMocks
+    private ProvisioningCategoryWritePlatformServiceJpaRepositoryImpl underTest;
+
+    @Mock
+    private ProvisioningCategoryRepository provisioningCategoryRepository;
+
+    @Mock
+    private ProvisioningCategoryDefinitionJsonDeserializer fromApiJsonDeserializer;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private JsonCommand command;
+
+    private static final Long CATEGORY_ID = 7L;
+
+    @Test
+    public void shouldDeleteCategoryWhenItIsNotUsedByAnyLoanProduct() {
+        final ProvisioningCategory category = Mockito.mock(ProvisioningCategory.class);
+        given(command.entityId()).willReturn(CATEGORY_ID);
+        given(provisioningCategoryRepository.findById(CATEGORY_ID)).willReturn(Optional.of(category));
+        // in-use check resolves to "false" -> not associated with any loan product
+        given(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class))).willReturn(false);
+
+        final CommandProcessingResult result = underTest.deleteProvisioningCateogry(command);
+
+        assertEquals(CATEGORY_ID, result.getResourceId());
+        verify(provisioningCategoryRepository).delete(category);
+        // a DELETE has no body, so create-validation must never run on this path
+        verify(fromApiJsonDeserializer, never()).validateForCreate(anyString());
+    }
+
+    @Test
+    public void shouldThrowNotFoundWhenCategoryDoesNotExist() {
+        given(command.entityId()).willReturn(CATEGORY_ID);
+        given(provisioningCategoryRepository.findById(CATEGORY_ID)).willReturn(Optional.empty());
+
+        assertThrows(ProvisioningCategoryNotFoundException.class, () -> underTest.deleteProvisioningCateogry(command));
+
+        verify(provisioningCategoryRepository, never()).delete(any(ProvisioningCategory.class));
+    }
+
+    @Test
+    public void shouldThrowCannotBeDeletedWhenCategoryIsUsedByLoanProduct() {
+        final ProvisioningCategory category = Mockito.mock(ProvisioningCategory.class);
+        given(command.entityId()).willReturn(CATEGORY_ID);
+        given(provisioningCategoryRepository.findById(CATEGORY_ID)).willReturn(Optional.of(category));
+        // in-use check resolves to "true" -> still referenced by a loan product
+        given(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class))).willReturn(true);
+
+        assertThrows(ProvisioningCategoryCannotBeDeletedException.class, () -> underTest.deleteProvisioningCateogry(command));
+
+        verify(provisioningCategoryRepository, never()).delete(any(ProvisioningCategory.class));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ProvisioningCategoryDeleteIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ProvisioningCategoryDeleteIntegrationTest.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.common;
+
+import com.google.gson.Gson;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.integrationtests.common.provisioning.ProvisioningHelper;
+import org.apache.fineract.integrationtests.common.provisioning.ProvisioningTransactionHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@code DELETE /provisioningcategory/{id}} — see FINERACT-2653. The endpoint was broken in several ways
+ * (create-validation run on a body-less DELETE, a transient entity with a null id, and an in-use check querying a
+ * non-existent table); these tests exercise both the success and the in-use-rejected paths end to end.
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class ProvisioningCategoryDeleteIntegrationTest {
+
+    private RequestSpecification requestSpec;
+    private ResponseSpecification responseSpec;
+    private AccountHelper accountHelper;
+    private LoanTransactionHelper loanTransactionHelper;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.requestSpec.header("Fineract-Platform-TenantId", "default");
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+    }
+
+    @Test
+    public void testDeleteUnusedProvisioningCategorySucceeds() {
+        final ProvisioningTransactionHelper transactionHelper = new ProvisioningTransactionHelper(requestSpec, responseSpec);
+
+        final String categoryName = Utils.randomStringGenerator("PROV_CAT_", 6);
+        final Integer categoryId = transactionHelper.createProvisioningCategory("{\"categoryname\":\"" + categoryName + "\"}");
+        Assertions.assertNotNull(categoryId);
+
+        // An unused category must delete cleanly. Regression guard: the in-use check previously queried a
+        // non-existent table (m_loanproduct_provisioning_details) and failed on every database.
+        final Integer deletedId = transactionHelper.deleteProvisioningCategory(categoryId);
+        Assertions.assertEquals(categoryId, deletedId);
+
+        final ArrayList categories = transactionHelper.retrieveAllProvisioningCategories();
+        for (Object category : categories) {
+            Assertions.assertNotEquals(categoryId, ((Map) category).get("id"));
+        }
+    }
+
+    @Test
+    public void testDeleteProvisioningCategoryInUseIsRejected() {
+        final ProvisioningTransactionHelper transactionHelper = new ProvisioningTransactionHelper(requestSpec, responseSpec);
+
+        // A brand-new category, referenced from a criteria below — so the test never touches the seed categories.
+        final String categoryName = Utils.randomStringGenerator("PROV_CAT_", 6);
+        final Integer categoryId = transactionHelper.createProvisioningCategory("{\"categoryname\":\"" + categoryName + "\"}");
+        Assertions.assertNotNull(categoryId);
+
+        final Integer loanProductId = createLoanProduct();
+        Assertions.assertNotNull(loanProductId);
+        final ArrayList<Integer> loanProducts = new ArrayList<>();
+        loanProducts.add(loanProductId);
+        final Account liability = accountHelper.createLiabilityAccount();
+        final Account expense = accountHelper.createExpenseAccount();
+
+        // Reference only the fresh category under test, so the criteria is valid regardless of any pre-existing
+        // provisioning data on the tenant (and so the test stays isolated from the seed categories).
+        final ArrayList allCategories = transactionHelper.retrieveAllProvisioningCategories();
+        final ArrayList categoriesUnderTest = new ArrayList();
+        for (Object category : allCategories) {
+            if (categoryId.equals(((Map) category).get("id"))) {
+                categoriesUnderTest.add(category);
+            }
+        }
+        final Map requestCriteria = ProvisioningHelper.createProvisioingCriteriaJson(loanProducts, categoriesUnderTest, liability, expense);
+        final Integer criteriaId = transactionHelper.createProvisioningCriteria(new Gson().toJson(requestCriteria));
+        Assertions.assertNotNull(criteriaId);
+
+        // Delete must be rejected with the domain-rule violation (HTTP 403), NOT a SQL/table error.
+        final ResponseSpecification errorSpec = new ResponseSpecBuilder().expectStatusCode(403).build();
+        final ArrayList<HashMap> error = (ArrayList<HashMap>) transactionHelper.deleteProvisioningCategoryExpectingError(errorSpec,
+                categoryId);
+        Assertions.assertEquals("error.msg.provisioningcategory.cannot.be.deleted.it.is.already.used.in.loanproduct",
+                error.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE));
+
+        // Once the referencing criteria is removed, the category can be deleted.
+        transactionHelper.deleteProvisioningCriteria(criteriaId);
+        final Integer deletedId = transactionHelper.deleteProvisioningCategory(categoryId);
+        Assertions.assertEquals(categoryId, deletedId);
+    }
+
+    private Integer createLoanProduct() {
+        final String loanProductJSON = new LoanProductTestBuilder() //
+                .withPrincipal("100000.00") //
+                .withNumberOfRepayments("4") //
+                .withRepaymentAfterEvery("1") //
+                .withRepaymentTypeAsMonth() //
+                .withinterestRatePerPeriod("1") //
+                .withInterestRateFrequencyTypeAsMonths() //
+                .withAmortizationTypeAsEqualInstallments() //
+                .withInterestTypeAsDecliningBalance() //
+                .withTranches(false) //
+                .withAccountingRuleAsNone() //
+                .build(null);
+        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/provisioning/ProvisioningTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/provisioning/ProvisioningTransactionHelper.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import org.apache.fineract.client.models.PageProvisioningEntryData;
 import org.apache.fineract.client.util.Calls;
+import org.apache.fineract.integrationtests.common.CommonConstants;
 import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 
@@ -53,6 +54,21 @@ public class ProvisioningTransactionHelper {
     @Deprecated(forRemoval = true)
     public ArrayList retrieveAllProvisioningCategories() {
         return Utils.performServerGet(requestSpec, responseSpec, PROVISIONING_CATEGORY_URL, "");
+    }
+
+    public Integer createProvisioningCategory(final String provisioningCategoryJson) {
+        return Utils.performServerPost(this.requestSpec, this.responseSpec, PROVISIONING_CATEGORY_URL, provisioningCategoryJson,
+                "resourceId");
+    }
+
+    public Integer deleteProvisioningCategory(final Integer categoryId) {
+        final String url = "/fineract-provider/api/v1/provisioningcategory/" + categoryId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerDelete(this.requestSpec, this.responseSpec, url, "resourceId");
+    }
+
+    public Object deleteProvisioningCategoryExpectingError(final ResponseSpecification errorResponseSpec, final Integer categoryId) {
+        final String url = "/fineract-provider/api/v1/provisioningcategory/" + categoryId + "?" + Utils.TENANT_IDENTIFIER;
+        return Utils.performServerDelete(this.requestSpec, errorResponseSpec, url, CommonConstants.RESPONSE_ERROR);
     }
 
     // TODO: Rewrite to use fineract-client instead!


### PR DESCRIPTION
Fix provisioning category delete failing with mandatory category name error

- Load the category by command.entityId() instead of running create-validation on the body-less DELETE.
- Drop ProvisioningCategory.fromJson(command), which left the @Id null so the in-use check and repository.delete() targeted a transient entity and never removed the row.
- Throw ProvisioningCategoryNotFoundException for an unknown id.
- Add ProvisioningCategoryWritePlatformServiceJpaRepositoryImplTest covering delete-success, not-found, and in-use-cannot-delete, asserting create-validation is never invoked on delete.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
