### PR TITLE
FINERACT-2661: Prevent Duplicate Command Handlers in DefaultCommandHandlerManager

### DIFF
--- a/fineract-command/src/main/java/org/apache/fineract/command/core/exception/CommandHandlerDuplicateException.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/core/exception/CommandHandlerDuplicateException.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.command.core.exception;
+
+public class CommandHandlerDuplicateException extends RuntimeException {
+
+    public CommandHandlerDuplicateException(Class<?> requestType, Class<?> userClass) {
+        super("Multiple handlers found for " + requestType.getSimpleName() + " command payload: Conflict found for "
+                + userClass.getSimpleName());
+    }
+}

--- a/fineract-command/src/main/java/org/apache/fineract/command/core/exception/CommandHandlerInvalidRequestTypeException.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/core/exception/CommandHandlerInvalidRequestTypeException.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.command.core.exception;
+
+public class CommandHandlerInvalidRequestTypeException extends RuntimeException {
+
+    public CommandHandlerInvalidRequestTypeException(Class<?> commandHandler) {
+        super("CommandHandler [" + commandHandler.getSimpleName()
+                + "] is malformed: It does not explicitly define its generic REQ payload type parameters.");
+    }
+}

--- a/fineract-command/src/main/java/org/apache/fineract/command/implementation/DefaultCommandHandlerManager.java
+++ b/fineract-command/src/main/java/org/apache/fineract/command/implementation/DefaultCommandHandlerManager.java
@@ -18,14 +18,21 @@
  */
 package org.apache.fineract.command.implementation;
 
+import jakarta.annotation.PostConstruct;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.command.core.Command;
 import org.apache.fineract.command.core.CommandHandler;
 import org.apache.fineract.command.core.CommandHandlerManager;
