### PR TITLE
FINERACT-2421: Working Capital grace days null value

### DIFF
--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/portfolio/workingcapitalloanproduct/service/WorkingCapitalLoanProductWritePlatformServiceImpl.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/portfolio/workingcapitalloanproduct/service/WorkingCapitalLoanProductWritePlatformServiceImpl.java
@@ -401,9 +401,9 @@ public class WorkingCapitalLoanProductWritePlatformServiceImpl implements Workin
                 .stringValueOfParameterNamed(WorkingCapitalLoanProductConstants.delinquencyStartTypeParamName);
         final WorkingCapitalLoanDelinquencyStartType delinquencyStartType = WorkingCapitalLoanDelinquencyStartType
                 .fromString(delinquencyStartTypeValue);
-        final Integer breachGraceDays = command.parameterExists(WorkingCapitalLoanProductConstants.breachGraceDaysParamName)
-                ? command.integerValueOfParameterNamed(WorkingCapitalLoanProductConstants.breachGraceDaysParamName)
-                : 0;
+        final Integer breachGraceDaysValue = command
+                .integerValueOfParameterNamed(WorkingCapitalLoanProductConstants.breachGraceDaysParamName);
+        final Integer breachGraceDays = breachGraceDaysValue != null ? breachGraceDaysValue : Integer.valueOf(0);
 
         final WorkingCapitalLoanProductRelatedDetail relatedDetail = new WorkingCapitalLoanProductRelatedDetail(amortizationType,
                 npvDayCount, principal, periodPaymentRate, repaymentEvery, repaymentFrequencyType, discount, delinquencyGraceDays,


### PR DESCRIPTION
## Description

Working Capital - Unable to create or edit a Working Capital product when "Breach grace days" is left empty 

The command input for Grace Days in null was generating NPE, so we are validating the null value

[FINERACT-2421](https://issues.apache.org/jira/browse/FINERACT-2421)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
