### PR TITLE
FINERACT-2501: Add operationIds to Infrastructure, Organisation and User Management modules to harden feign method names

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/CodeHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/helper/CodeHelper.java
@@ -55,7 +55,7 @@ public class CodeHelper {
     }
 
     public GetCodesResponse retrieveCodeByName(String name) {
-        return ok(() -> fineractClient.codes().retrieveCodes(Map.of())).stream().filter(r -> name.equals(r.getName())).findAny()
+        return ok(() -> fineractClient.codes().retrieveAllCodes(Map.of())).stream().filter(r -> name.equals(r.getName())).findAny()
                 .orElseThrow(() -> new IllegalArgumentException("Code with name " + name + " has not been found"));
     }
 

--- a/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/global/CodeGlobalInitializerStep.java
+++ b/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/global/CodeGlobalInitializerStep.java
@@ -109,7 +109,7 @@ public class CodeGlobalInitializerStep implements FineractGlobalInitializerStep 
     }
 
     private void fetchExistingCodesAndCodeValues() {
-        List<GetCodesResponse> existingCodes = fineractClient.codes().retrieveCodes();
+        List<GetCodesResponse> existingCodes = fineractClient.codes().retrieveAllCodes();
         existingCodes.forEach(code -> {
             List<GetCodeValuesDataResponse> existingCodeValues = fineractClient.codeValues()
                     .retrieveAllCodeValuesByCodeName(code.getName());

--- a/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/global/SchedulerGlobalInitializerStep.java
+++ b/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/global/SchedulerGlobalInitializerStep.java
@@ -38,6 +38,6 @@ public class SchedulerGlobalInitializerStep implements FineractGlobalInitializer
 
     @Override
     public void initialize() throws Exception {
-        executeVoid(() -> fineractClient.scheduler().changeSchedulerStatus(Map.of("command", SCHEDULER_STATUS_STOP)));
+        executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler(Map.of("command", SCHEDULER_STATUS_STOP)));
     }
 }

--- a/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/suite/JobSuiteInitializerStep.java
+++ b/fineract-e2e-tests-runner/src/test/java/org/apache/fineract/test/initializer/suite/JobSuiteInitializerStep.java
@@ -60,7 +60,7 @@ public class JobSuiteInitializerStep implements FineractSuiteInitializerStep {
         // CRITICAL: SchedulerGlobalInitializerStep stops the scheduler globally
         // Solution: START the scheduler so the job runs every 1 second automatically
         log.debug("Starting scheduler to enable automatic job execution every 1 second...");
-        executeVoid(() -> fineractClient.scheduler().changeSchedulerStatus("start", Map.of()));
+        executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler("start", Map.of()));
         log.debug("Scheduler started successfully");
 
         // Manually execute once immediately to publish any queued events from initialization
@@ -110,7 +110,7 @@ public class JobSuiteInitializerStep implements FineractSuiteInitializerStep {
         // Stop the scheduler to prevent jobs from running between test suites
         log.debug("Stopping scheduler...");
         try {
-            executeVoid(() -> fineractClient.scheduler().changeSchedulerStatus(Map.of("command", "stop")));
+            executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler(Map.of("command", "stop")));
             log.debug("Scheduler stopped successfully");
         } catch (Exception e) {
             log.warn("Failed to stop scheduler: {}", e.getMessage());

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/api/AccountNumberFormatsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/accountnumberformat/api/AccountNumberFormatsApiResource.java
@@ -75,7 +75,7 @@ public class AccountNumberFormatsApiResource {
     @GET
     @Path("template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Account number format Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
+    @Operation(summary = "Retrieve Account number format Template", operationId = "retrieveTemplateAccountNumberFormat", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
             + "\n" + "Field Defaults\n" + "Allowed Value Lists\n" + "\n" + "Example Request:\n" + "\n" + "accountnumberformats/template")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.GetAccountNumberFormatsResponseTemplate.class)))
     public String retrieveTemplate(@Context final UriInfo uriInfo) {
@@ -91,8 +91,8 @@ public class AccountNumberFormatsApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Account number formats", description = "Example Requests:\n" + "\n" + "accountnumberformats\n" + "\n" + "\n"
-            + "accountnumberformats?fields=accountType,prefixType")
+    @Operation(summary = "List Account number formats", operationId = "retrieveAllAccountNumberFormats", description = "Example Requests:\n"
+            + "\n" + "accountnumberformats\n" + "\n" + "\n" + "accountnumberformats?fields=accountType,prefixType")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.GetAccountNumberFormatsIdResponse.class))))
     public String retrieveAll(@Context final UriInfo uriInfo) {
 
@@ -108,8 +108,9 @@ public class AccountNumberFormatsApiResource {
     @GET
     @Path("{accountNumberFormatId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve an Account number format", description = "Example Requests:\n" + "\n" + "accountnumberformats/1\n" + "\n"
-            + "\n" + "accountnumberformats/1?template=true\n" + "\n" + "\n" + "accountnumberformats/1?fields=accountType,prefixType")
+    @Operation(summary = "Retrieve an Account number format", operationId = "retrieveOneAccountNumberFormat", description = "Example Requests:\n"
+            + "\n" + "accountnumberformats/1\n" + "\n" + "\n" + "accountnumberformats/1?template=true\n" + "\n" + "\n"
+            + "accountnumberformats/1?fields=accountType,prefixType")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.GetAccountNumberFormatsIdResponse.class)))
     public String retrieveOne(@Context final UriInfo uriInfo,
             @PathParam("accountNumberFormatId") @Parameter(description = "accountNumberFormatId") final Long accountNumberFormatId) {
@@ -132,7 +133,7 @@ public class AccountNumberFormatsApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create an Account number format", description = "Note: You may associate a single Account number format for a given account type\n"
+    @Operation(summary = "Create an Account number format", operationId = "createAccountNumberFormat", description = "Note: You may associate a single Account number format for a given account type\n"
             + "Mandatory Fields for Account number formats\n" + "accountType")
     @RequestBody(content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.PostAccountNumberFormatsRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.PostAccountNumberFormatsResponse.class)))
