### PR TITLE
FINERACT-2676: Fix named PPI survey score overview

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResource.java
@@ -123,7 +123,7 @@ public class SurveyApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission(SurveyApiConstants.SURVEY_RESOURCE_NAME);
 
-        List<ClientScoresOverview> scores = this.readSurveyService.retrieveClientSurveyScoreOverview(clientId);
+        List<ClientScoresOverview> scores = this.readSurveyService.retrieveClientSurveyScoreOverview(surveyName, clientId);
 
         return this.toApiJsonClientScoreOverviewSerializer.serialize(scores);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImpl.java
@@ -114,22 +114,27 @@ public class ReadSurveyServiceImpl implements ReadSurveyService {
 
     @Override
     public List<ClientScoresOverview> retrieveClientSurveyScoreOverview(String surveyName, Long clientId) {
+        sqlValidator.validate(surveyName);
+        final String registeredSurveyName = retrievePermittedSurveyName(surveyName);
+        if (registeredSurveyName == null) {
+            return List.of();
+        }
 
-        final String sql = "SELECT  tz.id, lkh.name, lkh.code, poverty_line, tz.date, tz.score FROM ? tz"
+        final String sql = "SELECT  tz.id, lkh.name, lkh.code, poverty_line, tz.date, tz.score FROM " + registeredSurveyName + " tz"
                 + " JOIN ppi_likelihoods_ppi lkp on lkp.ppi_name = ? AND enabled = ? "
                 + " JOIN ppi_scores sc on score_from  <= tz.score AND score_to >=tz.score"
                 + " JOIN ppi_poverty_line pvl on pvl.likelihood_ppi_id = lkp.id AND pvl.score_id = sc.id"
                 + " JOIN ppi_likelihoods lkh on lkh.id = lkp.likelihood_id " + " WHERE  client_id = ? ";
 
         final SqlRowSet rs = this.jdbcTemplate.queryForRowSet(sql,
-                new Object[] { surveyName, surveyName, LikelihoodStatus.ENABLED, clientId });
+                new Object[] { registeredSurveyName, LikelihoodStatus.ENABLED, clientId });
 
         List<ClientScoresOverview> scoresOverviews = new ArrayList<>();
 
         while (rs.next()) {
             scoresOverviews.add(new ClientScoresOverview().setLikelihoodCode(rs.getString("code")).setLikelihoodName(rs.getString("name"))
                     .setScore(rs.getLong("score")).setPovertyLine(rs.getDouble("poverty_line")).setDate(rs.getDate("date").toLocalDate())
-                    .setId(rs.getLong("id")).setSurveyName(surveyName));
+                    .setId(rs.getLong("id")).setSurveyName(registeredSurveyName));
         }
         return scoresOverviews;
     }
