### PR TITLE
FINERACT-2685: fix rules and re-branch for 1.15.0

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,8 +25,6 @@ github:
       branches:
         includes:
           - "develop"
-          - "release/*"
-          - "maintenance/*"
       restrict_deletion: true
       restrict_force_push: true
       required_signatures: true


### PR DESCRIPTION
## Description

FINERACT-2685

Relax branch protection rules for branches matching release/* and maintenance/* for easier branch maintenance.

I need to re-create the release/1.15.0 branch and the rules in our .asf.yaml didn't allow it. We'll be fine relaxing the rules for release and maintenance branches since develop (the one that really matters) has all the protections.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).