@@ -152,7 +153,7 @@ public class AccountNumberFormatsApiResource {
     @Path("{accountNumberFormatId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update an Account number format")
+    @Operation(summary = "Update an Account number format", operationId = "updateAccountNumberFormat")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.PutAccountNumberFormatsRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.PutAccountNumberFormatsResponse.class)))
     public String update(
@@ -172,7 +173,7 @@ public class AccountNumberFormatsApiResource {
     @DELETE
     @Path("{accountNumberFormatId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete an Account number format", description = "Note: Account numbers created while this format was active would remain unchanged.")
+    @Operation(summary = "Delete an Account number format", operationId = "deleteAccountNumberFormat", description = "Note: Account numbers created while this format was active would remain unchanged.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AccountNumberFormatsApiResourceSwagger.DeleteAccountNumberFormatsResponse.class)))
     public String delete(
             @PathParam("accountNumberFormatId") @Parameter(description = "accountNumberFormatId") final Long accountNumberFormatId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/api/CodesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/api/CodesApiResource.java
@@ -76,7 +76,8 @@ public class CodesApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Codes", description = "Returns the list of codes.\n" + "\n" + "Example Requests:\n" + "\n" + "codes")
+    @Operation(summary = "Retrieve Codes", operationId = "retrieveAllCodes", description = "Returns the list of codes.\n" + "\n"
+            + "Example Requests:\n" + "\n" + "codes")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = CodesApiResourceSwagger.GetCodesResponse.class))))
     public String retrieveCodes(@Context final UriInfo uriInfo) {
 
@@ -91,7 +92,7 @@ public class CodesApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a Code", description = "Creates a code. Codes created through api are always 'user defined' and so system defined is marked as false.")
+    @Operation(summary = "Create a Code", operationId = "createCode", description = "Creates a code. Codes created through api are always 'user defined' and so system defined is marked as false.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.PostCodesRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.PostCodesResponse.class)))
     public String createCode(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
@@ -106,8 +107,8 @@ public class CodesApiResource {
     @GET
     @Path("{codeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Code", description = "Returns the details of a Code.\n" + "\n" + "Example Requests:\n" + "\n"
-            + "codes/1")
+    @Operation(summary = "Retrieve a Code", operationId = "retrieveOneCode", description = "Returns the details of a Code.\n" + "\n"
+            + "Example Requests:\n" + "\n" + "codes/1")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.GetCodesResponse.class)))
     public String retrieveCode(@PathParam("codeId") @Parameter(description = "codeId") final Long codeId, @Context final UriInfo uriInfo) {
 
@@ -120,8 +121,8 @@ public class CodesApiResource {
     @GET
     @Path("name/{codeName}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Code", description = "Returns the details of a Code.\n" + "\n" + "Example Requests:\n" + "\n"
-            + "codes/1")
+    @Operation(summary = "Retrieve a Code", operationId = "retrieveOneCodeByName", description = "Returns the details of a Code.\n" + "\n"
+            + "Example Requests:\n" + "\n" + "codes/1")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.GetCodesResponse.class)))
     public String retrieveCodeByName(@PathParam("codeName") @Parameter(description = "codeName") final String codeName,
             @Context final UriInfo uriInfo) {
@@ -136,7 +137,7 @@ public class CodesApiResource {
     @Path("{codeId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Code", description = "Updates the details of a code if it is not system defined.")
+    @Operation(summary = "Update a Code", operationId = "updateCode", description = "Updates the details of a code if it is not system defined.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.PutCodesRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.PutCodesResponse.class)))
     public String updateCode(@PathParam("codeId") @Parameter(description = "codeId") final Long codeId,
@@ -152,7 +153,7 @@ public class CodesApiResource {
     @DELETE
     @Path("{codeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Code", description = "Deletes a code if it is not system defined.")
+    @Operation(summary = "Delete a Code", operationId = "deleteCode", description = "Deletes a code if it is not system defined.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CodesApiResourceSwagger.DeleteCodesResponse.class)))
     public String deleteCode(@PathParam("codeId") @Parameter(description = "codeId") final Long codeId) {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/ExternalServicesConfigurationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/api/ExternalServicesConfigurationApiResource.java
@@ -65,7 +65,7 @@ public class ExternalServicesConfigurationApiResource {
     @GET
     @Path("{servicename}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve External Services Configuration", description = "Returns a external Service configurations based on the Service Name.\n"
+    @Operation(summary = "Retrieve External Services Configuration", operationId = "retrieveExternalServicesConfiguration", description = "Returns a external Service configurations based on the Service Name.\n"
             + "\n" + "Service Names supported are S3 and SMTP.\n" + "\n" + "Example Requests:\n" + "\n" + "externalservice/SMTP")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ExternalServicesPropertiesData.class)))
     public String retrieveOne(@PathParam("servicename") @Parameter(description = "servicename") final String serviceName,
@@ -82,8 +82,8 @@ public class ExternalServicesConfigurationApiResource {
     @Path("{servicename}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update External Service", description = "Updates the external Service Configuration for a Service Name.\n" + "\n"
-            + "Example: \n" + "\n" + "externalservice/S3")
+    @Operation(summary = "Update External Service", operationId = "updateExternalServicesConfiguration", description = "Updates the external Service Configuration for a Service Name.\n"
+            + "\n" + "Example: \n" + "\n" + "externalservice/S3")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = ExternalServicesConfigurationApiResourceSwagger.PutExternalServiceRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK")
     public String updateExternalServiceProperties(

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResource.java
@@ -62,7 +62,7 @@ public class EntityDatatableChecksApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Entity-Datatable Checks", description = "The list capability of Entity-Datatable Checks can support pagination.\n"
+    @Operation(summary = "List Entity-Datatable Checks", operationId = "retrieveAllEntityDatatableChecks", description = "The list capability of Entity-Datatable Checks can support pagination.\n"
             + "\n" + "OPTIONAL ARGUMENTS\n"
             + "offset Integer optional, defaults to 0 Indicates the result from which pagination startslimit Integer optional, defaults to 200 Restricts the size of results returned. To override the default and return all entries you must explicitly pass a non-positive integer value for limit e.g. limit=0, or limit=-1\n"
             + "Example Request:\n" + "\n" + "entityDatatableChecks?offset=0&limit=15")
@@ -82,7 +82,7 @@ public class EntityDatatableChecksApiResource {
     @GET
     @Path("template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Entity-Datatable Checks Template", description = "This is a convenience resource useful for building maintenance user interface screens for Entity-Datatable Checks applications. The template data returned consists of:\n"
+    @Operation(summary = "Retrieve Entity-Datatable Checks Template", operationId = "retrieveTemplateEntityDatatableChecks", description = "This is a convenience resource useful for building maintenance user interface screens for Entity-Datatable Checks applications. The template data returned consists of:\n"
             + "\n" + "Allowed description Lists\n" + "Example Request:\n" + "\n" + "entityDatatableChecks/template")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EntityDatatableChecksApiResourceSwagger.GetEntityDatatableChecksTemplateResponse.class)))
     public String getTemplate(@Context final UriInfo uriInfo) {
@@ -95,8 +95,8 @@ public class EntityDatatableChecksApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create Entity-Datatable Checks", description = "Mandatory Fields : \n" + "entity, status, datatableName\n" + "\n"
-            + "Non-Mandatory Fields : \n" + "productId")
+    @Operation(summary = "Create Entity-Datatable Checks", operationId = "createEntityDatatableCheck", description = "Mandatory Fields : \n"
+            + "entity, status, datatableName\n" + "\n" + "Non-Mandatory Fields : \n" + "productId")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = EntityDatatableChecksApiResourceSwagger.PostEntityDatatableChecksTemplateRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EntityDatatableChecksApiResourceSwagger.PostEntityDatatableChecksTemplateResponse.class)))
     public String createEntityDatatableCheck(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
@@ -110,7 +110,7 @@ public class EntityDatatableChecksApiResource {
     @Path("{entityDatatableCheckId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete Entity-Datatable Checks", description = "Deletes an existing Entity-Datatable Check")
+    @Operation(summary = "Delete Entity-Datatable Checks", operationId = "deleteEntityDatatableCheck", description = "Deletes an existing Entity-Datatable Check")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EntityDatatableChecksApiResourceSwagger.DeleteEntityDatatableChecksTemplateResponse.class)))
     public String deleteDatatable(
             @PathParam("entityDatatableCheckId") @Parameter(description = "entityDatatableCheckId") final long entityDatatableCheckId,

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/api/HookApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/api/HookApiResource.java
@@ -67,14 +67,14 @@ public class HookApiResource {
     private final CommandDispatcher dispatcher;
 
     @GET
-    @Operation(summary = "Retrieve Hooks", description = "Returns the list of hooks")
+    @Operation(summary = "Retrieve Hooks", operationId = "retrieveAllHooks", description = "Returns the list of hooks")
     public Collection<HookData> retrieveHooks(@Context final UriInfo uriInfo) {
         return readPlatformService.retrieveAllHooks();
     }
 
     @GET
     @Path("{hookId}")
-    @Operation(summary = "Retrieve a Hook", description = "Returns the details of a Hook.")
+    @Operation(summary = "Retrieve a Hook", operationId = "retrieveOneHook", description = "Returns the details of a Hook.")
     public HookData retrieveHook(@PathParam("hookId") @Parameter(description = "hookId") final Long hookId,
             @QueryParam("template") @DefaultValue("false") @Parameter(description = "template") Boolean template) {
         var hook = readPlatformService.retrieveHook(hookId);
@@ -91,13 +91,13 @@ public class HookApiResource {
 
     @GET
     @Path("template")
-    @Operation(summary = "Retrieve Hooks Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications.")
+    @Operation(summary = "Retrieve Hooks Template", operationId = "retrieveTemplateHook", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications.")
     public HookDetailsData template() {
         return readPlatformService.retrieveNewHookDetails(null);
     }
 
     @POST
-    @Operation(summary = "Create a Hook", description = "")
+    @Operation(summary = "Create a Hook", operationId = "createHook", description = "")
     public HookCreateResponse createHook(@Valid final HookCreateRequest request) {
         final var command = new HookCreateCommand();
         command.setPayload(request);
@@ -109,7 +109,7 @@ public class HookApiResource {
 
     @PUT
     @Path("{hookId}")
-    @Operation(summary = "Update a Hook", description = "Updates the details of a hook.")
+    @Operation(summary = "Update a Hook", operationId = "updateHook", description = "Updates the details of a hook.")
     public HookUpdateResponse updateHook(@PathParam("hookId") @Parameter(description = "hookId") final Long hookId,
             @Valid HookUpdateRequest request) {
         requireNonNull(hookId, "hookId is required");
@@ -126,7 +126,7 @@ public class HookApiResource {
 
     @DELETE
     @Path("{hookId}")
-    @Operation(summary = "Delete a Hook", description = "Deletes a hook.")
+    @Operation(summary = "Delete a Hook", operationId = "deleteHook", description = "Deletes a hook.")
     public HookDeleteResponse deleteHook(@PathParam("hookId") @Parameter(description = "hookId") final Long hookId) {
         var request = HookDeleteRequest.builder().id(hookId).build();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/instancemode/api/InstanceModeApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/instancemode/api/InstanceModeApiResource.java
@@ -62,7 +62,7 @@ public class InstanceModeApiResource implements InitializingBean {
 
     @PUT
     @Consumes({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Changes the Fineract instance mode", description = "")
+    @Operation(summary = "Changes the Fineract instance mode", operationId = "updateInstanceMode", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = InstanceModeApiResourceSwagger.ChangeInstanceModeRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK")
     @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/InlineJobApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/InlineJobApiResource.java
@@ -53,7 +53,7 @@ public class InlineJobApiResource {
     @Path("{jobName}/inline")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Starts an inline Job", description = "Starts an inline Job")
+    @Operation(summary = "Starts an inline Job", operationId = "executeInlineJob", description = "Starts an inline Job")
     @RequestBody(content = @Content(schema = @Schema(implementation = InlineJobResourceSwagger.InlineJobRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = InlineJobResourceSwagger.InlineJobResponse.class)))
     @ApiResponse(responseCode = "400", description = "Request body item size validation error")

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/SchedulerApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/jobs/api/SchedulerApiResource.java
@@ -67,8 +67,8 @@ public class SchedulerApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Scheduler Status", description = "Returns the scheduler status.\n" + "\n" + "Example Requests:\n" + "\n"
-            + "scheduler")
+    @Operation(summary = "Retrieve Scheduler Status", operationId = "retrieveSchedulerStatus", description = "Returns the scheduler status.\n"
+            + "\n" + "Example Requests:\n" + "\n" + "scheduler")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SchedulerApiResourceSwagger.GetSchedulerResponse.class)))
     public String retrieveStatus(@Context final UriInfo uriInfo) {
         this.context.authenticatedUser().validateHasReadPermission(SchedulerJobApiConstants.SCHEDULER_RESOURCE_NAME);
@@ -82,7 +82,7 @@ public class SchedulerApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Activate Scheduler Jobs | Suspend Scheduler Jobs", description = "Activates the scheduler job service. | Suspends the scheduler job service.")
+    @Operation(summary = "Activate Scheduler Jobs | Suspend Scheduler Jobs", operationId = "handleCommandsScheduler", description = "Activates the scheduler job service. | Suspends the scheduler job service.")
     @ApiResponse(responseCode = "200", description = "POST :  scheduler?command=start\n\n" + "\n" + "POST : scheduler?command=stop")
     public Response changeSchedulerStatus(
             @QueryParam(SchedulerJobApiConstants.COMMAND) @Parameter(description = "command") final String commandParam) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResource.java
@@ -69,7 +69,7 @@ public class SurveyApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve surveys", description = "Retrieve surveys. This allows to retrieve the list of survey tables registered .")
+    @Operation(summary = "Retrieve surveys", operationId = "retrieveAllSurveys", description = "Retrieve surveys. This allows to retrieve the list of survey tables registered .")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SurveyApiResourceSwagger.GetSurveyResponse.class))))
     public String retrieveSurveys() {
 
@@ -82,7 +82,7 @@ public class SurveyApiResource {
     @GET
     @Path("{surveyName}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve survey", description = "Lists a registered survey table details and the Apache Fineract Core application table they are registered to.")
+    @Operation(summary = "Retrieve survey", operationId = "retrieveOneSurvey", description = "Lists a registered survey table details and the Apache Fineract Core application table they are registered to.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SurveyApiResourceSwagger.GetSurveyResponse.class)))
     public String retrieveSurvey(@PathParam("surveyName") @Parameter(description = "surveyName") final String surveyName) {
 
@@ -98,7 +98,7 @@ public class SurveyApiResource {
     @Path("{surveyName}/{apptableId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create an entry in the survey table", description = "Insert and entry in a survey table (full fill the survey)."
+    @Operation(summary = "Create an entry in the survey table", operationId = "createSurveyEntry", description = "Insert and entry in a survey table (full fill the survey)."
             + "\n" + "\n" + "Refer Link for sample Body:  [ https://fineract.apache.org/docs/legacy/#survey_create ] ")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SurveyApiResourceSwagger.PostSurveySurveyNameApptableIdRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SurveyApiResourceSwagger.PostSurveySurveyNameApptableIdResponse.class)))

--- a/fineract-provider/src/main/java/org/apache/fineract/notification/api/NotificationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/notification/api/NotificationApiResource.java
@@ -87,7 +87,7 @@ public class NotificationApiResource {
     @PUT
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update Notification Read Status", description = "Updates the read status of all notifications for the authenticated user.", tags = {
+    @Operation(summary = "Update Notification Read Status", operationId = "updateNotificationReadStatus", description = "Updates the read status of all notifications for the authenticated user.", tags = {
             "Notification" })
     public void update() {
         this.context.authenticatedUser();

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/api/HolidaysApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/holiday/api/HolidaysApiResource.java
@@ -80,7 +80,7 @@ public class HolidaysApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a Holiday", description = "Mandatory Fields: "
+    @Operation(summary = "Create a Holiday", operationId = "createHoliday", description = "Mandatory Fields: "
             + "name, description, fromDate, toDate, repaymentsRescheduledTo, offices")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PostHolidaysRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PostHolidaysResponse.class)))
@@ -97,7 +97,7 @@ public class HolidaysApiResource {
     @Path("{holidayId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Activate a Holiday", description = "Always Holidays are created in pending state. This API allows to activate a holiday.\n"
+    @Operation(summary = "Activate a Holiday", operationId = "handleCommandsHoliday", description = "Always Holidays are created in pending state. This API allows to activate a holiday.\n"
             + "\n" + "Only the active holidays are considered for rescheduling the loan repayment.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PostHolidaysHolidayIdRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PostHolidaysHolidayIdResponse.class)))
@@ -128,7 +128,8 @@ public class HolidaysApiResource {
     @GET
     @Path("{holidayId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Holiday", description = "Example Requests:\n" + "\n" + "holidays/1")
+    @Operation(summary = "Retrieve a Holiday", operationId = "retrieveOneHoliday", description = "Example Requests:\n" + "\n"
+            + "holidays/1")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.GetHolidaysResponse.class)))
     public String retrieveOne(@PathParam("holidayId") @Parameter(description = "holidayId") final Long holidayId,
             @Context final UriInfo uriInfo) {
@@ -146,7 +147,7 @@ public class HolidaysApiResource {
     @Path("{holidayId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Holiday", description = "If a holiday is in pending state (created and not activated) then all fields are allowed to modify. Once holidays become active only name and descriptions are allowed to modify.")
+    @Operation(summary = "Update a Holiday", operationId = "updateHoliday", description = "If a holiday is in pending state (created and not activated) then all fields are allowed to modify. Once holidays become active only name and descriptions are allowed to modify.")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PutHolidaysHolidayIdRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.PutHolidaysHolidayIdResponse.class)))
     public String update(@PathParam("holidayId") @Parameter(description = "holidayId") final Long holidayId,
@@ -162,7 +163,7 @@ public class HolidaysApiResource {
     @DELETE
     @Path("{holidayId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Holiday", description = "This API allows to delete a holiday. This is a soft delete the deleted holiday status is marked as deleted.")
+    @Operation(summary = "Delete a Holiday", operationId = "deleteHoliday", description = "This API allows to delete a holiday. This is a soft delete the deleted holiday status is marked as deleted.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = HolidaysApiResourceSwagger.DeleteHolidaysHolidayIdResponse.class)))
     public String delete(@PathParam("holidayId") @Parameter(description = "holidayId") final Long holidayId) {
         final CommandWrapper commandRequest = new CommandWrapperBuilder().deleteHoliday(holidayId).build();
@@ -176,7 +177,8 @@ public class HolidaysApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Holidays", description = "Example Requests:\n" + "\n" + "holidays?officeId=1")
+    @Operation(summary = "List Holidays", operationId = "retrieveAllHolidays", description = "Example Requests:\n" + "\n"
+            + "holidays?officeId=1")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = HolidaysApiResourceSwagger.GetHolidaysResponse.class))))
     public String retrieveAllHolidays(@Context final UriInfo uriInfo,
             @QueryParam("officeId") @Parameter(description = "officeId") final Long officeId,

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/office/api/OfficesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/office/api/OfficesApiResource.java
@@ -96,8 +96,8 @@ public class OfficesApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Offices", description = "Example Requests:\n" + "\n" + "offices\n" + "\n" + "\n"
-            + "offices?fields=id,name,openingDate")
+    @Operation(summary = "List Offices", operationId = "retrieveAllOffices", description = "Example Requests:\n" + "\n" + "offices\n" + "\n"
+            + "\n" + "offices?fields=id,name,openingDate")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = OfficesApiResourceSwagger.GetOfficesResponse.class))))
     public String retrieveOffices(@Context final UriInfo uriInfo,
             @DefaultValue("false") @QueryParam("includeAllOffices") @Parameter(description = "includeAllOffices") final boolean onlyManualEntries,
@@ -116,7 +116,7 @@ public class OfficesApiResource {
     @GET
     @Path("template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve Office Details Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
+    @Operation(summary = "Retrieve Office Details Template", operationId = "retrieveTemplateOffice", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for client applications. The template data returned consists of any or all of:\n"
             + "\n" + "Field Defaults\n" + "Allowed description Lists\n" + "Example Request:\n" + "\n" + "offices/template")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.GetOfficesTemplateResponse.class)))
     public String retrieveOfficeTemplate(@Context final UriInfo uriInfo) {
@@ -131,7 +131,8 @@ public class OfficesApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create an Office", description = "Mandatory Fields\n" + "name, openingDate, parentId")
+    @Operation(summary = "Create an Office", operationId = "createOffice", description = "Mandatory Fields\n"
+            + "name, openingDate, parentId")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.PostOfficesRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.PostOfficesResponse.class)))
     public String createOffice(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
@@ -146,8 +147,8 @@ public class OfficesApiResource {
     @GET
     @Path("{officeId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve an Office", description = "Example Requests:\n" + "\n" + "offices/1\n" + "\n" + "\n"
-            + "offices/1?template=true\n" + "\n" + "\n" + "offices/1?fields=id,name,parentName")
+    @Operation(summary = "Retrieve an Office", operationId = "retrieveOneOffice", description = "Example Requests:\n" + "\n" + "offices/1\n"
+            + "\n" + "\n" + "offices/1?template=true\n" + "\n" + "\n" + "offices/1?fields=id,name,parentName")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.GetOfficesResponse.class)))
     public String retrieveOffice(@PathParam("officeId") @Parameter(description = "officeId") final Long officeId,
             @Context final UriInfo uriInfo) {
@@ -164,8 +165,8 @@ public class OfficesApiResource {
     @GET
     @Path("/external-id/{externalId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve an Office using external id", description = "Example Requests:\n" + "\n" + "offices/external-id/asd123\n"
-            + "\n" + "\n" + "offices/external-id/asd123?template=true\n" + "\n" + "\n"
+    @Operation(summary = "Retrieve an Office using external id", operationId = "retrieveOneOfficeByExternalId", description = "Example Requests:\n"
+            + "\n" + "offices/external-id/asd123\n" + "\n" + "\n" + "offices/external-id/asd123?template=true\n" + "\n" + "\n"
             + "offices/external-id/asd123?fields=id,name,parentName")
     public OfficesApiResourceSwagger.GetOfficesResponse retrieveOfficeByExternalId(
             @PathParam("externalId") @Parameter(description = "externalId") final String externalId, @Context final UriInfo uriInfo) {
@@ -183,7 +184,7 @@ public class OfficesApiResource {
     @Path("{officeId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update Office", description = "")
+    @Operation(summary = "Update Office", operationId = "updateOffice", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.PutOfficesOfficeIdRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.PutOfficesOfficeIdResponse.class)))
     public String updateOffice(@PathParam("officeId") @Parameter(description = "officeId") final Long officeId,
@@ -200,7 +201,7 @@ public class OfficesApiResource {
     @Path("/external-id/{externalId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update Office", description = "")
+    @Operation(summary = "Update Office", operationId = "updateOfficeByExternalId", description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = OfficesApiResourceSwagger.PutOfficesOfficeIdRequest.class)))
     public OfficesApiResourceSwagger.PutOfficesOfficeIdResponse updateOfficeWithExternalId(
             @Parameter(description = "externalId") @PathParam("externalId") final String externalId,

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/api/ProvisioningCriteriaApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/provisioning/api/ProvisioningCriteriaApiResource.java
@@ -74,7 +74,7 @@ public class ProvisioningCriteriaApiResource {
     @GET
     @Path("{criteriaId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieves a Provisioning Criteria", description = "Retrieves a Provisioning Criteria")
+    @Operation(summary = "Retrieves a Provisioning Criteria", operationId = "retrieveOneProvisioningCriteria", description = "Retrieves a Provisioning Criteria")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.GetProvisioningCriteriaCriteriaIdResponse.class)))
     public ProvisioningCriteriaData retrieveProvisioningCriteria(
             @PathParam("criteriaId") @Parameter(description = "criteriaId") final Long criteriaId, @Context final UriInfo uriInfo) {
@@ -89,7 +89,7 @@ public class ProvisioningCriteriaApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieves all created Provisioning Criterias", description = "Retrieves all created Provisioning Criterias")
+    @Operation(summary = "Retrieves all created Provisioning Criterias", operationId = "retrieveAllProvisioningCriteria", description = "Retrieves all created Provisioning Criterias")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.GetProvisioningCriteriaResponse.class))))
     public List<ProvisioningCriteriaData> retrieveAllProvisioningCriterias() {
         platformSecurityContext.authenticatedUser();
@@ -99,8 +99,8 @@ public class ProvisioningCriteriaApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a new Provisioning Criteria", description = "Creates a new Provisioning Criteria\n" + "\n"
-            + "Mandatory Fields: \n" + "criteriaName\n" + "provisioningcriteria\n" + "\n" + "Optional Fields: \n" + "loanProducts")
+    @Operation(summary = "Create a new Provisioning Criteria", operationId = "createProvisioningCriteria", description = "Creates a new Provisioning Criteria\n"
+            + "\n" + "Mandatory Fields: \n" + "criteriaName\n" + "provisioningcriteria\n" + "\n" + "Optional Fields: \n" + "loanProducts")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.PostProvisioningCriteriaRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.PostProvisioningCriteriaResponse.class)))
     public CommandProcessingResult createProvisioningCriteria(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
@@ -113,8 +113,8 @@ public class ProvisioningCriteriaApiResource {
     @Path("{criteriaId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Updates a new Provisioning Criteria", description = "Updates a new Provisioning Criteria\n" + "\n"
-            + "Optional Fields\n" + "criteriaName, loanProducts, provisioningcriteria")
+    @Operation(summary = "Updates a new Provisioning Criteria", operationId = "updateProvisioningCriteria", description = "Updates a new Provisioning Criteria\n"
+            + "\n" + "Optional Fields\n" + "criteriaName, loanProducts, provisioningcriteria")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.PutProvisioningCriteriaRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.PutProvisioningCriteriaResponse.class)))
     public CommandProcessingResult updateProvisioningCriteria(
@@ -129,7 +129,7 @@ public class ProvisioningCriteriaApiResource {
     @DELETE
     @Path("{criteriaId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Deletes Provisioning Criteria", description = "Deletes Provisioning Criteria")
+    @Operation(summary = "Deletes Provisioning Criteria", operationId = "deleteProvisioningCriteria", description = "Deletes Provisioning Criteria")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ProvisioningCriteriaApiResourceSwagger.DeleteProvisioningCriteriaResponse.class)))
     public CommandProcessingResult deleteProvisioningCriteria(
             @PathParam("criteriaId") @Parameter(description = "criteriaId") final Long criteriaId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/api/StaffApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/api/StaffApiResource.java
@@ -125,7 +125,7 @@ public class StaffApiResource {
     @GET
     @Path("downloadtemplate")
     @Produces("application/vnd.ms-excel")
-    @Operation(summary = "Download bulk import template")
+    @Operation(summary = "Download bulk import template", operationId = "getBulkTemplateStaff")
     public Response getTemplate(@QueryParam("officeId") @Parameter(description = "officeId") final Long officeId,
             @QueryParam("dateFormat") @Parameter(description = "dateFormat") final String dateFormat) {
         return bulkImportWorkbookPopulatorService.getTemplate(GlobalEntityType.STAFF.toString(), officeId, null, dateFormat);
@@ -160,7 +160,7 @@ public class StaffApiResource {
     @PUT
     @Path("{staffId}")
     @Consumes({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Staff Member", description = "Updates the details of a staff member.")
+    @Operation(summary = "Update a Staff Member", operationId = "updateStaff", description = "Updates the details of a staff member.")
     public StaffUpdateResponse updateStaff(@PathParam("staffId") @Parameter(description = "staffId") final Long staffId,
             @RequestBody(required = true) @Valid StaffUpdateRequest request) {
         request.setId(staffId);

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/api/WorkingDaysApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/workingdays/api/WorkingDaysApiResource.java
@@ -54,7 +54,8 @@ public class WorkingDaysApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Working days", description = "Example Requests:\n" + "\n" + "workingdays")
+    @Operation(summary = "List Working days", operationId = "retrieveAllWorkingDays", description = "Example Requests:\n" + "\n"
+            + "workingdays")
     public WorkingDaysData retrieveAll() {
         return this.workingDaysReadPlatformService.retrieve();
     }
@@ -62,7 +63,7 @@ public class WorkingDaysApiResource {
     @PUT
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Working Day", description = "Mandatory Fields\n"
+    @Operation(summary = "Update a Working Day", operationId = "updateWorkingDay", description = "Mandatory Fields\n"
             + "recurrence,repaymentRescheduleType,extendTermForDailyRepayments,locale")
     public WorkingDaysUpdateResponse update(@Valid WorkingDaysUpdateRequest request) {
 
@@ -80,7 +81,7 @@ public class WorkingDaysApiResource {
     @GET
     @Path("/template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Working Days Template", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for working days.\n"
+    @Operation(summary = "Working Days Template", operationId = "retrieveTemplateWorkingDays", description = "This is a convenience resource. It can be useful when building maintenance user interface screens for working days.\n"
             + "\n" + "Example Request:\n" + "\n" + "workingdays/template")
     public WorkingDaysData template() {
         return this.workingDaysReadPlatformService.repaymentRescheduleType();

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/ForgotPasswordApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/ForgotPasswordApiResource.java
@@ -46,7 +46,7 @@ public class ForgotPasswordApiResource {
     @Path("/forgot")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Request password reset", description = """
+    @Operation(summary = "Request password reset", operationId = "forgotPassword", description = """
             Requests a password reset for the user with the given email.
             If the email exists and the user is active, a temporary password will be sent to the email address.
             The temporary password expires in 1 hour.""")

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PasswordPreferencesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PasswordPreferencesApiResource.java
@@ -67,7 +67,7 @@ public class PasswordPreferencesApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PasswordPreferencesApiResourceSwagger.GetPasswordPreferencesTemplateResponse.class))) })
-    @Operation(summary = "List Password Preferences", description = "Returns the password policies and their current status (active/inactive).", tags = {
+    @Operation(summary = "List Password Preferences", operationId = "retrieveAllPasswordPreferences", description = "Returns the password policies and their current status (active/inactive).", tags = {
             "Password preferences" })
     public String retrieve(@Context final UriInfo uriInfo) {
 
@@ -84,7 +84,8 @@ public class PasswordPreferencesApiResource {
     @PUT
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update password preferences", tags = { "Password preferences" }, description = "")
+    @Operation(summary = "Update password preferences", operationId = "updatePasswordPreferences", tags = {
+            "Password preferences" }, description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = PasswordPreferencesApiResourceSwagger.PutPasswordPreferencesTemplateRequest.class)))
     @ApiResponses({ @ApiResponse(responseCode = "200", description = "OK") })
     public String update(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
@@ -102,8 +103,8 @@ public class PasswordPreferencesApiResource {
     @GET
     @Path("/template")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Application Password validation policies", tags = { "Password preferences" }, description = "ARGUMENTS\n"
-            + "Example Requests:\n" + "\n" + "passwordpreferences")
+    @Operation(summary = "List Application Password validation policies", operationId = "retrieveTemplatePasswordPreferences", tags = {
+            "Password preferences" }, description = "ARGUMENTS\n" + "Example Requests:\n" + "\n" + "passwordpreferences")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PasswordPreferencesApiResourceSwagger.GetPasswordPreferencesTemplateResponse.class)))) })
     public String template(@Context final UriInfo uriInfo) {

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PermissionsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/PermissionsApiResource.java
@@ -72,13 +72,14 @@ public class PermissionsApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Application Permissions", tags = { "Permissions" }, description = "ARGUMENTS\n"
-            + "makerCheckerableoptional, Values are true, false. Default is false.\n"
-            + "If makerCheckerable=false or not supplied then a list of application permissions is returned. The \"selected\" attribute is always true in this case.\n"
-            + "\n"
-            + "If makerCheckerable=true then the \"selected\" attribute shows whether the permission is enabled for Maker Check functionality.\n"
-            + "\n" + "Note: Each Apache Fineract transaction is associated with a permission.\n" + "\n" + "Example Requests:\n" + "\n"
-            + "permissions\n" + "\n" + "\n" + "permissions?makerCheckerable=true\n" + "\n" + "\n" + "permissions?fields=grouping,code")
+    @Operation(summary = "List Application Permissions", operationId = "retrieveAllPermissions", tags = {
+            "Permissions" }, description = "ARGUMENTS\n" + "makerCheckerableoptional, Values are true, false. Default is false.\n"
+                    + "If makerCheckerable=false or not supplied then a list of application permissions is returned. The \"selected\" attribute is always true in this case.\n"
+                    + "\n"
+                    + "If makerCheckerable=true then the \"selected\" attribute shows whether the permission is enabled for Maker Check functionality.\n"
+                    + "\n" + "Note: Each Apache Fineract transaction is associated with a permission.\n" + "\n" + "Example Requests:\n"
+                    + "\n" + "permissions\n" + "\n" + "\n" + "permissions?makerCheckerable=true\n" + "\n" + "\n"
+                    + "permissions?fields=grouping,code")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PermissionsApiResourceSwagger.GetPermissionsResponse.class)))) })
     public String retrieveAllPermissions(@Context final UriInfo uriInfo) {
@@ -100,7 +101,8 @@ public class PermissionsApiResource {
     @PUT
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Enable/Disable Permissions for Maker Checker", tags = { "Permissions" }, description = "")
+    @Operation(summary = "Enable/Disable Permissions for Maker Checker", operationId = "updatePermissions", tags = {
+            "Permissions" }, description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = PermissionsApiResourceSwagger.PutPermissionsRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CommandProcessingResult.class))) })

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/RolesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/RolesApiResource.java
@@ -97,8 +97,8 @@ public class RolesApiResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "List Roles", tags = { "Roles" }, description = "Example Requests:\n" + "\n" + "roles\n" + "\n" + "\n"
-            + "roles?fields=name")
+    @Operation(summary = "List Roles", operationId = "retrieveAllRoles", tags = { "Roles" }, description = "Example Requests:\n" + "\n"
+            + "roles\n" + "\n" + "\n" + "roles?fields=name")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = RolesApiResourceSwagger.GetRolesResponse.class)))) })
     public String retrieveAllRoles(@Context final UriInfo uriInfo) {
@@ -114,7 +114,8 @@ public class RolesApiResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Create a New Role", tags = { "Roles" }, description = "Mandatory Fields\n" + "name, description")
+    @Operation(summary = "Create a New Role", operationId = "createRole", tags = { "Roles" }, description = "Mandatory Fields\n"
+            + "name, description")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PostRolesRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PostRolesResponse.class))) })
@@ -133,8 +134,8 @@ public class RolesApiResource {
     @GET
     @Path("{roleId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Role", tags = { "Roles" }, description = "Example Requests:\n" + "\n" + "roles/1\n" + "\n" + "\n"
-            + "roles/1?fields=name")
+    @Operation(summary = "Retrieve a Role", operationId = "retrieveOneRole", tags = { "Roles" }, description = "Example Requests:\n" + "\n"
+            + "roles/1\n" + "\n" + "\n" + "roles/1?fields=name")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.GetRolesRoleIdResponse.class))) })
     public String retrieveRole(@PathParam("roleId") @Parameter(description = "roleId") final Long roleId, @Context final UriInfo uriInfo) {
@@ -160,7 +161,7 @@ public class RolesApiResource {
     @Path("{roleId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Enable Role | Disable Role", tags = {
+    @Operation(summary = "Enable Role | Disable Role", operationId = "handleCommandsRole", tags = {
             "Roles" }, description = "Description : Enable role in case role is disabled. | Disable the role in case role is not associated with any users.\n\n\n\n"
                     + "\n\n" + "Example Request:   https://DomainName/api/v1/roles/{roleId}?command=enable" + "\n\n\n\n" + "\n\n"
                     + "https://DomainName/api/v1/roles/{roleId}?command=disable")
@@ -189,7 +190,7 @@ public class RolesApiResource {
     @Path("{roleId}")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Role", tags = { "Roles" }, description = "")
+    @Operation(summary = "Update a Role", operationId = "updateRole", tags = { "Roles" }, description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PutRolesRoleIdRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PutRolesRoleIdResponse.class))) })
@@ -209,8 +210,8 @@ public class RolesApiResource {
     @GET
     @Path("{roleId}/permissions")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Retrieve a Role's Permissions", tags = { "Roles" }, description = "Example Requests:\n" + "\n"
-            + "roles/1/permissions")
+    @Operation(summary = "Retrieve a Role's Permissions", operationId = "retrieveRolePermissions", tags = {
+            "Roles" }, description = "Example Requests:\n" + "\n" + "roles/1/permissions")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.GetRolesRoleIdPermissionsResponse.class))) })
     public String retrieveRolePermissions(@PathParam("roleId") @Parameter(description = "roleId") final Long roleId,
@@ -230,7 +231,7 @@ public class RolesApiResource {
     @Path("{roleId}/permissions")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Update a Role's Permissions", tags = { "Roles" }, description = "")
+    @Operation(summary = "Update a Role's Permissions", operationId = "updateRolePermissions", tags = { "Roles" }, description = "")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PutRolesRoleIdPermissionsRequest.class)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.PutRolesRoleIdPermissionsResponse.class))) })
@@ -256,7 +257,7 @@ public class RolesApiResource {
     @DELETE
     @Path("{roleId}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(summary = "Delete a Role", tags = {
+    @Operation(summary = "Delete a Role", operationId = "deleteRole", tags = {
             "Roles" }, description = "Description : Delete the role in case role is not associated with any users.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RolesApiResourceSwagger.DeleteRolesRoleIdResponse.class))) })

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/api/UsersApiResource.java
@@ -232,7 +232,8 @@ public class UsersApiResource {
     @GET
     @Path("downloadtemplate")
     @Produces("application/vnd.ms-excel")
-    @Operation(summary = "Download users template", description = "Returns an Excel template for bulk importing users.", tags = { "Users" })
+    @Operation(summary = "Download users template", operationId = "getBulkTemplateUser", description = "Returns an Excel template for bulk importing users.", tags = {
+            "Users" })
     public Response getUserTemplate(@QueryParam("officeId") final Long officeId, @QueryParam("staffId") final Long staffId,
             @QueryParam("dateFormat") final String dateFormat) {
         return bulkImportWorkbookPopulatorService.getTemplate(GlobalEntityType.USERS.toString(), officeId, staffId, dateFormat);
@@ -243,7 +244,7 @@ public class UsersApiResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @RequestBody(description = "Upload users template", content = {
             @Content(mediaType = MediaType.MULTIPART_FORM_DATA, schema = @Schema(implementation = UploadRequest.class)) })
-    @Operation(summary = "Upload users template", description = "Uploads a filled Excel template to create multiple users in bulk.", tags = {
+    @Operation(summary = "Upload users template", operationId = "postBulkTemplateUser", description = "Uploads a filled Excel template to create multiple users in bulk.", tags = {
             "Users" })
     public String postUsersTemplate(@FormDataParam("file") InputStream uploadedInputStream,
             @FormDataParam("file") FormDataContentDisposition fileDetail, @FormDataParam("locale") final String locale,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeTest.java
@@ -48,7 +48,7 @@ public class OfficeTest extends IntegrationTest {
     @Test
     @Order(2)
     void retrieveOneExistingInclDateFormat() { // see FINERACT-1220 re. what this tests re. Date Format
-        List<GetOfficesResponse> response = ok(fineractClient().offices.retrieveOffices(true, null, null));
+        List<GetOfficesResponse> response = ok(fineractClient().offices.retrieveAllOffices(true, null, null));
         assertThat(response.size()).isGreaterThanOrEqualTo(1);
         assertThat(response.get(0).getOpeningDate()).isNotNull();
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignNotificationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignNotificationHelper.java
@@ -46,7 +46,7 @@ public class FeignNotificationHelper {
     }
 
     public void markNotificationsAsRead() {
-        fineractClient.notification().update4();
+        fineractClient.notification().updateNotificationReadStatus();
     }
 
     public boolean areNotificationsAvailable() {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignOfficeHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignOfficeHelper.java
@@ -62,15 +62,15 @@ public class FeignOfficeHelper {
     }
 
     public GetOfficesResponse retrieveOffice(Long officeId) {
-        return ok(() -> fineractClient.offices().retrieveOffice(officeId));
+        return ok(() -> fineractClient.offices().retrieveOneOffice(officeId));
     }
 
     public GetOfficesResponse retrieveOfficeByExternalId(String externalId) {
-        return ok(() -> fineractClient.offices().retrieveOfficeByExternalId(externalId));
+        return ok(() -> fineractClient.offices().retrieveOneOfficeByExternalId(externalId));
     }
 
     public GetOfficesResponse getHeadOffice() {
-        return ok(() -> fineractClient.offices().retrieveOffice(HEAD_OFFICE_ID));
+        return ok(() -> fineractClient.offices().retrieveOneOffice(HEAD_OFFICE_ID));
     }
 
     public PutOfficesOfficeIdResponse updateOffice(Long officeId, String name, String openingDate) {
@@ -88,10 +88,10 @@ public class FeignOfficeHelper {
                 .openingDate(openingDate)//
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en");
-        return ok(() -> fineractClient.offices().updateOfficeWithExternalId(externalId, request));
+        return ok(() -> fineractClient.offices().updateOfficeByExternalId(externalId, request));
     }
 
     public List<GetOfficesResponse> retrieveAllOffices() {
-        return ok(() -> fineractClient.offices().retrieveOffices(false, null, null));
+        return ok(() -> fineractClient.offices().retrieveAllOffices(false, null, null));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSchedulerHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSchedulerHelper.java
@@ -40,11 +40,11 @@ public class FeignSchedulerHelper {
     }
 
     public void stopScheduler() {
-        FeignCalls.executeVoid(() -> fineractClient.scheduler().changeSchedulerStatus("stop"));
+        FeignCalls.executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler("stop"));
     }
 
     public void startScheduler() {
-        FeignCalls.executeVoid(() -> fineractClient.scheduler().changeSchedulerStatus("start"));
+        FeignCalls.executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler("start"));
     }
 
     public void executeAndAwaitJob(String jobDisplayName) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignClientLifecycleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/tests/FeignClientLifecycleTest.java
@@ -64,7 +64,7 @@ public class FeignClientLifecycleTest extends FeignIntegrationTest {
     }
 
     private Long resolveOrCreateCodeValue(String codeName) {
-        GetCodesResponse code = ok(() -> fineractClient.codes().retrieveCodeByName(codeName));
+        GetCodesResponse code = ok(() -> fineractClient.codes().retrieveOneCodeByName(codeName));
         assertNotNull(code.getId());
 
         PostCodeValuesDataRequest createRequest = new PostCodeValuesDataRequest()//

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/OfficeHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/OfficeHelper.java
@@ -32,11 +32,11 @@ public class OfficeHelper {
     public static final long HEAD_OFFICE_ID = 1L; // The ID is hardcoded in the initial Liquibase migration script
 
     public GetOfficesResponse retrieveOffice(Long officeId) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOffice(officeId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOneOffice(officeId));
     }
 
     public static GetOfficesResponse getHeadOffice() {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOffice(HEAD_OFFICE_ID));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOneOffice(HEAD_OFFICE_ID));
     }
 
     public PostOfficesResponse createOffice(final LocalDate openingDate) {
@@ -70,7 +70,7 @@ public class OfficeHelper {
     }
 
     public GetOfficesResponse retrieveOfficeByExternalId(String externalId) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOfficeByExternalId(externalId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().retrieveOneOfficeByExternalId(externalId));
     }
 
     public PutOfficesOfficeIdResponse updateOfficeByExternalId(String externalId, String name, String openingDate) {
@@ -79,6 +79,6 @@ public class OfficeHelper {
                 .openingDate(openingDate)//
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en");
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().updateOfficeWithExternalId(externalId, request));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().offices().updateOfficeByExternalId(externalId, request));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/PasswordPreferencesHelper.java
@@ -30,15 +30,15 @@ public final class PasswordPreferencesHelper {
     private PasswordPreferencesHelper() {}
 
     public static void updatePasswordPreferences(String validationPolicyId) {
-        executeVoid(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences()
-                .update7(new PutPasswordPreferencesTemplateRequest().validationPolicyId(Long.parseLong(validationPolicyId))));
+        executeVoid(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences().updatePasswordPreferences(
+                new PutPasswordPreferencesTemplateRequest().validationPolicyId(Long.parseLong(validationPolicyId))));
     }
 
     public static GetPasswordPreferencesTemplateResponse getActivePasswordPreference() {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences().retrieve2());
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences().retrieveAllPasswordPreferences());
     }
 
     public static List<GetPasswordPreferencesTemplateResponse> getAllPreferences() {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences().template4());
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().passwordPreferences().retrieveTemplatePasswordPreferences());
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/SchedulerJobHelper.java
@@ -107,7 +107,7 @@ public class SchedulerJobHelper {
 
     public void updateSchedulerStatus(final boolean on) {
         String command = on ? "start" : "stop";
-        Calls.ok(FineractClientHelper.getFineractClient().jobsScheduler.changeSchedulerStatus(command));
+        Calls.ok(FineractClientHelper.getFineractClient().jobsScheduler.handleCommandsScheduler(command));
     }
 
     // TODO: Rewrite to use fineract-client instead!

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/organisation/EntityDatatableChecksHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/organisation/EntityDatatableChecksHelper.java
@@ -39,11 +39,12 @@ public final class EntityDatatableChecksHelper {
     }
 
     public static DeleteEntityDatatableChecksTemplateResponse deleteEntityDatatableCheck(final Long entityDatatableCheckId) {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().entityDataTable().deleteDatatable1(entityDatatableCheckId));
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().entityDataTable()
+                .deleteEntityDatatableCheck(entityDatatableCheckId));
     }
 
     public static List<GetEntityDatatableChecksResponse> retrieveEntityDatatableCheck() {
-        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().entityDataTable().retrieveAll4(null, null, null, null, null))
-                .getPageItems();
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().entityDataTable().retrieveAllEntityDatatableChecks(null, null,
+                null, null, null)).getPageItems();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/CodeHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/system/CodeHelper.java
@@ -386,10 +386,10 @@ public final class CodeHelper {
     }
 
     public List<GetCodesResponse> retrieveCodes() {
-        return Calls.ok(FineractClientHelper.getFineractClient().codes.retrieveCodes());
+        return Calls.ok(FineractClientHelper.getFineractClient().codes.retrieveAllCodes());
     }
 
     public GetCodesResponse retrieveCodeByName(final String codeName) {
-        return Calls.ok(FineractClientHelper.getFineractClient().codes.retrieveCodeByName(codeName));
+        return Calls.ok(FineractClientHelper.getFineractClient().codes.retrieveOneCodeByName(codeName));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/useradministration/roles/RolesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/useradministration/roles/RolesHelper.java
@@ -129,7 +129,7 @@ public final class RolesHelper {
     }
 
     public CommandProcessingResult updatePermissions(PutPermissionsRequest request) {
-        return Calls.ok(FineractClientHelper.getFineractClient().permissions.updatePermissionsDetails(request));
+        return Calls.ok(FineractClientHelper.getFineractClient().permissions.updatePermissions(request));
     }
 
     // TODO: Rewrite to use fineract-client instead!


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/FINERACT-2501

This PR is a continuation of the work started in #5597, #5744, and #6042, which addressed the instability of auto-generated Feign client method names caused by Swagger deduplication numbers shifting when new endpoints are added.

This PR covers the Infrastructure, Organisation, and User Management modules, adding explicit operationId values to all endpoints that were missing them. The naming convention follows the same pattern established in the previous PRs: methodName + EntityName + DescriptionClause (for example, retrieveAllHolidays, handleCommandsScheduler, updateRolePermissions).

Files changed:

- AccountNumberFormatsApiResource (6 operationIds added)
- CodesApiResource (6 operationIds added)
- ExternalServicesConfigurationApiResource (2 operationIds added)
- EntityDatatableChecksApiResource (4 operationIds added)
- HookApiResource (6 operationIds added)
- InstanceModeApiResource (1 operationId added)
- InlineJobApiResource (1 operationId added)
- SchedulerApiResource (2 operationIds added)
- SurveyApiResource (3 operationIds added)
- HolidaysApiResource (6 operationIds added)
- OfficesApiResource (7 operationIds added)
- ProvisioningCriteriaApiResource (5 operationIds added)
- StaffApiResource (2 operationIds added)
- WorkingDaysApiResource (3 operationIds added)
- ForgotPasswordApiResource (1 operationId added)
- PasswordPreferencesApiResource (3 operationIds added)
- PermissionsApiResource (2 operationIds added)
- RolesApiResource (9 operationIds added)
- UsersApiResource (2 operationIds added)