### PR TITLE
FINERACT-2669: Fix bulk-import template HTTP 500 when a client or office name contains an apostrophe

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/AbstractWorkbookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/AbstractWorkbookPopulator.java
@@ -39,7 +39,11 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractWorkbookPopulator implements WorkbookPopulator {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractWorkbookPopulator.class);
-    private static final Pattern NAME_REGEX = Pattern.compile("[ @#&()<>,;.:$£€§°\\\\/=!\\?\\-\\+\\*\"\\[\\]]");
+    // Allowlist (not a denylist): Excel named ranges only permit letters, digits, period and underscore, so replace
+    // anything else with '_'. A denylist of "bad" characters silently misses any it forgot — e.g. the apostrophe in
+    // a client name like "IRE'S LIMITED" produced an invalid name 'Account_IRE'S_LIMITED_181_' and threw. Unicode
+    // letters/digits (\p{L}/\p{N}) are kept, matching the previous behaviour for accented names. See FINERACT-1256.
+    private static final Pattern NAME_REGEX = Pattern.compile("[^\\p{L}\\p{N}._]");
 
     protected void writeInt(int colIndex, Row row, int value) {
         row.createCell(colIndex).setCellValue(value);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/loanrepayment/LoanRepaymentWorkbookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/loanrepayment/LoanRepaymentWorkbookPopulator.java
@@ -171,8 +171,11 @@ public final class LoanRepaymentWorkbookPopulator extends AbstractWorkbookPopula
         DataValidationConstraint officeNameConstraint = validationHelper.createFormulaListConstraint("Office");
         DataValidationConstraint clientNameConstraint = validationHelper
                 .createFormulaListConstraint("INDIRECT(CONCATENATE(\"Client_\",$A1))");
+        // The account named range is built from the sanitised client display name (see setNames -> setSanitized). The
+        // formula must apply the SAME substitutions, including the apostrophe, or the dropdown fails to resolve for
+        // clients like "IRE'S LIMITED" (the Java sanitiser strips '\'' but this formula must too). See FINERACT-1256.
         DataValidationConstraint accountNumberConstraint = validationHelper.createFormulaListConstraint(
-                "INDIRECT(CONCATENATE(\"Account_\",SUBSTITUTE(SUBSTITUTE(SUBSTITUTE($B1,\" \",\"_\"),\"(\",\"_\"),\")\",\"_\")))");
+                "INDIRECT(CONCATENATE(\"Account_\",SUBSTITUTE(SUBSTITUTE(SUBSTITUTE(SUBSTITUTE($B1,\" \",\"_\"),\"(\",\"_\"),\")\",\"_\"),\"'\",\"_\")))");
         DataValidationConstraint repaymentDateConstraint = validationHelper.createDateConstraint(
                 DataValidationConstraint.OperatorType.BETWEEN, "=VLOOKUP($D1,$T$2:$X$" + (allloans.size() + 1) + ",4,FALSE)", "=TODAY()",
                 dateFormat);

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/AbstractWorkbookPopulatorSanitizeTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/AbstractWorkbookPopulatorSanitizeTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.bulkimport.populator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Name;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.jupiter.api.Test;
+
+class AbstractWorkbookPopulatorSanitizeTest {
+
+    // setSanitized is protected; expose it through a minimal concrete subclass.
+    private static final class TestPopulator extends AbstractWorkbookPopulator {
+
+        @Override
+        public void populate(Workbook workbook, String dateFormat) {
+            // no-op
+        }
+
+        void sanitize(Name name, String roughName) {
+            setSanitized(name, roughName);
+        }
+    }
+
+    @Test
+    void setSanitized_stripsApostropheIntoValidExcelName() throws Exception {
+        try (Workbook workbook = new HSSFWorkbook()) {
+            Name name = workbook.createName();
+            TestPopulator populator = new TestPopulator();
+            // A client display name with an apostrophe used to produce 'Account_IRE'S_LIMITED_181_', which POI rejects.
+            assertDoesNotThrow(() -> populator.sanitize(name, "Account_IRE'S LIMITED_181_"));
+            String sanitized = name.getNameName();
+            assertFalse(sanitized.contains("'"), "apostrophe must be stripped: " + sanitized);
+            assertFalse(sanitized.contains(" "), "space must be stripped: " + sanitized);
+            assertTrue(sanitized.matches("[\\p{L}\\p{N}._]+"), "only letter/digit/period/underscore allowed: " + sanitized);
+        }
+    }
+
+    @Test
+    void setSanitized_keepsUnicodeLetters() throws Exception {
+        try (Workbook workbook = new HSSFWorkbook()) {
+            Name name = workbook.createName();
+            assertDoesNotThrow(() -> new TestPopulator().sanitize(name, "Client_Zoé_42_"));
+            assertTrue(name.getNameName().contains("Zoé"), "accented letters must be preserved: " + name.getNameName());
+        }
+    }
+}


### PR DESCRIPTION
- Downloading a bulk-import template that embeds client lookups (e.g. loan repayment,
        GET /v1/loans/repayments/downloadtemplate) returns HTTP 500 with
        IllegalArgumentException: Invalid name: 'Account_IRE'S_LIMITED_181_' when any client in the requesting
        user's office hierarchy has an apostrophe in its display name (e.g. O'Brien, IRE'S LIMITED). Excel defined
        names allow only letters, digits, period and underscore.
      - Root cause: AbstractWorkbookPopulator.setSanitized sanitises the display name via a denylist regex that
        enumerates characters to strip. The apostrophe (and other Excel-illegal characters such as %, ~, ^, {, },
        backtick) are not in the list, so they survive into the defined name and POI rejects it. A denylist
        inherently misses any character it does not enumerate.
      - Invert the denylist into an allowlist: replace anything that is not a valid Excel defined-name character
        (Unicode letter, digit, period, underscore) with '_'. Unicode letters/digits are kept, so accented names
        behave as before; only truly invalid characters are replaced. This fixes every Excel-illegal character in
        one place, for every template that builds named ranges via setSanitized.
      - Also apply the same apostrophe substitution to the in-sheet account-dropdown formula in
        LoanRepaymentWorkbookPopulator.setRules: the INDIRECT/CONCATENATE/SUBSTITUTE formula that reconstructs the
        named-range key substituted space and parentheses but not the apostrophe, so after the sanitiser fix the
        formula key no longer matched the defined name and the cascading dropdown silently failed to resolve for
        apostrophe clients.
      - Add a unit test asserting an apostrophe/space name is sanitised into a valid Excel name without throwing and
        that Unicode letters are preserved.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