@@ -170,14 +175,29 @@ public class ReadSurveyServiceImpl implements ReadSurveyService {
     }
 
     private String retrieveAllSurveyNameSQL() {
+        return retrieveAllSurveyNameSQL("");
+    }
+
+    private String retrieveAllSurveyNameSQL(String andClause) {
         // PERMITTED datatables
         return "select cf.name from x_registered_table " + " join c_configuration cf on x_registered_table.registered_table_name = cf.name "
                 + " where exists" + " (select 'f'" + " from m_appuser_role ur " + " join m_role r on r.id = ur.role_id"
                 + " left join m_role_permission rp on rp.role_id = r.id" + " left join m_permission p on p.id = rp.permission_id"
                 + " where ur.appuser_id = " + this.context.authenticatedUser().getId()
                 + " and (p.code in ('ALL_FUNCTIONS', 'ALL_FUNCTIONS_READ') or p.code = concat('READ_', registered_table_name))) "
-                + " and x_registered_table.category = " + DataTableApiConstant.CATEGORY_PPI
+                + " and x_registered_table.category = " + DataTableApiConstant.CATEGORY_PPI + andClause
                 + " order by application_table_name, registered_table_name";
+    }
+
+    private String retrievePermittedSurveyName(String surveyName) {
+        final String sql = retrieveAllSurveyNameSQL(" and x_registered_table.registered_table_name = ?");
+        final SqlRowSet rs = this.jdbcTemplate.queryForRowSet(sql, surveyName);
+        if (rs.next()) {
+            final String registeredSurveyName = rs.getString("name");
+            sqlValidator.validate(registeredSurveyName);
+            return registeredSurveyName;
+        }
+        return null;
     }
 
     @Override

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResourceTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/api/SurveyApiResourceTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.survey.api;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.infrastructure.survey.data.ClientScoresOverview;
+import org.apache.fineract.infrastructure.survey.data.SurveyData;
+import org.apache.fineract.infrastructure.survey.service.ReadSurveyService;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyApiResourceTest {
+
+    private static final String SURVEY_NAME = "ppi_kenya_2026";
+    private static final Long CLIENT_ID = 11L;
+
+    @Mock
+    private DefaultToApiJsonSerializer<SurveyData> toApiJsonSerializer;
+    @Mock
+    private DefaultToApiJsonSerializer<ClientScoresOverview> toApiJsonClientScoreOverviewSerializer;
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private ReadSurveyService readSurveyService;
+    @Mock
+    private PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    @Mock
+    private GenericDataService genericDataService;
+    @Mock
+    private AppUser appUser;
+
+    private SurveyApiResource underTest;
+
+    @BeforeEach
+    void setUp() {
+        when(context.authenticatedUser()).thenReturn(appUser);
+        underTest = new SurveyApiResource(toApiJsonSerializer, toApiJsonClientScoreOverviewSerializer, context, readSurveyService,
+                commandsSourceWritePlatformService, genericDataService);
+    }
+
+    @Test
+    void getClientSurveyOverviewRetrievesScoresForRequestedSurvey() {
+        List<ClientScoresOverview> scores = List.of();
+        when(readSurveyService.retrieveClientSurveyScoreOverview(SURVEY_NAME, CLIENT_ID)).thenReturn(scores);
+        when(toApiJsonClientScoreOverviewSerializer.serialize(scores)).thenReturn("[]");
+
+        underTest.getClientSurveyOverview(SURVEY_NAME, CLIENT_ID);
+
+        verify(appUser).validateHasReadPermission(SurveyApiConstants.SURVEY_RESOURCE_NAME);
+        verify(readSurveyService).retrieveClientSurveyScoreOverview(SURVEY_NAME, CLIENT_ID);
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImplTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.survey.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.dataqueries.service.DatatableReadService;
+import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.infrastructure.security.service.SqlValidator;
+import org.apache.fineract.infrastructure.survey.data.ClientScoresOverview;
+import org.apache.fineract.infrastructure.survey.data.LikelihoodStatus;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReadSurveyServiceImplTest {
+
+    private static final Long USER_ID = 7L;
+    private static final Long CLIENT_ID = 11L;
+    private static final String SURVEY_NAME = "ppi_kenya_2026";
+
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private SqlValidator sqlValidator;
+    @Mock
+    private GenericDataService genericDataService;
+    @Mock
+    private DatatableReadService datatableReadService;
+    @Mock
+    private AppUser appUser;
+
+    private ReadSurveyServiceImpl underTest;
+
+    @BeforeEach
+    void setUp() {
+        when(context.authenticatedUser()).thenReturn(appUser);
+        when(appUser.getId()).thenReturn(USER_ID);
+        underTest = new ReadSurveyServiceImpl(context, jdbcTemplate, sqlValidator, genericDataService, datatableReadService);
+    }
+
+    @Test
+    void retrieveClientSurveyScoreOverviewUsesRegisteredSurveyNameAsSqlIdentifier() {
+        SqlRowSet surveyNames = Mockito.mock(SqlRowSet.class);
+        when(surveyNames.next()).thenReturn(true);
+        when(surveyNames.getString("name")).thenReturn(SURVEY_NAME);
+
+        SqlRowSet scoreRows = Mockito.mock(SqlRowSet.class);
+        when(scoreRows.next()).thenReturn(false);
+
+        when(jdbcTemplate.queryForRowSet(anyString(), any(Object[].class))).thenReturn(surveyNames, scoreRows);
+
+        List<ClientScoresOverview> result = underTest.retrieveClientSurveyScoreOverview(SURVEY_NAME, CLIENT_ID);
+
+        assertThat(result).isEmpty();
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object[]> paramsCaptor = ArgumentCaptor.forClass(Object[].class);
+        verify(jdbcTemplate, times(2)).queryForRowSet(sqlCaptor.capture(), paramsCaptor.capture());
+
+        String scoreSql = sqlCaptor.getAllValues().get(1);
+        Object[] scoreParams = paramsCaptor.getAllValues().get(1);
+
+        assertThat(scoreSql).contains("FROM " + SURVEY_NAME + " tz");
+        assertThat(scoreSql).doesNotContain("FROM ? tz");
+        assertThat(scoreParams).containsExactly(SURVEY_NAME, LikelihoodStatus.ENABLED, CLIENT_ID);
+        verify(sqlValidator, times(2)).validate(SURVEY_NAME);
+    }
+
+    @Test
+    void retrieveClientSurveyScoreOverviewReturnsEmptyListWhenSurveyIsNotPermitted() {
+        SqlRowSet surveyNames = Mockito.mock(SqlRowSet.class);
+        when(surveyNames.next()).thenReturn(false);
+        when(jdbcTemplate.queryForRowSet(anyString(), any(Object[].class))).thenReturn(surveyNames);
+
+        List<ClientScoresOverview> result = underTest.retrieveClientSurveyScoreOverview(SURVEY_NAME, CLIENT_ID);
+
+        assertThat(result).isEmpty();
+        verify(jdbcTemplate, times(1)).queryForRowSet(anyString(), any(Object[].class));
+    }
+}


### PR DESCRIPTION
## Description

Fixes [FINERACT-2676](https://issues.apache.org/jira/browse/FINERACT-2676).

The named PPI survey score overview endpoint accepted a `surveyName` path parameter, but the resource method delegated to the all-surveys service overload and the named-survey service path attempted to use a JDBC bind parameter as a SQL table identifier (`FROM ? tz`). JDBC parameters can safely bind values, but not SQL identifiers, so the named-survey query could not work correctly.

This PR updates the endpoint to delegate to the named-survey overload and updates `ReadSurveyServiceImpl.retrieveClientSurveyScoreOverview(String surveyName, Long clientId)` to:

- validate the requested `surveyName`;
- resolve it through the existing registered/permitted PPI datatable query, narrowed by `registered_table_name = ?`;
- return an empty result when the requested survey is not registered/permitted for the current user;
- build the `FROM` clause with the resolved registered survey table name;
- keep runtime values (`ppi_name`, enabled status, client id) bound as JDBC parameters.

The identifier is not additionally quoted in this change. Instead, the table name is first looked up from the existing PPI datatable registration/permission query and then validated again with `SqlValidator` before it is used as an identifier. This mirrors the existing all-surveys implementation in the same service, while narrowing it to the requested registered survey. The values that remain user/runtime data continue to use JDBC bind parameters.

Test coverage was added for both the API delegation and the SQL construction/permission behavior in the service.

## Testing

Targeted unit tests passed:

```bash
./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx3g -Dfile.encoding=UTF-8" :fineract-provider:test --tests "org.apache.fineract.infrastructure.survey.service.ReadSurveyServiceImplTest" --tests "org.apache.fineract.infrastructure.survey.api.SurveyApiResourceTest" --stacktrace
```

I also performed a deeper local smoke test on Windows with Docker Desktop:

- built a local Fineract image from this branch with `jibBuildTar` and loaded it into Docker;
- started the PostgreSQL test Docker Compose stack and confirmed Fineract reached `{"status":"UP","groups":["liveness","readiness"]}`;
- seeded two minimal registered PPI survey datatables, `ppi_test_alpha` and `ppi_test_beta`, plus the required PPI likelihood fixtures;
- verified `GET /fineract-provider/api/v1/survey/ppi_test_alpha/1` returned only `surveyName: ppi_test_alpha`;
- verified `GET /fineract-provider/api/v1/survey/ppi_test_beta/1` returned only `surveyName: ppi_test_beta`;
- verified an unknown survey returned `[]`.

That smoke test specifically checks that the named endpoint respects the requested `surveyName` instead of falling back to all registered PPI surveys.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes. N/A: this fixes behavior of an existing endpoint and does not change the public API contract.
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).

*This PR was developed by Codex with supervision from jmtdev0.*

