### PR TITLE
FINERACT-2662: Office search sanitise orderBy input

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/office/service/OfficeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/office/service/OfficeReadPlatformServiceImpl.java
@@ -31,8 +31,9 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.SearchParameters;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.security.exception.InputValidationException;
+import org.apache.fineract.infrastructure.security.service.InputValidator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
 import org.apache.fineract.organisation.monetary.service.CurrencyReadPlatformService;
 import org.apache.fineract.organisation.office.data.OfficeData;
@@ -53,7 +54,7 @@ public class OfficeReadPlatformServiceImpl implements OfficeReadPlatformService 
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final PlatformSecurityContext context;
     private final CurrencyReadPlatformService currencyReadPlatformService;
-    private final ColumnValidator columnValidator;
+    private final InputValidator inputValidator;
 
     private final OfficeRepository officeRepository;
     private final OfficeDataMapper officeDataMapper;
@@ -160,11 +161,15 @@ public class OfficeReadPlatformServiceImpl implements OfficeReadPlatformService 
         sqlBuilder.append(" where o.hierarchy like ? ");
         if (searchParameters != null) {
             if (searchParameters.hasOrderBy()) {
-                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getOrderBy());
-                sqlBuilder.append("order by ").append(searchParameters.getOrderBy());
+                String orderBy = searchParameters.getOrderBy();
+                this.inputValidator.validate("office-order-by", orderBy);
+                sqlBuilder.append("order by ").append(orderBy);
                 if (searchParameters.hasSortOrder()) {
-                    this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getSortOrder());
-                    sqlBuilder.append(' ').append(searchParameters.getSortOrder());
+                    String sortOrder = searchParameters.getSortOrder();
+                    if (!"ASC".equalsIgnoreCase(sortOrder) && !"DESC".equalsIgnoreCase(sortOrder)) {
+                        throw new InputValidationException(String.format("invalid sortOrder value '%s'", sortOrder));
+                    }
+                    sqlBuilder.append(' ').append(sortOrder);
                 }
             } else {
                 sqlBuilder.append("order by o.hierarchy");

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/office/starter/OrganisationOfficeConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/office/starter/OrganisationOfficeConfiguration.java
@@ -19,8 +19,8 @@
 package org.apache.fineract.organisation.office.starter;
 
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.security.service.InputValidator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.service.CurrencyReadPlatformService;
 import org.apache.fineract.organisation.office.domain.OfficeRepository;
@@ -44,9 +44,9 @@ public class OrganisationOfficeConfiguration {
     @Bean
     @ConditionalOnMissingBean(OfficeReadPlatformService.class)
     public OfficeReadPlatformService officeReadPlatformService(JdbcTemplate jdbcTemplate, DatabaseSpecificSQLGenerator sqlGenerator,
-            PlatformSecurityContext context, CurrencyReadPlatformService currencyReadPlatformService, ColumnValidator columnValidator,
+            PlatformSecurityContext context, CurrencyReadPlatformService currencyReadPlatformService, InputValidator inputValidator,
             OfficeRepository officeRepository, OfficeDataMapper officeDataMapper) {
-        return new OfficeReadPlatformServiceImpl(jdbcTemplate, sqlGenerator, context, currencyReadPlatformService, columnValidator,
+        return new OfficeReadPlatformServiceImpl(jdbcTemplate, sqlGenerator, context, currencyReadPlatformService, inputValidator,
                 officeRepository, officeDataMapper);
     }
 

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -343,8 +343,11 @@ fineract.input-validation.patterns[1].pattern=^\\d{4}-\\d{2}-\\d{2}$
 fineract.input-validation.patterns[2].name=client-order-by-strict
 fineract.input-validation.patterns[2].pattern=^(id|(display|office)Name|accountNo|officeId)$
 
-fineract.input-validation.patterns[3].name=client-order-by-generic
+fineract.input-validation.patterns[3].name=order-by-generic
 fineract.input-validation.patterns[3].pattern=^([a-z]\.)?[a-z][A-Za-z0-9_]*$
+
+fineract.input-validation.patterns[4].name=office-order-by-strict
+fineract.input-validation.patterns[4].pattern=^(id|name(Decorated)?|externalId|hierarchy|openingDate)$
 
 # input validation - profiles
 fineract.input-validation.profiles[0].name=number
@@ -364,6 +367,18 @@ fineract.input-validation.profiles[2].description=Client Search orderBy Paramete
 fineract.input-validation.profiles[2].patternRefs[0].name=client-order-by-strict
 fineract.input-validation.profiles[2].patternRefs[0].order=0
 fineract.input-validation.profiles[2].enabled=true
+
+fineract.input-validation.profiles[3].name=office-order-by
+fineract.input-validation.profiles[3].description=Office Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[3].patternRefs[0].name=office-order-by-strict
+fineract.input-validation.profiles[3].patternRefs[0].order=0
+fineract.input-validation.profiles[3].enabled=true
+
+fineract.input-validation.profiles[4].name=order-by
+fineract.input-validation.profiles[4].description=Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[4].patternRefs[0].name=order-by-generic
+fineract.input-validation.profiles[4].patternRefs[0].order=0
+fineract.input-validation.profiles[4].enabled=true
 
 #Cache - Default
 fineract.cache.default-template.ttl=1m

--- a/fineract-provider/src/test/resources/application-test.properties
+++ b/fineract-provider/src/test/resources/application-test.properties
@@ -230,6 +230,15 @@ fineract.input-validation.patterns[0].pattern=^-?\\d+(\\.\\d+)?$
 fineract.input-validation.patterns[1].name=date-literal
 fineract.input-validation.patterns[1].pattern=^\\d{4}-\\d{2}-\\d{2}$
 
+fineract.input-validation.patterns[2].name=client-order-by-strict
+fineract.input-validation.patterns[2].pattern=^(id|(display|office)Name|accountNo|officeId)$
+
+fineract.input-validation.patterns[3].name=order-by-generic
+fineract.input-validation.patterns[3].pattern=^([a-z]\.)?[a-z][A-Za-z0-9_]*$
+
+fineract.input-validation.patterns[4].name=office-order-by-strict
+fineract.input-validation.patterns[4].pattern=^(id|name(Decorated)?|externalId|hierarchy|openingDate)$
+
 # input validation - profiles
 fineract.input-validation.profiles[0].name=number
 fineract.input-validation.profiles[0].description=Numeric Parameter Validation Profile
@@ -242,6 +251,24 @@ fineract.input-validation.profiles[1].description=Date Parameter Validation Prof
 fineract.input-validation.profiles[1].patternRefs[0].name=date-literal
 fineract.input-validation.profiles[1].patternRefs[0].order=0
 fineract.input-validation.profiles[1].enabled=true
+
+fineract.input-validation.profiles[2].name=client-order-by
+fineract.input-validation.profiles[2].description=Client Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[2].patternRefs[0].name=client-order-by-strict
+fineract.input-validation.profiles[2].patternRefs[0].order=0
+fineract.input-validation.profiles[2].enabled=true
+
+fineract.input-validation.profiles[3].name=office-order-by
+fineract.input-validation.profiles[3].description=Office Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[3].patternRefs[0].name=office-order-by-strict
+fineract.input-validation.profiles[3].patternRefs[0].order=0
+fineract.input-validation.profiles[3].enabled=true
+
+fineract.input-validation.profiles[4].name=order-by
+fineract.input-validation.profiles[4].description=Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[4].patternRefs[0].name=order-by-generic
+fineract.input-validation.profiles[4].patternRefs[0].order=0
+fineract.input-validation.profiles[4].enabled=true
 
 #Cache - Default
 fineract.cache.default-template.ttl=1m

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeTest.java
@@ -26,6 +26,8 @@ import org.apache.fineract.client.models.PostOfficesRequest;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Integration Test for /offices API.
@@ -51,5 +53,155 @@ public class OfficeTest extends IntegrationTest {
         List<GetOfficesResponse> response = ok(fineractClient().offices.retrieveOffices(true, null, null));
         assertThat(response.size()).isGreaterThanOrEqualTo(1);
         assertThat(response.get(0).getOpeningDate()).isNotNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // ZDRES-035 — SQL Injection via Subquery in orderBy (ColumnValidator Bypass)
+    //
+    // Security regression tests for the vulnerability reported by Venkatraman
+    // Kumar (Securin) on 2026-04-14. The ColumnValidator (introduced as the
+    // CVE-2024-32838 fix) did not detect bare subqueries in ORDER BY position
+    // because:
+    // - No semicolons → inject-stacked-query regex skips
+    // - No AND/OR → inject-timing regex skips
+    // - No comparison operators → getOperand() returns empty set,
+    // validateColumn() passes with an empty map
+    //
+    // The fix replaces regex-based validation with a strict column-name whitelist
+    // defined in application.properties (fineract.input-validation.patterns[4],
+    // profile office-order-by). Invalid input is rejected with HTTP 403.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Whitelist positive test — all accepted column names from the /api/v1/offices response payload must continue to
+     * work after the fix.
+     *
+     * <p>
+     * Covers: id, name, nameDecorated, externalId, hierarchy, openingDate (pattern:
+     * ^(id|name(Decorated)?|externalId|hierarchy|openingDate)$)
+     */
+    @ParameterizedTest(name = "orderBy=''{0}'' is whitelisted — must succeed")
+    @ValueSource(strings = { "id", "name", "nameDecorated", "externalId", "hierarchy", "openingDate" })
+    @Order(3)
+    void retrieveOffices_withWhitelistedOrderByColumn_succeeds(String column) throws Exception {
+        var response = fineractClient().offices.retrieveOffices(false, column, null).execute();
+        assertThat(response.isSuccessful())
+                .as("GET /offices?orderBy=%s should return 2xx (whitelist over-blocks), got HTTP %d", column, response.code()).isTrue();
+        assertThat(response.body()).isNotNull();
+    }
+
+    /**
+     * Null and whitespace orderBy must be treated as absent (no ORDER BY clause) and accepted, consistent with the
+     * behaviour documented in ClientSearchTest (testClientSearchOrderByRejectsEmptyAndWhitespace → isTrue()).
+     */
+    @ParameterizedTest(name = "orderBy=''{0}'' is blank — treated as absent, must succeed")
+    @ValueSource(strings = { "   ", "\t" })
+    @Order(4)
+    void retrieveOffices_withBlankOrderBy_isAcceptedAsAbsent(String blank) throws Exception {
+        var response = fineractClient().offices.retrieveOffices(false, blank, null).execute();
+        assertThat(response.isSuccessful()).as("Blank orderBy [%s] should be treated as absent, not rejected", blank).isTrue();
+    }
+
+    /**
+     * Core ZDRES-035 regression — the exact subquery payloads from the Securin advisory that previously bypassed
+     * ColumnValidator and executed on the database. All must be rejected with HTTP 403.
+     *
+     * <p>
+     * Payloads included:
+     * <ul>
+     * <li>Basic time-based blind: confirmed 3.05 s in Securin DAST environment</li>
+     * <li>Scalable sleep: confirmed 10.05 s</li>
+     * <li>Data extraction via conditional timing: extracts DB user char by char</li>
+     * <li>DoS vector: holds one HikariCP connection for 5 minutes</li>
+     * <li>Minimal subquery: confirms the subquery execution path, no timing</li>
+     * <li>MySQL/MariaDB dual-table probe</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "ZDRES-035 subquery ''{0}'' must be rejected with 403")
+    @ValueSource(strings = { "(SELECT SLEEP(3))", "(SELECT SLEEP(10))", "(SELECT IF(SUBSTRING(user(),1,4)='root',SLEEP(2),0))",
+            "(SELECT SLEEP(300))", "(SELECT 1)", "(SELECT 1 FROM dual)", })
+    @Order(5)
+    void retrieveOffices_zdres035SubqueryPayloads_areRejected(String payload) throws Exception {
+        var response = fineractClient().offices.retrieveOffices(false, payload, null).execute();
+        assertThat(response.isSuccessful()).as("ZDRES-035 subquery [%s] must be rejected — whitelist fix not effective", payload).isFalse();
+        assertThat(response.code()).as("Expected HTTP 403 for payload [%s], got %d", payload, response.code()).isEqualTo(403);
+    }
+
+    /**
+     * Timing regression — verifies that (SELECT SLEEP(3)) is rejected in application code BEFORE the SQL reaches the
+     * database.
+     *
+     * <p>
+     * Without the whitelist fix, orderBy input is concatenated into SQL before ColumnValidator runs, so MariaDB
+     * executes the subquery and the response takes ≥ 3 seconds. With the fix, the 403 must arrive well under 1 second.
+     *
+     * <p>
+     * The assertion threshold is 2 000 ms — generous for CI variance, but a 3-second SLEEP executing on the database
+     * always exceeds it.
+     */
+    @Test
+    @Order(6)
+    void retrieveOffices_sleepSubquery_isRejectedBeforeDatabaseExecution() throws Exception {
+        long start = System.currentTimeMillis();
+        var response = fineractClient().offices.retrieveOffices(false, "(SELECT SLEEP(3))", null).execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(response.code()).as("Expected HTTP 403 for SLEEP(3) subquery, got %d", response.code()).isEqualTo(403);
+        assertThat(elapsed)
+                .as("Response took %d ms — if >= 2000 ms the SLEEP(3) executed on the DB; whitelist fix is not active on this code path",
+                        elapsed)
+                .isLessThan(2000L);
+    }
+
+    /**
+     * Classic SQL injection patterns that ColumnValidator already blocked before the ZDRES-035 fix. The stricter
+     * whitelist must continue to reject them — no regression in pre-existing coverage.
+     */
+    @ParameterizedTest(name = "classic injection ''{0}'' must be rejected with 403")
+    @ValueSource(strings = {
+            // Stacked query — caught by inject-stacked-query regex pre-fix
+            "id; SELECT 1--", "name; DROP TABLE m_office--",
+            // Timing with AND prefix — caught by inject-timing regex pre-fix
+            "id AND SLEEP(5)--",
+            // CASE-based blind — caught by inject-blind regex pre-fix
+            "CASE WHEN 1=1 THEN id ELSE name END",
+            // UNION
+            "id UNION SELECT 1,2,3,4,5--",
+            // Comment truncation
+            "id--", "id/*comment*/", })
+    @Order(7)
+    void retrieveOffices_classicInjectionPayloads_areRejected(String payload) throws Exception {
+        var response = fineractClient().offices.retrieveOffices(false, payload, null).execute();
+        assertThat(response.isSuccessful()).as("Injection payload [%s] must be rejected", payload).isFalse();
+        assertThat(response.code()).isEqualTo(403);
+    }
+
+    /**
+     * Non-whitelisted column names that are not injection payloads — internal schema columns, table-qualified forms,
+     * numeric literals, and a percent-encoded subquery (passed as a literal string through retrofit; the server
+     * receives the raw percent signs, which do not match any whitelisted column name and are therefore rejected).
+     *
+     * <p>
+     * Note: blank / whitespace-only values are tested separately in
+     * {@link #retrieveOffices_withBlankOrderBy_isAcceptedAsAbsent} because the framework treats them as absent rather
+     * than as invalid input.
+     */
+    @ParameterizedTest(name = "non-whitelisted column ''{0}'' must be rejected with 403")
+    @ValueSource(strings = {
+            // Internal schema columns not present in the API response
+            "parent_id", "created_date", "lastmodified_date", "createdby_id", "lastmodifiedby_id",
+            // Table-qualified forms — rejected even for whitelisted column names
+            "m_office.id", "o.name",
+            // Numeric literals
+            "1", "0",
+            // Percent-encoded subquery passed as a literal string value;
+            // retrofit re-encodes it, server receives the literal percent signs
+            // → no whitelist match → 403
+            "%28SELECT%20SLEEP%283%29%29", })
+    @Order(8)
+    void retrieveOffices_nonWhitelistedColumns_areRejected(String payload) throws Exception {
+        var response = fineractClient().offices.retrieveOffices(false, payload, null).execute();
+        assertThat(response.isSuccessful()).as("Non-whitelisted column [%s] must be rejected by the whitelist", payload).isFalse();
+        assertThat(response.code()).isEqualTo(403);
     }
 }


### PR DESCRIPTION
## Description

The orderBy parameter on `GET /api/v1/offices` is now validated against a strict column-name allowlist, using the same InputValidator framework introduced for the client search endpoint fix.

The allowed values are id, name, nameDecorated, externalId, hierarchy, and openingDate — exactly the fields present in the `/api/v1/offices` response payload. Anything outside this set is rejected with HTTP 403 before reaching `OfficeReadPlatformServiceImpl`. The allowlist is defined as a named pattern and profile in application.properties, consistent with the existing `client-order-by-strict` configuration.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
