### PR TITLE
FINERACT-2501: Add operationIds to Savings and Loans modules to harden feign method names

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
@@ -151,7 +151,7 @@ public class EventCheckHelper {
 
     public void undoApproveLoanEventCheck(PostLoansLoanIdResponse loanUndoApproveResponse) {
         waitForTransactionCommit();
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(loanUndoApproveResponse.getLoanId(),
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanUndoApproveResponse.getLoanId(),
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "", "exclude", "", "fields", "")));
 
         eventAssertion.assertEventRaised(LoanUndoApprovalEvent.class, body.getId());
@@ -159,7 +159,7 @@ public class EventCheckHelper {
 
     public void loanRejectedEventCheck(PostLoansLoanIdResponse loanRejectedResponse) {
         waitForTransactionCommit();
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(loanRejectedResponse.getLoanId(),
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanRejectedResponse.getLoanId(),
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "", "exclude", "", "fields", "")));
 
         eventAssertion.assertEventRaised(LoanRejectedEvent.class, body.getId());
@@ -181,7 +181,7 @@ public class EventCheckHelper {
     }
 
     private void loanAccountDataV1Check(Class<? extends AbstractLoanEvent> eventClazz, Long loanId) {
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
 
         eventAssertion.assertEvent(eventClazz, loanId)//
@@ -253,7 +253,7 @@ public class EventCheckHelper {
     }
 
     public GetLoansLoanIdTransactions findNthTransaction(String nthItemStr, String transactionType, String transactionDate, long loanId) {
-        GetLoansLoanIdResponse loanResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "transactions", "exclude", "", "fields", "")));
         List<GetLoansLoanIdTransactions> transactions = loanResponse.getTransactions();
         GetLoansLoanIdTransactions targetTransaction = getNthTransactionType(nthItemStr, transactionType, transactionDate, transactions);
@@ -289,7 +289,7 @@ public class EventCheckHelper {
         waitForTransactionCommit();
         Long disbursementTransactionId = loanDisburseResponse.getSubResourceId();
 
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(loanDisburseResponse.getLoanId(),
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanDisburseResponse.getLoanId(),
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "transactions", "exclude", "", "fields", "")));
         List<GetLoansLoanIdTransactions> transactions = body.getTransactions();
         GetLoansLoanIdTransactions disbursementTransaction = transactions//
@@ -424,7 +424,7 @@ public class EventCheckHelper {
             PostLoansLoanIdTransactionsResponse transactionResponse, TransactionType transactionType, String externalOwnerId) {
         Long loanId = transactionResponse.getLoanId();
         Long transactionId = transactionResponse.getResourceId();
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "transactions", "exclude", "", "fields", "")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions transactionFound = transactions//
@@ -584,7 +584,7 @@ public class EventCheckHelper {
         GlobalConfigurationPropertyData outstandingInterestStrategy = configurationHelper
                 .getGlobalConfiguration("outstanding-interest-calculation-strategy-for-external-asset-transfer");
         if ("PAYABLE_OUTSTANDING_INTEREST".equals(outstandingInterestStrategy.getStringValue())) {
-            GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+            GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                     Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
             totalOutstandingBalanceAmountExpected = zeroConversion(loanDetails.getSummary().getTotalOutstanding());
             outstandingInterestPortionExpected = zeroConversion(loanDetails.getSummary().getInterestOutstanding());
@@ -618,7 +618,7 @@ public class EventCheckHelper {
 
     public void loanAccountDelinquencyPauseChangedBusinessEventCheck(Long loanId) {
         waitForTransactionCommit();
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
         List<GetLoansLoanIdDelinquencyPausePeriod> delinquencyPausePeriodsActual = loanDetails.getDelinquent().getDelinquencyPausePeriods();
 
@@ -705,7 +705,7 @@ public class EventCheckHelper {
 
     public void createLoanEventCheck(PostLoansResponse createLoanResponse) {
         waitForTransactionCommit();
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(createLoanResponse.getLoanId(),
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(createLoanResponse.getLoanId(),
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
 
         eventAssertion.assertEvent(LoanCreatedEvent.class, createLoanResponse.getLoanId())//
@@ -720,7 +720,7 @@ public class EventCheckHelper {
 
     public void approveLoanEventCheck(PostLoansLoanIdResponse loanApproveResponse) {
         waitForTransactionCommit();
-        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveLoan(loanApproveResponse.getLoanId(),
+        GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanApproveResponse.getLoanId(),
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "", "exclude", "", "fields", "")));
 
         eventAssertion.assertEvent(LoanApprovedEvent.class, loanApproveResponse.getLoanId())//

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BatchApiStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BatchApiStepDef.java
@@ -822,7 +822,7 @@ public class BatchApiStepDef extends AbstractStepDef {
         Map<String, Object> loanQueryParams = new HashMap<>();
         loanQueryParams.put("staffInSelectedOfficeOnly", false);
         loanQueryParams.put("associations", "transactions");
-        GetLoansLoanIdResponse loanDetails = loansApi().retrieveLoan(loanId, loanQueryParams);
+        GetLoansLoanIdResponse loanDetails = loansApi().retrieveOneLoan(loanId, loanQueryParams);
 
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
         List<String> transactionsMatched = new ArrayList<>();
@@ -872,7 +872,7 @@ public class BatchApiStepDef extends AbstractStepDef {
 
         Map<String, Object> loanQueryParams = new HashMap<>();
         loanQueryParams.put("staffInSelectedOfficeOnly", false);
-        GetLoansLoanIdResponse response = loansApi().retrieveLoanByExternalId(loanExternalId, loanQueryParams);
+        GetLoansLoanIdResponse response = loansApi().retrieveOneLoanByExternalId(loanExternalId, loanQueryParams);
         assertThat(response.getId()).as(ErrorMessageHelper.idNull()).isNotNull();
     }
 
@@ -889,7 +889,7 @@ public class BatchApiStepDef extends AbstractStepDef {
 
         Map<String, Object> loanQueryParams = new HashMap<>();
         loanQueryParams.put("staffInSelectedOfficeOnly", false);
-        GetLoansLoanIdResponse response = loansApi().retrieveLoanByExternalId(loanExternalId, loanQueryParams);
+        GetLoansLoanIdResponse response = loansApi().retrieveOneLoanByExternalId(loanExternalId, loanQueryParams);
         GetLoansLoanIdStatus status = response.getStatus();
         Long statusIdActual = status.getId();
         Long statusIdExpected = LoanStatus.APPROVED.value.longValue();
@@ -955,7 +955,7 @@ public class BatchApiStepDef extends AbstractStepDef {
         // Feign throws exceptions on errors instead of returning error in response body
         ErrorResponse errorResponse = null;
         try {
-            loansApi().retrieveLoanByExternalId(loanExternalId, loanQueryParams);
+            loansApi().retrieveOneLoanByExternalId(loanExternalId, loanQueryParams);
             throw new IllegalStateException("Expected Feign exception but call succeeded");
         } catch (org.apache.fineract.client.feign.FeignException e) {
             errorResponse = fromJson(e.responseBodyAsString(), ErrorResponse.class);
@@ -1146,7 +1146,7 @@ public class BatchApiStepDef extends AbstractStepDef {
         Map<String, Object> loanQueryParams = new HashMap<>();
         loanQueryParams.put("staffInSelectedOfficeOnly", false);
         loanQueryParams.put("associations", "all");
-        GetLoansLoanIdResponse loanDetails = loansApi().retrieveLoan(loanId, loanQueryParams);
+        GetLoansLoanIdResponse loanDetails = loansApi().retrieveOneLoan(loanId, loanQueryParams);
         // Check loan has a CHARGE_OFF transaction on the specified date
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
         boolean hasChargeOffTransaction = loanDetails.getTransactions().stream().anyMatch(
@@ -1351,7 +1351,7 @@ public class BatchApiStepDef extends AbstractStepDef {
         Map<String, Object> loanQueryParams = new HashMap<>();
         loanQueryParams.put("staffInSelectedOfficeOnly", false);
         loanQueryParams.put("associations", "all");
-        GetLoansLoanIdResponse loanResponse = loansApi().retrieveLoan(loanId, loanQueryParams);
+        GetLoansLoanIdResponse loanResponse = loansApi().retrieveOneLoan(loanId, loanQueryParams);
         assertThat(loanResponse != null).isTrue();
         assertThat(loanResponse).isNotNull();
 

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/JournalEntriesStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/JournalEntriesStepDef.java
@@ -80,7 +80,7 @@ public class JournalEntriesStepDef extends AbstractStepDef {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("staffInSelectedOfficeOnly", false);
         queryParams.put("associations", "transactions");
-        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveLoan(loanId, queryParams);
+        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveOneLoan(loanId, queryParams);
         TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         String transactionTypeExpected = transactionType1.getValue();
 
@@ -190,7 +190,7 @@ public class JournalEntriesStepDef extends AbstractStepDef {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("staffInSelectedOfficeOnly", false);
         queryParams.put("associations", "transactions");
-        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveLoan(loanId, queryParams);
+        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveOneLoan(loanId, queryParams);
         TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         String transactionTypeExpected = transactionType1.getValue();
 
@@ -276,7 +276,7 @@ public class JournalEntriesStepDef extends AbstractStepDef {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("staffInSelectedOfficeOnly", false);
         queryParams.put("associations", "transactions");
-        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveLoan(loanId, queryParams);
+        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveOneLoan(loanId, queryParams);
         TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         String transactionTypeExpected = transactionType1.getValue();
 
@@ -347,7 +347,7 @@ public class JournalEntriesStepDef extends AbstractStepDef {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("staffInSelectedOfficeOnly", false);
         queryParams.put("associations", "transactions");
-        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveLoan(loanId, queryParams);
+        GetLoansLoanIdResponse loanDetailsResponse = loansApi().retrieveOneLoan(loanId, queryParams);
         TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         String transactionTypeExpected = transactionType1.getValue();
 

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanCapitalizedIncomeStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanCapitalizedIncomeStepDef.java
@@ -58,7 +58,7 @@ public class LoanCapitalizedIncomeStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "transactions")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "transactions")));
 
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions capitalizedIncomeAmortizationTransaction = transactions.stream()

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeAdjustmentStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeAdjustmentStepDef.java
@@ -75,7 +75,7 @@ public class LoanChargeAdjustmentStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "charges")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "charges")));
 
         Long transactionId = getTransactionIdForLastChargeMetConditions(chargeTypeEnum, date, loanDetailsResponse);
         makeChargeAdjustmentCall(loanId, transactionId, externalId, transactionAmount);
@@ -87,7 +87,7 @@ public class LoanChargeAdjustmentStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "charges")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "charges")));
 
         Long transactionId = getTransactionIdForLastChargeMetConditions(chargeTypeEnum, date, loanDetailsResponse);
         PostLoansLoanIdChargesChargeIdRequest chargeAdjustmentRequest = loanRequestFactory.defaultChargeAdjustmentRequest().amount(amount)
@@ -123,7 +123,7 @@ public class LoanChargeAdjustmentStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "transactions")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "transactions")));
 
         Long transactionId = getTransactionIdForTransactionMetConditions(transactionDate, transactionAmount, loanDetailsResponse);
 

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeBackStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeBackStepDef.java
@@ -83,7 +83,8 @@ public class LoanChargeBackStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "transactions")));
+        GetLoansLoanIdResponse loanDetails = ok(
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
 
         List<Long> transactionIdList = new ArrayList<>();
@@ -105,7 +106,8 @@ public class LoanChargeBackStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "transactions")));
+        GetLoansLoanIdResponse loanDetails = ok(
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
 
         List<Long> transactionIdList = new ArrayList<>();
@@ -126,7 +128,8 @@ public class LoanChargeBackStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "transactions")));
+        GetLoansLoanIdResponse loanDetails = ok(
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
 
         List<Long> transactionIdList = new ArrayList<>();
@@ -172,7 +175,7 @@ public class LoanChargeBackStepDef extends AbstractStepDef {
 
         // retrieve transaction details
         GetLoansLoanIdTransactionsTransactionIdResponse transactionResponseBody = ok(
-                () -> fineractClient.loanTransactions().retrieveTransaction(loanId, transactionId, Map.of()));
+                () -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, transactionId, Map.of()));
 
         // Get transaction type from response
         GetLoansType transactionType = transactionResponseBody.getType();

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanChargeStepDef.java
@@ -94,7 +94,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dueDate(transactionDate).amount(transactionAmount);
 
         PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_DUE_DATE_CHARGE_RESPONSE, loanChargeResponse);
         testContext().set(TestContextKey.ADD_NSF_FEE_RESPONSE, loanChargeResponse);
 
@@ -119,7 +119,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .amount(transactionPercentageAmount);
 
         PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_DUE_DATE_CHARGE_RESPONSE, loanChargeResponse);
     }
 
@@ -143,7 +143,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .chargeId(chargeTypeId).amount(amount);
 
         final PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_INSTALLMENT_FEE_CHARGE_RESPONSE, loanChargeResponse);
     }
 
@@ -160,7 +160,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .chargeId(chargeTypeId).amount(amount);
 
         try {
-            fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
+            fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
             throw new AssertionError("Expected FeignException but request succeeded");
         } catch (FeignException e) {
             final ErrorResponse errorDetails = ErrorResponse.fromFeignException(e);
@@ -185,7 +185,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dueDate(transactionDate).amount(transactionAmount);
 
         try {
-            fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
+            fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
             throw new AssertionError("Expected FeignException but request succeeded");
         } catch (FeignException e) {
             ErrorResponse errorDetails = ErrorResponse.fromFeignException(e);
@@ -205,7 +205,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dueDate(date).dateFormat(DEFAULT_DATE_FORMAT).locale(locale);
 
         PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_PROCESSING_FEE_RESPONSE, loanChargeResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
     }
@@ -220,7 +220,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dueDate(date).dateFormat(DEFAULT_DATE_FORMAT).locale(locale);
 
         PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_PROCESSING_FEE_RESPONSE, loanChargeResponse);
     }
 
@@ -234,7 +234,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dateFormat(DEFAULT_DATE_FORMAT);
 
         PostLoansLoanIdChargesResponse loanChargeResponse = ok(
-                () -> fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
+                () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of()));
         testContext().set(TestContextKey.ADD_NSF_FEE_RESPONSE, loanChargeResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
     }
@@ -275,7 +275,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
 
         final Long transactionId = transactions.stream().filter(t -> "loanTransactionType.waiveCharges".equals(t.getType().getCode()))
@@ -283,7 +283,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
 
         PutChargeTransactionChangesRequest undoWaiveRequest = new PutChargeTransactionChangesRequest();
         PutChargeTransactionChangesResponse undoWaiveResponse = ok(
-                () -> fineractClient.loanTransactions().undoWaiveCharge(loanId, transactionId, undoWaiveRequest));
+                () -> fineractClient.loanTransactions().undoWaiveChargeLoanTransaction(loanId, transactionId, undoWaiveRequest));
         testContext().set(TestContextKey.UNDO_WAIVE_RESPONSE, undoWaiveResponse);
     }
 
@@ -299,14 +299,14 @@ public class LoanChargeStepDef extends AbstractStepDef {
     public void checkLoanChargeAmount(float chargeAmount) throws IOException {
         PostLoansLoanIdChargesResponse response = testContext().get(TestContextKey.ADD_PROCESSING_FEE_RESPONSE);
         GetLoansLoanIdChargesChargeIdResponse loanChargeAmount = ok(
-                () -> fineractClient.loanCharges().retrieveLoanCharge(response.getLoanId(), Long.valueOf(response.getResourceId())));
+                () -> fineractClient.loanCharges().retrieveOneLoanCharge(response.getLoanId(), Long.valueOf(response.getResourceId())));
         assertThat(loanChargeAmount.getAmount()).as("Charge amount is wrong").isEqualByComparingTo(Double.valueOf(chargeAmount));
     }
 
     private void addChargeEventCheck(PostLoansLoanIdChargesResponse loanChargeResponse) throws IOException {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_EVENTS);
-        GetLoansLoanIdChargesChargeIdResponse chargeDetails = ok(
-                () -> fineractClient.loanCharges().retrieveLoanCharge(loanChargeResponse.getLoanId(), loanChargeResponse.getResourceId()));
+        GetLoansLoanIdChargesChargeIdResponse chargeDetails = ok(() -> fineractClient.loanCharges()
+                .retrieveOneLoanCharge(loanChargeResponse.getLoanId(), loanChargeResponse.getResourceId()));
         GetLoansLoanIdChargesChargeIdResponse body = chargeDetails;
 
         eventAssertion.assertEvent(LoanAddChargeEvent.class, loanChargeResponse.getResourceId()).extractingData(LoanChargeDataV1::getName)
@@ -341,7 +341,7 @@ public class LoanChargeStepDef extends AbstractStepDef {
                 .dueDate(transactionDate).amount(transactionAmount);
 
         try {
-            fineractClient.loanCharges().executeLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
+            fineractClient.loanCharges().createOrPayLoanCharge(loanId, loanIdChargesRequest, Map.<String, Object>of());
             throw new AssertionError("Expected FeignException but request succeeded");
         } catch (FeignException e) {
             ErrorResponse errorResponse = ErrorResponse.fromFeignException(e);

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanDelinquencyStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanDelinquencyStepDef.java
@@ -89,7 +89,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         Integer loanStatus = loanDetails.getStatus().getId() == null ? null : loanDetails.getStatus().getId().intValue();
 
         if (!LoanStatus.SUBMITTED_AND_PENDING_APPROVAL.value.equals(loanStatus) && !LoanStatus.APPROVED.value.equals(loanStatus)) {
@@ -127,7 +127,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         String expectedDelinquencyRangeValue = expectedDelinquencyRange.getValue();
 
         List<GetDelinquencyTagHistoryResponse> delinquencyHistoryDetails = ok(
-                () -> fineractClient.loans().getDelinquencyTagHistory(loanId));
+                () -> fineractClient.loans().retrieveDelinquencyTagHistoryLoan(loanId));
 
         String actualDelinquencyRangeValue = DelinquencyRange.NO_DELINQUENCY.value;
         String actualDelinquencyAddedOnDate = "";
@@ -153,7 +153,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        List<GetDelinquencyTagHistoryResponse> body = ok(() -> fineractClient.loans().getDelinquencyTagHistory(loanId));
+        List<GetDelinquencyTagHistoryResponse> body = ok(() -> fineractClient.loans().retrieveDelinquencyTagHistoryLoan(loanId));
 
         for (int i = 0; i < body.size(); i++) {
             List<String> line = dataExpected.get(i + 1);
@@ -190,7 +190,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
                 .dateFormat(DATE_FORMAT)//
                 .locale(DEFAULT_LOCALE);//
 
-        PostLoansDelinquencyActionResponse response = ok(() -> fineractClient.loans().createLoanDelinquencyAction(loanId, request));
+        PostLoansDelinquencyActionResponse response = ok(() -> fineractClient.loans().createDelinquencyActionLoan(loanId, request));
         testContext().set(TestContextKey.LOAN_DELINQUENCY_ACTION_RESPONSE, response);
         eventCheckHelper.loanAccountDelinquencyPauseChangedBusinessEventCheck(loanId);
     }
@@ -211,7 +211,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         String password = testContext().get(TestContextKey.CREATED_SIMPLE_USER_PASSWORD);
         FineractFeignClient userClient = createClientForUser(username, password);
 
-        PostLoansDelinquencyActionResponse response = ok(() -> userClient.loans().createLoanDelinquencyAction(loanId, request));
+        PostLoansDelinquencyActionResponse response = ok(() -> userClient.loans().createDelinquencyActionLoan(loanId, request));
         testContext().set(TestContextKey.LOAN_DELINQUENCY_ACTION_RESPONSE, response);
         eventCheckHelper.loanAccountDelinquencyPauseChangedBusinessEventCheck(loanId);
     }
@@ -235,7 +235,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         String password = testContext().get(TestContextKey.CREATED_SIMPLE_USER_PASSWORD);
         FineractFeignClient userClient = createClientForUser(username, password);
 
-        CallFailedRuntimeException exception = fail(() -> userClient.loans().createLoanDelinquencyAction(loanId, request));
+        CallFailedRuntimeException exception = fail(() -> userClient.loans().createDelinquencyActionLoan(loanId, request));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.wrongErrorCode(exception.getStatus(), errorCodeExpected))
                 .isEqualTo(errorCodeExpected);
@@ -258,7 +258,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
                 .dateFormat(DATE_FORMAT)//
                 .locale(DEFAULT_LOCALE);//
 
-        PostLoansDelinquencyActionResponse response = ok(() -> fineractClient.loans().createLoanDelinquencyAction(loanId, request));
+        PostLoansDelinquencyActionResponse response = ok(() -> fineractClient.loans().createDelinquencyActionLoan(loanId, request));
         testContext().set(TestContextKey.LOAN_DELINQUENCY_ACTION_RESPONSE, response);
         eventCheckHelper.loanAccountDelinquencyPauseChangedBusinessEventCheck(loanId);
     }
@@ -277,7 +277,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
                 .locale(DEFAULT_LOCALE);//
 
         PostLoansDelinquencyActionResponse response = ok(
-                () -> fineractClient.loans().createLoanDelinquencyActionByExternalId(loanExternalId, request));
+                () -> fineractClient.loans().createDelinquencyActionLoanByExternalId(loanExternalId, request));
         testContext().set(TestContextKey.LOAN_DELINQUENCY_ACTION_RESPONSE, response);
         eventCheckHelper.loanAccountDelinquencyPauseChangedBusinessEventCheck(loanId);
     }
@@ -295,7 +295,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
                 .locale(DEFAULT_LOCALE);//
 
         PostLoansDelinquencyActionResponse response = ok(
-                () -> fineractClient.loans().createLoanDelinquencyActionByExternalId(loanExternalId, request));
+                () -> fineractClient.loans().createDelinquencyActionLoanByExternalId(loanExternalId, request));
         testContext().set(TestContextKey.LOAN_DELINQUENCY_ACTION_RESPONSE, response);
         eventCheckHelper.loanAccountDelinquencyPauseChangedBusinessEventCheck(loanId);
     }
@@ -308,7 +308,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         List<List<String>> data = table.asLists();
         int nrOfLinesExpected = data.size() - 1;
 
-        List<GetDelinquencyActionsResponse> response = ok(() -> fineractClient.loans().getLoanDelinquencyActions(loanId));
+        List<GetDelinquencyActionsResponse> response = ok(() -> fineractClient.loans().retrieveDelinquencyActionsLoan(loanId));
         int nrOfLinesActual = response.size();
 
         assertThat(nrOfLinesActual)//
@@ -477,7 +477,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         List<GetLoansLoanIdLoanInstallmentLevelDelinquency> installmentLevelDelinquency = loanDetails.getDelinquent()
                 .getInstallmentLevelDelinquency() == null ? null : loanDetails.getDelinquent().getInstallmentLevelDelinquency();
         assertThat(installmentLevelDelinquency).isNull();
@@ -493,7 +493,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         String expectedDelinquencyRangeValue = expectedDelinquencyRange.getValue();
         expectedValuesList.set(0, expectedDelinquencyRangeValue);
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         String actualDelinquencyRangeValue = loanDetails.getDelinquencyRange() == null ? "NO_DELINQUENCY"
                 : loanDetails.getDelinquencyRange().getClassification();
         GetLoansLoanIdDelinquencySummary delinquent = loanDetails.getDelinquent();
