### PR TITLE
FINERACT-2674: Add AGENTS.md with security-model link for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md`
+for the project's threat model, in-scope / out-of-scope
+declarations, and known non-findings before reporting issues.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or
discuss as needed.** Nothing here is a requirement; the maintainer is the
decision-maker.

This adds an `AGENTS.md` so an automated scan agent can mechanically
discover the project's security model via the conventional
`AGENTS.md → SECURITY.md` chain. Fineract's `SECURITY.md` already contains
a complete threat model; this PR only adds the discoverability pointer to
it — no model content changes.

Context: the ASF Security team is preparing the project for an automated
agentic security scan we're piloting. Such scans refuse to run unless the
model is discoverable by that path (refusing upfront beats wasting PMC
reviewer cycles on a noise-heavy run against a model the agent never
found). Discoverability is the one hard gate; everything else is
suggestion.

Questions / pushback welcome — happy to adjust wording or file placement
to match project house style.
