### PR TITLE
FINERACT-2421: Uniform swagger datatype for fetching datatable via API

### DIFF
--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/support/ApiResponseDecoder.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/support/ApiResponseDecoder.java
@@ -21,8 +21,10 @@ package org.apache.fineract.client.feign.support;
 import feign.Response;
 import feign.codec.Decoder;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import org.apache.fineract.client.models.ApiResponse;
 
 /**
@@ -37,9 +39,12 @@ import org.apache.fineract.client.models.ApiResponse;
  * This decoder:
  * <ol>
  * <li>Detects if the return type is ApiResponse&lt;T&gt;</li>
- * <li>Extracts the inner type T and delegates body decoding to the underlying decoder</li>
+ * <li>Extracts the inner type T and decodes it</li>
  * <li>Wraps the decoded body with status code and headers into ApiResponse&lt;T&gt;</li>
  * </ol>
+ *
+ * Generated methods returning String represent raw response bodies in Fineract's OpenAPI output. They may contain JSON
+ * arrays or objects, so they must be read directly instead of being delegated to Jackson as JSON string literals.
  */
 public final class ApiResponseDecoder implements Decoder {
 
@@ -53,10 +58,36 @@ public final class ApiResponseDecoder implements Decoder {
     public Object decode(Response response, Type type) throws IOException {
         if (isApiResponseType(type)) {
             Type innerType = getApiResponseInnerType(type);
-            Object body = delegate.decode(response, innerType);
+            Object body = decodeBody(response, innerType);
             return new ApiResponse<>(response.status(), response.headers(), body);
         }
+        return decodeBody(response, type);
+    }
+
+    private Object decodeBody(Response response, Type type) throws IOException {
+        if (type == String.class) {
+            return decodeStringBody(response);
+        }
         return delegate.decode(response, type);
+    }
+
+    private Object decodeStringBody(Response response) throws IOException {
+        if (response.body() == null) {
+            return null;
+        }
+        String body;
+        try (InputStream inputStream = response.body().asInputStream()) {
+            body = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        if (isJsonStringLiteral(body)) {
+            return delegate.decode(response.toBuilder().body(body, StandardCharsets.UTF_8).build(), String.class);
+        }
+        return body;
+    }
+
+    private boolean isJsonStringLiteral(String body) {
+        String trimmedBody = body.trim();
+        return trimmedBody.length() >= 2 && trimmedBody.charAt(0) == '"' && trimmedBody.charAt(trimmedBody.length() - 1) == '"';
     }
 
     private boolean isApiResponseType(Type type) {

--- a/fineract-client-feign/src/test/java/org/apache/fineract/client/feign/support/ApiResponseDecoderTest.java
+++ b/fineract-client-feign/src/test/java/org/apache/fineract/client/feign/support/ApiResponseDecoderTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.client.feign.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Request;
+import feign.Response;
+import feign.jackson.JacksonDecoder;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.apache.fineract.client.feign.ObjectMapperFactory;
+import org.apache.fineract.client.models.ApiResponse;
+import org.junit.jupiter.api.Test;
+
+class ApiResponseDecoderTest {
+
+    private final ApiResponseDecoder decoder = new ApiResponseDecoder(new JacksonDecoder(ObjectMapperFactory.getShared()));
+
+    @Test
+    void decodeStringReturnsRawResponseBody() throws Exception {
+        final String body = "[{\"test_nr\":42}]";
+
+        final Object decoded = decoder.decode(response(body), String.class);
+
+        assertThat(decoded).isEqualTo(body);
+    }
+
+    @Test
+    void decodeStringReturnsDecodedJsonStringLiteral() throws Exception {
+        final Object decoded = decoder.decode(response("\"OK\""), String.class);
+
+        assertThat(decoded).isEqualTo("OK");
+    }
+
+    @Test
+    void decodeApiResponseStringReturnsRawResponseBody() throws Exception {
+        final String body = "[{\"test_nr\":42}]";
+
+        @SuppressWarnings("unchecked")
+        final ApiResponse<String> decoded = (ApiResponse<String>) decoder.decode(response(body), apiResponseStringType());
+
+        assertThat(decoded.getStatusCode()).isEqualTo(200);
+        assertThat(decoded.getData()).isEqualTo(body);
+    }
+
+    @Test
+    void decodeApiResponseStringReturnsDecodedJsonStringLiteral() throws Exception {
+        @SuppressWarnings("unchecked")
+        final ApiResponse<String> decoded = (ApiResponse<String>) decoder.decode(response("\"OK\""), apiResponseStringType());
+
+        assertThat(decoded.getStatusCode()).isEqualTo(200);
+        assertThat(decoded.getData()).isEqualTo("OK");
+    }
+
+    private Response response(final String body) {
+        final Request request = Request.create(Request.HttpMethod.GET, "/api/test", Collections.emptyMap(), null, StandardCharsets.UTF_8,
+                null);
+        return Response.builder().status(200).reason("OK").request(request).body(body, StandardCharsets.UTF_8).build();
+    }
+
+    private Type apiResponseStringType() {
+        return new ParameterizedType() {
+
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { String.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return ApiResponse.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+    }
+}

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/datatable/DatatablesStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/datatable/DatatablesStepDef.java
@@ -576,6 +576,9 @@ public class DatatablesStepDef extends AbstractStepDef {
     }
 
     private List<Map<?, ?>> toRowList(final Object response) {
+        if (response instanceof String serialized) {
+            return deserializeRowList(serialized);
+        }
         if (response instanceof List<?> list) {
             final List<Map<?, ?>> rows = new ArrayList<>();
             for (final Object item : list) {
@@ -589,6 +592,17 @@ public class DatatablesStepDef extends AbstractStepDef {
             return List.of(map);
         }
         return List.of();
+    }
+
+    private List<Map<?, ?>> deserializeRowList(final String serialized) {
+        if (serialized.isBlank()) {
+            return List.of();
+        }
+        try {
+            return toRowList(OBJECT_MAPPER.readValue(serialized, Object.class));
+        } catch (final JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize datatable row response", e);
+        }
     }
 
     private Long resolveEntityId(final DatatableEntityType entityType) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResource.java
@@ -287,7 +287,7 @@ public class DatatablesApiResource {
             datatables/extra_family_details/1?order=`Date of Birth` desc
 
             datatables/extra_client_details/1?genericResultSet=true""")
-    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Object.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class)))
     public String getDatatable(@PathParam("datatable") @Parameter(description = "datatable") final String datatable,
             @PathParam("apptableId") @Parameter(description = "apptableId") final Long apptableId,
             @QueryParam("order") @Parameter(description = "order") final String order, @Context final UriInfo uriInfo) {
@@ -315,7 +315,7 @@ public class DatatablesApiResource {
     @Operation(summary = "Retrieve Entry from Data Table (One to Many)", description = """
             Gets the entry (if it exists) for data tables that are one-to-many with the application table, by the \
             datatable entry id. Returns the stored row as a JSON object keyed by column name.""")
-    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Object.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class)))
     public String getDatatableManyEntry(@PathParam("datatable") final String datatable, @PathParam("apptableId") final Long apptableId,
             @PathParam("datatableId") final Long datatableId, @QueryParam("order") final String order,
             @DefaultValue("false") @QueryParam("genericResultSet") @Parameter(in = ParameterIn.QUERY, name = "genericResultSet", description = "Optional flag to format the response") final boolean genericResultSet,


### PR DESCRIPTION
## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