@@ -531,7 +531,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         String expectedDelinquencyRangeValue = expectedDelinquencyRange.getValue();
         expectedValuesList.set(0, expectedDelinquencyRangeValue);
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
 
         String actualDelinquencyRangeValue = loanDetails.getDelinquencyRange() == null ? "NO_DELINQUENCY"
                 : loanDetails.getDelinquencyRange().getClassification();
@@ -552,7 +552,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         List<GetLoansLoanIdLoanInstallmentLevelDelinquency> installmentLevelDelinquency = loanDetails.getDelinquent()
                 .getInstallmentLevelDelinquency();
 
@@ -581,7 +581,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         Long loanId = loanResponse.getLoanId();
 
         List<List<String>> expectedData = table.asLists();
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
 
         List<GetLoansLoanIdDelinquencyPausePeriod> delinquencyPausePeriods = loanDetails.getDelinquent().getDelinquencyPausePeriods();
 
@@ -606,7 +606,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         String actualDate = FORMATTER.format(loanDetails.getDelinquent().getNextPaymentDueDate());
 
         assertThat(actualDate).as(ErrorMessageHelper.wrongDataInNextPaymentDueDate(actualDate, expectedDate)).isEqualTo(expectedDate);
@@ -635,7 +635,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
         DelinquencyRangeData delinquencyRange = loanDetails.getDelinquencyRange();
         GetLoansLoanIdDelinquencySummary delinquent = loanDetails.getDelinquent();
 
@@ -707,7 +707,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "collection")));
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", "collection")));
 
         Double actualLastRepaymentAmount = loanDetails.getDelinquent().getLastRepaymentAmount().doubleValue();
         String actualLastRepaymentDate = FORMATTER.format(loanDetails.getDelinquent().getLastRepaymentDate());
@@ -739,7 +739,7 @@ public class LoanDelinquencyStepDef extends AbstractStepDef {
 
     private void errorMessageAssertationFeign(long loanId, PostLoansDelinquencyActionRequest request, int errorCodeExpected,
             String errorMessageExpected) {
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().createLoanDelinquencyAction(loanId, request));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().createDelinquencyActionLoan(loanId, request));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.wrongErrorCode(exception.getStatus(), errorCodeExpected))
                 .isEqualTo(errorCodeExpected);

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanOriginationStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanOriginationStepDef.java
@@ -429,7 +429,7 @@ public class LoanOriginationStepDef extends AbstractStepDef {
         PostLoansRequest loansRequest = loanRequestFactory.defaultLoansRequest(clientId).submittedOnDate(submitDate)
                 .expectedDisbursementDate(submitDate).addOriginatorsItem(originatorData);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
 
         assertThat(response.getLoanId()).isNotNull();
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
@@ -448,7 +448,7 @@ public class LoanOriginationStepDef extends AbstractStepDef {
                 .approvedLoanAmount(new BigDecimal(approvedAmount)).expectedDisbursementDate(expectedDisbursementDate);
 
         PostLoansLoanIdResponse loanApproveResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, approveRequest, Map.of("command", "approve")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, approveRequest, Map.of("command", "approve")));
         testContext().set(TestContextKey.LOAN_APPROVAL_RESPONSE, loanApproveResponse);
         log.info("Loan {} approved (event check skipped for separate verification)", loanId);
     }
@@ -653,7 +653,7 @@ public class LoanOriginationStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")));
         Long waiveTransactionId = loanDetails.getTransactions().stream()
                 .filter(t -> "loanTransactionType.waiveCharges".equals(t.getType().getCode())).map(GetLoansLoanIdTransactions::getId)
                 .findFirst().orElseThrow(() -> new IllegalStateException("Waiver transaction not found on loan " + loanId));
@@ -708,7 +708,7 @@ public class LoanOriginationStepDef extends AbstractStepDef {
         long loanId = getLoanId();
         String expectedExternalId = testContext().get(TestContextKey.ORIGINATOR_EXTERNAL_ID);
 
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         GetLoansLoanIdTransactions accrualTransaction = loanDetails.getTransactions().stream()
                 .filter(t -> date.equals(FORMATTER.format(t.getDate())) && "Accrual".equals(t.getType().getValue()))
@@ -897,7 +897,7 @@ public class LoanOriginationStepDef extends AbstractStepDef {
     }
 
     private List<GetLoansLoanIdOriginatorData> retrieveLoanOriginators(long loanId, String association) {
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", association, "exclude", "", "fields", "")));
         return loanDetails.getOriginators();
     }

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanOverrideFieldsStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanOverrideFieldsStepDef.java
@@ -54,7 +54,7 @@ public class LoanOverrideFieldsStepDef extends AbstractStepDef {
         final Long loanId = loanResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
 
         assertNotNull(loanDetails);
 
@@ -100,8 +100,7 @@ public class LoanOverrideFieldsStepDef extends AbstractStepDef {
             }
         });
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
 
     }

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanReAgingStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanReAgingStepDef.java
@@ -78,7 +78,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         );
 
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, reAgingRequest, Map.of("command", "reAge")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, reAgingRequest, Map.of("command", "reAge")));
         testContext().set(TestContextKey.LOAN_REAGING_RESPONSE, response);
     }
 
@@ -94,7 +94,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         );
 
         PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionByLoanExternalId(loanExternalId, reAgingRequest, Map.of("command", "reAge")));
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, reAgingRequest, Map.of("command", "reAge")));
         testContext().set(TestContextKey.LOAN_REAGING_RESPONSE, response);
     }
 
@@ -103,7 +103,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 new PostLoansLoanIdTransactionsRequest(), Map.of("command", "undoReAge")));
         testContext().set(TestContextKey.LOAN_REAGING_UNDO_RESPONSE, response);
     }
@@ -161,7 +161,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         Map<String, Object> queryParams = resolveReAgingQueryParams(table);
-        LoanScheduleData response = ok(() -> fineractClient.loanTransactions().previewReAgeSchedule(loanId, queryParams));
+        LoanScheduleData response = ok(() -> fineractClient.loanTransactions().previewReAgeLoanSchedule(loanId, queryParams));
         testContext().set(TestContextKey.LOAN_REAGING_PREVIEW_RESPONSE, response);
 
         log.info("Re-aging preview created for loan ID: {} with parameters: {}", loanId, queryParams);
@@ -173,7 +173,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
 
         Map<String, Object> queryParams = resolveReAgingQueryParams(table);
         LoanScheduleData result = ok(
-                () -> fineractClient.loanTransactions().previewReAgeScheduleByLoanExternalId(loanExternalId, queryParams));
+                () -> fineractClient.loanTransactions().previewReAgeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
         log.info("Re-aging preview is requested to be created with loan external ID: {} with parameters: {}", loanExternalId, queryParams);
         return result;
     }
@@ -193,7 +193,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
 
         Map<String, Object> queryParams = resolveReAgingQueryParams(table);
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().previewReAgeScheduleByLoanExternalId(loanExternalId, queryParams));
+                () -> fineractClient.loanTransactions().previewReAgeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.reAgeChargedOffLoanFailure());
@@ -207,7 +207,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         Map<String, Object> queryParams = resolveReAgingQueryParams(table);
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().previewReAgeScheduleByLoanExternalId(loanExternalId, queryParams));
+                () -> fineractClient.loanTransactions().previewReAgeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.reAgeContractTerminatedLoanFailure());
@@ -220,7 +220,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
 
         Map<String, Object> queryParams = resolveReAgingQueryParams(table);
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().previewReAgeScheduleByLoanExternalId(loanExternalId, queryParams));
+                () -> fineractClient.loanTransactions().previewReAgeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.reAgeClosedLoanFailure());
@@ -394,7 +394,7 @@ public class LoanReAgingStepDef extends AbstractStepDef {
         );
 
         CallFailedRuntimeException response = fail(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionByLoanExternalId(loanExternalId, reAgingRequest, Map.of("command", "reAge")));
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, reAgingRequest, Map.of("command", "reAge")));
         assertThat(response.getStatus()).isEqualTo(errorCode);
     }
 
@@ -409,7 +409,8 @@ public class LoanReAgingStepDef extends AbstractStepDef {
                 table.row(1) //
         );
 
-        return fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, reAgingRequest, Map.of("command", "reAge")));
+        return fail(
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, reAgingRequest, Map.of("command", "reAge")));
     }
 
     public void checkCreateLoanReAgeFailure(DataTable table, String errorMessage) {

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanReAmortizationStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanReAmortizationStepDef.java
@@ -66,7 +66,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
 
         PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest();
 
-        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 reAmortizationRequest, Map.of("command", "reAmortize")));
         testContext().set(TestContextKey.LOAN_REAMORTIZATION_RESPONSE, response);
     }
@@ -79,7 +79,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         final PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest()
                 .reAmortizationInterestHandling(reAmortizationInterestHandling);
 
-        fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, reAmortizationRequest,
+        fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, reAmortizationRequest,
                 Map.of("command", "reAmortize")));
     }
 
@@ -91,8 +91,8 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         final PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest()
                 .reAmortizationInterestHandling(reAmortizationInterestHandling);
 
-        final PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
-                reAmortizationRequest, Map.of("command", "reAmortize")));
+        final PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, reAmortizationRequest, Map.of("command", "reAmortize")));
         testContext().set(TestContextKey.LOAN_REAMORTIZATION_RESPONSE, response);
     }
 
@@ -104,7 +104,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest();
 
         PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionByLoanExternalId(loanExternalId, reAmortizationRequest, Map.of("command", "reAmortize")));
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, reAmortizationRequest, Map.of("command", "reAmortize")));
         testContext().set(TestContextKey.LOAN_REAMORTIZATION_RESPONSE, response);
     }
 
@@ -113,7 +113,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        PostLoansLoanIdTransactionsResponse response = ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 new PostLoansLoanIdTransactionsRequest(), Map.of("command", "undoReAmortize")));
         testContext().set(TestContextKey.LOAN_REAMORTIZATION_UNDO_RESPONSE, response);
     }
@@ -125,7 +125,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
 
         final PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest();
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 reAmortizationRequest, Map.of("command", "reAmortize")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(errorCode);
     }
@@ -138,7 +138,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         final PostLoansLoanIdTransactionsRequest reAmortizationRequest = loanRequestFactory.defaultLoanReAmortizationRequest()
                 .reAmortizationInterestHandling(reAmortizationInterestHandling);
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 reAmortizationRequest, Map.of("command", "reAmortize")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(errorCode);
     }
@@ -193,7 +193,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
             reAmortizationRequest.reAmortizationInterestHandling(reAmortizationInterestHandling);
         }
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 reAmortizationRequest, Map.of("command", "reAmortize")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(errorMessage);
@@ -223,7 +223,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
 
         final Map<String, Object> queryParams = Map.of("reAmortizationInterestHandling", reAmortizationInterestHandling);
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().previewReAmortizationScheduleByLoanExternalId(loanExternalId, queryParams));
+                () -> fineractClient.loanTransactions().previewReAmortizeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
         assertThat(exception.getStatus()).isEqualTo(errorCode);
     }
 
@@ -272,7 +272,7 @@ public class LoanReAmortizationStepDef extends AbstractStepDef {
         final String reAmortizationInterestHandling = data.getFirst();
 
         final Map<String, Object> queryParams = Map.of("reAmortizationInterestHandling", reAmortizationInterestHandling);
-        return ok(() -> fineractClient.loanTransactions().previewReAmortizationScheduleByLoanExternalId(loanExternalId, queryParams));
+        return ok(() -> fineractClient.loanTransactions().previewReAmortizeLoanScheduleByLoanExternalId(loanExternalId, queryParams));
     }
 
     @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRepaymentStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRepaymentStepDef.java
@@ -128,8 +128,8 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         String idempotencyKey = UUID.randomUUID().toString();
         testContext().set(TestContextKey.TRANSACTION_IDEMPOTENCY_KEY, idempotencyKey);
 
-        PostLoansLoanIdTransactionsResponse repaymentResponse = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
-                repaymentRequest, Map.<String, Object>of("command", "repayment")));
+        PostLoansLoanIdTransactionsResponse repaymentResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, repaymentRequest, Map.<String, Object>of("command", "repayment")));
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, repaymentResponse);
         EventAssertion.EventAssertionBuilder<LoanTransactionDataV1> transactionEvent = eventCheckHelper
                 .transactionEventCheck(repaymentResponse, TransactionType.REPAYMENT, transferExternalOwnerId);
@@ -161,7 +161,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
                 .credentials(user.getUsername(), PWD_USER_WITH_ROLE).tenantId(apiProperties.getTenantId()).disableSslVerification(true)
                 .readTimeout((int) apiProperties.getReadTimeout(), java.util.concurrent.TimeUnit.SECONDS).build();
 
-        PostLoansLoanIdTransactionsResponse repaymentResponse = ok(() -> userClient.loanTransactions().executeLoanTransaction(loanId,
+        PostLoansLoanIdTransactionsResponse repaymentResponse = ok(() -> userClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 repaymentRequest, Map.<String, Object>of("command", "repayment")));
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, repaymentResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
@@ -184,7 +184,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         testContext().set(TestContextKey.TRANSACTION_IDEMPOTENCY_KEY, idempotencyKey);
 
         PostLoansLoanIdTransactionsResponse repaymentResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransactionByLoanExternalId(resourceExternalId, repaymentRequest,
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransactionByLoanExternalId(resourceExternalId, repaymentRequest,
                         Map.<String, Object>of("command", "repayment")));
 
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, repaymentResponse);
@@ -218,7 +218,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
                 .readTimeout((int) apiProperties.getReadTimeout(), java.util.concurrent.TimeUnit.SECONDS).build();
 
         PostLoansLoanIdTransactionsResponse repaymentResponse = ok(
-                () -> userClient.loanTransactions().executeLoanTransactionByLoanExternalId(resourceExternalId, repaymentRequest,
+                () -> userClient.loanTransactions().handleCommandsLoanTransactionByLoanExternalId(resourceExternalId, repaymentRequest,
                         Map.<String, Object>of("command", "repayment")));
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, repaymentResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
@@ -236,7 +236,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
                 .transactionAmount(transactionAmount).paymentTypeId(paymentTypeValue).dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
         try {
-            ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, repaymentRequest,
+            ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, repaymentRequest,
                     Map.<String, Object>of("command", "repayment")));
             throw new IllegalStateException("Expected FeignException but call succeeded");
         } catch (feign.FeignException e) {
@@ -282,8 +282,8 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest repaymentRequest = loanRequestFactory.defaultRepaymentRequest().transactionDate(transactionDate)
                 .transactionAmount(transactionAmount).paymentTypeId(paymentTypeValue).dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, repaymentRequest,
-                Map.<String, Object>of("command", "repayment")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                repaymentRequest, Map.<String, Object>of("command", "repayment")));
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, null);
         testContext().set(TestContextKey.ERROR_RESPONSE, exception);
     }
@@ -298,8 +298,8 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
                 .locale(DEFAULT_LOCALE).accountNumber(DEFAULT_ACCOUNT_NB).checkNumber(DEFAULT_CHECK_NB).receiptNumber(DEFAULT_RECEIPT_NB)
                 .bankNumber(DEFAULT_BANK_NB);
 
-        PostLoansLoanIdTransactionsResponse refundResponse = ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
-                refundRequest, Map.<String, Object>of("command", "payoutRefund")));
+        PostLoansLoanIdTransactionsResponse refundResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, refundRequest, Map.<String, Object>of("command", "payoutRefund")));
         testContext().set(TestContextKey.LOAN_REFUND_RESPONSE, refundResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
     }
@@ -377,7 +377,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         int nthItem = Integer.parseInt(nthItemStr) - 1;
@@ -400,7 +400,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         int nthItem = Integer.parseInt(nthItemStr) - 1;
@@ -424,7 +424,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         int nthItem = Integer.parseInt(nthItemStr) - 1;
@@ -448,7 +448,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         GetLoansLoanIdTransactions targetTransaction = eventCheckHelper.getNthTransactionType(nthItemStr, transactionType, transactionDate,
@@ -550,7 +550,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         // check that here are 2 transactions - target and linked
@@ -578,7 +578,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         GetLoansLoanIdTransactionsTransactionIdResponse transactionResponse = ok(() -> fineractClient.loanTransactions()
-                .retrieveTransaction(loanId, repaymentResponse.getResourceId(), Map.<String, Object>of()));
+                .retrieveOneLoanTransaction(loanId, repaymentResponse.getResourceId(), Map.<String, Object>of()));
         assertThat(transactionResponse.getAmount()).isEqualTo(repaymentAmount);
         assertThat(transactionResponse.getPaymentDetailData().getPaymentType().getName()).isEqualTo(paymentType);
     }
@@ -596,7 +596,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId1 = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse getLoansLoanIdResponseCall = ok(() -> fineractClient.loans().retrieveLoan(loanId1,
+        GetLoansLoanIdResponse getLoansLoanIdResponseCall = ok(() -> fineractClient.loans().retrieveOneLoan(loanId1,
                 Map.<String, Object>of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "guarantors,futureSchedule")));
 
         List<GetLoansLoanIdRepaymentPeriod> periods = getLoansLoanIdResponseCall.getRepaymentSchedule().getPeriods();
@@ -632,8 +632,8 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
     public Double getLoanTransactionAmountToPayOff(PostLoansResponse loanResponse, String transactionDate) {
         long loanId1 = loanResponse.getLoanId();
         GetLoansLoanIdTransactionsTemplateResponse response = ok(
-                () -> fineractClient.loanTransactions().retrieveTransactionTemplate(loanId1, Map.<String, Object>of("command", "prepayLoan",
-                        "dateFormat", DATE_FORMAT, "transactionDate", transactionDate, "locale", DEFAULT_LOCALE)));
+                () -> fineractClient.loanTransactions().retrieveTemplateLoanTransaction(loanId1, Map.<String, Object>of("command",
+                        "prepayLoan", "dateFormat", DATE_FORMAT, "transactionDate", transactionDate, "locale", DEFAULT_LOCALE)));
         return response.getAmount();
     }
 
@@ -671,7 +671,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         int nthItem = Integer.parseInt(nthItemStr) - 1;
@@ -725,7 +725,7 @@ public class LoanRepaymentStepDef extends AbstractStepDef {
         assert loanResponse != null;
         final long loanId = loanResponse.getLoanId();
         final List<GetLoansLoanIdTransactions> transactions = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.<String, Object>of("associations", "transactions")))
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.<String, Object>of("associations", "transactions")))
                 .getTransactions();
 
         final int nthItem = Integer.parseInt(nthItemStr) - 1;

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRescheduleStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanRescheduleStepDef.java
@@ -102,7 +102,7 @@ public class LoanRescheduleStepDef extends AbstractStepDef {
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en");//
 
-        PostCreateRescheduleLoansResponse createResponse = ok(() -> fineractClient.rescheduleLoans().createLoanRescheduleRequest(request));
+        PostCreateRescheduleLoansResponse createResponse = ok(() -> fineractClient.rescheduleLoans().createRescheduleLoan(request));
 
         Long scheduleId = createResponse.getResourceId();
         PostUpdateRescheduleLoansRequest approveRequest = new PostUpdateRescheduleLoansRequest()//
@@ -110,7 +110,7 @@ public class LoanRescheduleStepDef extends AbstractStepDef {
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en");//
 
-        ok(() -> fineractClient.rescheduleLoans().updateLoanRescheduleRequest(scheduleId, approveRequest,
+        ok(() -> fineractClient.rescheduleLoans().updateRescheduleLoan(scheduleId, approveRequest,
                 Map.<String, Object>of("command", "approve")));
 
         if (newInterestRate != null) {
@@ -166,7 +166,7 @@ public class LoanRescheduleStepDef extends AbstractStepDef {
             throw new IllegalStateException("Parameter count in Error message does not met the criteria");
         }
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.rescheduleLoans().createLoanRescheduleRequest(request));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.rescheduleLoans().createRescheduleLoan(request));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.wrongErrorCode(exception.getStatus(), errorCodeExpected))
                 .isEqualTo(errorCodeExpected);
@@ -185,7 +185,7 @@ public class LoanRescheduleStepDef extends AbstractStepDef {
         String resourceId = String.valueOf(loanId);
 
         List<GetLoanRescheduleRequestResponse> loanRescheduleRequestResponses = ok(
-                () -> fineractClient.rescheduleLoans().retrieveAllRescheduleRequest("", loanId));
+                () -> fineractClient.rescheduleLoans().retrieveAllRescheduleLoans("", loanId));
         List<List<String>> data = table.asLists();
         List<String> header = table.row(0);
         checkLoanRescheduleTab(data, loanRescheduleRequestResponses, header, resourceId);

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
@@ -217,7 +217,7 @@ public class LoanStepDef extends AbstractStepDef {
         Long clientId = clientResponse.getClientId();
         PostLoansRequest loansRequest = loanRequestFactory.defaultLoansRequest(clientId);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -229,7 +229,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansRequest loansRequest = loanRequestFactory.defaultLoansRequest(clientId).submittedOnDate(date)
                 .expectedDisbursementDate(date);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -241,8 +241,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansRequest loansRequest = loanRequestFactory.defaultProgressiveLoansRequest(clientId).submittedOnDate(date)
                 .expectedDisbursementDate(date);
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -254,7 +253,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansRequest loansRequest = loanRequestFactory.defaultLoansRequest(clientId).submittedOnDate(date)
                 .expectedDisbursementDate(date);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_SECOND_LOAN_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -266,7 +265,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansRequest loansRequest = loanRequestFactory.defaultLoansRequest(clientId).submittedOnDate(date)
                 .expectedDisbursementDate(date);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_SECOND_LOAN_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -285,7 +284,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .loanTermFrequency(1)//
                 .repaymentEvery(1);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
     }
 
@@ -322,7 +321,7 @@ public class LoanStepDef extends AbstractStepDef {
         testContext().set(TestContextKey.TRANSACTION_IDEMPOTENCY_KEY, idempotencyKey);
 
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
                         transactionTypeValue, Map.of("Idempotency-Key", idempotencyKey)));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         eventCheckHelper.transactionEventCheck(paymentTransactionApiResponse.getData(), transactionType, externalOwnerId);
@@ -345,7 +344,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(transactionAmount).paymentTypeId(paymentTypeValue);
 
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
+                .handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         eventCheckHelper.transactionEventCheck(paymentTransactionApiResponse.getData(), transactionType, null);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
@@ -369,7 +368,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .externalId(externalId);
 
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
+                .handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         assertThat(paymentTransactionApiResponse.getData().getResourceExternalId()).as("External id is not correct").isEqualTo(externalId);
 
@@ -419,7 +418,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .interestRefundCalculation(interestRefundCalculation);
 
         final ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
+                .handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, paymentTransactionApiResponse.getData());
         eventCheckHelper.transactionEventCheck(paymentTransactionApiResponse.getData(), transactionType, null);
@@ -433,7 +432,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -458,7 +457,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -491,7 +490,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -512,7 +511,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -540,7 +539,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -570,7 +569,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
         final TransactionType transactionType = TransactionType.valueOf(transactionTypeInput);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -608,7 +607,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(transactionAmount).paymentTypeId(paymentTypeValue);
 
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
+                .handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         testContext().set(TestContextKey.LOAN_REPAYMENT_RESPONSE, paymentTransactionApiResponse.getData());
         eventCheckHelper.transactionEventCheck(paymentTransactionApiResponse.getData(), transactionType, externalOwnerId);
