### PR TITLE
FINERACT-2622: Preserve top-level ORDER BY when wrapping report SQL

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImpl.java
@@ -34,6 +34,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
@@ -225,7 +226,113 @@ public class GenericDataServiceImpl implements GenericDataService {
         // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7046875 - prevent
         // Invalid Column Name bug in sun's CachedRowSetImpl where it doesn't
         // pick up on label names, only column names
-        return "select x.* from (" + sql + ") x";
+
+        // FINERACT-2622: a derived table's ORDER BY is not guaranteed to be honored by the outer query, so lift a
+        // top-level trailing ORDER BY (together with any trailing LIMIT/OFFSET) onto the outer wrapper to preserve
+        // the requested ordering.
+        final int orderByIndex = topLevelTrailingOrderByIndex(sql);
+        if (orderByIndex < 0) {
+            return "select x.* from (" + sql + ") x";
+        }
+        final String inner = sql.substring(0, orderByIndex);
+        final String trailingOrderBy = sql.substring(orderByIndex);
+        return "select x.* from (" + inner + ") x " + trailingOrderBy;
+    }
+
+    private static final Pattern DOT_QUALIFIED_REFERENCE = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*\\s*\\.\\s*[A-Za-z_*]");
+
+    private static int topLevelTrailingOrderByIndex(final String sql) {
+        int depth = 0;
+        int lastTopLevelOrderBy = -1;
+        final int length = sql.length();
+        int i = 0;
+        while (i < length) {
+            final char c = sql.charAt(i);
+            if (c == '\'') {
+                i = skipStringLiteral(sql, i);
+                continue;
+            }
+            if (c == '-' && i + 1 < length && sql.charAt(i + 1) == '-') {
+                i = skipLineComment(sql, i);
+                continue;
+            }
+            if (c == '/' && i + 1 < length && sql.charAt(i + 1) == '*') {
+                i = skipBlockComment(sql, i);
+                continue;
+            }
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (depth == 0 && isOrderByAt(sql, i)) {
+                lastTopLevelOrderBy = i;
+            }
+            i++;
+        }
+        if (lastTopLevelOrderBy < 0 || DOT_QUALIFIED_REFERENCE.matcher(sql.substring(lastTopLevelOrderBy)).find()) {
+            return -1;
+        }
+        return lastTopLevelOrderBy;
+    }
+
+    private static int skipStringLiteral(final String sql, final int start) {
+        final int length = sql.length();
+        int i = start + 1;
+        while (i < length) {
+            if (sql.charAt(i) == '\'') {
+                if (i + 1 < length && sql.charAt(i + 1) == '\'') {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return i;
+    }
+
+    private static int skipLineComment(final String sql, final int start) {
+        final int length = sql.length();
+        int i = start + 2;
+        while (i < length && sql.charAt(i) != '\n') {
+            i++;
+        }
+        return i;
+    }
+
+    private static int skipBlockComment(final String sql, final int start) {
+        final int length = sql.length();
+        int i = start + 2;
+        while (i + 1 < length && !(sql.charAt(i) == '*' && sql.charAt(i + 1) == '/')) {
+            i++;
+        }
+        return Math.min(i + 2, length);
+    }
+
+    private static boolean isOrderByAt(final String sql, final int index) {
+        if (!sql.regionMatches(true, index, "order", 0, 5)) {
+            return false;
+        }
+        if (index > 0 && isWordChar(sql.charAt(index - 1))) {
+            return false;
+        }
+        int j = index + 5;
+        final int afterOrder = j;
+        while (j < sql.length() && Character.isWhitespace(sql.charAt(j))) {
+            j++;
+        }
+        if (j == afterOrder) {
+            return false;
+        }
+        if (!sql.regionMatches(true, j, "by", 0, 2)) {
+            return false;
+        }
+        final int afterBy = j + 2;
+        return afterBy >= sql.length() || !isWordChar(sql.charAt(afterBy));
+    }
+
+    private static boolean isWordChar(final char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
     }
 
     @Override

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/GenericDataServiceImplTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class GenericDataServiceImplTest {
+
+    private final GenericDataServiceImpl service = new GenericDataServiceImpl(null, null, null, null, null);
+
+    @Test
+    public void liftsTopLevelTrailingOrderByOntoOuterQuery() {
+        assertThat(service.wrapSQL("SELECT account_no FROM m_loan ORDER BY account_no DESC"))
+                .isEqualTo("select x.* from (SELECT account_no FROM m_loan ) x ORDER BY account_no DESC");
+    }
+
+    @Test
+    public void leavesQueryWithoutOrderByUnchanged() {
+        assertThat(service.wrapSQL("SELECT account_no FROM m_loan")).isEqualTo("select x.* from (SELECT account_no FROM m_loan) x");
+    }
+
+    @Test
+    public void carriesTrailingLimitWithOrderBy() {
+        assertThat(service.wrapSQL("SELECT a FROM t ORDER BY a DESC LIMIT 10"))
+                .isEqualTo("select x.* from (SELECT a FROM t ) x ORDER BY a DESC LIMIT 10");
+    }
+
+    @Test
+    public void doesNotLiftOrderByInsideSubquery() {
+        final String sql = "SELECT a FROM (SELECT a FROM t ORDER BY a) s";
+        assertThat(service.wrapSQL(sql)).isEqualTo("select x.* from (" + sql + ") x");
+    }
+
+    @Test
+    public void doesNotLiftOrderByInsideWindowFunction() {
+        final String sql = "SELECT ROW_NUMBER() OVER (ORDER BY a) rn FROM t";
+        assertThat(service.wrapSQL(sql)).isEqualTo("select x.* from (" + sql + ") x");
+    }
+
+    @Test
+    public void doesNotLiftDotQualifiedOrderBy() {
+        final String sql = "SELECT l.account_no FROM m_loan l ORDER BY l.account_no DESC";
+        assertThat(service.wrapSQL(sql)).isEqualTo("select x.* from (" + sql + ") x");
+    }
+
+    @Test
+    public void ignoresOrderByInsideStringLiteral() {
+        final String sql = "SELECT a FROM t WHERE note = 'order by x'";
+        assertThat(service.wrapSQL(sql)).isEqualTo("select x.* from (" + sql + ") x");
+    }
+}


### PR DESCRIPTION
## Description

Fixes [FINERACT-2622](https://issues.apache.org/jira/browse/FINERACT-2622).

### Problem
Report SQL is wrapped as `select x.* from (<sql>) x` in `GenericDataServiceImpl#wrapSQL`. A derived table's `ORDER BY` is not guaranteed to be honored by the outer query, so a user report ending in e.g. `ORDER BY account_no DESC` returns rows in an arbitrary order.

### Fix
Detect a top-level trailing `ORDER BY` (with any trailing `LIMIT`/`OFFSET`) and re-apply it on the outer wrapper, where it resolves against the columns exposed by `x.*`. The wrapping itself is kept (the `CachedRowSetImpl` column-label workaround).

The scan ignores `ORDER BY` that appears inside parentheses (subqueries / window functions), string literals, and SQL comments. As a safeguard against regressions, lifting is skipped when the trailing clause contains a dot-qualified reference (`alias.column`) that would not resolve in the outer scope, leaving today's behavior for that case.

Scope check: `wrapSQL` has three call sites in `ReadReportingServiceImpl` — `buildPreparedQuery` (user report SQL, the target of this fix) and `getSql` / `getReportType` (fixed internal queries with no `ORDER BY`, so their behavior is unchanged).

### Tests
Unit tests on `wrapSQL` cover: ORDER BY preserved, no-ORDER-BY unchanged, subquery ORDER BY not lifted, window-function ORDER BY not lifted, dot-qualified skipped, string-literal ORDER BY ignored, trailing LIMIT carried.

### Note on pagination
When pagination is enabled (`IS_PAGINATION_ALLOWED=true`), the wrapped SQL is passed to `paginationHelper.fetchPage`. If a user report SQL ends with a top-level `ORDER BY ... LIMIT`, the carried `LIMIT` could interact with pagination's own limiting. Flagging for reviewer confirmation on whether `PaginationHelper` appends or re-wraps; happy to skip `LIMIT`-carrying on that path if preferred. Also happy to add a DB-backed integration test if desired.

---

## Checklist

- [x] Write the commit message as per [our guidelines](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions)
- [x] Acknowledge that we will not review PRs that are not passing the build ("green") — it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] This PR must not be a "code dump". (Large changes can be made "in repository" via a branch. Ask on the list.)