### PR TITLE
FINERACT-2650: Client search API: sanitise orderBy, sortOrder inputs

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -42,6 +42,8 @@ import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
 import org.apache.fineract.infrastructure.core.service.SearchParameters;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.security.exception.InputValidationException;
+import org.apache.fineract.infrastructure.security.service.InputValidator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.portfolio.client.data.ClientCollateralManagementData;
@@ -84,6 +86,7 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
     private final ClientCollateralManagementRepositoryWrapper clientCollateralManagementRepositoryWrapper;
     private final ClientRepositoryWrapper clientRepositoryWrapper;
     private final ClientMapper clientMapper;
+    private final InputValidator inputValidator;
 
     @Override
     public Page<ClientData> retrieveAll(final SearchParameters searchParameters) {
@@ -120,11 +123,15 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
             }
 
             if (searchParameters.hasOrderBy()) {
-                sqlBuilder.append(" order by ").append(searchParameters.getOrderBy());
-                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getOrderBy());
+                String orderBy = searchParameters.getOrderBy();
+                this.inputValidator.validate("client-order-by", orderBy);
+                sqlBuilder.append(" order by ").append(orderBy);
                 if (searchParameters.hasSortOrder()) {
-                    sqlBuilder.append(' ').append(searchParameters.getSortOrder());
-                    this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getSortOrder());
+                    String sortOrder = searchParameters.getSortOrder();
+                    if (!"ASC".equalsIgnoreCase(sortOrder) && !"DESC".equalsIgnoreCase(sortOrder)) {
+                        throw new InputValidationException(String.format("invalid sortOrder value '%s'", sortOrder));
+                    }
+                    sqlBuilder.append(' ').append(sortOrder);
                 }
             }
 

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -340,6 +340,12 @@ fineract.input-validation.patterns[0].pattern=^-?\\d+(\\.\\d+)?$
 fineract.input-validation.patterns[1].name=date-literal
 fineract.input-validation.patterns[1].pattern=^\\d{4}-\\d{2}-\\d{2}$
 
+fineract.input-validation.patterns[2].name=client-order-by-strict
+fineract.input-validation.patterns[2].pattern=^(id|(display|office)Name|accountNo|officeId)$
+
+fineract.input-validation.patterns[3].name=client-order-by-generic
+fineract.input-validation.patterns[3].pattern=^([a-z]\.)?[a-z][A-Za-z0-9_]*$
+
 # input validation - profiles
 fineract.input-validation.profiles[0].name=number
 fineract.input-validation.profiles[0].description=Numeric Parameter Validation Profile
@@ -352,6 +358,12 @@ fineract.input-validation.profiles[1].description=Date Parameter Validation Prof
 fineract.input-validation.profiles[1].patternRefs[0].name=date-literal
 fineract.input-validation.profiles[1].patternRefs[0].order=0
 fineract.input-validation.profiles[1].enabled=true
+
+fineract.input-validation.profiles[2].name=client-order-by
+fineract.input-validation.profiles[2].description=Client Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[2].patternRefs[0].name=client-order-by-strict
+fineract.input-validation.profiles[2].patternRefs[0].order=0
+fineract.input-validation.profiles[2].enabled=true
 
 #Cache - Default
 fineract.cache.default-template.ttl=1m

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -34,11 +34,13 @@ import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostOfficesRequest;
 import org.apache.fineract.client.models.PostOfficesResponse;
 import org.apache.fineract.client.models.SortOrder;
