### PR TITLE
FINERACT-2657: Fix NPE updating a provisioning criteria by matching definitions on categoryId

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteria.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteria.java
@@ -31,11 +31,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.AbstractAuditableCustom;
 import org.apache.fineract.organisation.provisioning.constants.ProvisioningCriteriaConstants;
-import org.apache.fineract.organisation.provisioning.data.ProvisioningCriteriaDefinitionData;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.useradministration.domain.AppUser;
 
@@ -114,12 +114,19 @@ public class ProvisioningCriteria extends AbstractAuditableCustom {
         return actualChanges;
     }
 
-    public void update(ProvisioningCriteriaDefinitionData data, GLAccount liability, GLAccount expense) {
-        for (ProvisioningCriteriaDefinition def : provisioningCriteriaDefinition) {
-            if (data.getId().equals(def.getId())) {
-                def.update(data.getMinAge(), data.getMaxAge(), data.getProvisioningPercentage(), liability, expense);
-                break;
-            }
-        }
+    /**
+     * Index the existing definitions by their natural key, {@code categoryId}, for direct lookup during an update.
+     * <p>
+     * The public UPDATE payload keys each definition by {@code categoryId} (one definition per provisioning category),
+     * not by the surrogate {@code id}, which it never carries — matching on the always-null surrogate id is what threw
+     * a {@link NullPointerException} (HTTP 500) on every update. Callers resolve the definition to mutate with a single
+     * {@code get(categoryId)} instead of rescanning the whole set per incoming definition.
+     */
+    public Map<Long, ProvisioningCriteriaDefinition> getDefinitionsByCategoryId() {
+        // (criteria_id, category_id) is not DB-unique, so a criteria could in principle hold two definitions for the
+        // same category. Keep the first (the prior linear scan also matched the first and returned) rather than letting
+        // Collectors.toMap throw IllegalStateException on a duplicate key — an update must not 500 on this edge case.
+        return provisioningCriteriaDefinition.stream().collect(
+                Collectors.toMap(ProvisioningCriteriaDefinition::getCategoryId, Function.identity(), (existing, duplicate) -> existing));
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaDefinition.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaDefinition.java
@@ -79,6 +79,10 @@ public class ProvisioningCriteriaDefinition extends AbstractPersistableCustom<Lo
                 liabilityAccount, expenseAccount);
     }
 
+    public Long getCategoryId() {
+        return this.provisioningCategory == null ? null : this.provisioningCategory.getId();
+    }
+
     public void update(Long minAge, Long maxAge, BigDecimal percentage, GLAccount lia, GLAccount exp) {
         this.minimumAge = minAge;
         this.maximumAge = maxAge;

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl.java
@@ -33,14 +33,16 @@ import org.apache.fineract.accounting.glaccount.domain.GLAccount;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountRepository;
 import org.apache.fineract.accounting.provisioning.service.ProvisioningEntriesReadPlatformService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.organisation.provisioning.constants.ProvisioningCriteriaConstants;
-import org.apache.fineract.organisation.provisioning.data.ProvisioningCriteriaDefinitionData;
 import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteria;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteriaDefinition;
 import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteriaRepository;
 import org.apache.fineract.organisation.provisioning.exception.ProvisioningCategoryNotFoundException;
 import org.apache.fineract.organisation.provisioning.exception.ProvisioningCriteriaCannotBeDeletedException;
@@ -125,9 +127,11 @@ public class ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl implement
         final Locale locale = this.fromApiJsonHelper.extractLocaleParameter(command.parsedJson().getAsJsonObject());
         JsonArray jsonProvisioningCriteria = this.fromApiJsonHelper
                 .extractJsonArrayNamed(ProvisioningCriteriaConstants.JSON_PROVISIONING_DEFINITIONS_PARAM, command.parsedJson());
+        // Index the existing definitions by their natural key (categoryId) once, then resolve each incoming definition
+        // with a direct lookup. The payload carries no per-definition surrogate id to match on.
+        final Map<Long, ProvisioningCriteriaDefinition> existingByCategoryId = provisioningCriteria.getDefinitionsByCategoryId();
         for (JsonElement element : jsonProvisioningCriteria) {
             JsonObject jsonObject = element.getAsJsonObject();
-            Long id = this.fromApiJsonHelper.extractLongNamed("id", jsonObject);
             Long categoryId = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_CATEOGRYID_PARAM, jsonObject);
             Long minimumAge = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_MINIMUM_AGE_PARAM, jsonObject);
             Long maximumAge = this.fromApiJsonHelper.extractLongNamed(ProvisioningCriteriaConstants.JSON_MAXIMUM_AGE_PARAM, jsonObject);