@@ -628,7 +627,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(transactionAmount);
 
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
+                .handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest, transactionTypeValue, Map.of()));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
         eventCheckHelper.loanBalanceChangedEventCheck(loanId);
     }
@@ -639,7 +638,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         String transactionTypeValue = "creditBalanceRefund";
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 paymentTransactionRequest, Map.of("command", transactionTypeValue)));
 
         int errorCodeActual = exception.getStatus();
@@ -809,7 +808,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestPayment)//
                 .graceOnInterestPayment(graceOnInterestCharged).transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -879,8 +878,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestPayment)//
                 .graceOnInterestPayment(graceOnInterestCharged).transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue);//
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains("downpayment");
     }
@@ -951,7 +949,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestPayment)//
                 .graceOnInterestPayment(graceOnInterestCharged).transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -1022,7 +1020,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestPayment)//
                 .graceOnInterestPayment(graceOnInterestCharged).transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -1093,7 +1091,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .fixedLength(fixedLength);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -1164,8 +1162,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .fixedLength(fixedLength);//
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.wrongErrorCode(exception.getStatus(), errorCodeExpected))
                 .isEqualTo(errorCodeExpected);
         log.debug("ERROR CODE: {}", exception.getStatus());
@@ -1240,8 +1237,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestCharged)//
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue);//
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
 
         assertThat(exception.getStatus()).as(ErrorMessageHelper.wrongErrorCode(exception.getStatus(), errorCodeExpected))
                 .isEqualTo(errorCodeExpected);
@@ -1319,7 +1315,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .enableInstallmentLevelDelinquency(true);//
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -1335,7 +1331,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "collection")));
         GetLoansLoanIdDelinquencySummary delinquent = loanDetailsResponse.getDelinquent();
         String lastPaymentAmountActual = delinquent.getLastPaymentAmount() == null ? null
@@ -1365,7 +1361,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions lastRepaymentData = transactions.stream()
@@ -1417,7 +1413,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.value).submittedOnDate(submitDate)
                 .expectedDisbursementDate(submitDate);
 
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
     }
 
@@ -1437,7 +1433,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         String idempotencyKey = testContext().get(TestContextKey.TRANSACTION_IDEMPOTENCY_KEY);
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
                         transactionTypeValue, Map.of("Idempotency-Key", idempotencyKey)));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
     }
@@ -1458,7 +1454,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         String idempotencyKey = testContext().get(TestContextKey.TRANSACTION_IDEMPOTENCY_KEY);
         ApiResponse<PostLoansLoanIdTransactionsResponse> paymentTransactionApiResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransactionWithHttpInfo(loanId, paymentTransactionRequest,
                         transactionTypeValue, Map.of("Idempotency-Key", idempotencyKey)));
         storePaymentTransactionResponse(paymentTransactionApiResponse);
     }
@@ -1472,7 +1468,7 @@ public class LoanStepDef extends AbstractStepDef {
         PutLoansLoanIdRequest putLoansLoanIdRequest = loanRequestFactory.modifySubmittedOnDateOnLoan(clientId2, newSubmittedOnDate);
 
         PutLoansLoanIdResponse responseMod = ok(
-                () -> fineractClient.loans().modifyLoanApplication(loanId2, putLoansLoanIdRequest, Map.of()));
+                () -> fineractClient.loans().updateLoanApplication(loanId2, putLoansLoanIdRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_MODIFY_RESPONSE, responseMod);
     }
 
@@ -1481,8 +1477,8 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final Long loanId = loanResponse.getResourceId();
 
-        final GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
+        final GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
 
         final PutLoansLoanIdRequest putLoansLoanIdRequest = new PutLoansLoanIdRequest()//
                 .productId(loanDetails.getLoanProductId())//
@@ -1515,7 +1511,7 @@ public class LoanStepDef extends AbstractStepDef {
         }
 
         final PutLoansLoanIdResponse responseMod = ok(
-                () -> fineractClient.loans().modifyLoanApplication(loanId, putLoansLoanIdRequest, Map.of()));
+                () -> fineractClient.loans().updateLoanApplication(loanId, putLoansLoanIdRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_MODIFY_RESPONSE, responseMod);
     }
 
@@ -1531,8 +1527,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.value).submittedOnDate(submitDate)
                 .expectedDisbursementDate(submitDate);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
     }
 
@@ -1545,7 +1540,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .approvedLoanAmount(new BigDecimal(approvedAmount)).expectedDisbursementDate(expectedDisbursementDate);
 
         PostLoansLoanIdResponse loanApproveResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, approveRequest, Map.of("command", "approve")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, approveRequest, Map.of("command", "approve")));
         testContext().set(TestContextKey.LOAN_APPROVAL_RESPONSE, loanApproveResponse);
         assertThat(loanApproveResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_APPROVED);
         assertThat(loanApproveResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_APPROVED);
@@ -1560,7 +1555,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdRequest rejectRequest = loanRequestFactory.defaultLoanRejectRequest().rejectedOnDate(rejectDate);
 
         PostLoansLoanIdResponse loanRejectResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, rejectRequest, Map.of("command", "reject")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, rejectRequest, Map.of("command", "reject")));
         testContext().set(TestContextKey.LOAN_REJECT_RESPONSE, loanRejectResponse);
         assertThat(loanRejectResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_REJECTED);
         assertThat(loanRejectResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_REJECTED);
@@ -1575,7 +1570,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdRequest withdawnRequest = loanRequestFactory.defaultLoanWithdrawnRequest().withdrawnOnDate(withdrawnDate);
 
         PostLoansLoanIdResponse loanWithdrawnResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, withdawnRequest, Map.of("command", "withdrawnByApplicant")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, withdawnRequest, Map.of("command", "withdrawnByApplicant")));
         testContext().set(TestContextKey.LOAN_WITHDRAWN_RESPONSE, loanWithdrawnResponse);
         assertThat(loanWithdrawnResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_WITHDRAWN);
         assertThat(loanWithdrawnResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_WITHDRAWN);
@@ -1591,7 +1586,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .approvedLoanAmount(new BigDecimal(approvedAmount)).expectedDisbursementDate(expectedDisbursementDate);
 
         PostLoansLoanIdResponse loanApproveResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, approveRequest, Map.of("command", "approve")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, approveRequest, Map.of("command", "approve")));
         testContext().set(TestContextKey.LOAN_APPROVAL_SECOND_LOAN_RESPONSE, loanApproveResponse);
         assertThat(loanApproveResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_APPROVED);
         assertThat(loanApproveResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_APPROVED);
@@ -1604,7 +1599,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdRequest undoApprovalRequest = new PostLoansLoanIdRequest().note("");
 
         PostLoansLoanIdResponse undoApprovalResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, undoApprovalRequest, Map.of("command", "undoapproval")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, undoApprovalRequest, Map.of("command", "undoapproval")));
         testContext().set(TestContextKey.LOAN_UNDO_APPROVAL_RESPONSE, loanApproveResponse);
         assertThat(undoApprovalResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_SUBMITTED_AND_PENDING);
     }
@@ -1617,7 +1612,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .approvedLoanAmount(new BigDecimal(approvedAmount)).expectedDisbursementDate(expectedDisbursementDate);
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, approveRequest, Map.of("command", "approve")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, approveRequest, Map.of("command", "approve")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.loanApproveDateInFutureFailureMsg());
     }
@@ -1630,7 +1625,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .approvedLoanAmount(new BigDecimal(approvedAmount)).expectedDisbursementDate(expectedDisbursementDate);
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, approveRequest, Map.of("command", "approve")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, approveRequest, Map.of("command", "approve")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.loanApproveMaxAmountFailureMsg());
     }
@@ -1645,12 +1640,12 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         PostLoansLoanIdResponse loanDisburseResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         testContext().set(TestContextKey.LOAN_DISBURSE_RESPONSE, loanDisburseResponse);
         Long statusActual = loanDisburseResponse.getChanges().getStatus().getId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         Long statusExpected = Long.valueOf(loanDetails.getStatus().getId());
 
         assertThat(statusActual)//
@@ -1667,7 +1662,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
         Set<GetLoansLoanIdDisbursementDetails> disbursementDetailsList = loanDetails.getDisbursementDetails();
 
         List<DisbursementDetail> disbursementData = new ArrayList<>();
@@ -1707,7 +1702,7 @@ public class LoanStepDef extends AbstractStepDef {
         String resourceId = String.valueOf(loanId);
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
         Set<GetLoansLoanIdDisbursementDetails> disbursementDetails = loanDetailsResponse.getDisbursementDetails();
         List<List<String>> data = table.asLists();
         for (int i = 1; i < data.size(); i++) {
@@ -1735,7 +1730,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
         BigDecimal availableDisbursementAmountActual = loanDetails.getDelinquent().getAvailableDisbursementAmount();
         assertThat(availableDisbursementAmountActual).isEqualByComparingTo(BigDecimal.valueOf(availableDisbursementAmountExpected));
     }
@@ -1749,13 +1744,13 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdRequest disburseRequest = loanRequestFactory.defaultLoanDisburseRequest()
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
-        PostLoansLoanIdResponse loanDisburseResponse = ok(() -> fineractClient.loans().stateTransitions(loanId, disburseRequest,
+        PostLoansLoanIdResponse loanDisburseResponse = ok(() -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest,
                 Map.of("command", "disburseWithoutAutoDownPayment")));
         testContext().set(TestContextKey.LOAN_DISBURSE_RESPONSE, loanDisburseResponse);
         Long statusActual = loanDisburseResponse.getChanges().getStatus().getId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         Long statusExpected = Long.valueOf(loanDetails.getStatus().getId());
 
         assertThat(statusActual)//
@@ -1797,7 +1792,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         PostLoansLoanIdResponse loanDisburseResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         testContext().set(TestContextKey.LOAN_DISBURSE_SECOND_LOAN_RESPONSE, loanDisburseResponse);
         assertThat(loanDisburseResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_ACTIVE);
 
@@ -1811,7 +1806,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanApproveResponse.getLoanId();
 
         PostLoansLoanIdRequest undoDisbursalRequest = new PostLoansLoanIdRequest().note("");
-        ok(() -> fineractClient.loans().stateTransitions(loanId, undoDisbursalRequest, Map.of("command", "undodisbursal")));
+        ok(() -> fineractClient.loans().handleCommandsLoan(loanId, undoDisbursalRequest, Map.of("command", "undodisbursal")));
     }
 
     @When("Admin successfully undo last disbursal")
@@ -1820,7 +1815,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanApproveResponse.getLoanId();
 
         PostLoansLoanIdRequest undoDisbursalRequest = new PostLoansLoanIdRequest().note("");
-        ok(() -> fineractClient.loans().stateTransitions(loanId, undoDisbursalRequest, Map.of("command", "undolastdisbursal")));
+        ok(() -> fineractClient.loans().handleCommandsLoan(loanId, undoDisbursalRequest, Map.of("command", "undolastdisbursal")));
     }
 
     @Then("Admin can successfully undone the loan disbursal")
@@ -1830,7 +1825,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdRequest undoDisbursalRequest = new PostLoansLoanIdRequest().note("");
 
         PostLoansLoanIdResponse undoDisbursalResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, undoDisbursalRequest, Map.of("command", "undodisbursal")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, undoDisbursalRequest, Map.of("command", "undodisbursal")));
         testContext().set(TestContextKey.LOAN_UNDO_DISBURSE_RESPONSE, undoDisbursalResponse);
         assertThat(undoDisbursalResponse.getChanges().getStatus().getValue()).isEqualTo(LOAN_STATE_APPROVED);
     }
@@ -1843,7 +1838,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.disburseDateFailure((int) loanId));
     }
@@ -1856,7 +1851,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).containsPattern(ErrorMessageHelper.disburseMaxAmountFailure());
         log.debug("Error message: {}", exception.getDeveloperMessage());
@@ -1870,7 +1865,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionAmount(new BigDecimal(disbursementAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(400);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.disburseIsNotAllowedFailure());
     }
@@ -1883,7 +1878,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(disbursementDate).transactionAmount(new BigDecimal(disbursementAmount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.disburseIsNotAllowedExceedApprovedAmountFailure());
     }
@@ -1896,7 +1891,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).containsPattern(ErrorMessageHelper.disburseChargedOffLoanFailure());
         log.debug("Error message: {}", exception.getDeveloperMessage());
@@ -1911,7 +1906,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         String futureApproveDateISO = FORMATTER_EVENTS.format(FORMATTER.parse(futureApproveDate));
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage())
                 .contains(ErrorMessageHelper.disbursePastDateFailure((int) loanId, futureApproveDateISO));
@@ -1925,7 +1920,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.addDisbursementExceedApprovedAmountFailure()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.addDisbursementExceedApprovedAmountFailure());
     }
@@ -1939,7 +1934,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         assertThat(exception.getStatus())
                 .as(ErrorMessageHelper.addDisbursementExceedMaxAppliedAmountFailure(totalDisbursalAmount, maxDisbursalAmount))
                 .isEqualTo(403);
@@ -1966,8 +1961,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                chargeOffRequest, Map.of("command", "charge-off")));
 
         Integer httpStatusCodeExpected = 403;
         String developerMessageExpected = String.format(
@@ -1993,13 +1988,13 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest()
                 .chargeOffReasonId(chargeOffReasonId).transactionDate(transactionDate).dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        PostLoansLoanIdTransactionsResponse chargeOffResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        PostLoansLoanIdTransactionsResponse chargeOffResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
         testContext().set(TestContextKey.LOAN_CHARGE_OFF_RESPONSE, chargeOffResponse);
         Long transactionId = chargeOffResponse.getResourceId();
 
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -2021,8 +2016,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                chargeOffRequest, Map.of("command", "charge-off")));
         assertThat(exception.getDeveloperMessage())
                 .isEqualTo(String.format("Loan: %s Charge-off is not allowed. Loan Account is interest bearing", loanId));
     }
@@ -2035,8 +2030,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                chargeOffRequest, Map.of("command", "charge-off")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.secondChargeOffFailure(loanId)).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.secondChargeOffFailure(loanId));
     }
@@ -2055,7 +2050,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffUndoRequest = loanRequestFactory.defaultUndoChargeOffRequest();
 
         PostLoansLoanIdTransactionsResponse chargeOffUndoResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransaction(loanId, chargeOffUndoRequest, Map.of("command", "undo-charge-off")));
+                .handleCommandsLoanTransaction(loanId, chargeOffUndoRequest, Map.of("command", "undo-charge-off")));
         testContext().set(TestContextKey.LOAN_CHARGE_OFF_UNDO_RESPONSE, chargeOffUndoResponse);
         return chargeOffUndoResponse;
     }
@@ -2064,8 +2059,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        PostLoansLoanIdTransactionsResponse chargeOffResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        PostLoansLoanIdTransactionsResponse chargeOffResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
         testContext().set(TestContextKey.LOAN_CHARGE_OFF_RESPONSE, chargeOffResponse);
         return chargeOffResponse;
     }
@@ -2078,8 +2073,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                chargeOffRequest, Map.of("command", "charge-off")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.chargeOffUndoFailureCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.chargeOffUndoFailure(loanId));
     }
@@ -2092,8 +2087,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest chargeOffRequest = loanRequestFactory.defaultChargeOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, chargeOffRequest, Map.of("command", "charge-off")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                chargeOffRequest, Map.of("command", "charge-off")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.chargeOffFailureDueToMonetaryActivityBefore(loanId)).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.chargeOffFailureDueToMonetaryActivityBefore(loanId));
     }
@@ -2105,7 +2100,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         PostLoansLoanIdTransactionsRequest chargeOffUndoRequest = loanRequestFactory.defaultUndoChargeOffRequest();
 
-        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 chargeOffUndoRequest, Map.of("command", "undo-charge-off")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.chargeOffUndoFailureCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.notChargedOffFailure(loanId));
@@ -2117,7 +2112,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         Double totalOutstandingActual = loanDetailsResponse.getSummary().getTotalOutstanding().doubleValue();
@@ -2133,7 +2128,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanCreateResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         assert loanDetailsResponse != null;
@@ -2150,7 +2145,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "repaymentSchedule")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
@@ -2166,7 +2161,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         Double totalOutstandingActual = loanDetailsResponse.getSummary().getTotalOutstanding().doubleValue();
@@ -2194,7 +2189,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         Double totalOverdueActual = loanDetailsResponse.getSummary().getTotalOverdue().doubleValue();
@@ -2209,7 +2204,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanCreateResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         assert Objects.requireNonNull(loanDetailsResponse).getSummary() != null;
@@ -2225,7 +2220,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "collection")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
@@ -2239,7 +2234,7 @@ public class LoanStepDef extends AbstractStepDef {
     public void loanActualNoTermCheck(Integer activeNoTermExpected) {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         Long loanId = loanCreateResponse.getLoanId();
-        GetLoansLoanIdResponse loanIdResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of()));
+        GetLoansLoanIdResponse loanIdResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of()));
         Assertions.assertNotNull(loanIdResponse);
         Assertions.assertEquals(activeNoTermExpected, loanIdResponse.getActualNoTerm());
     }
@@ -2251,7 +2246,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "repaymentSchedule")));
         List<GetLoansLoanIdRepaymentPeriod> repaymentPeriods = loanDetailsResponse.getRepaymentSchedule().getPeriods();
 
@@ -2283,7 +2278,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "repaymentSchedule")));
         GetLoansLoanIdRepaymentSchedule repaymentSchedule = loanDetailsResponse.getRepaymentSchedule();
         validateRepaymentScheduleTotal(header, repaymentSchedule, expectedValues);
@@ -2295,7 +2290,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
 
@@ -2316,7 +2311,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         List<List<String>> data = table.asLists();
@@ -2414,7 +2409,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions().stream()
                 .filter(lt -> !lt.getType().getAccrual() && !"Accrual Adjustment".equalsIgnoreCase(lt.getType().getValue())).toList();
@@ -2433,14 +2428,14 @@ public class LoanStepDef extends AbstractStepDef {
     }
 
     public List<GetLoansLoanIdTransactions> getAccrualTransactions(Long loanId) {
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         return loanDetailsResponse.getTransactions().stream()
                 .filter(lt -> isLoanTransactionAccrual(lt) || isLoanTransactionAccrualAdjustment(lt)).toList();
     }
 
     public List<GetLoansLoanIdTransactions> getBuyDownFeeAmortizationTransactions(Long loanId) {
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         return loanDetailsResponse.getTransactions().stream()
                 .filter(lt -> isLoanTransactionBuyDownFeeAmortization(lt) || isLoanTransactionBuyDownFeeAmortizationAdjustment(lt))
@@ -2491,7 +2486,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         int nthTransaction = nthTransactionStr == null ? transactions.size() - 1 : Integer.parseInt(nthTransactionStr) - 1;
@@ -2511,7 +2506,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         List<GetLoansLoanIdTransactions> transactionsMatch = transactions//
@@ -2528,7 +2523,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         List<GetLoansLoanIdTransactions> transactionsMatch = transactions//
@@ -2546,7 +2541,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         int nthItem = Integer.parseInt(nthTransactionStr) - 1;
@@ -2565,7 +2560,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
 
@@ -2587,7 +2582,7 @@ public class LoanStepDef extends AbstractStepDef {
         Long targetTransactionId = targetTransaction.getId();
 
         GetLoansLoanIdTransactionsTransactionIdResponse transaction = ok(
-                () -> fineractClient.loanTransactions().retrieveTransaction(loanId, targetTransactionId, Map.of()));
+                () -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, targetTransactionId, Map.of()));
         assertThat(transaction.getExternalId())
                 .as(ErrorMessageHelper.transactionHasNullResourceValue(transaction.getType().getCode(), "external-id")).isNotNull();
     }
@@ -2597,7 +2592,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         assertThat(transactions.size()).isZero();
@@ -2609,8 +2604,8 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
         List<GetLoansLoanIdLoanChargeData> charges = loanDetailsResponse.getCharges();
 
         List<List<String>> data = table.asLists();
@@ -2631,8 +2626,8 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
         String resourceId = String.valueOf(loanId);
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "charges")));
         List<GetLoansLoanIdLoanChargeData> charges = loanDetailsResponse.getCharges();
 
         List<List<String>> data = table.asLists();
@@ -2687,7 +2682,7 @@ public class LoanStepDef extends AbstractStepDef {
         String resourceId = String.valueOf(loanId);
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
         Long loanStatusActualValue = loanDetailsResponse.getStatus().getId();
 
@@ -2704,7 +2699,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "repaymentSchedule")));
         List<GetLoansLoanIdRepaymentPeriod> repaymentPeriods = loanDetailsResponse.getRepaymentSchedule().getPeriods();
 
@@ -2726,7 +2721,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanCreateResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
         if ("null".equals(date)) {
             assertThat(loanDetailsResponse.getTimeline().getClosedOnDate()).isNull();
@@ -2743,10 +2738,10 @@ public class LoanStepDef extends AbstractStepDef {
         PutLoansLoanIdRequest putLoansLoanIdRequest = loanRequestFactory.enableFraudFlag();
 
         PutLoansLoanIdResponse responseMod = ok(
-                () -> fineractClient.loans().modifyLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
+                () -> fineractClient.loans().updateLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
         testContext().set(TestContextKey.LOAN_FRAUD_MODIFY_RESPONSE, responseMod);
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         Boolean fraudFlagActual = loanDetailsResponse.getFraud();
@@ -2761,10 +2756,10 @@ public class LoanStepDef extends AbstractStepDef {
         PutLoansLoanIdRequest putLoansLoanIdRequest = loanRequestFactory.disableFraudFlag();
 
         PutLoansLoanIdResponse responseMod = ok(
-                () -> fineractClient.loans().modifyLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
+                () -> fineractClient.loans().updateLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
         testContext().set(TestContextKey.LOAN_FRAUD_MODIFY_RESPONSE, responseMod);
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         Boolean fraudFlagActual = loanDetailsResponse.getFraud();
@@ -2779,7 +2774,7 @@ public class LoanStepDef extends AbstractStepDef {
         PutLoansLoanIdRequest putLoansLoanIdRequest = loanRequestFactory.disableFraudFlag();
 
         CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
+                () -> fineractClient.loans().updateLoanApplication(loanId, putLoansLoanIdRequest, Map.of("command", "markAsFraud")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(403);
         assertThat(exception.getDeveloperMessage()).contains(ErrorMessageHelper.loanFraudFlagModificationMsg(loanId.toString()));
     }
@@ -2850,7 +2845,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
 
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
@@ -2878,7 +2873,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_SECOND_LOAN_RESPONSE);
         long loanId = loanResponse.getLoanId();
-        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
 
         List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
@@ -2920,7 +2915,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
         LocalDate expectedChargeOffDate = LocalDate.parse(chargeOffDate, FORMATTER);
@@ -2935,7 +2930,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
         log.debug("Loan ID: {}", loanId);
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         if ("null".equals(date)) {
             assertThat(loanDetails.getLastClosedBusinessDate()).isNull();
         } else {
@@ -2993,7 +2988,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         LocalDate actualMaturityDate = loanDetailsResponse.getTimeline().getActualMaturityDate();
         String actualMaturityDateActual = FORMATTER.format(actualMaturityDate);
 
@@ -3007,7 +3002,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions accrualTransaction = transactions.stream()
@@ -3024,7 +3019,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions accrualAdjustmentTransaction = transactions.stream()
@@ -3040,7 +3035,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
 
@@ -3061,7 +3056,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
 
@@ -3076,7 +3071,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
 
@@ -3091,7 +3086,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        return ok(() -> fineractClient.loanTransactions().retrieveTransaction(loanId, transactionId, Map.of()));
+        return ok(() -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, transactionId, Map.of()));
     }
 
     @Then("{string} transaction on {string} got reverse-replayed on {string}")
@@ -3188,7 +3183,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .isEqualTo(externalIdExpected);
 
         GetLoansLoanIdTransactionsTransactionIdResponse originalTransaction = ok(
-                () -> fineractClient.loanTransactions().retrieveTransaction(loanId, originalTransactionId, Map.of()));
+                () -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, originalTransactionId, Map.of()));
         assertNull(originalTransaction.getExternalId(),
                 String.format("Original transaction external id is not null %n%s", originalTransaction));
     }
@@ -3198,7 +3193,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions accrualTransaction = transactions.stream()
@@ -3228,7 +3223,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "collection")));
         GetLoansLoanIdDelinquencySummary delinquent = loanDetailsResponse.getDelinquent();
         String lastPaymentAmountActual = delinquent.getLastPaymentAmount() == null ? null
