### PR TITLE
FINERACT-2675: Fix template endpoint

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/template/api/TemplatesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/api/TemplatesApiResource.java
@@ -20,7 +20,10 @@ package org.apache.fineract.template.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
@@ -41,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.command.core.CommandDispatcher;
 import org.apache.fineract.infrastructure.core.annotation.AlternativeOperationId;
@@ -52,6 +56,8 @@ import org.apache.fineract.template.data.TemplateCreateResponse;
 import org.apache.fineract.template.data.TemplateData;
 import org.apache.fineract.template.data.TemplateDeleteRequest;
 import org.apache.fineract.template.data.TemplateDeleteResponse;
+import org.apache.fineract.template.data.TemplateDetailsData;
+import org.apache.fineract.template.data.TemplateItemData;
 import org.apache.fineract.template.data.TemplateUpdateRequest;
 import org.apache.fineract.template.data.TemplateUpdateResponse;
 import org.apache.fineract.template.domain.TemplateEntity;
@@ -99,7 +105,7 @@ public class TemplatesApiResource {
             @DefaultValue("-1") @QueryParam("typeId") @Parameter(description = "typeId") final int typeId,
             @DefaultValue("-1") @QueryParam("entityId") @Parameter(description = "entityId") final int entityId) {
         if (typeId != -1 && entityId != -1) {
-            return templateService.getAllByEntityAndType(TemplateEntity.values()[entityId], TemplateType.values()[typeId]);
+            return templateService.getAllByEntityAndType(findTemplateEntity(entityId), findTemplateType(typeId));
         } else {
             return templateService.getAll();
         }
@@ -119,12 +125,10 @@ public class TemplatesApiResource {
             Example Request:
 
             templates/template
-            """)
+            """, responses = @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = TemplateData.class))))
     @AlternativeOperationId("template_20")
-    public TemplateData retrieveTemplateDetails() {
-        // TODO: why?!? The original code was also limited to return only the ID attribute...
-        // which we don't have; the parser will remove all null values
-        return new TemplateData();
+    public TemplateDetailsData retrieveTemplateDetails() {
+        return templateDetails(null);
     }
 
     @GET
@@ -140,10 +144,10 @@ public class TemplatesApiResource {
 
     @GET
     @Path("{templateId}/template")
-    @Operation(operationId = "retrieveTemplateById")
+    @Operation(operationId = "retrieveTemplateById", responses = @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = TemplateData.class))))
     @AlternativeOperationId("getTemplateByTemplate")