+import org.apache.fineract.command.core.exception.CommandHandlerDuplicateException;
+import org.apache.fineract.command.core.exception.CommandHandlerInvalidRequestTypeException;
 import org.apache.fineract.command.core.exception.CommandHandlerNotFoundException;
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -37,6 +44,11 @@ public class DefaultCommandHandlerManager implements CommandHandlerManager {
 
     private final List<CommandHandler> handlers;
 
+    @PostConstruct
+    public void init() {
+        ensureCommandHandlerUniqueness(this.handlers);
+    }
+
     @Override
     public <REQ, RES> RES handle(Command<REQ> command) {
         CommandHandler<REQ, RES> handler = lookup(command);
@@ -45,12 +57,37 @@ public class DefaultCommandHandlerManager implements CommandHandlerManager {
     }
 
     private <REQ, RES> CommandHandler<REQ, RES> lookup(Command<REQ> command) {
-        // TODO: make sure there are no duplicate handlers
         if (command == null) {
             throw new CommandHandlerNotFoundException(command);
         }
 
         return handlers.stream().filter(handler -> handler.matches(command)).findFirst()
                 .orElseThrow(() -> new CommandHandlerNotFoundException(command));
+    }
+
+    private void ensureCommandHandlerUniqueness(List<CommandHandler> commandHandlers) {
+        final Set<Class<?>> registeredRequestTypes = new HashSet<>();
+
+        for (CommandHandler handler : commandHandlers) {
+            Class<?> userClass = AopProxyUtils.ultimateTargetClass(handler);
+
+            Class<?> requestType = ResolvableType.forClass(userClass).as(CommandHandler.class).getGeneric(0).resolve();
+
+            if (requestType == null) {
+                log.error("Warning: Could not resolve request payload type for handler: {}", userClass.getName());
+                throw new CommandHandlerInvalidRequestTypeException(userClass);
+            }
+
+            if (!registeredRequestTypes.add(requestType)) {
+
+                log.error("Critical Configuration ERROR: Duplicate CommandHandlers detected for request type [{}]. Conflict found for: {}",
+                        requestType.getName(), userClass.getSimpleName());
+
+                throw new CommandHandlerDuplicateException(requestType, userClass);
+            }
+        }
+
+        log.info("CommandHandler validation successful. Verified {} handler(s) uniquely map to their respective requests.",
+                commandHandlers.size());
     }
 }

--- a/fineract-command/src/test/java/org/apache/fineract/command/DefaultCommandHandlerManagerTest.java
+++ b/fineract-command/src/test/java/org/apache/fineract/command/DefaultCommandHandlerManagerTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.command;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.List;
+import org.apache.fineract.command.core.Command;
+import org.apache.fineract.command.core.CommandHandler;
+import org.apache.fineract.command.core.exception.CommandHandlerDuplicateException;
+import org.apache.fineract.command.core.exception.CommandHandlerInvalidRequestTypeException;
+import org.apache.fineract.command.implementation.DefaultCommandHandlerManager;
+import org.apache.fineract.command.test.sample.data.DummyRequest;
+import org.apache.fineract.command.test.sample.data.DummyResponse;
+import org.junit.jupiter.api.Test;
+
+public class DefaultCommandHandlerManagerTest {
+
+    static class DummyCommandHandlerOriginal implements CommandHandler<DummyRequest, DummyResponse> {
+
+        @Override
+        public DummyResponse handle(Command<DummyRequest> command) {
+            return DummyResponse.builder().content("res1").build();
+        }
+
+    }
+
+    static class DummyCommandHandlerDuplicate implements CommandHandler<DummyRequest, DummyResponse> {
+
+        @Override
+        public DummyResponse handle(Command<DummyRequest> command) {
+
+            return DummyResponse.builder().content("res2").build();
+        }
+    }
+
+    static class DummyCommandHandlerNoType implements CommandHandler {
+
+        @Override
+        public DummyResponse handle(Command command) {
+
+            return DummyResponse.builder().content("res2").build();
+        }
+    }
+
+    /*
+     * Integration test for initialization
+     */
+    @Test
+    void processInit() {
+        List<CommandHandler> handlers = List.of(new DummyCommandHandlerOriginal());
+
+        DefaultCommandHandlerManager manager = new DefaultCommandHandlerManager(handlers);
+
+        assertDoesNotThrow(() -> manager.init());
+    }
+
+    @Test
+    void errorDuplicateCommandHandlers() {
+
+        List<CommandHandler> handlers = List.of(new DummyCommandHandlerOriginal(), new DummyCommandHandlerDuplicate());
+
+        DefaultCommandHandlerManager manager = new DefaultCommandHandlerManager(handlers);
+
+        var ex = assertThrows(CommandHandlerDuplicateException.class, () -> manager.init());
+
+        assertNotNull(ex);
+
+    }
+
+    @Test
+    void errorInvalidCommandRequestType() {
+        List<CommandHandler> handlers = List.of(new DummyCommandHandlerDuplicate(), new DummyCommandHandlerNoType());
+
+        DefaultCommandHandlerManager manager = new DefaultCommandHandlerManager(handlers);
+        var ex = assertThrows(CommandHandlerInvalidRequestTypeException.class, () -> manager.init());
+
+        assertNotNull(ex);
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -224,7 +224,8 @@ public class ClientSearchTest extends IntegrationTest {
         clientHelper.createClient(request1);
 
         PostClientsRequest request2 = ClientHelper.defaultClientCreationRequest();
-        request2.setMobileNo(Utils.randomNumberGenerator(8).toString());
+        // request2.setMobileNo(Utils.randomNumberGenerator(8).toString());
+        request2.setMobileNo(Utils.randomStringGenerator("", 8, Utils.SOURCE_SET_NUMBERS));
         clientHelper.createClient(request2);
 
         PostClientsRequest request3 = ClientHelper.defaultClientCreationRequest();
@@ -258,7 +259,8 @@ public class ClientSearchTest extends IntegrationTest {
     public void testClientSearchWorks_ByClientIdentifier() {
         // given
         PostClientsRequest request1 = ClientHelper.defaultClientCreationRequest();
-        request1.setMobileNo(Utils.randomNumberGenerator(8).toString());
+        // request1.setMobileNo(Utils.randomNumberGenerator(8).toString());
+        request1.setMobileNo(Utils.randomStringGenerator("", 8, Utils.SOURCE_SET_NUMBERS));
         PostClientsResponse clientResponse = clientHelper.createClient(request1);
         final Long documentType = 1L;
         PostClientsClientIdIdentifiersRequest identifierRequest = ClientHelper.createClientIdentifer(documentType);
@@ -393,7 +395,8 @@ public class ClientSearchTest extends IntegrationTest {
 
     @Test
     public void testClientSearchOrderByRejectsSnakeCaseColumnName() {
-        // given - undocumented internal SQL column form should no longer be accepted directly
+        // given - undocumented internal SQL column form should no longer be accepted
+        // directly
         // when
         Response<GetClientsResponse> response1 = callRetrieveAllClients("c.display_name", null);
         // then


### PR DESCRIPTION

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

This PR introduces a startup validation layer to catch misconfigured handlers like duplicate payload mappings and raw-type generic definitions immediately during the Spring context initialization phase, preventing subtle runtime bugs.
Proxy-Aware Class Resolution.
Fail-Fast Structural Validations.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [y] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [y] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [y] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [y] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [y] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [y] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