@@ -3283,12 +3278,12 @@ public class LoanStepDef extends AbstractStepDef {
                 .reversalExternalId(reversalExternalId);
 
         PostLoansLoanIdTransactionsResponse chargeOffUndoResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransaction(loanId, chargeOffUndoRequest, Map.of("command", "undo-charge-off")));
+                .handleCommandsLoanTransaction(loanId, chargeOffUndoRequest, Map.of("command", "undo-charge-off")));
         testContext().set(TestContextKey.LOAN_CHARGE_OFF_UNDO_RESPONSE, chargeOffUndoResponse);
         Long transactionId = chargeOffUndoResponse.getResourceId();
 
         GetLoansLoanIdTransactionsTransactionIdResponse transactionResponse = ok(
-                () -> fineractClient.loanTransactions().retrieveTransaction(loanId, transactionId, Map.of()));
+                () -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, transactionId, Map.of()));
         assertThat(transactionResponse.getReversalExternalId()).isEqualTo(reversalExternalId);
     }
 
@@ -3297,7 +3292,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions chargeOffTransaction = transactions.stream().filter(t -> "Charge-off".equals(t.getType().getValue()))
@@ -3321,7 +3316,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
         GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         GetLoansLoanIdTimeline timeline = loanDetailsResponse.getTimeline();
         String actualMaturityDateActual = FORMATTER.format(timeline.getActualMaturityDate());
         String expectedMaturityDateActual = FORMATTER.format(timeline.getExpectedMaturityDate());
@@ -3410,8 +3405,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest writeOffRequest = loanRequestFactory.defaultWriteOffRequest().transactionDate(transactionDate)
                 .dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        PostLoansLoanIdTransactionsResponse writeOffResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, writeOffRequest, Map.of("command", "writeoff")));
+        PostLoansLoanIdTransactionsResponse writeOffResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, writeOffRequest, Map.of("command", "writeoff")));
         testContext().set(TestContextKey.LOAN_WRITE_OFF_RESPONSE, writeOffResponse);
     }
 
@@ -3431,8 +3426,8 @@ public class LoanStepDef extends AbstractStepDef {
                 .locale(DEFAULT_LOCALE)//
                 .note("Write Off");//
 
-        PostLoansLoanIdTransactionsResponse writeOffResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, writeOffRequest, Map.of("command", "writeoff")));
+        PostLoansLoanIdTransactionsResponse writeOffResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, writeOffRequest, Map.of("command", "writeoff")));
         testContext().set(TestContextKey.LOAN_WRITE_OFF_RESPONSE, writeOffResponse);
     }
 
@@ -3447,8 +3442,8 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansLoanIdTransactionsRequest repaymentRequest = loanRequestFactory.defaultRepaymentRequest().transactionDate(transactionDate)
                 .transactionAmount(transactionAmount).paymentTypeId(paymentTypeValue).dateFormat(DATE_FORMAT).locale(DEFAULT_LOCALE);
 
-        CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, repaymentRequest, Map.of("command", "repayment")));
+        CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                repaymentRequest, Map.of("command", "repayment")));
         assertThat(exception.getStatus()).as(ErrorMessageHelper.dateFailureErrorCodeMsg()).isEqualTo(400);
     }
 
@@ -3458,7 +3453,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         Double expectedAmountParsed = Double.parseDouble(expectedAmount);
         Double totalRepaymentTransaction = loanDetails.getSummary().getTotalRepaymentTransaction().doubleValue();
 
@@ -3473,7 +3468,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         Integer fixedLengthactual = loanDetails.getFixedLength();
         assertThat(fixedLengthactual).as(ErrorMessageHelper.wrongfixedLength(fixedLengthactual, fieldValue)).isEqualTo(fieldValue);
     }
@@ -3484,7 +3479,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         assert loanDetails.getRepaymentStartDateType() != null;
         assert loanDetails.getRepaymentStartDateType().getId() != null;
         final Integer actualValue = loanDetails.getRepaymentStartDateType().getId().intValue();
@@ -3498,7 +3493,7 @@ public class LoanStepDef extends AbstractStepDef {
         assert loanResponse != null;
         final long loanId = loanResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetails = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "collection")));
         assert loanDetails != null;
         assert loanDetails.getDelinquent() != null;
@@ -3517,7 +3512,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanCreateResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetailsResponse = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "all")));
         final List<GetLoansLoanIdLoanTermVariations> emiAmountVariations = loanDetailsResponse.getEmiAmountVariations();
 
         final List<List<String>> data = table.asLists();
@@ -3544,7 +3539,7 @@ public class LoanStepDef extends AbstractStepDef {
         assertNotNull(loanCreateResponse);
         final long loanId = loanCreateResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "loanTermVariations")));
         final List<GetLoansLoanIdLoanTermVariations> loanTermVariations = loanDetailsResponse.getLoanTermVariations();
         assertNotNull(loanTermVariations);
@@ -3575,7 +3570,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanCreateResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final int nthTransactionFrom = nthTransactionFromStr == null ? transactions.size() - 1
@@ -3744,8 +3739,7 @@ public class LoanStepDef extends AbstractStepDef {
             loansRequest.fixedEmiAmount(new BigDecimal(emiStr));
         }
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -3814,8 +3808,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .graceOnInterestPayment(graceOnInterestCharged).transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)
                 .charges(loanCharges);
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -3888,8 +3881,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .interestRateFrequencyType(interestRateFrequencyTypeValue);//
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -3961,8 +3953,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .graceOnArrearsAgeing(graceOnArrearsAgeingValue);//
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4039,8 +4030,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .charges(charges);//
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4146,8 +4136,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .disbursementData(disbursementDetail)//
                 .charges(charges);//
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4265,8 +4254,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionProcessingStrategyCode(transactionProcessingStrategyCodeValue)//
                 .disbursementData(disbursementDetail);//
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4305,8 +4293,7 @@ public class LoanStepDef extends AbstractStepDef {
                         : InterestCalculationPeriodTime.SAME_AS_REPAYMENT_PERIOD.value)//
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION.value);
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4342,8 +4329,7 @@ public class LoanStepDef extends AbstractStepDef {
                         : InterestCalculationPeriodTime.SAME_AS_REPAYMENT_PERIOD.value)//
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION.value);
 
-        final PostLoansResponse response = ok(
-                () -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(loansRequest, Map.of()));
+        final PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(loansRequest, Map.of()));
         testContext().set(TestContextKey.LOAN_CREATE_RESPONSE, response);
         eventCheckHelper.createLoanEventCheck(response);
     }