-    public TemplateData retrieveTemplateById(@PathParam("templateId") final Long templateId) {
-        return templateService.findOneById(templateId);
+    public TemplateDetailsData retrieveTemplateById(@PathParam("templateId") final Long templateId) {
+        return templateDetails(templateService.findOneById(templateId));
     }
 
     @POST
@@ -212,5 +216,29 @@ public class TemplatesApiResource {
         parametersMap.putAll(result);
 
         return this.templateMergeService.compile(template, parametersMap);
+    }
+
+    private TemplateDetailsData templateDetails(final TemplateData template) {
+        return TemplateDetailsData.builder().entities(retrieveEntities()).types(retrieveTypes()).template(template).build();
+    }
+
+    private List<TemplateItemData> retrieveEntities() {
+        return Stream.of(TemplateEntity.values())
+                .map(entity -> TemplateItemData.builder().id(entity.getId()).name(entity.getName()).build()).toList();
+    }
+
+    private List<TemplateItemData> retrieveTypes() {
+        return Stream.of(TemplateType.values()).map(type -> TemplateItemData.builder().id(type.getId()).name(type.getName()).build())
+                .toList();
+    }
+
+    private TemplateEntity findTemplateEntity(final int entityId) {
+        return Stream.of(TemplateEntity.values()).filter(entity -> entity.getId() == entityId).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid template entity id: " + entityId));
+    }
+
+    private TemplateType findTemplateType(final int typeId) {
+        return Stream.of(TemplateType.values()).filter(type -> type.getId() == typeId).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid template type id: " + typeId));
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/template/data/TemplateDetailsData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/data/TemplateDetailsData.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.template.data;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
@@ -31,17 +30,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public final class TemplateData implements Serializable {
+public final class TemplateDetailsData implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private Long id;
-    private String name;
-    private String text;
-    @Schema(implementation = Integer.class)
-    private String entity;
-    @Schema(implementation = Integer.class)
-    private String type;
-    private List<TemplateMapperData> mappers;
+    private List<TemplateItemData> entities;
+    private List<TemplateItemData> types;
+    private TemplateData template;
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/template/mapper/TemplateMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/mapper/TemplateMapper.java
@@ -23,10 +23,13 @@ import org.apache.fineract.infrastructure.core.config.MapstructMapperConfig;
 import org.apache.fineract.template.data.TemplateData;
 import org.apache.fineract.template.domain.Template;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(config = MapstructMapperConfig.class, uses = { TemplateMapperMapper.class })
 public interface TemplateMapper {
 
+    @Mapping(target = "entity", expression = "java(source.getEntity() == null ? null : source.getEntity().getName())")
+    @Mapping(target = "type", expression = "java(source.getType() == null ? null : source.getType().getName())")
     TemplateData map(Template source);
 
     List<TemplateData> map(List<Template> source);

--- a/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateDomainServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/template/service/TemplateDomainServiceImpl.java
@@ -55,7 +55,7 @@ public class TemplateDomainServiceImpl implements TemplateDomainService {
 
     @Override
     public List<TemplateData> getAll() {
-        return templateRepository.findAll().stream().map(template -> TemplateData.builder().id(template.getId()).build()).toList();
+        return templateMapper.map(templateRepository.findAll());
     }
 
     @Override
@@ -127,7 +127,6 @@ public class TemplateDomainServiceImpl implements TemplateDomainService {
 
     @Override
     public List<TemplateData> getAllByEntityAndType(final TemplateEntity entity, final TemplateType type) {
-        return templateRepository.findByEntityAndType(entity, type).stream()
-                .map(template -> TemplateData.builder().id(template.getId()).build()).toList();
+        return templateMapper.map(templateRepository.findByEntityAndType(entity, type));
     }
 }

--- a/fineract-provider/src/test/java/org/apache/fineract/template/api/TemplatesApiResourceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/template/api/TemplatesApiResourceTest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.template.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.command.core.CommandDispatcher;
+import org.apache.fineract.template.data.TemplateData;
+import org.apache.fineract.template.data.TemplateDetailsData;
+import org.apache.fineract.template.data.TemplateItemData;
+import org.apache.fineract.template.data.TemplateMapperData;
+import org.apache.fineract.template.domain.TemplateEntity;
+import org.apache.fineract.template.domain.TemplateType;
+import org.apache.fineract.template.service.TemplateDomainService;
+import org.apache.fineract.template.service.TemplateMergeServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TemplatesApiResourceTest {
+
+    @Mock
+    private TemplateDomainService templateService;
+
+    @Mock
+    private TemplateMergeServiceImpl templateMergeService;
+
+    @Mock
+    private CommandDispatcher dispatcher;
+
+    @InjectMocks
+    private TemplatesApiResource resource;
+
+    @Test
+    void retrieveAllTemplatesFiltersByApiTypeAndEntityIds() {
+        TemplateData template = TemplateData.builder().id(3L).name("sms-template").entity("loan").type("SMS").text("hello")
+                .mappers(List.of(TemplateMapperData.builder().mapperorder(0).mapperkey("loan").mappervalue("loans/{{loanId}}").build()))
+                .build();
+        when(templateService.getAllByEntityAndType(TemplateEntity.LOAN, TemplateType.SMS)).thenReturn(List.of(template));
+
+        List<TemplateData> response = resource.retrieveAllTemplates(2, 1);
+
+        verify(templateService).getAllByEntityAndType(TemplateEntity.LOAN, TemplateType.SMS);
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().getId()).isEqualTo(3L);
+        assertThat(response.getFirst().getName()).isEqualTo("sms-template");
+        assertThat(response.getFirst().getEntity()).isEqualTo("loan");
+        assertThat(response.getFirst().getType()).isEqualTo("SMS");
+        assertThat(response.getFirst().getText()).isEqualTo("hello");
+        assertThat(response.getFirst().getMappers()).hasSize(1);
+    }
+
+    @Test
+    void retrieveTemplateByIdReturnsEditWrapperWithOptionsAndTemplate() {
+        TemplateData template = template();
+        when(templateService.findOneById(2L)).thenReturn(template);
+
+        TemplateDetailsData response = resource.retrieveTemplateById(2L);
+
+        assertThat(response.getTemplate()).isSameAs(template);
+        assertThat(response.getTemplate().getEntity()).isEqualTo("loan");
+        assertThat(response.getTemplate().getType()).isEqualTo("Document");
+        assertThat(response.getTemplate().getMappers()).hasSize(1);
+        assertThat(response.getEntities()).extracting(TemplateItemData::getName).containsExactly("client", "loan");
+        assertThat(response.getTypes()).extracting(TemplateItemData::getName).containsExactly("Document", "SMS");
+        assertThat(response.getTypes()).extracting(TemplateItemData::getId).containsExactly(0, 2);
+    }
+
+    @Test
+    void retrieveTemplateDetailsReturnsCreateWrapperOptions() {
+        TemplateDetailsData response = resource.retrieveTemplateDetails();
+
+        assertThat(response.getTemplate()).isNull();
+        assertThat(response.getEntities()).extracting(TemplateItemData::getName).containsExactly("client", "loan");
+        assertThat(response.getTypes()).extracting(TemplateItemData::getName).containsExactly("Document", "SMS");
+    }
+
+    @Test
+    void retrieveOneTemplateKeepsRawTemplateResponse() {
+        TemplateData template = template();
+        when(templateService.findOneById(2L)).thenReturn(template);
+
+        TemplateData response = resource.retrieveOneTemplate(2L);
+
+        assertThat(response).isSameAs(template);
+        assertThat(response.getEntity()).isEqualTo("loan");
+        assertThat(response.getType()).isEqualTo("Document");
+    }
+
+    private TemplateData template() {
+        return TemplateData.builder().id(2L).name("anvay").entity("loan").type("Document").text("<p>anything</p>")
+                .mappers(List.of(TemplateMapperData.builder().mapperorder(0).mapperkey("loan")
+                        .mappervalue("loans/{{loanId}}?associations=all&tenantIdentifier=default").build()))
+                .build();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/template/mapper/TemplateMapperTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/template/mapper/TemplateMapperTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.template.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.fineract.template.data.TemplateData;
+import org.apache.fineract.template.domain.Template;
+import org.apache.fineract.template.domain.TemplateEntity;
+import org.apache.fineract.template.domain.TemplateType;
+import org.junit.jupiter.api.Test;
+
+class TemplateMapperTest {
+
+    private final TemplateMapper mapper = new TemplateMapperImpl(new TemplateMapperMapperImpl());
+
+    @Test
+    void mapsTemplateEntityAndTypeAsApiNames() {
+        Template template = new Template().setName("anvay").setEntity(TemplateEntity.LOAN).setType(TemplateType.DOCUMENT)
+                .setText("<p>anything</p>").setMappers(List.of(new org.apache.fineract.template.domain.TemplateMapper(0, "loan",
+                        "loans/{{loanId}}?associations=all&tenantIdentifier=default")));
+        template.setId(2L);
+
+        TemplateData response = mapper.map(template);
+
+        assertThat(response.getId()).isEqualTo(2L);
+        assertThat(response.getName()).isEqualTo("anvay");
+        assertThat(response.getEntity()).isEqualTo("loan");
+        assertThat(response.getType()).isEqualTo("Document");
+        assertThat(response.getText()).isEqualTo("<p>anything</p>");
+        assertThat(response.getMappers()).hasSize(1);
+        assertThat(response.getMappers().getFirst().getMapperorder()).isZero();
+        assertThat(response.getMappers().getFirst().getMapperkey()).isEqualTo("loan");
+        assertThat(response.getMappers().getFirst().getMappervalue())
+                .isEqualTo("loans/{{loanId}}?associations=all&tenantIdentifier=default");
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/template/service/TemplateDomainServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/template/service/TemplateDomainServiceImplTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.template.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.command.jdbc.store.mapping.CommandMapper;
+import org.apache.fineract.template.data.TemplateData;
+import org.apache.fineract.template.data.TemplateMapperData;
+import org.apache.fineract.template.domain.Template;
+import org.apache.fineract.template.domain.TemplateEntity;
+import org.apache.fineract.template.domain.TemplateRepository;
+import org.apache.fineract.template.domain.TemplateType;
+import org.apache.fineract.template.mapper.TemplateMapper;
+import org.apache.fineract.template.mapper.TemplateMapperDataMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TemplateDomainServiceImplTest {
+
+    @Mock
+    private CommandMapper commandMapper;
+
+    @Mock
+    private TemplateRepository templateRepository;
+
+    @Mock
+    private TemplateMapper templateMapper;
+
+    @Mock
+    private TemplateMapperDataMapper templateMapperDataMapper;
+
+    @InjectMocks
+    private TemplateDomainServiceImpl service;
+
+    @Test
+    void getAllReturnsFullTemplateDataFromMapper() {
+        Template template = new Template().setName("anvay");
+        List<Template> templates = List.of(template);
+        List<TemplateData> mappedTemplates = List.of(templateData());
+        when(templateRepository.findAll()).thenReturn(templates);
+        when(templateMapper.map(templates)).thenReturn(mappedTemplates);
+
+        List<TemplateData> response = service.getAll();
+
+        assertThat(response).isSameAs(mappedTemplates);
+        assertThat(response.getFirst().getName()).isEqualTo("anvay");
+        assertThat(response.getFirst().getEntity()).isEqualTo("loan");
+        assertThat(response.getFirst().getType()).isEqualTo("Document");
+        assertThat(response.getFirst().getText()).isEqualTo("<p>anything</p>");
+        assertThat(response.getFirst().getMappers()).hasSize(1);
+    }
+
+    @Test
+    void getAllByEntityAndTypeReturnsFullTemplateDataFromMapper() {
+        Template template = new Template().setName("anvay");
+        List<Template> templates = List.of(template);
+        List<TemplateData> mappedTemplates = List.of(templateData());
+        when(templateRepository.findByEntityAndType(TemplateEntity.LOAN, TemplateType.DOCUMENT)).thenReturn(templates);
+        when(templateMapper.map(templates)).thenReturn(mappedTemplates);
+
+        List<TemplateData> response = service.getAllByEntityAndType(TemplateEntity.LOAN, TemplateType.DOCUMENT);
+
+        assertThat(response).isSameAs(mappedTemplates);
+        assertThat(response.getFirst().getName()).isEqualTo("anvay");
+        assertThat(response.getFirst().getEntity()).isEqualTo("loan");
+        assertThat(response.getFirst().getType()).isEqualTo("Document");
+    }
+
+    private TemplateData templateData() {
+        return TemplateData.builder().id(2L).name("anvay").entity("loan").type("Document").text("<p>anything</p>")
+                .mappers(List.of(TemplateMapperData.builder().mapperorder(0).mapperkey("loan")
+                        .mappervalue("loans/{{loanId}}?associations=all&tenantIdentifier=default").build()))
+                .build();
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes **FINERACT-2675** by restoring the template endpoint responses expected by the Mifos Web App.

### Problem

After recent backend changes, the Templates API response contract changed:

- `GET /templates` returned only template IDs, causing the **Name**, **Entity**, and **Type** columns to appear blank.
- `GET /templates/{id}/template` returned a raw template object instead of the wrapper containing `template`, `entities`, and `types`, causing the Edit Template page to fail.

### Changes

- Restore full template data for `GET /templates`.
- Restore the response wrapper for `GET /templates/{id}/template` containing:
  - `template`
  - `entities`
  - `types`
- Preserve the existing behavior of `GET /templates/{id}`.
- Return template entity and type values in the format expected by the Web App.
- Add regression tests covering:
  - Template list response
  - Template edit response
  - Template retrieval
  - Entity/type mapping
  - Query filtering

### Testing

Verified by:

- Running the relevant unit tests.
- Running Spotless checks.
- Confirming the restored API response matches the expected Web App contract.

Fixes **FINERACT-2675**.