+import org.apache.fineract.client.util.Calls;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrofit2.Response;
 
 public class ClientSearchTest extends IntegrationTest {
 
@@ -337,6 +339,119 @@ public class ClientSearchTest extends IntegrationTest {
         assertThat(entityClients.getTotalFilteredRecords()).isEqualTo(2);
         assertThat(entityClients.getPageItems().get(0).getId()).isEqualTo(entityClientResponse.getClientId());
         assertThat(entityClients.getPageItems().get(1).getId()).isEqualTo(secondEntityClientResponse.getClientId());
+    }
+
+    // ------------------------------------------------------------------
+    // orderBy / sortOrder input validation (CVE fix coverage)
+    //
+    // These exercise GET /api/v1/clients (ClientsApiResource#retrieveAll)
+    // directly via the generated retrieveAllClients(...) call, since that
+    // is the endpoint targeted by the security report
+    //
+    // retrieveAllClients param order (from ClientApi.java):
+    // officeId, externalId, displayName, firstName, lastName, status,
+    // underHierarchy, offset, limit, orderBy, sortOrder, orphansOnly,
+    // legalForm, staffId
+    // ------------------------------------------------------------------
+
+    private Response<GetClientsResponse> callRetrieveAllClients(String orderBy, String sortOrder) {
+        return Calls.executeU(fineractClient().clients.retrieveAllClients(null, null, null, null, null, null, null, null, null, orderBy,
+                sortOrder, null, null, null));
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsSqlInjectionPoc() {
+        // given
+        String maliciousOrderBy = "c.office_id, (CASE WHEN (ASCII(SUBSTRING((SELECT table_name FROM "
+                + "information_schema.tables WHERE table_schema REGEXP database() LIMIT 0,1),1,1)) - 109) "
+                + "THEN c.id ELSE (c.id*-1) END)";
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients(maliciousOrderBy, null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsSubstringBypassAttempt() {
+        // given - "officeId" appears as a substring; confirms regex anchors hold
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("officeId, (CASE WHEN (1=1) THEN 1 END)", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsCaseMismatch() {
+        // given - documented value is "displayName", not "DisplayName" or "DISPLAYNAME"
+        // when
+        Response<GetClientsResponse> response1 = callRetrieveAllClients("DisplayName", null);
+        Response<GetClientsResponse> response2 = callRetrieveAllClients("DISPLAYNAME", null);
+        // then
+        assertThat(response1.isSuccessful()).isFalse();
+        assertThat(response2.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsSnakeCaseColumnName() {
+        // given - undocumented internal SQL column form should no longer be accepted directly
+        // when
+        Response<GetClientsResponse> response1 = callRetrieveAllClients("c.display_name", null);
+        // then
+        assertThat(response1.isSuccessful()).isFalse(); // for generic validation this should be isTrue()
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsCommaSeparatedList() {
+        // given - multi-column orderBy is out of scope for this allowlist
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("displayName,accountNo", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsEmptyAndWhitespace() {
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("   ", null);
+        // then
+        assertThat(response.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void testClientSearchOrderByRejectsSqlKeyword() {
+        // given - sanity check against trivial payloads, not just the sophisticated PoC
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("id; DROP TABLE m_client", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchSortOrderRejectsArbitraryValue() {
+        // given - direction value outside ASC/DESC should be rejected
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("displayName", "RANDOM");
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchSortOrderRejectsInjectionAttempt() {
+        // when
+        Response<GetClientsResponse> response = callRetrieveAllClients("displayName", "ASC; DROP TABLE m_client--");
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testClientSearchOrderByAcceptsAllDocumentedValues() {
+        // given - the 4 documented allowlist values from the API docs
+        for (String validOrderBy : new String[] { "displayName", "accountNo", "officeId", "officeName" }) {
+            // when
+            Response<GetClientsResponse> response = callRetrieveAllClients(validOrderBy, "ASC");
+            // then
+            assertThat(response.isSuccessful()).isTrue();
+        }
     }
 
 }


### PR DESCRIPTION
## Description

This sanitises orderBy, sortOrder inputs to client search API. Configurable pattern in application.properties default setting to strict. Only allows documented values for sortOrder: id, officeName, displayName, officeId, accountNo. Setting can be set to generic allowing e.g c.id or c.display_name as sort column.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
