### PR TITLE
FINERACT-2676: Escape survey table name instead of binding it as a JDBC parameter

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.dataqueries.api.DataTableApiConstant;
 import org.apache.fineract.infrastructure.dataqueries.data.DatatableData;
 import org.apache.fineract.infrastructure.dataqueries.data.GenericResultsetData;
@@ -47,6 +48,7 @@ public class ReadSurveyServiceImpl implements ReadSurveyService {
     private final SqlValidator sqlValidator;
     private final GenericDataService genericDataService;
     private final DatatableReadService datatableReadService;
+    private final DatabaseSpecificSQLGenerator sqlGenerator;
 
     @Override
     public List<SurveyDataTableData> retrieveAllSurveys() {
@@ -120,8 +122,8 @@ public class ReadSurveyServiceImpl implements ReadSurveyService {
             return List.of();
         }
 
-        final String sql = "SELECT  tz.id, lkh.name, lkh.code, poverty_line, tz.date, tz.score FROM " + registeredSurveyName + " tz"
-                + " JOIN ppi_likelihoods_ppi lkp on lkp.ppi_name = ? AND enabled = ? "
+        final String sql = "SELECT  tz.id, lkh.name, lkh.code, poverty_line, tz.date, tz.score FROM "
+                + sqlGenerator.escape(registeredSurveyName) + " tz" + " JOIN ppi_likelihoods_ppi lkp on lkp.ppi_name = ? AND enabled = ? "
                 + " JOIN ppi_scores sc on score_from  <= tz.score AND score_to >=tz.score"
                 + " JOIN ppi_poverty_line pvl on pvl.likelihood_ppi_id = lkp.id AND pvl.score_id = sc.id"
                 + " JOIN ppi_likelihoods lkh on lkh.id = lkp.likelihood_id " + " WHERE  client_id = ? ";

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/survey/service/ReadSurveyServiceImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.dataqueries.service.DatatableReadService;
 import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
@@ -64,6 +65,8 @@ class ReadSurveyServiceImplTest {
     @Mock
     private DatatableReadService datatableReadService;
     @Mock
+    private DatabaseSpecificSQLGenerator sqlGenerator;
+    @Mock
     private AppUser appUser;
 
     private ReadSurveyServiceImpl underTest;
@@ -72,11 +75,11 @@ class ReadSurveyServiceImplTest {
     void setUp() {
         when(context.authenticatedUser()).thenReturn(appUser);
         when(appUser.getId()).thenReturn(USER_ID);
-        underTest = new ReadSurveyServiceImpl(context, jdbcTemplate, sqlValidator, genericDataService, datatableReadService);
+        underTest = new ReadSurveyServiceImpl(context, jdbcTemplate, sqlValidator, genericDataService, datatableReadService, sqlGenerator);
     }
 
     @Test
-    void retrieveClientSurveyScoreOverviewUsesRegisteredSurveyNameAsSqlIdentifier() {
+    void retrieveClientSurveyScoreOverviewEscapesRegisteredSurveyNameAsSqlIdentifier() {
         SqlRowSet surveyNames = Mockito.mock(SqlRowSet.class);
         when(surveyNames.next()).thenReturn(true);
         when(surveyNames.getString("name")).thenReturn(SURVEY_NAME);
@@ -85,6 +88,7 @@ class ReadSurveyServiceImplTest {
         when(scoreRows.next()).thenReturn(false);
 
         when(jdbcTemplate.queryForRowSet(anyString(), any(Object[].class))).thenReturn(surveyNames, scoreRows);
+        when(sqlGenerator.escape(SURVEY_NAME)).thenReturn("\"" + SURVEY_NAME + "\"");
 
         List<ClientScoresOverview> result = underTest.retrieveClientSurveyScoreOverview(SURVEY_NAME, CLIENT_ID);
 
@@ -97,7 +101,7 @@ class ReadSurveyServiceImplTest {
         String scoreSql = sqlCaptor.getAllValues().get(1);
         Object[] scoreParams = paramsCaptor.getAllValues().get(1);
 
-        assertThat(scoreSql).contains("FROM " + SURVEY_NAME + " tz");
+        assertThat(scoreSql).contains("FROM \"" + SURVEY_NAME + "\" tz");
         assertThat(scoreSql).doesNotContain("FROM ? tz");
         assertThat(scoreParams).containsExactly(SURVEY_NAME, LikelihoodStatus.ENABLED, CLIENT_ID);
         verify(sqlValidator, times(2)).validate(SURVEY_NAME);


### PR DESCRIPTION
## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
