### PR TITLE
FINERACT-2662: Office search API: sanitise orderBy parameter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/office/service/OfficeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/office/service/OfficeReadPlatformServiceImpl.java
@@ -31,8 +31,9 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.SearchParameters;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.security.exception.InputValidationException;
+import org.apache.fineract.infrastructure.security.service.InputValidator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
 import org.apache.fineract.organisation.monetary.service.CurrencyReadPlatformService;
 import org.apache.fineract.organisation.office.data.OfficeData;
@@ -53,7 +54,7 @@ public class OfficeReadPlatformServiceImpl implements OfficeReadPlatformService 
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final PlatformSecurityContext context;
     private final CurrencyReadPlatformService currencyReadPlatformService;
-    private final ColumnValidator columnValidator;
+    private final InputValidator inputValidator;
 
     private final OfficeRepository officeRepository;
     private final OfficeDataMapper officeDataMapper;
@@ -160,11 +161,15 @@ public class OfficeReadPlatformServiceImpl implements OfficeReadPlatformService 
         sqlBuilder.append(" where o.hierarchy like ? ");
         if (searchParameters != null) {
             if (searchParameters.hasOrderBy()) {
-                this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getOrderBy());
-                sqlBuilder.append("order by ").append(searchParameters.getOrderBy());
+                final String orderBy = searchParameters.getOrderBy();
+                this.inputValidator.validate("office-order-by", orderBy);
+                sqlBuilder.append("order by ").append(orderBy);
                 if (searchParameters.hasSortOrder()) {
-                    this.columnValidator.validateSqlInjection(sqlBuilder.toString(), searchParameters.getSortOrder());
-                    sqlBuilder.append(' ').append(searchParameters.getSortOrder());
+                    final String sortOrder = searchParameters.getSortOrder();
+                    if (!"ASC".equalsIgnoreCase(sortOrder) && !"DESC".equalsIgnoreCase(sortOrder)) {
+                        throw new InputValidationException(String.format("invalid sortOrder value '%s'", sortOrder));
+                    }
+                    sqlBuilder.append(' ').append(sortOrder);
                 }
             } else {
                 sqlBuilder.append("order by o.hierarchy");

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/office/starter/OrganisationOfficeConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/office/starter/OrganisationOfficeConfiguration.java
@@ -19,8 +19,8 @@
 package org.apache.fineract.organisation.office.starter;
 
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.security.service.InputValidator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.service.CurrencyReadPlatformService;
 import org.apache.fineract.organisation.office.domain.OfficeRepository;
@@ -44,9 +44,9 @@ public class OrganisationOfficeConfiguration {
     @Bean
     @ConditionalOnMissingBean(OfficeReadPlatformService.class)
     public OfficeReadPlatformService officeReadPlatformService(JdbcTemplate jdbcTemplate, DatabaseSpecificSQLGenerator sqlGenerator,
-            PlatformSecurityContext context, CurrencyReadPlatformService currencyReadPlatformService, ColumnValidator columnValidator,
+            PlatformSecurityContext context, CurrencyReadPlatformService currencyReadPlatformService, InputValidator inputValidator,
             OfficeRepository officeRepository, OfficeDataMapper officeDataMapper) {
-        return new OfficeReadPlatformServiceImpl(jdbcTemplate, sqlGenerator, context, currencyReadPlatformService, columnValidator,
+        return new OfficeReadPlatformServiceImpl(jdbcTemplate, sqlGenerator, context, currencyReadPlatformService, inputValidator,
                 officeRepository, officeDataMapper);
     }
 

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -346,6 +346,9 @@ fineract.input-validation.patterns[2].pattern=^(id|(display|office)Name|accountN
 fineract.input-validation.patterns[3].name=client-order-by-generic
 fineract.input-validation.patterns[3].pattern=^([a-z]\.)?[a-z][A-Za-z0-9_]*$
 
+fineract.input-validation.patterns[4].name=office-order-by-strict
+fineract.input-validation.patterns[4].pattern=^(id|name|nameDecorated|externalId|openingDate|hierarchy|parentId|parentName)$
+
 # input validation - profiles
 fineract.input-validation.profiles[0].name=number
 fineract.input-validation.profiles[0].description=Numeric Parameter Validation Profile
@@ -364,6 +367,12 @@ fineract.input-validation.profiles[2].description=Client Search orderBy Paramete
 fineract.input-validation.profiles[2].patternRefs[0].name=client-order-by-strict
 fineract.input-validation.profiles[2].patternRefs[0].order=0
 fineract.input-validation.profiles[2].enabled=true
+
+fineract.input-validation.profiles[3].name=office-order-by
+fineract.input-validation.profiles[3].description=Office Search orderBy Parameter Validation Profile
+fineract.input-validation.profiles[3].patternRefs[0].name=office-order-by-strict
+fineract.input-validation.profiles[3].patternRefs[0].order=0
+fineract.input-validation.profiles[3].enabled=true
 
 #Cache - Default
 fineract.cache.default-template.ttl=1m

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/OfficeSearchTest.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.fineract.client.models.GetOfficesResponse;
+import org.apache.fineract.client.util.Calls;
+import org.junit.jupiter.api.Test;
+import retrofit2.Response;
+
+/**
+ * Covers orderBy / sortOrder input validation on GET /api/v1/offices (OfficesApiResource#retrieveOffices), the endpoint
+ * targeted by FINERACT-2662. The orderBy parameter is concatenated into an ORDER BY clause, so it must be restricted to
+ * a strict allowlist of known column names and sortOrder to ASC/DESC.
+ *
+ * retrieveOffices param order (from OfficesApi.java): includeAllOffices, orderBy, sortOrder
+ */
+public class OfficeSearchTest extends IntegrationTest {
+
+    private Response<List<GetOfficesResponse>> callRetrieveOffices(String orderBy, String sortOrder) {
+        return Calls.executeU(fineractClient().offices.retrieveOffices(null, orderBy, sortOrder));
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsSqlInjectionPoc() {
+        // given - the same style of blind boolean-based payload reported against the search endpoints
+        String maliciousOrderBy = "o.id, (CASE WHEN (ASCII(SUBSTRING((SELECT table_name FROM "
+                + "information_schema.tables WHERE table_schema REGEXP database() LIMIT 0,1),1,1)) - 109) "
+                + "THEN o.id ELSE (o.id*-1) END)";
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices(maliciousOrderBy, null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsSubstringBypassAttempt() {
+        // given - "name" appears as a substring; confirms regex anchors hold
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("name, (CASE WHEN (1=1) THEN 1 END)", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsCaseMismatch() {
+        // given - documented value is "name", not "Name" or "NAME"
+        // when
+        Response<List<GetOfficesResponse>> response1 = callRetrieveOffices("Name", null);
+        Response<List<GetOfficesResponse>> response2 = callRetrieveOffices("NAME", null);
+        // then
+        assertThat(response1.isSuccessful()).isFalse();
+        assertThat(response2.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsSnakeCaseColumnName() {
+        // given - undocumented internal SQL column form should no longer be accepted directly
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("o.opening_date", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsCommaSeparatedList() {
+        // given - multi-column orderBy is out of scope for this allowlist
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("name,hierarchy", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByAllowsEmpty() {
+        // given - blank orderBy falls through to the default ordering
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("   ", null);
+        // then
+        assertThat(response.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByRejectsSqlKeyword() {
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("id; DROP TABLE m_office", null);
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchSortOrderRejectsArbitraryValue() {
+        // given - direction value outside ASC/DESC should be rejected
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("name", "RANDOM");
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchSortOrderRejectsInjectionAttempt() {
+        // when
+        Response<List<GetOfficesResponse>> response = callRetrieveOffices("name", "ASC; DROP TABLE m_office--");
+        // then
+        assertThat(response.isSuccessful()).isFalse();
+    }
+
+    @Test
+    public void testOfficeSearchOrderByAcceptsAllDocumentedValues() {
+        // given - the allowlisted columns exposed by the office search response
+        for (String validOrderBy : new String[] { "id", "name", "nameDecorated", "externalId", "openingDate", "hierarchy", "parentId",
+                "parentName" }) {
+            // when
+            Response<List<GetOfficesResponse>> response = callRetrieveOffices(validOrderBy, "ASC");
+            // then
+            assertThat(response.isSuccessful()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Closes [FINERACT-2662](https://issues.apache.org/jira/browse/FINERACT-2662)

`GET /api/v1/offices` concatenated the `orderBy` query parameter into an `ORDER BY` clause after only a blacklist-based `ColumnValidator.validateSqlInjection()` check. Payloads that avoid the operator/keyword patterns (e.g. boolean-based `CASE WHEN` expressions) slip through, reaching SQL execution.

## Changes

Mirrors the approach merged for the Client search endpoint in FINERACT-2650:

- **Allowlist validation:** `OfficeReadPlatformServiceImpl` now validates `orderBy` via `InputValidator.validate("office-order-by", ...)` against a strict column-name allowlist (`id, name, nameDecorated, externalId, openingDate, hierarchy, parentId, parentName`).
- **sortOrder:** restricted to `ASC`/`DESC` (case-insensitive), else `InputValidationException`.
- **Config:** added `office-order-by-strict` pattern + `office-order-by` profile in `application.properties`.
- **Wiring:** `OrganisationOfficeConfiguration` injects `InputValidator` (the now-unused `ColumnValidator` dependency removed from this service).

## Tests

New `OfficeSearchTest` integration test with 10 cases: SQL-injection PoC, substring-bypass, case mismatch, snake_case column, comma-separated list, SQL keyword, sortOrder injection/arbitrary value, blank orderBy, and all 8 valid columns.

## Checklist
- [x] `:fineract-provider:compileJava` passes
- [x] `:integration-tests:compileTestJava` passes
- [x] spotless clean
- [x] Follows the existing FINERACT-2650 pattern