### PR TITLE
FINERACT-2656: Fix NPE disbursing a loan with an account-transfer charge and no linked savings account

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
@@ -38,6 +38,7 @@ import org.apache.fineract.portfolio.loanaccount.data.LoanInstallmentChargeData;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeReadPlatformService;
+import org.apache.fineract.portfolio.loanproduct.exception.LinkedAccountRequiredException;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
@@ -69,6 +70,13 @@ public class TransferFeeChargeForLoansTasklet implements Tasklet {
                                 portfolioAccountData = accountAssociationsReadPlatformService
                                         .retriveLoanLinkedAssociation(chargeData.getLoanId());
                             }
+                            if (portfolioAccountData == null) {
+                                errors.add(new LinkedAccountRequiredException("loan.transfer.fee.charge",
+                                        "Loan with id:" + chargeData.getLoanId()
+                                                + " has a charge payable by account transfer but no linked savings account",
+                                        chargeData.getLoanId()));
+                                break;
+                            }
                             final boolean isExceptionForBalanceCheck = false;
                             final AccountTransferDTO accountTransferDTO = new AccountTransferDTO(DateUtils.getBusinessLocalDate(),
                                     installmentChargeData.getAmountOutstanding(), PortfolioAccountType.SAVINGS, PortfolioAccountType.LOAN,
@@ -82,6 +90,13 @@ public class TransferFeeChargeForLoansTasklet implements Tasklet {
                 } else if (chargeData.getDueDate() != null && !DateUtils.isDateInTheFuture(chargeData.getDueDate())) {
                     final PortfolioAccountData portfolioAccountData = accountAssociationsReadPlatformService
                             .retriveLoanLinkedAssociation(chargeData.getLoanId());
+                    if (portfolioAccountData == null) {
+                        errors.add(new LinkedAccountRequiredException("loan.transfer.fee.charge",
+                                "Loan with id:" + chargeData.getLoanId()
+                                        + " has a charge payable by account transfer but no linked savings account",
+                                chargeData.getLoanId()));
+                        continue;
+                    }
                     final boolean isExceptionForBalanceCheck = false;
                     final AccountTransferDTO accountTransferDTO = new AccountTransferDTO(DateUtils.getBusinessLocalDate(),
                             chargeData.getAmountOutstanding(), PortfolioAccountType.SAVINGS, PortfolioAccountType.LOAN,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -433,6 +433,10 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
                 if (isAccountTransfer && loan.shouldCreateStandingInstructionAtDisbursement()) {
                     final PortfolioAccountData linkedSavingsAccountData = this.accountAssociationsReadPlatformService
                             .retriveLoanLinkedAssociation(loanId);
+                    if (linkedSavingsAccountData == null) {
+                        throw new LinkedAccountRequiredException("loan.disburse.downpayment",
+                                "Loan with id:" + loanId + " requires a linked savings account for the down payment transfer", loanId);
+                    }
                     final SavingsAccount fromSavingsAccount = null;
                     final boolean isRegularTransaction = true;
                     final boolean isExceptionForBalanceCheck = false;
@@ -483,6 +487,10 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
 
         for (final Map.Entry<Long, BigDecimal> entrySet : disBuLoanCharges.entrySet()) {
             final PortfolioAccountData savingAccountData = this.accountAssociationsReadPlatformService.retriveLoanLinkedAssociation(loanId);
+            if (savingAccountData == null) {
+                throw new LinkedAccountRequiredException("loan.disburse.charge",
+                        "Loan with id:" + loanId + " has a charge payable by account transfer but no linked savings account", loanId);
+            }
             final SavingsAccount fromSavingsAccount = null;
             final boolean isRegularTransaction = true;
             final boolean isExceptionForBalanceCheck = false;
@@ -830,6 +838,11 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
             for (final Map.Entry<Long, BigDecimal> entrySet : disBuLoanCharges.entrySet()) {
                 final PortfolioAccountData savingAccountData = this.accountAssociationsReadPlatformService
                         .retriveLoanLinkedAssociation(loan.getId());
+                if (savingAccountData == null) {
+                    throw new LinkedAccountRequiredException("loan.disburse.charge",
+                            "Loan with id:" + loan.getId() + " has a charge payable by account transfer but no linked savings account",
+                            loan.getId());
+                }
                 final SavingsAccount fromSavingsAccount = null;
                 final boolean isRegularTransaction = true;
                 final boolean isExceptionForBalanceCheck = false;

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImplTest.java
@@ -72,6 +72,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepositor
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanTransactionValidator;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
+import org.apache.fineract.portfolio.loanproduct.exception.LinkedAccountRequiredException;
 import org.apache.fineract.portfolio.paymentdetail.service.PaymentDetailWritePlatformService;
 import org.apache.fineract.useradministration.domain.AppUser;
 import org.junit.jupiter.api.BeforeEach;
@@ -394,6 +395,89 @@ public class LoanWritePlatformServiceJpaRepositoryImplTest {
         // ASSERT: The private disburseLoan() calls updateLoanSummaryDerivedFields once.
         // Our fix adds a second call after the account-transfer charge loop.
         verify(loanBalanceService, times(2)).updateLoanSummaryDerivedFields(loan);
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    public void disburseLoan_withAccountTransferDisbursementChargeButNoLinkedAccount_shouldThrowLinkedAccountRequired() {
+        setupMoneyHelper();
+
+        final LocalDate disbursementDate = DateUtils.parseLocalDate("2025-05-20");
+        final MonetaryCurrency currency = new MonetaryCurrency("KES", 2, null);
+
+        // Setup loan product
+        LoanProductRelatedDetail loanProductDetail = mock(LoanProductRelatedDetail.class);
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loanProduct.getLoanProductRelatedDetail()).thenReturn(loanProductDetail);
+        when(loanProduct.isMultiDisburseLoan()).thenReturn(false);
+        when(loanProduct.isDisallowExpectedDisbursements()).thenReturn(false);
+        when(loanProduct.getId()).thenReturn(1L);
+        when(loanProduct.isIncludeInBorrowerCycle()).thenReturn(false);
+
+        // A disbursement charge payable by ACCOUNT_TRANSFER — requires a linked savings account.
+        LoanCharge disbursementCharge = mock(LoanCharge.class);
+        when(disbursementCharge.isDueAtDisbursement()).thenReturn(true);
+        when(disbursementCharge.getChargePaymentMode()).thenReturn(ChargePaymentMode.ACCOUNT_TRANSFER);
+        when(disbursementCharge.isChargePending()).thenReturn(true);
+        when(disbursementCharge.amountOutstanding()).thenReturn(BigDecimal.valueOf(500));
+        when(disbursementCharge.getId()).thenReturn(100L);
+        when(disbursementCharge.isActive()).thenReturn(true);
+
+        // Setup repayment schedule installment
+        LoanRepaymentScheduleInstallment installment = mock(LoanRepaymentScheduleInstallment.class);
+        when(installment.getDueDate()).thenReturn(disbursementDate.plusMonths(1));
+
+        // Setup summary
+        LoanSummary summary = mock(LoanSummary.class);
+        when(summary.getTotalInterestCharged()).thenReturn(BigDecimal.ZERO);
+
+        // Setup loan as mock for full control over method return values
+        loan = mock(Loan.class);
+        when(loan.getId()).thenReturn(LOAN_ID);
+        when(loan.loanProduct()).thenReturn(loanProduct);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loan.getLoanProductRelatedDetail()).thenReturn(loanProductDetail);
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(loanProductDetail);
+        when(loan.getActiveCharges()).thenReturn(Set.of(disbursementCharge));
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(installment));
+        when(loan.fetchRepaymentScheduleInstallment(1)).thenReturn(installment);
+        when(loan.isGroupLoan()).thenReturn(false);
+        when(loan.getClientId()).thenReturn(1L);
+        when(loan.getStatus()).thenReturn(LoanStatus.APPROVED);
+        when(loan.getLoanStatus()).thenReturn(LoanStatus.ACTIVE);
+        when(loan.isMultiDisburmentLoan()).thenReturn(false);
+        when(loan.isTopup()).thenReturn(false);
+        when(loan.getPrincipal()).thenReturn(Money.of(currency, BigDecimal.valueOf(20000)));
+        when(loan.getCurrency()).thenReturn(currency);
+        when(loan.getSummary()).thenReturn(summary);
+        when(loan.getNextPossibleRepaymentDateForRescheduling()).thenReturn(disbursementDate.plusMonths(1));
+        when(loan.deriveSumTotalOfChargesDueAtDisbursement()).thenReturn(BigDecimal.valueOf(500));
+        when(loan.shouldCreateStandingInstructionAtDisbursement()).thenReturn(false);
+        when(loan.getIsFloatingInterestRate()).thenReturn(false);
+        when(loan.getExternalId()).thenReturn(ExternalId.empty());
+
+        // Setup command
+        command = mock(JsonCommand.class);
+        when(command.localDateValueOfParameterNamed("actualDisbursementDate")).thenReturn(disbursementDate);
+        when(command.extractLocale()).thenReturn(Locale.ENGLISH);
+        when(command.dateFormat()).thenReturn("dd MMMM yyyy");
+
+        // Setup service mocks
+        when(loanAssembler.assembleFrom(LOAN_ID)).thenReturn(loan);
+        when(loanLifecycleStateMachine.dryTransition(any(), any())).thenReturn(LoanStatus.ACTIVE);
+        when(loanDisbursementService.adjustDisburseAmount(any(), any(), any())).thenReturn(Money.of(currency, BigDecimal.valueOf(20000)));
+        when(externalIdFactory.createFromCommand(any(), any())).thenReturn(ExternalId.empty());
+
+        // The loan has NO linked savings account — this is the bug scenario that used to NPE.
+        when(accountAssociationsReadPlatformService.retriveLoanLinkedAssociation(LOAN_ID)).thenReturn(null);
+        when(loanRepositoryWrapper.getClientOrJLGLoansDisbursedAfter(any(), anyLong())).thenReturn(List.of());
+        when(loanRepositoryWrapper.saveAndFlush(any(Loan.class))).thenReturn(loan);
+
+        // ACT + ASSERT: a clean domain-rule exception instead of a NullPointerException.
+        assertThrows(LinkedAccountRequiredException.class, () -> loanWritePlatformService.disburseLoan(LOAN_ID, command, true, false));
+
+        // No funds transfer is attempted when the linked account is missing.
+        verify(accountTransfersWritePlatformService, times(0)).transferFunds(any());
     }
 
     @Test


### PR DESCRIPTION

## Description

- Guard retriveLoanLinkedAssociation(...) for null in disburseLoan's account-transfer
  disbursement-charge loop, the down-payment auto-transfer block, and bulkLoanDisbursal's
  charge loop, throwing LinkedAccountRequiredException (as the disburse-to-savings path
  already does) instead of NullPointerException / HTTP 500.
- Guard both TransferFeeChargeForLoansTasklet call sites so the scheduled job records the
  error and skips the misconfigured loan instead of aborting the batch.
- Add LoanWritePlatformServiceJpaRepositoryImplTest coverage asserting the exception is
  raised and no account transfer is attempted when the loan has no linked savings account.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
