### PR TITLE
FINERACT-2661: Validate and reject duplicate CommandHandlers at startup

### DIFF
--- a/fineract-command/src/main/java/org/apache/fineract/command/core/exception/DuplicateCommandHandlerException.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/core/exception/DuplicateCommandHandlerException.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.command.core.exception;
+
+import java.util.List;
+import org.apache.fineract.command.core.Command;
+import org.apache.fineract.command.core.CommandHandler;
+
+public class DuplicateCommandHandlerException extends RuntimeException {
+
+    public DuplicateCommandHandlerException(Command<?> command, List<? extends CommandHandler> duplicates) {
+        super("Multiple handlers found for " + command.getClass().getSimpleName() + " command: "
+                + duplicates.stream().map(h -> h.getClass().getSimpleName()).toList());
+    }
+}

--- a/fineract-command/src/main/java/org/apache/fineract/command/implementation/DefaultCommandHandlerManager.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/implementation/DefaultCommandHandlerManager.java
@@ -18,13 +18,17 @@
  */
 package org.apache.fineract.command.implementation;
 
+import jakarta.annotation.PostConstruct;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.command.core.Command;
 import org.apache.fineract.command.core.CommandHandler;
 import org.apache.fineract.command.core.CommandHandlerManager;
 import org.apache.fineract.command.core.exception.CommandHandlerNotFoundException;
+import org.apache.fineract.command.core.exception.DuplicateCommandHandlerException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
@@ -37,6 +41,23 @@ public class DefaultCommandHandlerManager implements CommandHandlerManager {
 
     private final List<CommandHandler> handlers;
 
+    @PostConstruct
+    public void validateNoDuplicateHandlers() {
+        Map<String, List<CommandHandler>> grouped = handlers.stream()
+                .collect(Collectors.groupingBy(h -> h.getClass().getGenericInterfaces()[0].getTypeName()));
+
+        grouped.forEach((commandType, matched) -> {
+            if (matched.size() > 1) {
+                log.error("Duplicate CommandHandlers detected for {}: {}", commandType,
+                        matched.stream().map(h -> h.getClass().getSimpleName()).toList());
+                throw new IllegalStateException("Duplicate CommandHandlers detected for command type: " + commandType
+                        + " -> " + matched.stream().map(h -> h.getClass().getSimpleName()).toList());
+            }
+        });
+
+        log.debug("CommandHandler validation passed: {} handler(s) registered, no duplicates found.", handlers.size());
+    }
+
     @Override
     public <REQ, RES> RES handle(Command<REQ> command) {
         CommandHandler<REQ, RES> handler = lookup(command);
@@ -45,12 +66,17 @@ public class DefaultCommandHandlerManager implements CommandHandlerManager {
     }
 
     private <REQ, RES> CommandHandler<REQ, RES> lookup(Command<REQ> command) {
-        // TODO: make sure there are no duplicate handlers
         if (command == null) {
             throw new CommandHandlerNotFoundException(command);
         }
 
-        return handlers.stream().filter(handler -> handler.matches(command)).findFirst()
+        List<CommandHandler> matched = handlers.stream().filter(handler -> handler.matches(command)).toList();
+
+        if (matched.size() > 1) {
+            throw new DuplicateCommandHandlerException(command, matched);
+        }
+
+        return (CommandHandler<REQ, RES>) matched.stream().findFirst()
                 .orElseThrow(() -> new CommandHandlerNotFoundException(command));
     }
 }

--- a/fineract-command/src/test/java/org/apache/fineract/command/DefaultCommandHandlerManagerTest.java
+++ b/fineract-command/src/test/java/org/apache/fineract/command/DefaultCommandHandlerManagerTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.command;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.fineract.command.core.Command;
+import org.apache.fineract.command.core.CommandHandler;
+import org.apache.fineract.command.core.exception.DuplicateCommandHandlerException;
+import org.apache.fineract.command.implementation.DefaultCommandHandlerManager;
+import org.apache.fineract.command.test.sample.command.DummyCommand;
+import org.apache.fineract.command.test.sample.data.DummyRequest;
+import org.apache.fineract.command.test.sample.data.DummyResponse;
+import org.junit.jupiter.api.Test;
+
+class DefaultCommandHandlerManagerTest {
+
+    static class HandlerA implements CommandHandler<DummyRequest, DummyResponse> {
+
+        @Override
+        public DummyResponse handle(Command<DummyRequest> command) {
+            return DummyResponse.builder().content("A").build();
+        }
+    }
+
+    static class HandlerB implements CommandHandler<DummyRequest, DummyResponse> {
+
+        @Override
+        public DummyResponse handle(Command<DummyRequest> command) {
+            return DummyResponse.builder().content("B").build();
+        }
+    }
+
+    @Test
+    void startupValidation_noDuplicates_passes() {
+        var manager = new DefaultCommandHandlerManager(List.of(new HandlerA()));
+        assertDoesNotThrow(() -> manager.validateNoDuplicateHandlers());
+    }
+
+    @Test
+    void startupValidation_withDuplicates_throwsIllegalStateException() {
+        var manager = new DefaultCommandHandlerManager(List.of(new HandlerA(), new HandlerB()));
+        var ex = assertThrows(IllegalStateException.class, () -> manager.validateNoDuplicateHandlers());
+        assertNotNull(ex.getMessage());
+        assertTrue(ex.getMessage().contains("Duplicate CommandHandlers detected"));
+    }
+
+    @Test
+    void handle_withDuplicateHandlersMatchingCommand_throwsDuplicateCommandHandlerException() {
+        var manager = new DefaultCommandHandlerManager(List.of(new HandlerA(), new HandlerB()));
+        var command = new DummyCommand();
+        command.setPayload(DummyRequest.builder().content("test").build());
+
+        assertThrows(DuplicateCommandHandlerException.class, () -> manager.handle(command));
+    }
+
+    @Test
+    void handle_withSingleHandler_returnsResult() {
+        var manager = new DefaultCommandHandlerManager(List.of(new HandlerA()));
+        var command = new DummyCommand();
+        command.setPayload(DummyRequest.builder().content("test").build());
+
+        var result = (DummyResponse) manager.handle(command);
+        assertNotNull(result);
+        assertTrue("A".equals(result.getContent()));
+    }
+}


### PR DESCRIPTION
## Description

Closes [FINERACT-2661](https://issues.apache.org/jira/browse/FINERACT-2661)

`DefaultCommandHandlerManager.lookup()` previously used `.findFirst()` to resolve a matching handler. If two handlers both matched the same command, the first one would silently win — producing unpredictable behavior. The original code even had a `// TODO: make sure there are no duplicate handlers` comment acknowledging this gap.

## Changes

**Startup validation (`@PostConstruct`):** Added `validateNoDuplicateHandlers()` that groups all registered `CommandHandler` beans by their generic `CommandHandler<REQ, RES>` type signature. If duplicates exist, the application fails fast at startup with an `IllegalStateException` listing the offending handlers.

**Runtime guard:** Hardened `lookup()` to collect all matching handlers and throw `DuplicateCommandHandlerException` if more than one matches — defense in depth for handlers with custom `matches()` logic.

**New exception:** `DuplicateCommandHandlerException` added alongside existing exception classes.

## Tests

4 unit tests in `DefaultCommandHandlerManagerTest` (no Spring context needed) — all pass.

## Checklist
- [x] Code compiles cleanly
- [x] Unit tests added and passing
- [x] Follows existing exception class pattern
