### PR TITLE
FINERACT-2689: Fix NPE in deposit withholding tax when net interest posted is zero

### DIFF
--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -578,7 +578,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public boolean createWithHoldTransaction(final BigDecimal amount, final LocalDate date, final boolean backdatedTxnsAllowedTill) {
         boolean isTaxAdded = false;
-        if (this.taxGroup != null && amount.compareTo(BigDecimal.ZERO) > 0) {
+        if (this.taxGroup != null && amount != null && amount.compareTo(BigDecimal.ZERO) > 0) {
             Map<TaxComponent, BigDecimal> taxSplit = TaxUtils.splitTax(amount, date, this.taxGroup.getTaxGroupMappings(), amount.scale());
             BigDecimal totalTax = TaxUtils.totalTaxAmount(taxSplit);
             if (totalTax.compareTo(BigDecimal.ZERO) > 0) {
@@ -597,7 +597,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     protected boolean updateWithHoldTransaction(final BigDecimal amount, final SavingsAccountTransaction withholdTransaction) {
         boolean isTaxAdded = false;
-        if (this.taxGroup != null && amount.compareTo(BigDecimal.ZERO) > 0) {
+        if (this.taxGroup != null && amount != null && amount.compareTo(BigDecimal.ZERO) > 0) {
             Map<TaxComponent, BigDecimal> taxSplit = TaxUtils.splitTax(amount, withholdTransaction.getTransactionDate(),
                     this.taxGroup.getTaxGroupMappings(), amount.scale());
             BigDecimal totalTax = TaxUtils.totalTaxAmount(taxSplit);

--- a/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountWithHoldTaxNullAmountTest.java
+++ b/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountWithHoldTaxNullAmountTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.apache.fineract.portfolio.tax.domain.TaxGroup;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the withholding-tax NPE on deposit-account closure.
+ *
+ * <p>
+ * When a withholding-tax account (taxGroup set) posts/closes with <em>zero</em> total interest posted,
+ * {@code SavingsAccountTransactionSummaryWrapper.calculateTotalInterestPosted} returns {@code null} (via
+ * {@code getAmountDefaultedToNullIfZero()}). That null flows into {@link SavingsAccount#createWithHoldTransaction} /
+ * {@link SavingsAccount#updateWithHoldTransaction}, which previously did an unguarded {@code amount.compareTo(ZERO)}
+ * and threw {@code NullPointerException: Cannot invoke "java.math.BigDecimal.compareTo(...)" because "amount" is null}.
+ *
+ * <p>
+ * Real-world trigger: premature-closing a short-term fixed deposit whose pre-closure penalty exceeds the chart rate, so
+ * the effective interest is clamped to zero and no interest-posting transaction is created.
+ */
+class SavingsAccountWithHoldTaxNullAmountTest {
+
+    // Fixed literal date — the transaction date is never dereferenced on the null/zero-amount path under test,
+    // and a constant keeps the test deterministic and clear of the JavaTimeDefaultTimeZone ban on LocalDate.now().
+    private static final LocalDate FIXED_DATE = LocalDate.of(2024, 1, 1);
+
+    private SavingsAccount accountWithTaxGroup() {
+        SavingsAccount account = new SavingsAccount() {};
+        setPrivateField(account, "taxGroup", mock(TaxGroup.class));
+        return account;
+    }
+
+    @Test
+    void createWithHoldTransaction_withNullAmount_doesNotThrowAndAddsNoTax() {
+        SavingsAccount account = accountWithTaxGroup();
+
+        assertThatCode(() -> {
+            boolean isTaxAdded = account.createWithHoldTransaction(null, FIXED_DATE, false);
+            assertThat(isTaxAdded).isFalse();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void updateWithHoldTransaction_withNullAmount_doesNotThrowAndAddsNoTax() {
+        SavingsAccount account = accountWithTaxGroup();
+
+        assertThatCode(() -> {
+            boolean isTaxAdded = account.updateWithHoldTransaction(null, mock(SavingsAccountTransaction.class));
+            assertThat(isTaxAdded).isFalse();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void createWithHoldTransaction_withZeroAmount_addsNoTax() {
+        SavingsAccount account = accountWithTaxGroup();
+
+        boolean isTaxAdded = account.createWithHoldTransaction(BigDecimal.ZERO, FIXED_DATE, false);
+
+        assertThat(isTaxAdded).isFalse();
+    }
+
+    private static void setPrivateField(final Object target, final String fieldName, final Object value) {
+        try {
+            final Field field = SavingsAccount.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to set field " + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
- Closing (or posting interest on) a withholding-tax deposit account threw a 500
        NullPointerException whenever the net interest posted on the account was zero:
        SavingsAccount.createWithHoldTransaction / updateWithHoldTransaction guard only on
        the tax group and then evaluate amount.compareTo(BigDecimal.ZERO), but amount can be
        null. SavingsAccountTransactionSummaryWrapper.calculateTotalInterestPosted returns
        total.getAmountDefaultedToNullIfZero() -- i.e. null -- when there are no net
        interest-posting transactions, and that null is passed straight into both helpers.
      - The common real-world trigger is premature-closing a short-term fixed deposit whose
        pre-closure penalty rate is greater than or equal to the chart rate: the effective
        interest is clamped to zero (FixedDepositAccount.getEffectiveInterestRateAsFraction),
        so postPreMaturityInterest posts no interest transaction, and the withholding-tax pass
        then runs with a null interest total. For a withholding-tax account the tax group is
        non-null, so the first clause passes and amount.compareTo throws; the whole command
        rolls back and the account cannot be closed.
      - Null-guard amount in both createWithHoldTransaction and updateWithHoldTransaction: a
        null (or non-positive) interest total means there is nothing to withhold tax on, so
        both no-op and return false. No behaviour change when interest is actually posted -- a
        non-null positive amount takes the same path as before.
      - Add a unit test (SavingsAccountWithHoldTaxNullAmountTest) that sets a non-null tax
        group so the guard is exercised rather than short-circuited, and asserts that a null
        or zero amount no longer throws and adds no withholding transaction.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