@@ -139,16 +143,15 @@ public class ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl implement
                     jsonObject);
             GLAccount liabilityAccount = glAccountRepository.findById(liabilityAccountId).orElse(null);
             GLAccount expenseAccount = glAccountRepository.findById(expenseAccountId).orElse(null);
-            String categoryName = null;
-            String liabilityAccountName = null;
-            String expenseAccountName = null;
-            ProvisioningCriteriaDefinitionData data = new ProvisioningCriteriaDefinitionData().setId(id).setCategoryId(categoryId)
-                    .setCategoryName(categoryName).setMinAge(minimumAge).setMaxAge(maximumAge)
-                    .setProvisioningPercentage(provisioningpercentage).setLiabilityAccount(liabilityAccount.getId())
-                    .setLiabilityCode(liabilityAccount.getGlCode()).setLiabilityName(liabilityAccountName)
-                    .setExpenseAccount(expenseAccount.getId()).setExpenseCode(expenseAccount.getGlCode())
-                    .setExpenseName(expenseAccountName);
-            provisioningCriteria.update(data, liabilityAccount, expenseAccount);
+
+            final ProvisioningCriteriaDefinition definition = existingByCategoryId.get(categoryId);
+            if (definition == null) {
+                throw new PlatformApiDataValidationException(
+                        List.of(ApiParameterError.parameterError("error.msg.provisioningcriteria.definition.category.not.found",
+                                "Provisioning criteria has no definition for the given category",
+                                ProvisioningCriteriaConstants.JSON_CATEOGRYID_PARAM, categoryId)));
+            }
+            definition.update(minimumAge, maximumAge, provisioningpercentage, liabilityAccount, expenseAccount);
         }
     }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/domain/ProvisioningCriteriaTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.provisioning.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for {@link ProvisioningCriteria#getDefinitionsByCategoryId()}.
+ *
+ * <p>
+ * The public UPDATE payload keys each definition only by {@code categoryId}; it never carries the surrogate {@code id}.
+ * The update path used to match definitions by {@code data.getId().equals(def.getId())}, so {@code data.getId()} was
+ * null and every update threw a {@link NullPointerException} (HTTP 500). The criteria now exposes its definitions
+ * indexed by {@code categoryId}, so the service resolves the definition to mutate with a single direct lookup (and
+ * turns a missing key into a clean validation error) instead of rescanning the set per incoming definition.
+ */
+class ProvisioningCriteriaTest {
+
+    @Test
+    void definitionsAreIndexedByCategoryIdForDirectLookup() {
+        final ProvisioningCriteriaDefinition first = mock(ProvisioningCriteriaDefinition.class);
+        when(first.getCategoryId()).thenReturn(2L);
+        final ProvisioningCriteriaDefinition second = mock(ProvisioningCriteriaDefinition.class);
+        when(second.getCategoryId()).thenReturn(5L);
+
+        final ProvisioningCriteria criteria = new ProvisioningCriteria();
+        criteria.setProvisioningCriteriaDefinitions(Set.of(first, second));
+
+        final Map<Long, ProvisioningCriteriaDefinition> byCategoryId = criteria.getDefinitionsByCategoryId();
+
+        assertThat(byCategoryId).containsOnlyKeys(2L, 5L);
+        assertThat(byCategoryId.get(2L)).isSameAs(first);
+        assertThat(byCategoryId.get(5L)).isSameAs(second);
+        // An unknown categoryId yields no match — the service translates this into a 400 validation error rather than
+        // dereferencing a null surrogate id.
+        assertThat(byCategoryId.get(99L)).isNull();
+    }
+
+    @Test
+    void getDefinitionsByCategoryId_withNoDefinitions_returnsEmptyMap() {
+        final ProvisioningCriteria criteria = new ProvisioningCriteria();
+        criteria.setProvisioningCriteriaDefinitions(Set.of());
+
+        assertThat(criteria.getDefinitionsByCategoryId()).isEmpty();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/organisation/provisioning/service/ProvisioningCriteriaWritePlatformServiceJpaRepositoryImplTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.provisioning.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepository;
+import org.apache.fineract.accounting.provisioning.service.ProvisioningEntriesReadPlatformService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteria;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteriaDefinition;
+import org.apache.fineract.organisation.provisioning.domain.ProvisioningCriteriaRepository;
+import org.apache.fineract.organisation.provisioning.serialization.ProvisioningCriteriaDefinitionJsonDeserializer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the update path that FINERACT-2657 fixes:
+ * {@link ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl#updateProvisioningCriteria(Long, JsonCommand)}.
+ *
+ * <p>
+ * The public UPDATE payload keys each definition only by {@code categoryId}; it never carries the surrogate {@code id}.
+ * The service used to match definitions by that always-null surrogate id, so every update threw a
+ * {@link NullPointerException} (HTTP 500). It now resolves the definition to mutate by a direct {@code categoryId}
+ * lookup and rejects an unknown category with a clean {@link PlatformApiDataValidationException} (HTTP 400).
+ */
+class ProvisioningCriteriaWritePlatformServiceJpaRepositoryImplTest {
+
+    private static final long CRITERIA_ID = 1L;
+
+    private final ProvisioningCriteriaDefinitionJsonDeserializer deserializer = mock(ProvisioningCriteriaDefinitionJsonDeserializer.class);
+    private final ProvisioningCriteriaAssembler assembler = mock(ProvisioningCriteriaAssembler.class);
+    private final ProvisioningCriteriaRepository criteriaRepository = mock(ProvisioningCriteriaRepository.class);
+    private final GLAccountRepository glAccountRepository = mock(GLAccountRepository.class);
+    private final ProvisioningEntriesReadPlatformService entriesReadService = mock(ProvisioningEntriesReadPlatformService.class);
+
+    private final ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl service = new ProvisioningCriteriaWritePlatformServiceJpaRepositoryImpl(
+            deserializer, assembler, criteriaRepository, new FromJsonHelper(), glAccountRepository, entriesReadService);
+
+    @Test
+    void update_appliesChangesToDefinitionMatchedByCategoryId() {
+        final ProvisioningCriteriaDefinition definition = mock(ProvisioningCriteriaDefinition.class);
+        stubCriteriaWith(definition);
+
+        service.updateProvisioningCriteria(CRITERIA_ID, command("""
+                { "locale": "en", "criteriaName": "Standard", "loanProducts": [],
+                  "definitions": [ { "categoryId": 7, "minAge": 0, "maxAge": 30, "provisioningPercentage": 1.5,
+                                     "liabilityAccount": 5, "expenseAccount": 12 } ] }
+                """));
+
+        // The definition keyed by categoryId 7 is mutated with the new ages — never an NPE.
+        verify(definition, times(1)).update(eq(0L), eq(30L), any(), any(), any());
+    }
+
+    @Test
+    void update_withUnknownCategoryId_throwsValidationExceptionNotNpe() {
+        final ProvisioningCriteriaDefinition definition = mock(ProvisioningCriteriaDefinition.class);
+        stubCriteriaWith(definition);
+
+        // categoryId 99 has no definition on the criteria, and the payload carries no surrogate id (the real shape).
+        final JsonCommand command = command("""
+                { "locale": "en", "criteriaName": "Standard", "loanProducts": [],
+                  "definitions": [ { "categoryId": 99, "minAge": 0, "maxAge": 30, "provisioningPercentage": 1.5,
+                                     "liabilityAccount": 5, "expenseAccount": 12 } ] }
+                """);
+
+        assertThrows(PlatformApiDataValidationException.class, () -> service.updateProvisioningCriteria(CRITERIA_ID, command));
+        verify(definition, never()).update(any(), any(), any(), any(), any());
+    }
+
+    private void stubCriteriaWith(final ProvisioningCriteriaDefinition definition) {
+        final ProvisioningCriteria criteria = mock(ProvisioningCriteria.class);
+        // Non-empty changes so the service proceeds to apply the definition edits (the changes gate).
+        when(criteria.update(any(), any())).thenReturn(Map.of("loanProducts", "changed"));
+        // The criteria exposes its definitions indexed by categoryId; the service looks up directly into this.
+        when(criteria.getDefinitionsByCategoryId()).thenReturn(Map.of(7L, definition));
+        when(criteriaRepository.findById(CRITERIA_ID)).thenReturn(Optional.of(criteria));
+        when(assembler.parseLoanProducts(any())).thenReturn(List.of());
+        when(glAccountRepository.findById(anyLong())).thenReturn(Optional.of(mock(GLAccount.class)));
+    }
+
+    private JsonCommand command(final String json) {
+        final FromJsonHelper fromJsonHelper = new FromJsonHelper();
+        return new JsonCommand(1L, fromJsonHelper.parse(json), fromJsonHelper);
+    }
+}


### PR DESCRIPTION
## Description

- ProvisioningCriteria.update matched incoming definitions by the surrogate id, but the public UPDATE
  payload keys each definition only by categoryId, so data.getId() was null and update() threw a
  NullPointerException (HTTP 500) on every provisioning-criteria update.
- Match the existing definition by categoryId (its natural key, unique per criteria) and reject an
  unknown categoryId with a clean validation error instead of the NPE; add a getCategoryId() accessor
  on ProvisioningCriteriaDefinition.
- Add ProvisioningCriteriaTest covering the match-by-categoryId update path and the unknown-category
  validation path.
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