@@ -4351,7 +4337,7 @@ public class LoanStepDef extends AbstractStepDef {
     private void performLoanDisbursementAndVerifyStatus(final long loanId, final PostLoansLoanIdRequest disburseRequest)
             throws IOException {
         final PostLoansLoanIdResponse loanDisburseResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         testContext().set(TestContextKey.LOAN_DISBURSE_RESPONSE, loanDisburseResponse);
         assertNotNull(loanDisburseResponse);
         assertNotNull(loanDisburseResponse.getChanges());
@@ -4360,7 +4346,7 @@ public class LoanStepDef extends AbstractStepDef {
         assertNotNull(statusActual);
 
         final GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         assertNotNull(loanDetails);
         assertNotNull(loanDetails.getStatus());
         final Long statusExpected = Long.valueOf(loanDetails.getStatus().getId());
@@ -4801,7 +4787,7 @@ public class LoanStepDef extends AbstractStepDef {
         if (excludedTypesList != null && !excludedTypesList.isEmpty()) {
             queryParams.put("excludedTypes", excludedTypesList);
         }
-        return ok(() -> fineractClient.loanTransactions().retrieveTransactionsByLoanId(loanId, queryParams));
+        return ok(() -> fineractClient.loanTransactions().retrieveAllLoanTransactions(loanId, queryParams));
     }
 
     private GetLoansLoanIdTransactionsResponse getTransactionsByLoanIExternalIdFiltered(String loanExternalId, String excludedTypes) {
@@ -4810,7 +4796,7 @@ public class LoanStepDef extends AbstractStepDef {
         if (excludedTypesList != null && !excludedTypesList.isEmpty()) {
             queryParams.put("excludedTypes", excludedTypesList);
         }
-        return ok(() -> fineractClient.loanTransactions().retrieveTransactionsByExternalLoanId(loanExternalId, queryParams));
+        return ok(() -> fineractClient.loanTransactions().retrieveAllLoanTransactionsByExternalId(loanExternalId, queryParams));
     }
 
     public static List<org.apache.fineract.client.models.TransactionType> parseExcludedTypes(String excludedTypes) {
@@ -4858,7 +4844,7 @@ public class LoanStepDef extends AbstractStepDef {
             queryParams.put("size", size);
         }
         GetLoansLoanIdTransactionsResponse transactionsByLoanIdFiltered = ok(
-                () -> fineractClient.loanTransactions().retrieveTransactionsByLoanId(loanId, queryParams));
+                () -> fineractClient.loanTransactions().retrieveAllLoanTransactions(loanId, queryParams));
 
         Integer totalPagesActual = transactionsByLoanIdFiltered.getTotalPages();
 
@@ -4880,7 +4866,7 @@ public class LoanStepDef extends AbstractStepDef {
         final Long loanId = loanResponse.getLoanId();
 
         final GetLoansLoanIdResponse loanDetails = ok(
-                () -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                () -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         assertNotNull(loanDetails);
 
         final Long targetLoanProductId = loanDetails.getLoanProductId();
@@ -4935,7 +4921,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         Optional<GetLoansLoanIdResponse> loanDetailsResponseOptional = Optional
-                .of(fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                .of(fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         GetLoansLoanIdResponse loanDetailsResponse = loanDetailsResponseOptional
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve loan details - response is null"));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
@@ -4986,7 +4972,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         Optional<GetLoansLoanIdResponse> loanDetailsResponseOptional = Optional
-                .of(fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                .of(fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         GetLoansLoanIdResponse loanDetailsResponse = loanDetailsResponseOptional
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve loan details - response is null"));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
@@ -5001,7 +4987,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         Optional<GetLoansLoanIdResponse> loanDetailsResponseOptional = Optional
-                .of(fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                .of(fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         GetLoansLoanIdResponse loanDetailsResponse = loanDetailsResponseOptional
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve loan details - response is null"));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
@@ -5018,7 +5004,7 @@ public class LoanStepDef extends AbstractStepDef {
         long loanId = loanResponse.getLoanId();
 
         Optional<GetLoansLoanIdResponse> loanDetailsResponseOptional = Optional
-                .of(fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
+                .of(fineractClient.loans().retrieveOneLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false")));
         GetLoansLoanIdResponse loanDetailsResponse = loanDetailsResponseOptional
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve loan details - response is null"));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
@@ -5044,7 +5030,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .externalId("EXT-CAP-INC-" + UUID.randomUUID());
 
         final PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
+                .handleCommandsLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
         return capitalizedIncomeResponse;
     }
 
@@ -5061,7 +5047,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .externalId("EXT-CAP-INC-" + UUID.randomUUID()).classificationId(24L);
 
         final PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
+                .handleCommandsLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
         return capitalizedIncomeResponse;
     }
 
@@ -5098,7 +5084,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .externalId("EXT-CAP-INC-" + UUID.randomUUID()).classificationId(classificationId);
 
         final PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = ok(() -> fineractClient.loanTransactions()
-                .executeLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
+                .handleCommandsLoanTransaction(loanId, capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
         return capitalizedIncomeResponse;
     }
 
@@ -5130,7 +5116,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(Double.valueOf(amount)).paymentTypeId(paymentTypeValue)
                 .externalId("EXT-CAP-INC-" + UUID.randomUUID());
 
-        final CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        final CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
 
         assertThat(exception.getStatus()).isEqualTo(400);
@@ -5148,7 +5134,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(Double.valueOf(amount)).paymentTypeId(paymentTypeValue)
                 .externalId("EXT-CAP-INC-" + UUID.randomUUID());
 
-        final CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId,
+        final CallFailedRuntimeException exception = fail(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
                 capitalizedIncomeRequest, Map.of("command", "capitalizedIncome")));
 
         assertThat(exception.getStatus()).isEqualTo(400);
@@ -5160,7 +5146,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions finalAmortizationTransaction = transactions.stream()
@@ -5178,7 +5164,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions finalAmortizationTransaction = transactions.stream()
@@ -5197,7 +5183,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions finalAmortizationTransaction = transactions.stream()
@@ -5213,7 +5199,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions finalAmortizationTransaction = transactions.stream()
@@ -5236,7 +5222,7 @@ public class LoanStepDef extends AbstractStepDef {
         String currentBusinessDate = businessDateHelper.getBusinessDate();
         log.debug("Current business date: {}, Transaction date: {}", currentBusinessDate, transactionDate);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions capitalizedIncomeTransaction = transactions.stream()
@@ -5260,7 +5246,7 @@ public class LoanStepDef extends AbstractStepDef {
         String currentBusinessDate = businessDateHelper.getBusinessDate();
         log.debug("Current business date: {}, Transaction date: {}", currentBusinessDate, transactionDate);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         assert loanDetailsResponse != null;
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
@@ -5287,7 +5273,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "collection")));
 
         // Extract availableDisbursementAmount from collection data
@@ -5303,7 +5289,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions capitalizedIncomeTransaction = transactions.stream()
@@ -5328,7 +5314,7 @@ public class LoanStepDef extends AbstractStepDef {
         String currentBusinessDate = businessDateHelper.getBusinessDate();
         log.debug("Current business date: {}, Transaction date: {}", currentBusinessDate, transactionDate);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions capitalizedIncomeTransaction = transactions.stream()
@@ -5403,7 +5389,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         final PostLoansLoanIdRequest contractTerminationRequest = loanRequestFactory.defaultLoanContractTerminationRequest();
 
-        final PostLoansLoanIdResponse loanContractTerminationResponse = ok(() -> fineractClient.loans().stateTransitions(loanId,
+        final PostLoansLoanIdResponse loanContractTerminationResponse = ok(() -> fineractClient.loans().handleCommandsLoan(loanId,
                 contractTerminationRequest, Map.of("command", "contractTermination")));
         testContext().set(TestContextKey.LOAN_CONTRACT_TERMINATION_RESPONSE, loanContractTerminationResponse);
         assert loanContractTerminationResponse != null;
@@ -5421,7 +5407,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         final PostLoansLoanIdRequest contractTerminationRequest = loanRequestFactory.defaultLoanContractTerminationRequest();
 
-        final PostLoansLoanIdResponse loanContractTerminationResponse = ok(() -> fineractClient.loans().stateTransitions(loanId,
+        final PostLoansLoanIdResponse loanContractTerminationResponse = ok(() -> fineractClient.loans().handleCommandsLoan(loanId,
                 contractTerminationRequest, Map.of("command", "contractTermination")));
         testContext().set(TestContextKey.LOAN_CONTRACT_TERMINATION_RESPONSE, loanContractTerminationResponse);
     }
@@ -5435,9 +5421,8 @@ public class LoanStepDef extends AbstractStepDef {
         assert loanContractTerminationResponse != null;
         final Long loanId = loanResponse.getLoanId();
 
-        final List<GetLoansLoanIdTransactions> transactions = Objects.requireNonNull(
-                fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")))
-                .getTransactions();
+        final List<GetLoansLoanIdTransactions> transactions = Objects.requireNonNull(fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions"))).getTransactions();
 
         assert transactions != null;
         final GetLoansLoanIdTransactions targetTransaction = transactions.stream().filter(t -> {
@@ -5448,7 +5433,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansLoanIdRequest request = loanRequestFactory.defaultContractTerminationUndoRequest();
 
         final PostLoansLoanIdResponse response = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "undoContractTermination")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "undoContractTermination")));
         testContext().set(TestContextKey.LOAN_UNDO_CONTRACT_TERMINATION_RESPONSE, response);
         assert targetTransaction != null;
         eventCheckHelper.checkTransactionWithLoanTransactionAdjustmentBizEvent(targetTransaction);
@@ -5461,7 +5446,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanCreateResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions loanContractTerminationTransaction = transactions.stream()
@@ -5478,7 +5463,7 @@ public class LoanStepDef extends AbstractStepDef {
             final String amount) {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions capitalizedIncomeTransaction = transactions.stream()
@@ -5511,8 +5496,8 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(Double.valueOf(amount)).paymentTypeId(paymentTypeValue)
                 .externalId("EXT-BUY-DOWN-FEE" + UUID.randomUUID());
 
-        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
+        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
         return buyDownFeeResponse;
     }
 
@@ -5528,8 +5513,8 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(Double.valueOf(amount)).paymentTypeId(paymentTypeValue)
                 .externalId("EXT-BUY-DOWN-FEE" + UUID.randomUUID()).classificationId(25L);
 
-        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
+        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
         return buyDownFeeResponse;
     }
 
@@ -5584,8 +5569,8 @@ public class LoanStepDef extends AbstractStepDef {
                 .transactionDate(transactionDate).transactionAmount(Double.valueOf(amount)).paymentTypeId(paymentTypeValue)
                 .externalId("EXT-BUY-DOWN-FEE" + UUID.randomUUID()).classificationId(classificationId);
 
-        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
+        final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = ok(() -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, buyDownFeeRequest, Map.of("command", "buyDownFee")));
         return buyDownFeeResponse;
     }
 
@@ -5595,7 +5580,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions buyDownFeeTransaction = transactions.stream()
@@ -5615,7 +5600,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final GetLoansLoanIdTransactions buyDownFeeTransaction = transactions.stream().filter(t -> {
@@ -5679,23 +5664,25 @@ public class LoanStepDef extends AbstractStepDef {
     public void updateLoanApprovedAmount(final String amount) {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
-        ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
+        ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final PutLoansApprovedAmountRequest modifyLoanApprovedAmountRequest = new PutLoansApprovedAmountRequest().locale(LOCALE_EN)
                 .amount(new BigDecimal(amount));
 
-        ok(() -> fineractClient.loans().modifyLoanApprovedAmount(loanId, modifyLoanApprovedAmountRequest));
+        ok(() -> fineractClient.loans().updateApprovedAmountLoan(loanId, modifyLoanApprovedAmountRequest));
     }
 
     @Then("Update loan approved amount is forbidden with amount {string} due to exceed applied amount")
     public void updateLoanApprovedAmountForbiddenExceedAppliedAmount(final String amount) {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
-        ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
+        ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final PutLoansApprovedAmountRequest modifyLoanApprovedAmountRequest = new PutLoansApprovedAmountRequest().locale(LOCALE_EN)
                 .amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanApprovedAmount(loanId, modifyLoanApprovedAmountRequest));
+                () -> fineractClient.loans().updateApprovedAmountLoan(loanId, modifyLoanApprovedAmountRequest));
         assertThat(exception.getStatus()).isEqualTo(403);
     }
 
@@ -5703,12 +5690,13 @@ public class LoanStepDef extends AbstractStepDef {
     public void updateLoanApprovedAmountForbiddenHigherPrincipalAmountOnLoan(final String amount) {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
-        ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
+        ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final PutLoansApprovedAmountRequest modifyLoanApprovedAmountRequest = new PutLoansApprovedAmountRequest().locale(LOCALE_EN)
                 .amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanApprovedAmount(loanId, modifyLoanApprovedAmountRequest));
+                () -> fineractClient.loans().updateApprovedAmountLoan(loanId, modifyLoanApprovedAmountRequest));
         assertThat(exception.getStatus()).isEqualTo(403);
     }
 
@@ -5716,12 +5704,13 @@ public class LoanStepDef extends AbstractStepDef {
     public void updateLoanApprovedAmountForbiddenMinAllowedAmount(final String amount) {
         final PostLoansResponse loanResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanResponse.getLoanId();
-        ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
+        ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final PutLoansApprovedAmountRequest modifyLoanApprovedAmountRequest = new PutLoansApprovedAmountRequest().locale(LOCALE_EN)
                 .amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanApprovedAmount(loanId, modifyLoanApprovedAmountRequest));
+                () -> fineractClient.loans().updateApprovedAmountLoan(loanId, modifyLoanApprovedAmountRequest));
         assertThat(exception.getStatus()).isEqualTo(403);
     }
 
@@ -5732,7 +5721,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PutLoansAvailableDisbursementAmountRequest modifyLoanAvailableDisbursementAmountRequest = new PutLoansAvailableDisbursementAmountRequest()
                 .locale(LOCALE_EN).amount(new BigDecimal(amount));
 
-        ok(() -> fineractClient.loans().modifyLoanAvailableDisbursementAmount(loanId, modifyLoanAvailableDisbursementAmountRequest));
+        ok(() -> fineractClient.loans().updateAvailableDisbursementAmountLoan(loanId, modifyLoanAvailableDisbursementAmountRequest));
     }
 
     @Then("Update loan available disbursement amount by external-id with new amount {string} value")
@@ -5742,7 +5731,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PutLoansAvailableDisbursementAmountRequest modifyLoanAvailableDisbursementAmountRequest = new PutLoansAvailableDisbursementAmountRequest()
                 .locale(LOCALE_EN).amount(new BigDecimal(amount));
 
-        ok(() -> fineractClient.loans().modifyLoanAvailableDisbursementAmountByExternalId(externalId,
+        ok(() -> fineractClient.loans().updateAvailableDisbursementAmountLoanByExternalId(externalId,
                 modifyLoanAvailableDisbursementAmountRequest));
     }
 
@@ -5754,7 +5743,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .locale(LOCALE_EN).amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(() -> fineractClient.loans()
-                .modifyLoanAvailableDisbursementAmountByExternalId(externalId, modifyLoanAvailableDisbursementAmountRequest));
+                .updateAvailableDisbursementAmountLoanByExternalId(externalId, modifyLoanAvailableDisbursementAmountRequest));
 
         assertThat(exception.getStatus()).isEqualTo(403);
         // API returns generic validation error - ideally should contain specific message about exceeding amount
@@ -5770,7 +5759,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .locale(LOCALE_EN).amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanAvailableDisbursementAmount(loanId, modifyLoanAvailableDisbursementAmountRequest));
+                () -> fineractClient.loans().updateAvailableDisbursementAmountLoan(loanId, modifyLoanAvailableDisbursementAmountRequest));
 
         assertThat(exception.getStatus()).isEqualTo(403);
         // API returns generic validation error - ideally should contain specific message about min amount
@@ -5785,7 +5774,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .locale(LOCALE_EN).amount(new BigDecimal(amount));
 
         final CallFailedRuntimeException exception = fail(
-                () -> fineractClient.loans().modifyLoanAvailableDisbursementAmount(loanId, modifyLoanAvailableDisbursementAmountRequest));
+                () -> fineractClient.loans().updateAvailableDisbursementAmountLoan(loanId, modifyLoanAvailableDisbursementAmountRequest));
 
         assertThat(exception.getStatus()).isEqualTo(403);
         // API returns generic validation error - ideally should contain specific message about zero amount
@@ -5834,7 +5823,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions buyDownFeeTransaction = transactions.stream()
@@ -5850,7 +5839,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions buyDownFeeAmortizationTransaction = transactions.stream()
@@ -5868,7 +5857,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions buyDownFeeAdjustmentTransaction = transactions.stream()
@@ -5885,7 +5874,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions buyDownFeeAmortizationAdjustmentTransaction = transactions.stream().filter(
@@ -5903,7 +5892,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         GetLoansLoanIdTransactions transaction = transactions.stream()
@@ -5913,7 +5902,7 @@ public class LoanStepDef extends AbstractStepDef {
 
         // Get detailed transaction information including classification
         GetLoansLoanIdTransactionsTransactionIdResponse transactionDetailsResponse = ok(
-                () -> fineractClient.loanTransactions().retrieveTransaction(loanId, transaction.getId(), (String) null));
+                () -> fineractClient.loanTransactions().retrieveOneLoanTransaction(loanId, transaction.getId(), (String) null));
         GetLoansLoanIdTransactionsTransactionIdResponse transactionDetails = transactionDetailsResponse;
         assertThat(transactionDetails.getClassification()).as(String.format("%s transaction should have classification", transactionType))
                 .isNotNull();
@@ -5942,7 +5931,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanCreateResponse.getLoanId();
         final String resourceId = String.valueOf(loanId);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         final String transactionTypeExpected = transactionType1.getValue();
@@ -5977,7 +5966,7 @@ public class LoanStepDef extends AbstractStepDef {
         final long loanId = loanCreateResponse.getLoanId();
         final String resourceId = String.valueOf(loanId);
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final TransactionType transactionType1 = TransactionType.valueOf(transactionType);
         final String transactionTypeExpected = transactionType1.getValue();
@@ -6009,7 +5998,7 @@ public class LoanStepDef extends AbstractStepDef {
         PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         long loanId = loanCreateResponse.getLoanId();
 
-        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "repaymentSchedule")));
         testContext().set(TestContextKey.LOAN_RESPONSE, loanDetailsResponse);
 
@@ -6064,7 +6053,7 @@ public class LoanStepDef extends AbstractStepDef {
         final PostLoansResponse loanCreateResponse = testContext().get(TestContextKey.LOAN_CREATE_RESPONSE);
         final long loanId = loanCreateResponse.getLoanId();
 
-        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveLoan(loanId,
+        final GetLoansLoanIdResponse loanDetailsResponse = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", "false", "associations", "transactions")));
         final List<GetLoansLoanIdTransactions> transactions = loanDetailsResponse.getTransactions();
         final int nthTransactionFrom = nthTransactionFromStr == null ? transactions.size() - 1
@@ -6106,7 +6095,7 @@ public class LoanStepDef extends AbstractStepDef {
                 .actualDisbursementDate(actualDisbursementDate).transactionAmount(new BigDecimal(transactionAmount));
 
         PostLoansLoanIdResponse loanDisburseResponse = ok(
-                () -> fineractClient.loans().stateTransitions(loanId, disburseRequest, Map.of("command", "disburse")));
+                () -> fineractClient.loans().handleCommandsLoan(loanId, disburseRequest, Map.of("command", "disburse")));
         testContext().set(TestContextKey.LOAN_DISBURSE_RESPONSE, loanDisburseResponse);
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanScheduleApiResource.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanScheduleApiResource.java
@@ -65,7 +65,7 @@ public class LoanScheduleApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Calculate loan repayment schedule based on Loan term variations | Updates loan repayment schedule based on Loan term variations | Updates loan repayment schedule by removing Loan term variations", description = "Calculate loan repayment schedule based on Loan term variations:\n\n"
+    @Operation(summary = "Calculate loan repayment schedule based on Loan term variations | Updates loan repayment schedule based on Loan term variations | Updates loan repayment schedule by removing Loan term variations", operationId = "handleCommandsLoanSchedule", description = "Calculate loan repayment schedule based on Loan term variations:\n\n"
             + "Mandatory Fields: exceptions,locale,dateFormat\n\n" + "Updates loan repayment schedule based on Loan term variations:\n\n"
             + "Mandatory Fields: exceptions,locale,dateFormat\n\n" + "Updates loan repayment schedule by removing Loan term variations:\n\n"
             + "It updates the loan repayment schedule by removing Loan term variations\n\n"

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResource.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/api/RescheduleLoansApiResource.java
@@ -73,7 +73,7 @@ public class RescheduleLoansApiResource {
     @GET
     @Path("template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve all reschedule loan reasons", description = "Retrieve all reschedule loan reasons as a template")
+    @Operation(summary = "Retrieve all reschedule loan reasons", operationId = "retrieveAllRescheduleLoanReasons", description = "Retrieve all reschedule loan reasons as a template")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.GetRescheduleReasonsTemplateResponse.class)))
     public String retrieveTemplate(@Context final UriInfo uriInfo) {
 
@@ -89,7 +89,7 @@ public class RescheduleLoansApiResource {
     @GET
     @Path("{scheduleId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve loan reschedule request by schedule id", description = "Retrieve loan reschedule request by schedule id")
+    @Operation(summary = "Retrieve loan reschedule request by schedule id", operationId = "retrieveOneRescheduleLoan", description = "Retrieve loan reschedule request by schedule id")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.GetLoanRescheduleRequestResponse.class)))
     public String readLoanRescheduleRequest(@Context final UriInfo uriInfo, @PathParam("scheduleId") final Long scheduleId,
             @QueryParam("command") final String command) {
@@ -112,7 +112,7 @@ public class RescheduleLoansApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create loan reschedule request", description = "Create a loan reschedule request.")
+    @Operation(summary = "Create loan reschedule request", operationId = "createRescheduleLoan", description = "Create a loan reschedule request.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.PostCreateRescheduleLoansRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.PostCreateRescheduleLoansResponse.class)))
     public String createLoanRescheduleRequest(final String apiRequestBodyAsJson) {
@@ -128,7 +128,7 @@ public class RescheduleLoansApiResource {
     @Path("{scheduleId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update loan reschedule request", description = "Update a loan reschedule request by either approving/rejecting it.")
+    @Operation(summary = "Update loan reschedule request", operationId = "updateRescheduleLoan", description = "Update a loan reschedule request by either approving/rejecting it.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.PostUpdateRescheduleLoansRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.PostUpdateRescheduleLoansResponse.class)))
     public String updateLoanRescheduleRequest(@PathParam("scheduleId") final Long scheduleId, @QueryParam("command") final String command,
@@ -169,7 +169,7 @@ public class RescheduleLoansApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve all reschedule requests", description = "Retrieve all reschedule requests.")
+    @Operation(summary = "Retrieve all reschedule requests", operationId = "retrieveAllRescheduleLoans", description = "Retrieve all reschedule requests.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = RescheduleLoansApiResourceSwagger.GetLoanRescheduleRequestResponse.class))))
     public String retrieveAllRescheduleRequest(@Context final UriInfo uriInfo, @QueryParam("command") final String command,
             @QueryParam("loanId") Long loanId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
@@ -94,8 +94,8 @@ public class LoanChargesApiResource {
     @GET
     @Path("{loanId}/charges")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Loan Charges", description = "It lists all the Loan Charges specific to a Loan \n\n" + "Example Requests:\n"
-            + "\n" + "loans/1/charges\n" + "\n" + "\n" + "loans/1/charges?fields=name,amountOrPercentage")
+    @Operation(summary = "List Loan Charges", operationId = "retrieveAllLoanCharges", description = "It lists all the Loan Charges specific to a Loan \n\n"
+            + "Example Requests:\n" + "\n" + "loans/1/charges\n" + "\n" + "\n" + "loans/1/charges?fields=name,amountOrPercentage")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = LoanChargesApiResourceSwagger.GetLoansLoanIdChargesChargeIdResponse.class))))
     public String retrieveAllLoanCharges(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
             @Context final UriInfo uriInfo) {
@@ -143,7 +143,7 @@ public class LoanChargesApiResource {
     @GET
     @Path("{loanId}/charges/{loanChargeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan Charge", description = "Retrieves Loan Charge according to the Loan ID and Loan Charge ID"
+    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveOneLoanCharge", description = "Retrieves Loan Charge according to the Loan ID and Loan Charge ID"
             + "Example Requests:\n" + "\n" + "/loans/1/charges/1\n" + "\n" + "\n" + "/loans/1/charges/1?fields=name,amountOrPercentage")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.GetLoansLoanIdChargesChargeIdResponse.class)))
     public String retrieveLoanCharge(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
@@ -155,7 +155,7 @@ public class LoanChargesApiResource {
     @GET
     @Path("{loanId}/charges/external-id/{loanChargeExternalId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveLoanChargeByChargeExternalId", description = "Retrieves Loan Charge according to the Loan ID and Loan Charge External ID"
+    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveOneLoanChargeByChargeExternalId", description = "Retrieves Loan Charge according to the Loan ID and Loan Charge External ID"
             + "Example Requests:\n" + "\n" + "/loans/1/charges/1\n" + "\n" + "\n"
             + "/loans/1/charges/external-id/1?fields=name,amountOrPercentage")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.GetLoansLoanIdChargesChargeIdResponse.class)))
@@ -169,7 +169,7 @@ public class LoanChargesApiResource {
     @GET
     @Path("external-id/{loanExternalId}/charges/{loanChargeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveLoanChargeByLoanExternalId", description = "Retrieves Loan Charge according to the Loan external ID and Loan Charge ID"
+    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveOneLoanChargeByLoanExternalId", description = "Retrieves Loan Charge according to the Loan external ID and Loan Charge ID"
             + "Example Requests:\n" + "\n" + "/loans/1/charges/1\n" + "\n" + "\n" + "/loans/1/charges/1?fields=name,amountOrPercentage")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.GetLoansLoanIdChargesChargeIdResponse.class)))
     public String retrieveLoanCharge(@PathParam("loanExternalId") @Parameter(description = "loanExternalId") final String loanExternalId,
@@ -181,7 +181,7 @@ public class LoanChargesApiResource {
     @GET
     @Path("external-id/{loanExternalId}/charges/external-id/{loanChargeExternalId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveLoanChargeByLoanAndChargeExternalId", description = "Retrieves Loan Charge according to the Loan External ID and Loan Charge External ID"
+    @Operation(summary = "Retrieve a Loan Charge", operationId = "retrieveOneLoanChargeByLoanAndChargeExternalId", description = "Retrieves Loan Charge according to the Loan External ID and Loan Charge External ID"
             + "Example Requests:\n" + "\n" + "/loans/1/charges/1\n" + "\n" + "\n" + "/loans/1/charges/1?fields=name,amountOrPercentage")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.GetLoansLoanIdChargesChargeIdResponse.class)))
     public String retrieveLoanCharge(@PathParam("loanExternalId") @Parameter(description = "loanExternalId") final String loanExternalId,
@@ -195,7 +195,7 @@ public class LoanChargesApiResource {
     @Path("{loanId}/charges")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a Loan Charge (no command provided) or Pay a charge (command=pay)", description = "Creates a Loan Charge | Pay a Loan Charge")
+    @Operation(summary = "Create a Loan Charge (no command provided) or Pay a charge (command=pay)", operationId = "createOrPayLoanCharge", description = "Creates a Loan Charge | Pay a Loan Charge")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.PostLoansLoanIdChargesRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.PostLoansLoanIdChargesResponse.class)))
     public String executeLoanCharge(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
@@ -283,7 +283,7 @@ public class LoanChargesApiResource {
     @Path("{loanId}/charges/{loanChargeId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Loan Charge", description = "Currently Loan Charges may be updated only if the Loan is not yet approved")
+    @Operation(summary = "Update a Loan Charge", operationId = "updateLoanCharge", description = "Currently Loan Charges may be updated only if the Loan is not yet approved")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.PutLoansLoanIdChargesChargeIdRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.PutLoansLoanIdChargesChargeIdResponse.class)))
     public String updateLoanCharge(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
@@ -338,7 +338,7 @@ public class LoanChargesApiResource {
     @DELETE
     @Path("{loanId}/charges/{loanChargeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Loan Charge", description = "Note: Currently, A Loan Charge may only be removed from Loans that are not yet approved.")
+    @Operation(summary = "Delete a Loan Charge", operationId = "deleteLoanCharge", description = "Note: Currently, A Loan Charge may only be removed from Loans that are not yet approved.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanChargesApiResourceSwagger.DeleteLoansLoanIdChargesChargeIdResponse.class)))
     public String deleteLoanCharge(@PathParam("loanId") @Parameter(description = "loanId") final Long loanId,
             @PathParam("loanChargeId") @Parameter(description = "loanChargeId") final Long loanChargeId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResource.java
@@ -118,7 +118,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions/template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Loan Transaction Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
+    @Operation(summary = "Retrieve Loan Transaction Template", operationId = "retrieveTemplateLoanTransaction", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
             + "\n" + "Field Defaults\n" + "Allowed Value Lists\n\n" + "Example Requests:\n" + "\n"
             + "loans/1/transactions/template?command=repayment" + "loans/1/transactions/template?command=merchantIssuedRefund"
             + "loans/1/transactions/template?command=payoutRefund" + "loans/1/transactions/template?command=goodwillCredit" + "\n"
@@ -148,7 +148,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions/template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Loan Transaction Template", operationId = "retrieveTransactionTemplateByLoanExternalId", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
+    @Operation(summary = "Retrieve Loan Transaction Template", operationId = "retrieveTemplateLoanTransactionByLoanExternalId", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
             + "\n" + "Field Defaults\n" + "Allowed Value Lists\n\n" + "Example Requests:\n" + "\n"
             + "loans/1/transactions/template?command=repayment" + "loans/1/transactions/template?command=merchantIssuedRefund"
             + "loans/1/transactions/template?command=payoutRefund" + "loans/1/transactions/template?command=goodwillCredit" + "\n"
@@ -180,8 +180,8 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions/{transactionId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Transaction Details", description = "Retrieves a Transaction Details\n\n" + "Example Request:\n" + "\n"
-            + "loans/5/transactions/3")
+    @Operation(summary = "Retrieve a Transaction Details", operationId = "retrieveOneLoanTransaction", description = "Retrieves a Transaction Details\n\n"
+            + "Example Request:\n" + "\n" + "loans/5/transactions/3")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsTransactionIdResponse.class))) })
     public String retrieveTransaction(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
@@ -195,8 +195,8 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions/external-id/{externalTransactionId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Transaction Details", description = "Retrieves a Transaction Details\n\n" + "Example Request:\n" + "\n"
-            + "loans/5/transactions/external-id/5dd80a7c-ccba-4446-b378-01eb6f53e871")
+    @Operation(summary = "Retrieve a Transaction Details", operationId = "retrieveOneLoanTransactionByExternalId", description = "Retrieves a Transaction Details\n\n"
+            + "Example Request:\n" + "\n" + "loans/5/transactions/external-id/5dd80a7c-ccba-4446-b378-01eb6f53e871")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsTransactionIdResponse.class))) })
     public String retrieveTransactionByTransactionExternalId(
@@ -211,8 +211,8 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions/{transactionId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Transaction Details", description = "Retrieves a Transaction Details\n\n" + "Example Request:\n" + "\n"
-            + "loans/5/transactions/3")
+    @Operation(summary = "Retrieve a Transaction Details", operationId = "retrieveOneLoanTransactionByLoanExternalId", description = "Retrieves a Transaction Details\n\n"
+            + "Example Request:\n" + "\n" + "loans/5/transactions/3")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsTransactionIdResponse.class))) })
     public String retrieveTransactionByLoanExternalIdAndTransactionId(
@@ -227,7 +227,8 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions/external-id/{externalTransactionId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Transaction Details", description = "Retrieves a Transaction Details\n\n" + "Example Request:\n" + "\n"
+    @Operation(summary = "Retrieve a Transaction Details", operationId = "retrieveOneLoanTransactionByLoanExternalIdAndTransactionExternalId", description = "Retrieves a Transaction Details\n\n"
+            + "Example Request:\n" + "\n"
             + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854/transactions/external-id/5dd80a7c-ccba-4446-b378-01eb6f53e871")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsTransactionIdResponse.class))) })
@@ -243,7 +244,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Transactions", description = "Retrieves transactions of a loan")
+    @Operation(summary = "Retrieve Transactions", operationId = "retrieveAllLoanTransactions", description = "Retrieves transactions of a loan")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsResponse.class))) })
     public Page<LoanTransactionData> retrieveTransactionsByLoanId(
@@ -259,7 +260,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Transactions", description = "Retrieves transactions of a loan")
+    @Operation(summary = "Retrieve Transactions", operationId = "retrieveAllLoanTransactionsByExternalId", description = "Retrieves transactions of a loan")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.GetLoansLoanIdTransactionsResponse.class))) })
     public Page<LoanTransactionData> retrieveTransactionsByExternalLoanId(
@@ -276,7 +277,7 @@ public class LoanTransactionsApiResource {
     @Path("{loanId}/transactions")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Significant Loan Transactions", description = "This API covers the major loan transaction functionality\n\n"
+    @Operation(summary = "Significant Loan Transactions", operationId = "handleCommandsLoanTransaction", description = "This API covers the major loan transaction functionality\n\n"
             + "Example Requests:\n\n" + "loans/1/transactions?command=repayment" + " | Make a Repayment | \n"
             + "loans/1/transactions?command=merchantIssuedRefund" + " | Merchant Issued Refund | \n"
             + "loans/1/transactions?command=payoutRefund" + " | Payout Refund | \n" + "loans/1/transactions?command=goodwillCredit"
@@ -304,7 +305,7 @@ public class LoanTransactionsApiResource {
     @Path("external-id/{loanExternalId}/transactions")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Significant Loan Transactions", operationId = "executeLoanTransactionByLoanExternalId", description = "This API covers the major loan transaction functionality\n\n"
+    @Operation(summary = "Significant Loan Transactions", operationId = "handleCommandsLoanTransactionByLoanExternalId", description = "This API covers the major loan transaction functionality\n\n"
             + "Example Requests:\n\n" + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854/transactions?command=repayment"
             + " | Make a Repayment | \n"
             + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854/transactions?command=merchantIssuedRefund"
@@ -340,7 +341,7 @@ public class LoanTransactionsApiResource {
     @Path("{loanId}/transactions/{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Adjust a Transaction", description = "Note: there is no need to specify command={transactionType} parameter.\n\n"
+    @Operation(summary = "Adjust a Transaction", operationId = "adjustLoanTransaction", description = "Note: there is no need to specify command={transactionType} parameter.\n\n"
             + "Mandatory Fields: transactionDate, transactionAmount")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PostLoansLoanIdTransactionsTransactionIdRequest.class)))
     @ApiResponses({
@@ -410,7 +411,7 @@ public class LoanTransactionsApiResource {
     @Path("{loanId}/transactions/{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Undo a Waive Charge Transaction", description = "Undo a Waive Charge Transaction")
+    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeLoanTransaction", description = "Undo a Waive Charge Transaction")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesResponse.class))) })
@@ -424,7 +425,7 @@ public class LoanTransactionsApiResource {
     @Path("external-id/{loanExternalId}/transactions/{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeByLoanExternalId", description = "Undo a Waive Charge Transaction")
+    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeLoanTransactionByLoanExternalId", description = "Undo a Waive Charge Transaction")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesResponse.class))) })
@@ -439,7 +440,7 @@ public class LoanTransactionsApiResource {
     @Path("{loanId}/transactions/external-id/{transactionExternalId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeByTransactionExternalId", description = "Undo a Waive Charge Transaction")
+    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeLoanTransactionByTransactionExternalId", description = "Undo a Waive Charge Transaction")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesResponse.class))) })
@@ -453,7 +454,7 @@ public class LoanTransactionsApiResource {
     @Path("external-id/{loanExternalId}/transactions/external-id/{transactionExternalId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeByLoanAndTransactionExternalId", description = "Undo a Waive Charge Transaction")
+    @Operation(summary = "Undo a Waive Charge Transaction", operationId = "undoWaiveChargeLoanTransactionByLoanAndTransactionExternalId", description = "Undo a Waive Charge Transaction")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PutChargeTransactionChangesResponse.class))) })
@@ -783,7 +784,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions/reage-preview")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Preview Re-Age Schedule", description = "Generates a preview of the re-aged loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
+    @Operation(summary = "Preview Re-Age Schedule", operationId = "previewReAgeLoanSchedule", description = "Generates a preview of the re-aged loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
     public LoanScheduleData previewReAgeSchedule(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
             @Valid @BeanParam final ReAgePreviewRequest reAgePreviewRequest) {
         this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
@@ -793,7 +794,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions/reage-preview")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Preview Re-Age Schedule", operationId = "previewReAgeScheduleByLoanExternalId", description = "Generates a preview of the re-aged loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
+    @Operation(summary = "Preview Re-Age Schedule", operationId = "previewReAgeLoanScheduleByLoanExternalId", description = "Generates a preview of the re-aged loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
     public LoanScheduleData previewReAgeSchedule(
             @PathParam("loanExternalId") @Parameter(description = "loanExternalId", required = true) final String loanExternalId,
             @Valid @BeanParam final ReAgePreviewRequest reAgePreviewRequest) {
@@ -804,7 +805,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("{loanId}/transactions/reamortization-preview")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Preview Re-Amortized Schedule", description = "Generates a preview of the re-amortized loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
+    @Operation(summary = "Preview Re-Amortized Schedule", operationId = "previewReAmortizeLoanSchedule", description = "Generates a preview of the re-amortized loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
     public LoanScheduleData previewReAmortizationSchedule(
             @PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
             @Valid @BeanParam final ReAmortizationPreviewRequest reAmortizationPreviewRequest) {
@@ -815,7 +816,7 @@ public class LoanTransactionsApiResource {
     @GET
     @Path("external-id/{loanExternalId}/transactions/reamortization-preview")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Preview Re-amortized Schedule", operationId = "previewReAmortizationScheduleByLoanExternalId", description = "Generates a preview of the re-amortized loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
+    @Operation(summary = "Preview Re-amortized Schedule", operationId = "previewReAmortizeLoanScheduleByLoanExternalId", description = "Generates a preview of the re-amortized loan schedule based on the provided parameters without creating any transactions or modifying the loan.")
     public LoanScheduleData previewReAmortizationSchedule(
             @PathParam("loanExternalId") @Parameter(description = "loanExternalId", required = true) final String loanExternalId,
             @Valid @BeanParam final ReAmortizationPreviewRequest reAmortizationPreviewRequest) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -326,6 +326,7 @@ public class LoansApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.GetLoansApprovalTemplateResponse.class))) })
+    @Operation(summary = "Retrieve Loan Approval Template", operationId = "retrieveApprovalTemplate")
     public String retrieveApprovalTemplate(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
             @QueryParam("templateType") @Parameter(description = "templateType") final String templateType,
             @Context final UriInfo uriInfo) {
@@ -335,7 +336,7 @@ public class LoansApiResource {
     @GET
     @Path("template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Loan Details Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
+    @Operation(summary = "Retrieve Loan Details Template", operationId = "retrieveTemplateLoan", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
             + "\n" + "Field Defaults\n" + "Allowed description Lists\n" + "Example Requests:\n" + "\n"
             + "loans/template?templateType=individual&clientId=1\n" + "\n" + "\n"
             + "loans/template?templateType=individual&clientId=1&productId=1")
@@ -461,7 +462,7 @@ public class LoansApiResource {
     @GET
     @Path("{loanId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan", description = "Note: template=true parameter doesn't apply to this resource."
+    @Operation(summary = "Retrieve a Loan", operationId = "retrieveOneLoan", description = "Note: template=true parameter doesn't apply to this resource."
             + "Example Requests:\n" + "\n" + "loans/1\n" + "\n" + "\n" + "loans/1?fields=id,principal,annualInterestRate\n" + "\n" + "\n"
             + "loans/1?associations=all\n" + "\n" + "loans/1?associations=all&exclude=guarantors\n" + "\n" + "\n"
             + "loans/1?fields=id,principal,annualInterestRate&associations=repaymentSchedule,transactions")
@@ -550,7 +551,7 @@ public class LoansApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Calculate loan repayment schedule | Submit a new Loan Application", description = "It calculates the loan repayment Schedule\n"
+    @Operation(summary = "Calculate loan repayment schedule | Submit a new Loan Application", operationId = "calculateOrSubmitLoanApplication", description = "It calculates the loan repayment Schedule\n"
             + "Submits a new loan application\n"
             + "Mandatory Fields: clientId, productId, principal, loanTermFrequency, loanTermFrequencyType, loanType, numberOfRepayments, repaymentEvery, repaymentFrequencyType, interestRatePerPeriod, amortizationType, interestType, interestCalculationPeriodType, transactionProcessingStrategyCode, expectedDisbursementDate, submittedOnDate, loanType\n"
             + "Optional Fields: graceOnPrincipalPayment, graceOnInterestPayment, graceOnInterestCharged, linkAccountId, allowPartialPeriodInterestCalculation, fixedEmiAmount, maxOutstandingLoanBalance, disbursementData, graceOnArrearsAgeing, createStandingInstructionAtDisbursement (requires linkedAccountId if set to true)\n"
@@ -585,7 +586,7 @@ public class LoansApiResource {
     @Path("{loanId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Modify a loan application", description = "Loan application can only be modified when in 'Submitted and pending approval' state. Once the application is approved, the details cannot be changed using this method.")
+    @Operation(summary = "Modify a loan application", operationId = "updateLoanApplication", description = "Loan application can only be modified when in 'Submitted and pending approval' state. Once the application is approved, the details cannot be changed using this method.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansLoanIdRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansLoanIdResponse.class))) })
@@ -598,7 +599,7 @@ public class LoansApiResource {
     @DELETE
     @Path("{loanId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Loan Application", description = "Note: Only loans in \"Submitted and awaiting approval\" status can be deleted.")
+    @Operation(summary = "Delete a Loan Application", operationId = "deleteLoanApplication", description = "Note: Only loans in \"Submitted and awaiting approval\" status can be deleted.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.DeleteLoansLoanIdResponse.class))) })
     public String deleteLoanApplication(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId) {
@@ -609,7 +610,7 @@ public class LoansApiResource {
     @Path("{loanId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Approve Loan Application | Recover Loan Guarantee | Undo Loan Application Approval | Assign a Loan Officer | Unassign a Loan Officer | Reject Loan Application | Applicant Withdraws from Loan Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", description = "Approve Loan Application:\n"
+    @Operation(summary = "Approve Loan Application | Recover Loan Guarantee | Undo Loan Application Approval | Assign a Loan Officer | Unassign a Loan Officer | Reject Loan Application | Applicant Withdraws from Loan Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", operationId = "handleCommandsLoan", description = "Approve Loan Application:\n"
             + "Mandatory Fields: approvedOnDate\n" + "Optional Fields: approvedLoanAmount and expectedDisbursementDate\n"
             + "Approves the loan application\n\n" + "Recover Loan Guarantee:\n" + "Recovers the loan guarantee\n\n"
             + "Undo Loan Application Approval:\n" + "Undoes the Loan Application Approval\n\n" + "Assign a Loan Officer:\n"
@@ -652,7 +653,7 @@ public class LoansApiResource {
     @Path("glimAccount/{glimId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Approve GLIM Application | Undo GLIM Application Approval | Reject GLIM Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", description = "Approve GLIM Application:\n"
+    @Operation(summary = "Approve GLIM Application | Undo GLIM Application Approval | Reject GLIM Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", operationId = "handleCommandsGlimLoan", description = "Approve GLIM Application:\n"
             + "Mandatory Fields: approvedOnDate\n" + "Optional Fields: approvedLoanAmount and expectedDisbursementDate\n"
             + "Approves the GLIM application\n\n" + "Undo GLIM Application Approval:\n" + "Undoes the GLIM Application Approval\n\n"
             + "Reject GLIM Application:\n" + "Mandatory Fields: rejectedOnDate\n" + "Allows you to reject the GLIM application\n\n"
@@ -728,7 +729,7 @@ public class LoansApiResource {
     @GET
     @Path("{loanId}/delinquencytags")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve the Loan Delinquency Tag history using the Loan Id", description = "")
+    @Operation(summary = "Retrieve the Loan Delinquency Tag history using the Loan Id", operationId = "retrieveDelinquencyTagHistoryLoan", description = "")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DelinquencyApiResourceSwagger.GetDelinquencyTagHistoryResponse.class)))) })
     public String getDelinquencyTagHistory(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
@@ -753,7 +754,7 @@ public class LoansApiResource {
     @GET
     @Path("external-id/{loanExternalId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Loan", operationId = "retrieveLoanByExternalId", description = "Note: template=true parameter doesn't apply to this resource."
+    @Operation(summary = "Retrieve a Loan", operationId = "retrieveOneLoanByExternalId", description = "Note: template=true parameter doesn't apply to this resource."
             + "Example Requests:\n" + "\n" + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854\n" + "\n" + "\n"
             + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854?fields=id,principal,annualInterestRate\n" + "\n" + "\n"
             + "loans/external-id/7dd80a7c-ycba-a446-t378-91eb6f53e854?associations=all\n" + "\n"
@@ -776,7 +777,7 @@ public class LoansApiResource {
     @Path("external-id/{loanExternalId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Modify a loan application", operationId = "modifyLoanApplicationByExternalId", description = "Loan application can only be modified when in 'Submitted and pending approval' state. Once the application is approved, the details cannot be changed using this method.")
+    @Operation(summary = "Modify a loan application", operationId = "updateLoanApplicationByExternalId", description = "Loan application can only be modified when in 'Submitted and pending approval' state. Once the application is approved, the details cannot be changed using this method.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansLoanIdRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansLoanIdResponse.class))) })
@@ -802,7 +803,7 @@ public class LoansApiResource {
     @Path("external-id/{loanExternalId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Approve Loan Application | Recover Loan Guarantee | Undo Loan Application Approval | Assign a Loan Officer | Unassign a Loan Officer | Reject Loan Application | Applicant Withdraws from Loan Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", operationId = "stateTransitionsByExternalId", description = "Approve Loan Application:\n"
+    @Operation(summary = "Approve Loan Application | Recover Loan Guarantee | Undo Loan Application Approval | Assign a Loan Officer | Unassign a Loan Officer | Reject Loan Application | Applicant Withdraws from Loan Application | Disburse Loan Disburse Loan To Savings Account | Undo Loan Disbursal", operationId = "handleCommandsLoanByExternalId", description = "Approve Loan Application:\n"
             + "Mandatory Fields: approvedOnDate\n" + "Optional Fields: approvedLoanAmount and expectedDisbursementDate\n"
             + "Approves the loan application\n\n" + "Recover Loan Guarantee:\n" + "Recovers the loan guarantee\n\n"
             + "Undo Loan Application Approval:\n" + "Undoes the Loan Application Approval\n\n" + "Assign a Loan Officer:\n"
@@ -827,7 +828,7 @@ public class LoansApiResource {
     @GET
     @Path("external-id/{loanExternalId}/delinquencytags")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve the Loan Delinquency Tag history using the Loan Id", operationId = "getDelinquencyTagHistoryByExternalId", description = "")
+    @Operation(summary = "Retrieve the Loan Delinquency Tag history using the Loan Id", operationId = "retrieveDelinquencyTagHistoryLoanByExternalId", description = "")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DelinquencyApiResourceSwagger.GetDelinquencyTagHistoryResponse.class)))) })
     public String getDelinquencyTagHistory(
@@ -839,7 +840,7 @@ public class LoansApiResource {
     @GET
     @Path("{loanId}/delinquency-actions")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve delinquency actions related to the loan", description = "")
+    @Operation(summary = "Retrieve delinquency actions related to the loan", operationId = "retrieveDelinquencyActionsLoan", description = "")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DelinquencyApiResourceSwagger.GetDelinquencyActionsResponse.class)))) })
     public String getLoanDelinquencyActions(@PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId,
@@ -850,7 +851,7 @@ public class LoansApiResource {
     @GET
     @Path("external-id/{loanExternalId}/delinquency-actions")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve delinquency actions related to the loan", operationId = "getLoanDelinquencyActionsByExternalId", description = "")
+    @Operation(summary = "Retrieve delinquency actions related to the loan", operationId = "retrieveDelinquencyActionsLoanByExternalId", description = "")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DelinquencyApiResourceSwagger.GetDelinquencyActionsResponse.class)))) })
     public String getLoanDelinquencyActions(
@@ -863,7 +864,7 @@ public class LoansApiResource {
     @Path("{loanId}/delinquency-actions")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Adds a new delinquency action for a loan", description = "")
+    @Operation(summary = "Adds a new delinquency action for a loan", operationId = "createDelinquencyActionLoan", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = DelinquencyApiResourceSwagger.PostLoansDelinquencyActionRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DelinquencyApiResourceSwagger.PostLoansDelinquencyActionResponse.class))) })
@@ -876,7 +877,7 @@ public class LoansApiResource {
     @Path("external-id/{loanExternalId}/delinquency-actions")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Adds a new delinquency action for a loan", operationId = "createLoanDelinquencyActionByExternalId", description = "")
+    @Operation(summary = "Adds a new delinquency action for a loan", operationId = "createDelinquencyActionLoanByExternalId", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = DelinquencyApiResourceSwagger.PostLoansDelinquencyActionRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DelinquencyApiResourceSwagger.PostLoansDelinquencyActionResponse.class))) })
@@ -890,7 +891,7 @@ public class LoansApiResource {
     @Path("{loanId}/approved-amount")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Modifies the approved amount of the loan", description = "")
+    @Operation(summary = "Modifies the approved amount of the loan", operationId = "updateApprovedAmountLoan", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansApprovedAmountRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansApprovedAmountResponse.class))) })
@@ -904,7 +905,7 @@ public class LoansApiResource {
     @Path("external-id/{loanExternalId}/approved-amount")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Modifies the approved amount of the loan", description = "")
+    @Operation(summary = "Modifies the approved amount of the loan", operationId = "updateApprovedAmountLoanByExternalId", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansApprovedAmountRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansApprovedAmountResponse.class))) })
@@ -917,7 +918,7 @@ public class LoansApiResource {
     @GET
     @Path("{loanId}/approved-amount")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Collects and returns the approved amount modification history for a given loan", description = "")
+    @Operation(summary = "Collects and returns the approved amount modification history for a given loan", operationId = "retrieveApprovedAmountHistoryLoan", description = "")
     public List<LoanApprovedAmountHistoryData> getLoanApprovedAmountHistory(
             @PathParam("loanId") @Parameter(description = "loanId", required = true) final Long loanId, @Context final UriInfo uriInfo) {
         return getLoanApprovedAmountHistory(loanId, ExternalId.empty());
@@ -926,7 +927,7 @@ public class LoansApiResource {
     @GET
     @Path("external-id/{loanExternalId}/approved-amount")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Collects and returns the approved amount modification history for a given loan", description = "")
+    @Operation(summary = "Collects and returns the approved amount modification history for a given loan", operationId = "retrieveApprovedAmountHistoryLoanByExternalId", description = "")
     public List<LoanApprovedAmountHistoryData> getLoanApprovedAmountHistory(
             @PathParam("loanExternalId") @Parameter(description = "loanExternalId", required = true) final String loanExternalId,
             @Context final UriInfo uriInfo) {
@@ -937,7 +938,7 @@ public class LoansApiResource {
     @Path("{loanId}/available-disbursement-amount")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Modifies the available disbursement amount of the loan", description = "Modifies the available disbursement amount of the loan, this indirectly modifies the approved amount that can be disbursed on the loan")
+    @Operation(summary = "Modifies the available disbursement amount of the loan", operationId = "updateAvailableDisbursementAmountLoan", description = "Modifies the available disbursement amount of the loan, this indirectly modifies the approved amount that can be disbursed on the loan")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansAvailableDisbursementAmountRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansAvailableDisbursementAmountResponse.class))) })
@@ -951,7 +952,7 @@ public class LoansApiResource {
     @Path("external-id/{loanExternalId}/available-disbursement-amount")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Modifies the available disbursement amount of the loan", operationId = "modifyLoanAvailableDisbursementAmountByExternalId", description = "Modifies the available disbursement amount of the loan, this indirectly modifies the approved amount that can be disbursed on the loan")
+    @Operation(summary = "Modifies the available disbursement amount of the loan", operationId = "updateAvailableDisbursementAmountLoanByExternalId", description = "Modifies the available disbursement amount of the loan, this indirectly modifies the approved amount that can be disbursed on the loan")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansAvailableDisbursementAmountRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoansApiResourceSwagger.PutLoansAvailableDisbursementAmountResponse.class))) })

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountTransactionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountTransactionsApiResource.java
@@ -165,7 +165,7 @@ public class FixedDepositAccountTransactionsApiResource {
     @Path("{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Adjust Transaction | Undo transaction", description = "Adjust Transaction:\n\nThis command modifies the given transaction.\n\n"
+    @Operation(summary = "Adjust Transaction | Undo transaction", operationId = "handleCommandsFixedDepositAccountTransaction", description = "Adjust Transaction:\n\nThis command modifies the given transaction.\n\n"
             + "Undo transaction:\n\nThis command reverses the given transaction.\n\n" + "Showing request/response for 'Adjust Transaction'")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = FixedDepositAccountTransactionsApiResourceSwagger.PostFixedDepositAccountsFixedDepositAccountIdTransactionsRequest.class)))
     @ApiResponses({

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResource.java
@@ -182,7 +182,7 @@ public class FixedDepositAccountsApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Submit new fixed deposit application", description = """
+    @Operation(summary = "Submit new fixed deposit application", operationId = "createFixedDepositAccount", description = """
             Submits a new fixed deposit application
             Mandatory Fields: clientId or groupId, productId, submittedOnDate, depositAmount, depositPeriod, depositPeriodFrequencyId
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/RecurringDepositAccountTransactionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/RecurringDepositAccountTransactionsApiResource.java
@@ -188,7 +188,7 @@ public class RecurringDepositAccountTransactionsApiResource {
     @Path("{transactionId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Adjust Transaction | Undo transaction", description = "Adjust Transaction:\n\n"
+    @Operation(summary = "Adjust Transaction | Undo transaction", operationId = "handleCommandsRecurringDepositAccountTransaction", description = "Adjust Transaction:\n\n"
             + "This command modifies the given transaction.\n\n" + "Undo transaction:\n\n"
             + "This command reverses the given transaction.\n\n" + "Showing request/response for 'Adjust Transaction'")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RecurringDepositAccountTransactionsApiResourceSwagger.PostRecurringDepositAccountsRecurringDepositAccountIdTransactionsRequest.class)))

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountChargesApiResource.java
@@ -84,8 +84,8 @@ public class SavingsAccountChargesApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Savings Charges", description = "Lists Savings Charges\n\n" + "Example Requests:\n" + "\n"
-            + "savingsaccounts/1/charges\n" + "\n" + "savingsaccounts/1/charges?chargeStatus=all\n" + "\n"
+    @Operation(summary = "List Savings Charges", operationId = "retrieveAllSavingsAccountCharges", description = "Lists Savings Charges\n\n"
+            + "Example Requests:\n" + "\n" + "savingsaccounts/1/charges\n" + "\n" + "savingsaccounts/1/charges?chargeStatus=all\n" + "\n"
             + "savingsaccounts/1/charges?chargeStatus=inactive\n" + "\n" + "savingsaccounts/1/charges?chargeStatus=active\n" + "\n"
             + "savingsaccounts/1/charges?fields=name,amountOrPercentage")
     @ApiResponses({
@@ -134,8 +134,9 @@ public class SavingsAccountChargesApiResource {
     @GET
     @Path("{savingsAccountChargeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Savings account Charge", description = "Retrieves a Savings account Charge\n\n" + "Example Requests:\n"
-            + "\n" + "/savingsaccounts/1/charges/5\n" + "\n" + "\n" + "/savingsaccounts/1/charges/5?fields=name,amountOrPercentage")
+    @Operation(summary = "Retrieve a Savings account Charge", operationId = "retrieveOneSavingsAccountCharge", description = "Retrieves a Savings account Charge\n\n"
+            + "Example Requests:\n" + "\n" + "/savingsaccounts/1/charges/5\n" + "\n" + "\n"
+            + "/savingsaccounts/1/charges/5?fields=name,amountOrPercentage")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountChargesApiResourceSwagger.GetSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdResponse.class))) })
     public String retrieveSavingsAccountCharge(
@@ -156,7 +157,7 @@ public class SavingsAccountChargesApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a Savings account Charge", description = "Creates a Savings account Charge\n\n"
+    @Operation(summary = "Create a Savings account Charge", operationId = "createSavingsAccountCharge", description = "Creates a Savings account Charge\n\n"
             + "Mandatory Fields for Savings account Charges: chargeId, amount\n\n" + "chargeId, amount, dueDate, dateFormat, locale\n\n"
             + "chargeId, amount, feeOnMonthDay, monthDayFormat, locale")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountChargesApiResourceSwagger.PostSavingsAccountsSavingsAccountIdChargesRequest.class)))
@@ -178,7 +179,7 @@ public class SavingsAccountChargesApiResource {
     @Path("{savingsAccountChargeId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Savings account Charge", description = "Currently Savings account Charges may be updated only if the Savings account is not yet approved.")
+    @Operation(summary = "Update a Savings account Charge", operationId = "updateSavingsAccountCharge", description = "Currently Savings account Charges may be updated only if the Savings account is not yet approved.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SavingsAccountChargesApiResourceSwagger.PutSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountChargesApiResourceSwagger.PutSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdResponse.class))) })
@@ -199,7 +200,7 @@ public class SavingsAccountChargesApiResource {
     @Path("{savingsAccountChargeId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Pay a Savings account Charge | Waive off a Savings account Charge | Inactivate a Savings account Charge", description = "Pay a Savings account Charge:\n\n"
+    @Operation(summary = "Pay a Savings account Charge | Waive off a Savings account Charge | Inactivate a Savings account Charge", operationId = "handleCommandsSavingsAccountCharge", description = "Pay a Savings account Charge:\n\n"
             + "An active charge will be paid when savings account is active and having sufficient balance.\n\n"
             + "Waive off a Savings account Charge:\n\n" + "Outstanding charge amount will be waived off.\n\n"
             + "Inactivate a Savings account Charge:\n\n"
@@ -247,7 +248,7 @@ public class SavingsAccountChargesApiResource {
     @DELETE
     @Path("{savingsAccountChargeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Savings account Charge", description = "Note: Currently, A Savings account Charge may only be removed from Savings that are not yet approved.")
+    @Operation(summary = "Delete a Savings account Charge", operationId = "deleteSavingsAccountCharge", description = "Note: Currently, A Savings account Charge may only be removed from Savings that are not yet approved.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountChargesApiResourceSwagger.DeleteSavingsAccountsSavingsAccountIdChargesSavingsAccountChargeIdResponse.class))) })
     public String deleteSavingsAccountCharge(

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -284,7 +284,8 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
     }
 
     protected GetLoansLoanIdTransactionsTemplateResponse getPrepayAmount(Long loanId, String date) {
-        return ok(fineractClient().loanTransactions.retrieveTransactionTemplate(loanId, "prepayLoan", DATETIME_PATTERN, date, "en", null));
+        return ok(fineractClient().loanTransactions.retrieveTemplateLoanTransaction(loanId, "prepayLoan", DATETIME_PATTERN, date, "en",
+                null));
     }
 
     protected Long verifyPrepayAmountByRepayment(Long loanId, String date) {
@@ -319,8 +320,8 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
      */
     public PostLoansLoanIdTransactionsResponse makeLoanTransactionWithPermissionVerification(final Long loanId,
             PostLoansLoanIdTransactionsRequest postLoansLoanIdTransactionsRequest, final String command, final String permission) {
-        return performPermissionTestForRequest(permission, fineractClient -> fineractClient.loanTransactions.executeLoanTransaction(loanId,
-                postLoansLoanIdTransactionsRequest, command));
+        return performPermissionTestForRequest(permission, fineractClient -> fineractClient.loanTransactions
+                .handleCommandsLoanTransaction(loanId, postLoansLoanIdTransactionsRequest, command));
     }
 
     /**
@@ -1072,17 +1073,17 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
 
     protected PutLoansApprovedAmountResponse modifyLoanApprovedAmount(Long loanId, BigDecimal approvedAmount) {
         PutLoansApprovedAmountRequest request = new PutLoansApprovedAmountRequest().amount(approvedAmount).locale("en");
-        return Calls.ok(fineractClient().loans.modifyLoanApprovedAmount(loanId, request));
+        return Calls.ok(fineractClient().loans.updateApprovedAmountLoan(loanId, request));
     }
 
     protected List<LoanApprovedAmountHistoryData> getLoanApprovedAmountHistory(Long loanId) {
-        return Calls.ok(fineractClient().loans.getLoanApprovedAmountHistory(loanId));
+        return Calls.ok(fineractClient().loans.retrieveApprovedAmountHistoryLoan(loanId));
     }
 
     protected PutLoansAvailableDisbursementAmountResponse modifyLoanAvailableDisbursementAmount(Long loanId, BigDecimal approvedAmount) {
         PutLoansAvailableDisbursementAmountRequest request = new PutLoansAvailableDisbursementAmountRequest().amount(approvedAmount)
                 .locale("en");
-        return Calls.ok(fineractClient().loans.modifyLoanAvailableDisbursementAmount(loanId, request));
+        return Calls.ok(fineractClient().loans.updateAvailableDisbursementAmountLoan(loanId, request));
     }
 
     protected void verifyOutstanding(LoanPointInTimeData loan, OutstandingAmounts outstanding) {
@@ -1513,7 +1514,7 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
     }
 
     protected void deactivateOverdueLoanCharges(Long loanId, String fromDueDate) {
-        ok(fineractClient().loanCharges.executeLoanCharge(loanId,
+        ok(fineractClient().loanCharges.createOrPayLoanCharge(loanId,
                 new PostLoansLoanIdChargesRequest().dueDate(fromDueDate).dateFormat(DATETIME_PATTERN).locale("en"), "deactivateOverdue"));
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/UserLoanPermissionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/UserLoanPermissionTest.java
@@ -123,18 +123,18 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
         runAt("1 January 2025", () -> {
             // disbursement should be rejected upon validation error
             Response<PostLoansLoanIdResponse> response = Calls.executeU(
-                    fineractClient().loans.stateTransitions(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
+                    fineractClient().loans.handleCommandsLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
                             .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"), "disburse"));
 
             Assertions.assertEquals(403, response.code());
 
             // update approved amount
             performPermissionTestForRequest("UPDATE_APPROVED_AMOUNT_LOAN",
-                    fineractClient -> fineractClient.loans.modifyLoanApprovedAmount(loanId,
+                    fineractClient -> fineractClient.loans.updateApprovedAmountLoan(loanId,
                             new PutLoansApprovedAmountRequest().amount(BigDecimal.valueOf(4000.0d)).locale("en")));
 
             // disbursement should be performed without error
-            Calls.ok(fineractClient().loans.stateTransitions(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
+            Calls.ok(fineractClient().loans.handleCommandsLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"), "disburse"));
         });
     }
@@ -143,11 +143,11 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
     public void testContractTerminationAndUndoContractTerminationPermission() {
 
         runAt("2 January 2025", () -> {
-            performPermissionTestForRequest("CONTRACT_TERMINATION_LOAN", fineractClient -> fineractClient.loans.stateTransitions(loanId,
+            performPermissionTestForRequest("CONTRACT_TERMINATION_LOAN", fineractClient -> fineractClient.loans.handleCommandsLoan(loanId,
                     new PostLoansLoanIdRequest().note(""), "contractTermination"));
 
             performPermissionTestForRequest("CONTRACT_TERMINATION_UNDO_LOAN",
-                    fineractClient -> fineractClient.loans.stateTransitions(loanId,
+                    fineractClient -> fineractClient.loans.handleCommandsLoan(loanId,
                             new PostLoansLoanIdRequest().note("Contract Termination Undo Test Note"), "undoContractTermination"));
         });
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
@@ -109,69 +109,70 @@ public class FeignLoanHelper {
     }
 
     public Long applyForLoan(PostLoansRequest request) {
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(request, (String) null));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, (String) null));
         return response.getLoanId();
     }
 
     public PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "approve")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "approve")));
     }
 
     public PostLoansLoanIdResponse disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "disburse")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "disburse")));
     }
 
     public PostLoansLoanIdResponse disburseToSavings(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "disburseToSavings")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "disburseToSavings")));
     }
 
     public PostLoansLoanIdResponse rejectLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "reject")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "reject")));
     }
 
     public PostLoansLoanIdResponse withdrawLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "withdrawnByApplicant")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "withdrawnByApplicant")));
     }
 
     public PostLoansLoanIdResponse moveLoanState(Long loanId, PostLoansLoanIdRequest request, String command) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", command)));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", command)));
     }
 
     public PutLoansLoanIdResponse markAsFraud(Long loanId, boolean fraud) {
-        return ok(() -> fineractClient.loans().modifyLoanApplication(loanId, new PutLoansLoanIdRequest().fraud(fraud),
+        return ok(() -> fineractClient.loans().updateLoanApplication(loanId, new PutLoansLoanIdRequest().fraud(fraud),
                 Map.of("command", "markAsFraud")));
     }
 
     public PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "close")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "close")));
     }
 
     public PostLoansLoanIdResponse closeAsRescheduled(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "closeAsRescheduled")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "closeAsRescheduled")));
     }
 
     public PostLoansLoanIdTransactionsResponse forecloseLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "foreclosure")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "foreclosure")));
     }
 
     public PostLoansLoanIdResponse assignLoanOfficer(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "assignLoanOfficer")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "assignLoanOfficer")));
     }
 
     public PostLoansLoanIdResponse unassignLoanOfficer(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "unassignLoanOfficer")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "unassignLoanOfficer")));
     }
 
     public PostLoansLoanIdResponse recoverGuarantee(Long loanId, PostLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "recoverFromGuarantor")));
+        return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "recoverFromGuarantor")));
     }
 
     public GetLoansLoanIdResponse getLoanDetails(Long loanId) {
-        return ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", "all", "exclude", "guarantors,futureSchedule")));
+        return ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
+                Map.of("associations", "all", "exclude", "guarantors,futureSchedule")));
     }
 
     public GetLoansLoanIdResponse getLoanDetailsByExternalId(String loanExternalId) {
-        return ok(() -> fineractClient.loans().retrieveLoanByExternalId(loanExternalId, false, "all", null, null));
+        return ok(() -> fineractClient.loans().retrieveOneLoanByExternalId(loanExternalId, false, "all", null, null));
     }
 
     public PostLoansLoanIdResponse disburseLoanWithAmount(Long loanId, String date, double amount) {
@@ -180,21 +181,21 @@ public class FeignLoanHelper {
     }
 
     public GetLoansLoanIdResponse getLoanDetailsWithAssociations(Long loanId, String associations) {
-        return ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", associations)));
+        return ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", associations)));
     }
 
     public GetLoansLoanIdResponse getLoanDetailsWithAssociationsAndExclude(Long loanId, String associations, String exclude) {
-        return ok(() -> fineractClient.loans().retrieveLoan(loanId, Map.of("associations", associations, "exclude", exclude)));
+        return ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", associations, "exclude", exclude)));
     }
 
     public void undoApproval(Long loanId) {
         PostLoansLoanIdRequest request = new PostLoansLoanIdRequest();
-        ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "undoApproval")));
+        ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "undoApproval")));
     }
 
     public void undoDisbursement(Long loanId) {
         PostLoansLoanIdRequest request = new PostLoansLoanIdRequest();
-        ok(() -> fineractClient.loans().stateTransitions(loanId, request, Map.of("command", "undoDisbursal")));
+        ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "undoDisbursal")));
     }
 
     public Long applyAndApproveLoan(Long clientId, Long productId, String submittedOnDate, Double principal, Integer numberOfRepayments) {
@@ -263,14 +264,14 @@ public class FeignLoanHelper {
     public Long createSubmittedLoanWithOriginators(Long clientId, List<PostLoansOriginatorData> originators) {
         PostLoansRequest request = buildSubmittedLoanRequest(clientId);
         request.setOriginators(originators);
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(request, (String) null));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, (String) null));
         return response.getLoanId();
     }
 
     public Long createSubmittedLoanWithOriginators(Long clientId, Long productId, List<PostLoansOriginatorData> originators) {
         PostLoansRequest request = buildSubmittedLoanRequest(clientId, productId);
         request.setOriginators(originators);
-        PostLoansResponse response = ok(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(request, (String) null));
+        PostLoansResponse response = ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, (String) null));
         return response.getLoanId();
     }
 
@@ -278,7 +279,7 @@ public class FeignLoanHelper {
             List<PostLoansOriginatorData> originators) {
         PostLoansRequest request = buildSubmittedLoanRequest(clientId);
         request.setOriginators(originators);
-        return fail(() -> fineractClient.loans().calculateLoanScheduleOrSubmitLoanApplication(request, (String) null));
+        return fail(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, (String) null));
     }
 
     private PostLoansRequest buildSubmittedLoanRequest(Long clientId) {
@@ -286,7 +287,7 @@ public class FeignLoanHelper {
     }
 
     public PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, PostLoansLoanIdChargesRequest request) {
-        return ok(() -> fineractClient.loanCharges().executeLoanCharge(loanId, request, (String) null));
+        return ok(() -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, request, (String) null));
     }
 
     public List<GetLoansLoanIdChargesChargeIdResponse> getLoanCharges(Long loanId) {
@@ -294,7 +295,7 @@ public class FeignLoanHelper {
     }
 
     public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(Long loanId, Long loanChargeId) {
-        return ok(() -> fineractClient.loanCharges().retrieveLoanCharge(loanId, loanChargeId));
+        return ok(() -> fineractClient.loanCharges().retrieveOneLoanCharge(loanId, loanChargeId));
     }
 
     public PutLoansLoanIdChargesChargeIdResponse updateLoanCharge(Long loanId, Long loanChargeId,
@@ -364,17 +365,17 @@ public class FeignLoanHelper {
 
     public PutLoansAvailableDisbursementAmountResponse modifyAvailableDisbursementAmount(Long loanId,
             PutLoansAvailableDisbursementAmountRequest request) {
-        return ok(() -> fineractClient.loans().modifyLoanAvailableDisbursementAmount(loanId, request));
+        return ok(() -> fineractClient.loans().updateAvailableDisbursementAmountLoan(loanId, request));
     }
 
     public Long createRescheduleRequest(PostCreateRescheduleLoansRequest request) {
-        PostCreateRescheduleLoansResponse response = ok(() -> fineractClient.rescheduleLoans().createLoanRescheduleRequest(request));
+        PostCreateRescheduleLoansResponse response = ok(() -> fineractClient.rescheduleLoans().createRescheduleLoan(request));
         return response.getResourceId();
     }
 
     public Long approveRescheduleRequest(Long scheduleId, PostUpdateRescheduleLoansRequest request) {
         PostUpdateRescheduleLoansResponse response = ok(
-                () -> fineractClient.rescheduleLoans().updateLoanRescheduleRequest(scheduleId, request, "approve"));
+                () -> fineractClient.rescheduleLoans().updateRescheduleLoan(scheduleId, request, "approve"));
         return response.getResourceId();
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTransactionHelper.java
@@ -44,30 +44,31 @@ public class FeignTransactionHelper {
     }
 
     public GetLoansLoanIdTransactionsTemplateResponse getPrepaymentAmount(Long loanId, String transactionDate, String dateFormat) {
-        return ok(() -> fineractClient.loanTransactions().retrieveTransactionTemplate(loanId, "prepayLoan", dateFormat, transactionDate,
+        return ok(() -> fineractClient.loanTransactions().retrieveTemplateLoanTransaction(loanId, "prepayLoan", dateFormat, transactionDate,
                 "en", null));
     }
 
     public Long addRepayment(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "repayment")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "repayment")));
         return response.getResourceId();
     }
 
     public Long addInterestWaiver(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "waiveInterest")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "waiveInterest")));
         return response.getResourceId();
     }
 
     public Long chargeOff(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "charge-off")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "charge-off")));
         return response.getResourceId();
     }
 
     public PostLoansLoanIdTransactionsResponse undoChargeOff(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "undo-charge-off")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request,
+                Map.of("command", "undo-charge-off")));
     }
 
     public Long addChargeback(Long loanId, Long transactionId, PostLoansLoanIdTransactionsRequest request) {
@@ -84,58 +85,61 @@ public class FeignTransactionHelper {
 
     public Long reAge(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "reAge")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "reAge")));
         return response.getResourceId();
     }
 
     public Long undoReAge(Long loanId, PostLoansLoanIdTransactionsRequest request) {
         PostLoansLoanIdTransactionsResponse response = ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "undoReAge")));
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "undoReAge")));
         return response.getResourceId();
     }
 
     public PostLoansLoanIdTransactionsResponse makeMerchantIssuedRefund(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "merchantIssuedRefund")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request,
+                Map.of("command", "merchantIssuedRefund")));
     }
 
     public PostLoansLoanIdTransactionsResponse makePayoutRefund(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "payoutRefund")));
+        return ok(
+                () -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "payoutRefund")));
     }
 
     public PostLoansLoanIdTransactionsResponse makeGoodwillCredit(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "goodwillCredit")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request,
+                Map.of("command", "goodwillCredit")));
     }
 
     public PostLoansLoanIdTransactionsResponse makeInterestPaymentWaiver(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request,
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request,
                 Map.of("command", "interestPaymentWaiver")));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(Long loanId, String command, String date, Double amount) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, new PostLoansLoanIdTransactionsRequest()
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, new PostLoansLoanIdTransactionsRequest()
                 .transactionAmount(amount).transactionDate(date).dateFormat("dd MMMM yyyy").locale("en"), Map.of("command", command)));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "repayment")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "repayment")));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransactionByLoanExternalId(loanExternalId, request, "repayment"));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request,
+                "repayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse chargeOffLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "charge-off")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "charge-off")));
     }
 
     public PostLoansLoanIdTransactionsResponse makeMerchantIssuedRefund(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransactionByLoanExternalId(loanExternalId, request,
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request,
                 "merchantIssuedRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeCreditBalanceRefund(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(() -> fineractClient.loanTransactions().executeLoanTransactionByLoanExternalId(loanExternalId, request,
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request,
                 "creditBalanceRefund"));
     }
 
@@ -166,12 +170,12 @@ public class FeignTransactionHelper {
     }
 
     public PostLoansLoanIdTransactionsResponse makeCreditBalanceRefund(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return ok(
-                () -> fineractClient.loanTransactions().executeLoanTransaction(loanId, request, Map.of("command", "creditBalanceRefund")));
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request,
+                Map.of("command", "creditBalanceRefund")));
     }
 
     public GetLoansLoanIdTransactionsTransactionIdResponse getLoanTransactionDetails(Long loanId, String transactionExternalId) {
-        return ok(() -> fineractClient.loanTransactions().retrieveTransactionByTransactionExternalId(loanId, transactionExternalId, ""));
+        return ok(() -> fineractClient.loanTransactions().retrieveOneLoanTransactionByExternalId(loanId, transactionExternalId, ""));
     }
 
     public PostLoansLoanIdTransactionsResponse createManualInterestRefund(Long loanId, Long targetTransactionId, String transactionDate,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignLoanAdjustmentOriginatorEnricherTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignLoanAdjustmentOriginatorEnricherTest.java
@@ -127,7 +127,7 @@ public class FeignLoanAdjustmentOriginatorEnricherTest extends FeignLoanTestBase
 
             // Add a fee charge to the loan
             final Long chargeId = createFlatFeeCharge(100.0, "EUR");
-            ok(() -> fineractClient.loanCharges().executeLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeId)
+            ok(() -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeId)
                     .amount(100.0).locale("en").dateFormat("dd MMMM yyyy").dueDate(today), (String) null));
 
             externalEventHelper.deleteAllExternalEvents();
@@ -162,8 +162,9 @@ public class FeignLoanAdjustmentOriginatorEnricherTest extends FeignLoanTestBase
 
             // Add a fee charge and waive it
             final Long chargeId = createFlatFeeCharge(100.0, "EUR");
-            final Long loanChargeId = ok(() -> fineractClient.loanCharges().executeLoanCharge(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeId).amount(100.0).locale("en").dateFormat("dd MMMM yyyy").dueDate(today), (String) null))
+            final Long loanChargeId = ok(
+                    () -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeId)
+                            .amount(100.0).locale("en").dateFormat("dd MMMM yyyy").dueDate(today), (String) null))
                     .getResourceId();
 
             ok(() -> fineractClient.loanCharges().executeLoanChargeOnExistingCharge(loanId, loanChargeId,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignLoanChargeOriginatorEnricherTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignLoanChargeOriginatorEnricherTest.java
@@ -71,7 +71,7 @@ public class FeignLoanChargeOriginatorEnricherTest extends FeignIntegrationTest 
 
             // When: a charge is added to the loan
             ok(() -> fineractClient.loanCharges()
-                    .executeLoanCharge(loanId,
+                    .createOrPayLoanCharge(loanId,
                             new PostLoansLoanIdChargesRequest().chargeId(chargeId).amount(50.0).locale("en").dateFormat("dd MMMM yyyy")
                                     .dueDate(org.apache.fineract.integrationtests.common.Utils.dateFormatter
                                             .format(org.apache.fineract.integrationtests.common.Utils.getLocalDateOfTenant())),
@@ -120,7 +120,7 @@ public class FeignLoanChargeOriginatorEnricherTest extends FeignIntegrationTest 
 
             // When: a charge is added
             ok(() -> fineractClient.loanCharges()
-                    .executeLoanCharge(loanId,
+                    .createOrPayLoanCharge(loanId,
                             new PostLoansLoanIdChargesRequest().chargeId(chargeId).amount(75.0).locale("en").dateFormat("dd MMMM yyyy")
                                     .dueDate(org.apache.fineract.integrationtests.common.Utils.dateFormatter
                                             .format(org.apache.fineract.integrationtests.common.Utils.getLocalDateOfTenant())),
@@ -159,7 +159,7 @@ public class FeignLoanChargeOriginatorEnricherTest extends FeignIntegrationTest 
 
             // When: a charge is added
             ok(() -> fineractClient.loanCharges()
-                    .executeLoanCharge(loanId,
+                    .createOrPayLoanCharge(loanId,
                             new PostLoansLoanIdChargesRequest().chargeId(chargeId).amount(50.0).locale("en").dateFormat("dd MMMM yyyy")
                                     .dueDate(org.apache.fineract.integrationtests.common.Utils.dateFormatter
                                             .format(org.apache.fineract.integrationtests.common.Utils.getLocalDateOfTenant())),

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignTrialBalanceSummaryReportTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignTrialBalanceSummaryReportTest.java
@@ -384,7 +384,7 @@ public class FeignTrialBalanceSummaryReportTest extends FeignIntegrationTest {
         assertNotNull(loanId);
 
         if (chargeId != null) {
-            ok(() -> fineractClient().loanCharges().executeLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeId)
+            ok(() -> fineractClient().loanCharges().createOrPayLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeId)
                     .amount(500.0).dueDate(disburseDate).dateFormat(LoanTestData.DATETIME_PATTERN).locale(LoanTestData.LOCALE),
                     (String) null));
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/LoanRescheduleRequestHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/LoanRescheduleRequestHelper.java
@@ -32,25 +32,25 @@ public final class LoanRescheduleRequestHelper {
     private LoanRescheduleRequestHelper() {}
 
     public static PostCreateRescheduleLoansResponse createLoanRescheduleRequest(PostCreateRescheduleLoansRequest request) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().createLoanRescheduleRequest(request));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().createRescheduleLoan(request));
     }
 
     public static PostUpdateRescheduleLoansResponse approveLoanRescheduleRequest(Long scheduleId,
             PostUpdateRescheduleLoansRequest request) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().updateLoanRescheduleRequest(scheduleId,
-                request, "approve"));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().updateRescheduleLoan(scheduleId, request,
+                "approve"));
     }
 
     public static PostUpdateRescheduleLoansResponse rejectLoanRescheduleRequest(Long scheduleId, PostUpdateRescheduleLoansRequest request) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().updateLoanRescheduleRequest(scheduleId,
-                request, "reject"));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().updateRescheduleLoan(scheduleId, request,
+                "reject"));
     }
 
     public static GetLoanRescheduleRequestResponse readLoanRescheduleRequest(final Long requestId, final String command) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().readLoanRescheduleRequest(requestId, command));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().retrieveOneRescheduleLoan(requestId, command));
     }
 
     public static List<GetLoanRescheduleRequestResponse> retrieveLoanRescheduleRequestsByLoan(final String command, final Long loanId) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().retrieveAllRescheduleRequest(command, loanId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().rescheduleLoans().retrieveAllRescheduleLoans(command, loanId));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/fixeddeposit/FixedDepositAccountHelper.java
@@ -649,9 +649,10 @@ public class FixedDepositAccountHelper {
 
     public Long undoFixedDepositTransaction(final Integer fixedDepositAccountId, final Integer transactionId) {
         LOG.info("--------------------------------- UNDO FIXED DEPOSIT TRANSACTION --------------------------------");
-        return Calls.ok(FineractClientHelper.getFineractClient().fixedDepositAccountTransactions.adjustTransaction(
-                fixedDepositAccountId.longValue(), transactionId.longValue(),
-                new PostFixedDepositAccountsFixedDepositAccountIdTransactionsRequest(), "undo")).getResourceId();
+        return Calls.ok(FineractClientHelper.getFineractClient().fixedDepositAccountTransactions
+                .handleCommandsFixedDepositAccountTransaction(fixedDepositAccountId.longValue(), transactionId.longValue(),
+                        new PostFixedDepositAccountsFixedDepositAccountIdTransactionsRequest(), "undo"))
+                .getResourceId();
     }
 
     public Long adjustFixedDepositTransaction(final Integer fixedDepositAccountId, final Integer transactionId,
@@ -660,8 +661,8 @@ public class FixedDepositAccountHelper {
         final PostFixedDepositAccountsFixedDepositAccountIdTransactionsRequest request = new PostFixedDepositAccountsFixedDepositAccountIdTransactionsRequest()
                 .dateFormat("dd MMMM yyyy").locale("en").transactionDate(transactionDate).transactionAmount(transactionAmount);
         return Calls
-                .ok(FineractClientHelper.getFineractClient().fixedDepositAccountTransactions
-                        .adjustTransaction(fixedDepositAccountId.longValue(), transactionId.longValue(), request, "modify"))
+                .ok(FineractClientHelper.getFineractClient().fixedDepositAccountTransactions.handleCommandsFixedDepositAccountTransaction(
+                        fixedDepositAccountId.longValue(), transactionId.longValue(), request, "modify"))
                 .getResourceId();
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTestLifecycleExtension.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTestLifecycleExtension.java
@@ -74,11 +74,11 @@ public class LoanTestLifecycleExtension implements AfterEachCallback, BeforeEach
 
     private void closeActiveLoan(Long loanId, LocalDate cleanupDate) {
         GetLoansLoanIdResponse loanResponse = Calls
-                .ok(FineractClientHelper.getFineractClient().loans.retrieveLoan(loanId, null, "all", null, null));
+                .ok(FineractClientHelper.getFineractClient().loans.retrieveOneLoan(loanId, null, "all", null, null));
         if (MathUtil.isLessThan(loanResponse.getApprovedPrincipal(), loanResponse.getProposedPrincipal())) {
             PutLoansApprovedAmountRequest request = new PutLoansApprovedAmountRequest().amount(loanResponse.getProposedPrincipal())
                     .locale("en");
-            Calls.ok(FineractClientHelper.getFineractClient().loans.modifyLoanApprovedAmount(loanId, request));
+            Calls.ok(FineractClientHelper.getFineractClient().loans.updateApprovedAmountLoan(loanId, request));
         }
         loanResponse.getDisbursementDetails().forEach(disbursementDetail -> {
             if (disbursementDetail.getActualDisbursementDate() == null) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/loans/LoanTransactionHelper.java
@@ -304,7 +304,7 @@ public class LoanTransactionHelper {
 
     public PutLoansLoanIdResponse modifyLoanApplication(final String loanExternalId, final String command,
             final PutLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.modifyLoanApplicationByExternalId(loanExternalId, request, command));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.updateLoanApplicationByExternalId(loanExternalId, request, command));
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -416,25 +416,25 @@ public class LoanTransactionHelper {
     }
 
     public List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(final Long loanID) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.getLoanDelinquencyActions(loanID));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveDelinquencyActionsLoan(loanID));
     }
 
     public List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(String externalId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.getLoanDelinquencyActionsByExternalId(externalId));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveDelinquencyActionsLoanByExternalId(externalId));
     }
 
     public PostLoansDelinquencyActionResponse createLoanDelinquencyAction(final Long loanid, DelinquencyAction action, String startDate,
             String endDate) {
         PostLoansDelinquencyActionRequest postLoansDelinquencyAction = new PostLoansDelinquencyActionRequest().action(action.name())
                 .startDate(startDate).endDate(endDate).locale("en").dateFormat("dd MMMM yyyy");
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.createLoanDelinquencyAction(loanid, postLoansDelinquencyAction));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.createDelinquencyActionLoan(loanid, postLoansDelinquencyAction));
     }
 
     public PostLoansDelinquencyActionResponse createLoanDelinquencyAction(String externalId, DelinquencyAction action, String startDate,
             String endDate) {
         PostLoansDelinquencyActionRequest postLoansDelinquencyAction = new PostLoansDelinquencyActionRequest().action(action.name())
                 .startDate(startDate).endDate(endDate).locale("en").dateFormat("dd MMMM yyyy");
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.createLoanDelinquencyActionByExternalId(externalId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.createDelinquencyActionLoanByExternalId(externalId,
                 postLoansDelinquencyAction));
     }
 
@@ -894,7 +894,7 @@ public class LoanTransactionHelper {
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(final Long loanId, final String command, final String date,
             final Double amountToBePaid) {
         log.info("Make loan transaction. Command - {} with amount {} in {} for Loan {}", command, amountToBePaid, date, loanId);
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId,
                 new PostLoansLoanIdTransactionsRequest().transactionAmount(amountToBePaid).transactionDate(date).dateFormat("dd MMMM yyyy")
                         .locale("en"),
                 command));
@@ -911,22 +911,23 @@ public class LoanTransactionHelper {
 
     public PostLoansLoanIdTransactionsResponse executeLoanTransaction(final Long loanId, final PostLoansLoanIdTransactionsRequest request,
             final String command) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, command));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, command));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "repayment"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "repayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(final Long loanId, final PostLoansLoanIdTransactionsRequest request,
             final String user, final String pass) {
-        return Calls.ok(FineractClientHelper.createNewFineractClient(user, pass).loanTransactions.executeLoanTransaction(loanId, request,
-                "repayment"));
+        return Calls.ok(FineractClientHelper.createNewFineractClient(user, pass).loanTransactions.handleCommandsLoanTransaction(loanId,
+                request, "repayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse addCapitalizedIncome(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "capitalizedIncome"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "capitalizedIncome"));
     }
 
     public PostLoansLoanIdTransactionsResponse addCapitalizedIncome(final Long loanId, final String transactionDate, final double amount) {
@@ -1078,58 +1079,61 @@ public class LoanTransactionHelper {
 
     public PostLoansLoanIdTransactionsResponse makeInterestPaymentWaiver(final Long loanId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "interestPaymentWaiver"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "interestPaymentWaiver"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeInterestPaymentWaiver(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "interestPaymentWaiver"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "interestPaymentWaiver"));
     }
 
     public PostLoansLoanIdTransactionsResponse reAge(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "reAge"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "reAge"));
     }
 
     public PostLoansLoanIdTransactionsResponse reAmortize(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "reAmortize"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "reAmortize"));
     }
 
     public PostLoansLoanIdTransactionsResponse undoReAge(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "undoReAge"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "undoReAge"));
     }
 
     public PostLoansLoanIdTransactionsResponse undoReAmortize(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "undoReAmortize"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "undoReAmortize"));
     }
 
     public PutChargeTransactionChangesResponse undoWaiveLoanCharge(final Long loanId, final Long transactionId,
             final PutChargeTransactionChangesRequest request) {
         log.info("--------------------------------- UNDO WAIVE CHARGES FOR LOAN --------------------------------");
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.undoWaiveCharge(loanId, transactionId, request));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.undoWaiveChargeLoanTransaction(loanId, transactionId, request));
     }
 
     public PutChargeTransactionChangesResponse undoWaiveLoanCharge(final Long loanId, final String transactionExternalId,
             final PutChargeTransactionChangesRequest request) {
         log.info("--------------------------------- UNDO WAIVE CHARGES FOR LOAN --------------------------------");
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.undoWaiveChargeByTransactionExternalId(loanId,
-                transactionExternalId, request));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .undoWaiveChargeLoanTransactionByTransactionExternalId(loanId, transactionExternalId, request));
     }
 
     public PutChargeTransactionChangesResponse undoWaiveLoanCharge(final String loanExternalId, final Long transactionId,
             final PutChargeTransactionChangesRequest request) {
         log.info("--------------------------------- UNDO WAIVE CHARGES FOR LOAN --------------------------------");
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.undoWaiveChargeByLoanExternalId(loanExternalId,
-                transactionId, request));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .undoWaiveChargeLoanTransactionByLoanExternalId(loanExternalId, transactionId, request));
     }
 
     public PutChargeTransactionChangesResponse undoWaiveLoanCharge(final String loanExternalId, final String transactionExternalId,
             final PutChargeTransactionChangesRequest request) {
         log.info("--------------------------------- UNDO WAIVE CHARGES FOR LOAN --------------------------------");
         return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
-                .undoWaiveChargeByLoanAndTransactionExternalId(loanExternalId, transactionExternalId, request));
+                .undoWaiveChargeLoanTransactionByLoanAndTransactionExternalId(loanExternalId, transactionExternalId, request));
     }
 
     public PostLoansLoanIdChargesChargeIdResponse waiveLoanCharge(final Long loanId, final Long loanChargeId,
@@ -1158,40 +1162,42 @@ public class LoanTransactionHelper {
 
     public PostLoansLoanIdTransactionsResponse makeLoanRepayment(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "repayment"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "repayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeMerchantIssuedRefund(final Long loanId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "merchantIssuedRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "merchantIssuedRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeMerchantIssuedRefund(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "merchantIssuedRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "merchantIssuedRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makePayoutRefund(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "payoutRefund"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "payoutRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makePayoutRefund(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "payoutRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "payoutRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeChargeRefund(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "chargeRefund"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "chargeRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeChargeRefund(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "chargeRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "chargeRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse manualInterestRefund(final Long loanId, final Long targetTransactionId,
@@ -1201,76 +1207,80 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdTransactionsResponse makeGoodwillCredit(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "goodwillCredit"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "goodwillCredit"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeGoodwillCredit(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "goodwillCredit"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "goodwillCredit"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeWaiveInterest(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "waiveinterest"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "waiveinterest"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeWaiveInterest(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "waiveinterest"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "waiveinterest"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeWriteoff(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "writeoff"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "writeoff"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeWriteoff(final String loanExternalId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "writeoff"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "writeoff"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeUndoWriteoff(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "undowriteoff"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "undowriteoff"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeUndoWriteoff(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "undowriteoff"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "undowriteoff"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeRecoveryPayment(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "recoverypayment"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "recoverypayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeRecoveryPayment(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "recoverypayment"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "recoverypayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeRefundByCash(final Long loanId, final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "refundByCash"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "refundByCash"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeRefundByCash(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "refundByCash"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "refundByCash"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeCreditBalanceRefund(final Long loanId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "creditBalanceRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "creditBalanceRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeCreditBalanceRefund(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "creditBalanceRefund"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "creditBalanceRefund"));
     }
 
     public PostLoansLoanIdTransactionsResponse reverseLoanTransaction(final String loanExternalId, final Long transactionId,
@@ -1396,7 +1406,7 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdChargesResponse addLoanCharge(final Long loanId, final PostLoansLoanIdChargesRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.executeLoanCharge(loanId, request, ""));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.createOrPayLoanCharge(loanId, request, ""));
     }
 
     public PostLoansLoanIdChargesResponse addLoanCharge(final String loanExternalId, final PostLoansLoanIdChargesRequest request) {
@@ -1437,7 +1447,7 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdChargesResponse addChargesForLoan(final Long loanId, PostLoansLoanIdChargesRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.executeLoanCharge(loanId, request, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.createOrPayLoanCharge(loanId, request, null));
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -1640,21 +1650,21 @@ public class LoanTransactionHelper {
     }
 
     public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(final Long loanId, final Long loanChargeId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.retrieveLoanCharge(loanId, loanChargeId));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.retrieveOneLoanCharge(loanId, loanChargeId));
     }
 
     public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(final String loanExternalId, final Long loanChargeId) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanCharges.retrieveLoanChargeByLoanExternalId(loanExternalId, loanChargeId));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanCharges.retrieveOneLoanChargeByLoanExternalId(loanExternalId, loanChargeId));
     }
 
     public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(final Long loanId, final String loanChargeExternalId) {
         return Calls.ok(
-                FineractClientHelper.getFineractClient().loanCharges.retrieveLoanChargeByChargeExternalId(loanId, loanChargeExternalId));
+                FineractClientHelper.getFineractClient().loanCharges.retrieveOneLoanChargeByChargeExternalId(loanId, loanChargeExternalId));
     }
 
     public GetLoansLoanIdChargesChargeIdResponse getLoanCharge(final String loanExternalId, final String loanChargeExternalId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.retrieveLoanChargeByLoanAndChargeExternalId(loanExternalId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loanCharges.retrieveOneLoanChargeByLoanAndChargeExternalId(loanExternalId,
                 loanChargeExternalId));
     }
 
@@ -1669,33 +1679,34 @@ public class LoanTransactionHelper {
     }
 
     public GetLoansLoanIdTransactionsTransactionIdResponse getLoanTransactionDetails(final Long loanId, final Long transactionId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransaction(loanId, transactionId, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveOneLoanTransaction(loanId, transactionId, null));
     }
 
     public GetLoansLoanIdTransactionsTransactionIdResponse getLoanTransactionDetails(final String loanExternalId,
             final Long transactionId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
-                .retrieveTransactionByLoanExternalIdAndTransactionId(loanExternalId, transactionId, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveOneLoanTransactionByLoanExternalId(loanExternalId,
+                transactionId, null));
     }
 
     public GetLoansLoanIdTransactionsTransactionIdResponse getLoanTransactionDetails(final Long loanId,
             final String transactionExternalId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionByTransactionExternalId(loanId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveOneLoanTransactionByExternalId(loanId,
                 transactionExternalId, null));
     }
 
     public GetLoansLoanIdTransactionsTransactionIdResponse getLoanTransactionDetails(final String loanExternalId,
             final String transactionExternalId) {
         return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
-                .retrieveTransactionByLoanExternalIdAndTransactionExternalId(loanExternalId, transactionExternalId, null));
+                .retrieveOneLoanTransactionByLoanExternalIdAndTransactionExternalId(loanExternalId, transactionExternalId, null));
     }
 
     public GetLoansLoanIdResponse getLoanDetails(final Long loanId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveLoan(loanId, false, "all", null, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveOneLoan(loanId, false, "all", null, null));
     }
 
     public GetLoansLoanIdResponse getLoanDetails(final String loanExternalId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveLoanByExternalId(loanExternalId, false, "all", null, null));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loans.retrieveOneLoanByExternalId(loanExternalId, false, "all", null, null));
     }
 
     public GetLoansLoanIdTransactionsResponse getLoanTransactions(final Long loanId) {
@@ -1708,7 +1719,7 @@ public class LoanTransactionHelper {
 
     public GetLoansLoanIdTransactionsResponse getLoanTransactions(final Long loanId, List<TransactionType> excludedTransactionTypes,
             Integer page, Integer size, String sort) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionsByLoanId(loanId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveAllLoanTransactions(loanId,
                 excludedTransactionTypes, page, size, sort));
     }
 
@@ -1723,7 +1734,7 @@ public class LoanTransactionHelper {
 
     public GetLoansLoanIdTransactionsResponse getLoanTransactionsByExternalId(final String loanExternalId,
             List<TransactionType> excludedTransactionTypes, Integer page, Integer size, String sort) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionsByExternalLoanId(loanExternalId,
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveAllLoanTransactionsByExternalId(loanExternalId,
                 excludedTransactionTypes, page, size, sort));
     }
 
@@ -2445,7 +2456,7 @@ public class LoanTransactionHelper {
 
     public GetLoansLoanIdTransactionsTemplateResponse getPrepaymentAmount(final Long loanId, final String transactionDate,
             String dateformat) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionTemplate(loanId, "prepayLoan",
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTemplateLoanTransaction(loanId, "prepayLoan",
                 dateformat, transactionDate, "en", null));
     }
 
@@ -2929,20 +2940,20 @@ public class LoanTransactionHelper {
 
     public GetLoansLoanIdTransactionsTemplateResponse retrieveTransactionTemplate(Long loanId, String command, String dateFormat,
             String transactionDate, String locale, Long transactionId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionTemplate(loanId, command, dateFormat,
-                transactionDate, locale, transactionId));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTemplateLoanTransaction(loanId, command,
+                dateFormat, transactionDate, locale, transactionId));
     }
 
     public GetLoansLoanIdTransactionsTemplateResponse retrieveTransactionTemplate(Long loanId, String command, String dateFormat,
             String transactionDate, String locale) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTransactionTemplate(loanId, command, dateFormat,
-                transactionDate, locale, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.retrieveTemplateLoanTransaction(loanId, command,
+                dateFormat, transactionDate, locale, null));
     }
 
     public GetLoansLoanIdTransactionsTemplateResponse retrieveTransactionTemplate(String loanExternalIdStr, String command,
             String dateFormat, String transactionDate, String locale) {
         return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
-                .retrieveTransactionTemplateByLoanExternalId(loanExternalIdStr, command, dateFormat, transactionDate, locale, null));
+                .retrieveTemplateLoanTransactionByLoanExternalId(loanExternalIdStr, command, dateFormat, transactionDate, locale, null));
     }
 
     public GetLoansApprovalTemplateResponse getLoanApprovalTemplate(String loanExternalIdStr) {
@@ -2954,54 +2965,54 @@ public class LoanTransactionHelper {
     }
 
     public List<GetDelinquencyTagHistoryResponse> getLoanDelinquencyTags(String loanExternalId) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.getDelinquencyTagHistoryByExternalId(loanExternalId));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.retrieveDelinquencyTagHistoryLoanByExternalId(loanExternalId));
     }
 
     public PostLoansResponse applyLoan(PostLoansRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.calculateLoanScheduleOrSubmitLoanApplication(request, null));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.calculateOrSubmitLoanApplication(request, null));
     }
 
     public void applyLoanWithError(PostLoansRequest request, Integer httpStatus) {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> Calls.ok(FineractClientHelper.getFineractClient().loans.calculateLoanScheduleOrSubmitLoanApplication(request, null)));
+                () -> Calls.ok(FineractClientHelper.getFineractClient().loans.calculateOrSubmitLoanApplication(request, null)));
         assertEquals(exception.getResponse().code(), httpStatus);
     }
 
     public PostLoansLoanIdResponse approveLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "approve"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request, "approve"));
     }
 
     public PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "approve"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "approve"));
     }
 
     public PostLoansLoanIdResponse rejectLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "reject"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request, "reject"));
     }
 
     public PostLoansLoanIdResponse rejectLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "reject"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "reject"));
     }
 
     public PostLoansLoanIdResponse withdrawnByApplicantLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "withdrawnByApplicant"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "withdrawnByApplicant"));
     }
 
     public PostLoansLoanIdResponse withdrawnByApplicantLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request,
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
                 "withdrawnByApplicant"));
     }
 
     public PostLoansLoanIdResponse disburseLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "disburse"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request, "disburse"));
     }
 
     public PostLoansLoanIdResponse disburseLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "disburse"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "disburse"));
     }
 
     public PostLoansLoanIdResponse moveLoanState(Long loanId, PostLoansLoanIdRequest request, String command) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, command));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, command));
     }
 
     /**
@@ -3021,98 +3032,100 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdResponse disburseToSavingsLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "disburseToSavings"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
+                "disburseToSavings"));
     }
 
     public PostLoansLoanIdResponse undoApprovalLoan(String loanExternalId, PostLoansLoanIdRequest request) {
         return Calls
-                .ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "undoapproval"));
+                .ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request, "undoapproval"));
     }
 
     public PostLoansLoanIdResponse undoDisbursalLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "undodisbursal"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request, "undodisbursal"));
     }
 
     public PostLoansLoanIdResponse undoDisbursalLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "undodisbursal"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "undodisbursal"));
     }
 
     public PostLoansLoanIdResponse undoLastDisbursalLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "undolastdisbursal"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
+                "undolastdisbursal"));
     }
 
     public PostLoansLoanIdResponse undoLastDisbursalLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "undolastdisbursal"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "undolastdisbursal"));
     }
 
     public PostLoansLoanIdResponse assignLoanOfficerLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "assignloanofficer"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
+                "assignloanofficer"));
     }
 
     public PostLoansLoanIdResponse unassignLoanOfficerLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request,
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
                 "unassignloanofficer"));
     }
 
     public PostLoansLoanIdResponse recoverGuaranteesLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "recoverGuarantees"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
+                "recoverGuarantees"));
     }
 
     public PostLoansLoanIdResponse assignDelinquencyLoan(String loanExternalId, PostLoansLoanIdRequest request) {
-        return Calls.ok(
-                FineractClientHelper.getFineractClient().loans.stateTransitionsByExternalId(loanExternalId, request, "assigndelinquency"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoanByExternalId(loanExternalId, request,
+                "assigndelinquency"));
     }
 
     public PostLoansLoanIdTransactionsResponse closeRescheduledLoan(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "close-rescheduled"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "close-rescheduled"));
     }
 
     public PostLoansLoanIdTransactionsResponse closeRescheduledLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "close-rescheduled"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "close-rescheduled"));
     }
 
     public PostLoansLoanIdTransactionsResponse closeLoan(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "close"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "close"));
     }
 
     public PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "close"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "close"));
     }
 
     public PostLoansLoanIdTransactionsResponse forecloseLoan(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "foreclosure"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "foreclosure"));
     }
 
     public PostLoansLoanIdTransactionsResponse forecloseLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "foreclosure"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "foreclosure"));
     }
 
     public PostLoansLoanIdTransactionsResponse chargeOffLoan(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "charge-off"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "charge-off"));
     }
 
     public PostLoansLoanIdTransactionsResponse chargeOffLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "charge-off"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "charge-off"));
     }
 
     public PostLoansLoanIdTransactionsResponse undoChargeOffLoan(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "undo-charge-off"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "undo-charge-off"));
     }
 
     public PostLoansLoanIdTransactionsResponse undoChargeOffLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls
-                .ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "undo-charge-off"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request,
+                "undo-charge-off"));
     }
 
     @Deprecated(forRemoval = true)
@@ -3149,16 +3162,18 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanDownPayment(String loanExternalId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "downPayment"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "downPayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanDownPayment(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "downPayment"));
+        return Calls.ok(
+                FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "downPayment"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransaction(loanId, request, "buyDownFee"));
+        return Calls
+                .ok(FineractClientHelper.getFineractClient().loanTransactions.handleCommandsLoanTransaction(loanId, request, "buyDownFee"));
     }
 
     public PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, String date, double amount) {
@@ -3182,8 +3197,8 @@ public class LoanTransactionHelper {
 
     public PostLoansLoanIdTransactionsResponse writeOffLoanAccount(final String loanExternalId,
             final PostLoansLoanIdTransactionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions.executeLoanTransactionByLoanExternalId(loanExternalId,
-                request, "writeoff"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loanTransactions
+                .handleCommandsLoanTransactionByLoanExternalId(loanExternalId, request, "writeoff"));
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -3206,15 +3221,15 @@ public class LoanTransactionHelper {
     }
 
     public PostLoansLoanIdResponse undoApprovalForLoan(Long loanId, PostLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.stateTransitions(loanId, request, "undoapproval"));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.handleCommandsLoan(loanId, request, "undoapproval"));
     }
 
     public PutLoansLoanIdResponse modifyApplicationForLoan(final Long loanId, final String command, final PutLoansLoanIdRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.modifyLoanApplication(loanId, request, command));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.updateLoanApplication(loanId, request, command));
     }
 
     public PostLoansResponse calculateRepaymentScheduleForApplyLoan(PostLoansRequest request, String command) {
-        return Calls.ok(FineractClientHelper.getFineractClient().loans.calculateLoanScheduleOrSubmitLoanApplication(request, command));
+        return Calls.ok(FineractClientHelper.getFineractClient().loans.calculateOrSubmitLoanApplication(request, command));
     }
 
     // TODO: Rewrite to use fineract-client instead!

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/AccountTransferWithdrawalFeeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/AccountTransferWithdrawalFeeTest.java
@@ -73,7 +73,7 @@ public class AccountTransferWithdrawalFeeTest extends BaseSavingsIntegrationTest
 
         // Add withdrawal fee charge to FROM savings account
         final PostSavingsAccountsSavingsAccountIdChargesResponse chargeResponse = ok(fineractClient().savingsAccountCharges
-                .addSavingsAccountCharge(fromSavingsId, new PostSavingsAccountsSavingsAccountIdChargesRequest()
+                .createSavingsAccountCharge(fromSavingsId, new PostSavingsAccountsSavingsAccountIdChargesRequest()
                         .chargeId(withdrawalCharge.getResourceId()).amount(100.0f).locale("en")));
         Assertions.assertNotNull(chargeResponse.getResourceId());
 
@@ -142,7 +142,7 @@ public class AccountTransferWithdrawalFeeTest extends BaseSavingsIntegrationTest
 
         // Add payment-type withdrawal fee charge to FROM savings account
         final PostSavingsAccountsSavingsAccountIdChargesResponse chargeResponse = ok(fineractClient().savingsAccountCharges
-                .addSavingsAccountCharge(fromSavingsId, new PostSavingsAccountsSavingsAccountIdChargesRequest()
+                .createSavingsAccountCharge(fromSavingsId, new PostSavingsAccountsSavingsAccountIdChargesRequest()
                         .chargeId(withdrawalCharge.getResourceId()).amount(100.0f).locale("en")));
         Assertions.assertNotNull(chargeResponse.getResourceId());
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/FINERACT-2501

## Description

This PR is a continuation of the work started in #5597 and #5744, which addressed the instability of auto-generated Feign client method names caused by Swagger deduplication numbers shifting when new endpoints are added.

This PR covers the Savings and Loans modules, adding explicit operationId values to all endpoints that were missing them. The naming convention follows the same pattern established in the previous PRs: methodName + EntityName + DescriptionClause (for example, retrieveOneSavingsAccountCharge, handleCommandsLoanTransaction).

Files changed:
- SavingsAccountChargesApiResource (6 operationIds added)
- FixedDepositAccountsApiResource (1 operationId added)
- FixedDepositAccountTransactionsApiResource (1 operationId added)
- RecurringDepositAccountTransactionsApiResource (1 operationId added)
- LoansApiResource (15 operationIds added)
- LoanTransactionsApiResource (12 operationIds added)
- LoanChargesApiResource (5 operationIds added)
- RescheduleLoansApiResource (5 operationIds added)
- LoanScheduleApiResource (1 operationId added)