### PR TITLE
FINERACT-2688: Fix loan disbursement for checker-only users via maker-checker permission check

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.domain;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,6 +29,17 @@ import org.springframework.data.repository.query.Param;
 public interface CommandSourceRepository extends JpaRepository<CommandSource, Long>, JpaSpecificationExecutor<CommandSource> {
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
+
+    @Query("""
+            select c.id from CommandSource c
+            where upper(c.actionName) = upper(:actionName)
+            and upper(c.entityName) = upper(:entityName)
+            and (c.resourceId = :resourceId or c.loanId = :resourceId or c.savingsId = :resourceId)
+            and c.status = :status
+            order by c.madeOnDate desc
+            """)
+    List<Long> findPendingIdsByActionAndEntityAndResource(@Param("actionName") String actionName, @Param("entityName") String entityName,
+            @Param("resourceId") Long resourceId, @Param("status") Integer status);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from CommandSource c where c.status = :status and c.madeOnDate is not null and c.madeOnDate <= :dateForPurgeCriteria")

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -30,19 +30,15 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
 
-    @Query(value = """
-            select distinct c.* from m_portfolio_command_source c
-            where upper(c.action_name) = upper(:actionName)
-            and upper(c.entity_name) = upper(:entityName)
-            and (
-                c.resource_id = :resourceId
-                or c.loan_id = :resourceId
-                or c.savings_account_id = :resourceId
-            )
+    @Query("""
+            select c.id from CommandSource c
+            where upper(c.actionName) = upper(:actionName)
+            and upper(c.entityName) = upper(:entityName)
+            and (c.resourceId = :resourceId or c.loanId = :resourceId or c.savingsId = :resourceId)
             and c.status = :status
-            order by c.made_on_date_utc desc
-            """, nativeQuery = true)
-    List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,
+            order by c.madeOnDate desc
+            """)
+    List<Long> findPendingIdsByActionAndEntityAndResource(@Param("actionName") String actionName,
             @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
 
     @Modifying(flushAutomatically = true)

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.domain;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,6 +29,28 @@ import org.springframework.data.repository.query.Param;
 public interface CommandSourceRepository extends JpaRepository<CommandSource, Long>, JpaSpecificationExecutor<CommandSource> {
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
+
+    @Query(value = """
+            select distinct c.* from m_portfolio_command_source c
+            where upper(c.action_name) = upper(?1)
+            and upper(c.entity_name) = upper(?2)
+            and (
+                c.resource_id = ?3
+                or c.subresource_id = ?3
+                or c.client_id = ?3
+                or c.loan_id = ?3
+                or c.savings_account_id = ?3
+                or c.group_id = ?3
+                or c.office_id = ?3
+                or c.product_id = ?3
+                or c.creditbureau_id = ?3
+                or c.organisation_creditbureau_id = ?3
+            )
+            and c.status = ?4
+            order by c.made_on_date_utc desc
+            """, nativeQuery = true)
+    List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,
+            @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from CommandSource c where c.status = :status and c.madeOnDate is not null and c.madeOnDate <= :dateForPurgeCriteria")

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -30,14 +30,18 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
 
-    @Query("""
-            select distinct c from CommandSource c
-            where upper(c.actionName) = upper(:actionName)
-            and upper(c.entityName) = upper(:entityName)
-            and (c.resourceId = :resourceId or c.loanId = :resourceId or c.savingsId = :resourceId)
+    @Query(value = """
+            select distinct c.* from m_portfolio_command_source c
+            where upper(c.action_name) = upper(:actionName)
+            and upper(c.entity_name) = upper(:entityName)
+            and (
+                c.resource_id = :resourceId
+                or c.loan_id = :resourceId
+                or c.savings_account_id = :resourceId
+            )
             and c.status = :status
-            order by c.madeOnDate desc
-            """)
+            order by c.made_on_date_utc desc
+            """, nativeQuery = true)
     List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,
             @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
 

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -36,15 +36,8 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
             and upper(c.entity_name) = upper(?2)
             and (
                 c.resource_id = ?3
-                or c.subresource_id = ?3
-                or c.client_id = ?3
                 or c.loan_id = ?3
                 or c.savings_account_id = ?3
-                or c.group_id = ?3
-                or c.office_id = ?3
-                or c.product_id = ?3
-                or c.creditbureau_id = ?3
-                or c.organisation_creditbureau_id = ?3
             )
             and c.status = ?4
             order by c.made_on_date_utc desc

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -30,18 +30,14 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
 
-    @Query(value = """
-            select distinct c.* from m_portfolio_command_source c
-            where upper(c.action_name) = upper(:actionName)
-            and upper(c.entity_name) = upper(:entityName)
-            and (
-                c.resource_id = :resourceId
-                or c.loan_id = :resourceId
-                or c.savings_account_id = :resourceId
-            )
+    @Query("""
+            select distinct c from CommandSource c
+            where upper(c.actionName) = upper(:actionName)
+            and upper(c.entityName) = upper(:entityName)
+            and (c.resourceId = :resourceId or c.loanId = :resourceId or c.savingsId = :resourceId)
             and c.status = :status
-            order by c.made_on_date_utc desc
-            """, nativeQuery = true)
+            order by c.madeOnDate desc
+            """)
     List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,
             @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
 

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -32,14 +32,14 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
 
     @Query(value = """
             select distinct c.* from m_portfolio_command_source c
-            where upper(c.action_name) = upper(?1)
-            and upper(c.entity_name) = upper(?2)
+            where upper(c.action_name) = upper(:actionName)
+            and upper(c.entity_name) = upper(:entityName)
             and (
-                c.resource_id = ?3
-                or c.loan_id = ?3
-                or c.savings_account_id = ?3
+                c.resource_id = :resourceId
+                or c.loan_id = :resourceId
+                or c.savings_account_id = :resourceId
             )
-            and c.status = ?4
+            and c.status = :status
             order by c.made_on_date_utc desc
             """, nativeQuery = true)
     List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,

--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -38,8 +38,8 @@ public interface CommandSourceRepository extends JpaRepository<CommandSource, Lo
             and c.status = :status
             order by c.madeOnDate desc
             """)
-    List<Long> findPendingIdsByActionAndEntityAndResource(@Param("actionName") String actionName,
-            @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
+    List<Long> findPendingIdsByActionAndEntityAndResource(@Param("actionName") String actionName, @Param("entityName") String entityName,
+            @Param("resourceId") Long resourceId, @Param("status") Integer status);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from CommandSource c where c.status = :status and c.madeOnDate is not null and c.madeOnDate <= :dateForPurgeCriteria")

--- a/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerCheckerOnlyInitiationException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerCheckerOnlyInitiationException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+/**
+ * Thrown when a checker-only user (has _CHECKER permission but not the base permission) attempts to initiate an action
+ * directly, with no pending maker submission to approve.
+ */
+public class MakerCheckerCheckerOnlyInitiationException extends AbstractPlatformDomainRuleException {
+
+    public MakerCheckerCheckerOnlyInitiationException(final String permissionCode) {
+        super("error.msg.maker.checker.checker.only.cannot.initiate",
+                "You have checker-only permission for this action. You cannot initiate it. Use the maker-checker approval flow to approve a pending submission.",
+                permissionCode);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerDuplicatePendingSubmissionException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerDuplicatePendingSubmissionException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+/**
+ * Thrown when a maker attempts to submit an action that already has a pending checker approval entry for the same
+ * action, entity, and resource.
+ */
+public class MakerCheckerDuplicatePendingSubmissionException extends AbstractPlatformDomainRuleException {
+
+    public MakerCheckerDuplicatePendingSubmissionException(final String actionName, final String entityName) {
+        super("error.msg.maker.checker.duplicate.pending.submission",
+                "This action is already pending checker approval. Please wait for it to be approved or rejected before resubmitting.",
+                actionName, entityName);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
@@ -128,8 +128,7 @@ public class CommandSourceService {
         String permission = commandSource.getPermissionCode();
         boolean isMakerChecker = configurationDomainService.isMakerCheckerEnabledForTask(permission);
         if (isMakerChecker || result.isRollbackTransaction()) {
-            boolean userHasCheckerPermission = !user.hasNotPermissionForAnyOf("CHECKER_SUPER_USER", permission + "_CHECKER");
-            if (isApprovedByChecker || userHasCheckerPermission) {
+            if (isApprovedByChecker || user.isCheckerSuperUser()) {
                 commandSource.markAsChecked(user);
             } else {
                 if (commandSource.isSanitized()) {

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandSourceService.java
@@ -128,7 +128,8 @@ public class CommandSourceService {
         String permission = commandSource.getPermissionCode();
         boolean isMakerChecker = configurationDomainService.isMakerCheckerEnabledForTask(permission);
         if (isMakerChecker || result.isRollbackTransaction()) {
-            if (isApprovedByChecker || user.isCheckerSuperUser()) {
+            boolean userHasCheckerPermission = !user.hasNotPermissionForAnyOf("CHECKER_SUPER_USER", permission + "_CHECKER");
+            if (isApprovedByChecker || userHasCheckerPermission) {
                 commandSource.markAsChecked(user);
             } else {
                 if (commandSource.isSanitized()) {

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -23,11 +23,14 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.exception.CommandNotAwaitingApprovalException;
 import org.apache.fineract.commands.exception.CommandNotFoundException;
+import org.apache.fineract.commands.exception.MakerCheckerCheckerOnlyInitiationException;
+import org.apache.fineract.commands.exception.MakerCheckerDuplicatePendingSubmissionException;
 import org.apache.fineract.commands.exception.UnsupportedCommandException;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -56,18 +59,45 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
     @Override
     public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
         boolean isApprovedByChecker = false;
+        final AppUser currentUser = this.context.authenticatedUser(wrapper);
 
         // check if is update of own account details
-        if (wrapper.isChangeOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+        if (wrapper.isChangeOfOwnUserDetails(currentUser.getId())) {
             // then allow this operation to proceed.
             // maker checker doesnt mean anything here.
             isApprovedByChecker = true; // set to true in case permissions have
                                         // been maker-checker enabled by
                                         // accident.
         } else {
-            // if not user changing their own details - check user has
-            // permission to perform specific task.
-            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+            final String taskPermission = wrapper.getTaskPermissionName();
+            final boolean hasBasePermission = !currentUser.hasNotPermissionForAnyOf(taskPermission);
+            final boolean hasCheckerPermission = !currentUser.hasNotPermissionForAnyOf("CHECKER_SUPER_USER", taskPermission + "_CHECKER");
+
+            if (!hasBasePermission && hasCheckerPermission) {
+                // Checker-only user: find and approve the pending entry for this action+entity+resource
+                final Long resourceId = resolveResourceId(wrapper);
+                final List<Long> pendingIds = findPendingCommandIdsByResource(wrapper, resourceId);
+                if (!pendingIds.isEmpty()) {
+                    final Long pendingCommandId = pendingIds.get(0);
+                    log.debug("Checker-only user {} auto-approving pending command id={} for {}/{}", currentUser.getUsername(),
+                            pendingCommandId, wrapper.entityName(), wrapper.actionName());
+                    return approveEntry(pendingCommandId);
+                } else {
+                    throw new MakerCheckerCheckerOnlyInitiationException(taskPermission);
+                }
+            } else {
+                currentUser.validateHasPermissionTo(taskPermission);
+
+                if (!hasCheckerPermission && configurationService.isMakerCheckerEnabledForTask(taskPermission)) {
+                    final Long resourceId = resolveResourceId(wrapper);
+                    final List<Long> pendingIds = findPendingCommandIdsByResource(wrapper, resourceId);
+                    if (!pendingIds.isEmpty()) {
+                        log.warn("Maker {} attempted duplicate submission for {}/{} - pending id={}", currentUser.getUsername(),
+                                wrapper.entityName(), wrapper.actionName(), pendingIds.get(0));
+                        throw new MakerCheckerDuplicatePendingSubmissionException(wrapper.actionName(), wrapper.entityName());
+                    }
+                }
+            }
         }
         validateIsUpdateAllowed();
 
@@ -140,6 +170,33 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
 
     private void validateIsUpdateAllowed() {
         this.schedulerJobRunnerReadService.isUpdatesAllowed();
+    }
+
+    private List<Long> findPendingCommandIdsByResource(final CommandWrapper wrapper, final Long resourceId) {
+        if (resourceId == null) {
+            return List.of();
+        }
+        return this.commandSourceRepository.findPendingIdsByActionAndEntityAndResource(wrapper.actionName(), wrapper.entityName(),
+                resourceId, CommandProcessingResultType.AWAITING_APPROVAL.getValue());
+    }
+
+    private Long resolveResourceId(final CommandWrapper wrapper) {
+        if (wrapper.getEntityId() != null) {
+            return wrapper.getEntityId();
+        }
+        if (wrapper.getLoanId() != null) {
+            return wrapper.getLoanId();
+        }
+        if (wrapper.getSavingsId() != null) {
+            return wrapper.getSavingsId();
+        }
+        if (wrapper.getClientId() != null) {
+            return wrapper.getClientId();
+        }
+        if (wrapper.getGroupId() != null) {
+            return wrapper.getGroupId();
+        }
+        return null;
     }
 
     @Override

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -23,11 +23,14 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.exception.CommandNotAwaitingApprovalException;
 import org.apache.fineract.commands.exception.CommandNotFoundException;
+import org.apache.fineract.commands.exception.MakerCheckerCheckerOnlyInitiationException;
+import org.apache.fineract.commands.exception.MakerCheckerDuplicatePendingSubmissionException;
 import org.apache.fineract.commands.exception.UnsupportedCommandException;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -56,18 +59,45 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
     @Override
     public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
         boolean isApprovedByChecker = false;
+        final AppUser currentUser = this.context.authenticatedUser(wrapper);
 
         // check if is update of own account details
-        if (wrapper.isChangeOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+        if (wrapper.isChangeOfOwnUserDetails(currentUser.getId())) {
             // then allow this operation to proceed.
             // maker checker doesnt mean anything here.
             isApprovedByChecker = true; // set to true in case permissions have
                                         // been maker-checker enabled by
                                         // accident.
         } else {
-            // if not user changing their own details - check user has
-            // permission to perform specific task.
-            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+            final String taskPermission = wrapper.getTaskPermissionName();
+            final boolean hasBasePermission = !currentUser.hasNotPermissionForAnyOf(taskPermission);
+            final boolean hasCheckerPermission = !currentUser.hasNotPermissionForAnyOf("CHECKER_SUPER_USER", taskPermission + "_CHECKER");
+
+            if (!hasBasePermission && hasCheckerPermission) {
+                // Checker-only user: find and approve the pending entry for this action+entity+resource
+                final Long resourceId = resolveResourceId(wrapper);
+                final List<CommandSource> pendingCommands = findPendingCommandsByResource(wrapper, resourceId);
+                if (!pendingCommands.isEmpty()) {
+                    final CommandSource pendingCommand = pendingCommands.get(0);
+                    log.debug("Checker-only user {} auto-approving pending command id={} for {}/{}", currentUser.getUsername(),
+                            pendingCommand.getId(), wrapper.entityName(), wrapper.actionName());
+                    return approveEntry(pendingCommand.getId());
+                } else {
+                    throw new MakerCheckerCheckerOnlyInitiationException(taskPermission);
+                }
+            } else {
+                currentUser.validateHasPermissionTo(taskPermission);
+
+                if (!hasCheckerPermission && configurationService.isMakerCheckerEnabledForTask(taskPermission)) {
+                    final Long resourceId = resolveResourceId(wrapper);
+                    final List<CommandSource> pendingCommands = findPendingCommandsByResource(wrapper, resourceId);
+                    if (!pendingCommands.isEmpty()) {
+                        log.warn("Maker {} attempted duplicate submission for {}/{} - pending id={}", currentUser.getUsername(),
+                                wrapper.entityName(), wrapper.actionName(), pendingCommands.get(0).getId());
+                        throw new MakerCheckerDuplicatePendingSubmissionException(wrapper.actionName(), wrapper.entityName());
+                    }
+                }
+            }
         }
         validateIsUpdateAllowed();
 
@@ -140,6 +170,33 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
 
     private void validateIsUpdateAllowed() {
         this.schedulerJobRunnerReadService.isUpdatesAllowed();
+    }
+
+    private List<CommandSource> findPendingCommandsByResource(final CommandWrapper wrapper, final Long resourceId) {
+        if (resourceId == null) {
+            return List.of();
+        }
+        return this.commandSourceRepository.findPendingByActionAndEntityAndResource(wrapper.actionName(), wrapper.entityName(), resourceId,
+                CommandProcessingResultType.AWAITING_APPROVAL.getValue());
+    }
+
+    private Long resolveResourceId(final CommandWrapper wrapper) {
+        if (wrapper.getEntityId() != null) {
+            return wrapper.getEntityId();
+        }
+        if (wrapper.getLoanId() != null) {
+            return wrapper.getLoanId();
+        }
+        if (wrapper.getSavingsId() != null) {
+            return wrapper.getSavingsId();
+        }
+        if (wrapper.getClientId() != null) {
+            return wrapper.getClientId();
+        }
+        if (wrapper.getGroupId() != null) {
+            return wrapper.getGroupId();
+        }
+        return null;
     }
 
     @Override

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -76,12 +76,12 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
             if (!hasBasePermission && hasCheckerPermission) {
                 // Checker-only user: find and approve the pending entry for this action+entity+resource
                 final Long resourceId = resolveResourceId(wrapper);
-                final List<CommandSource> pendingCommands = findPendingCommandsByResource(wrapper, resourceId);
-                if (!pendingCommands.isEmpty()) {
-                    final CommandSource pendingCommand = pendingCommands.get(0);
+                final List<Long> pendingIds = findPendingCommandIdsByResource(wrapper, resourceId);
+                if (!pendingIds.isEmpty()) {
+                    final Long pendingCommandId = pendingIds.get(0);
                     log.debug("Checker-only user {} auto-approving pending command id={} for {}/{}", currentUser.getUsername(),
-                            pendingCommand.getId(), wrapper.entityName(), wrapper.actionName());
-                    return approveEntry(pendingCommand.getId());
+                            pendingCommandId, wrapper.entityName(), wrapper.actionName());
+                    return approveEntry(pendingCommandId);
                 } else {
                     throw new MakerCheckerCheckerOnlyInitiationException(taskPermission);
                 }
@@ -90,10 +90,10 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
 
                 if (!hasCheckerPermission && configurationService.isMakerCheckerEnabledForTask(taskPermission)) {
                     final Long resourceId = resolveResourceId(wrapper);
-                    final List<CommandSource> pendingCommands = findPendingCommandsByResource(wrapper, resourceId);
-                    if (!pendingCommands.isEmpty()) {
+                    final List<Long> pendingIds = findPendingCommandIdsByResource(wrapper, resourceId);
+                    if (!pendingIds.isEmpty()) {
                         log.warn("Maker {} attempted duplicate submission for {}/{} - pending id={}", currentUser.getUsername(),
-                                wrapper.entityName(), wrapper.actionName(), pendingCommands.get(0).getId());
+                                wrapper.entityName(), wrapper.actionName(), pendingIds.get(0));
                         throw new MakerCheckerDuplicatePendingSubmissionException(wrapper.actionName(), wrapper.entityName());
                     }
                 }
@@ -172,12 +172,12 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
         this.schedulerJobRunnerReadService.isUpdatesAllowed();
     }
 
-    private List<CommandSource> findPendingCommandsByResource(final CommandWrapper wrapper, final Long resourceId) {
+    private List<Long> findPendingCommandIdsByResource(final CommandWrapper wrapper, final Long resourceId) {
         if (resourceId == null) {
             return List.of();
         }
-        return this.commandSourceRepository.findPendingByActionAndEntityAndResource(wrapper.actionName(), wrapper.entityName(), resourceId,
-                CommandProcessingResultType.AWAITING_APPROVAL.getValue());
+        return this.commandSourceRepository.findPendingIdsByActionAndEntityAndResource(wrapper.actionName(), wrapper.entityName(),
+                resourceId, CommandProcessingResultType.AWAITING_APPROVAL.getValue());
     }
 
     private Long resolveResourceId(final CommandWrapper wrapper) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.PutPermissionsRequest;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.commands.MakercheckersHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
+import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
+import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for the CBS-509 / FINERACT-2688 fix: maker-checker support for checker-only users on loan
+ * disbursement.
+ *
+ * <p>
+ * Covers the complete flow:
+ * <ol>
+ * <li>Maker submits disbursement → queued as AWAITING_APPROVAL (HTTP 200, loanId null)</li>
+ * <li>Maker submits again → HTTP 403 duplicate.pending.submission</li>
+ * <li>Checker-only user submits for loan with no pending entry → HTTP 403 checker.only.cannot.initiate</li>
+ * <li>Checker-only user submits for loan A (has pending entry) → auto-approves and disburses (loanId not null)</li>
+ * <li>Traditional /makerchecker/{id}?command=approve flow still works correctly</li>
+ * </ol>
+ */
+public class LoanDisbursementMakerCheckerIntegrationTest {
+
+    private static final String DISBURSAL_DATE = "01 January 2024";
+    private static final String LOAN_SUBMISSION_DATE = "01 January 2024";
+    private static final String LOAN_TERM_FREQUENCY = "12";
+    private static final String LOAN_REPAYMENT_PERIOD = "1";
+    private static final String LOAN_PRINCIPAL = "10000.00";
+    private static final String DISBURSE_LOAN_PERMISSION = "DISBURSE_LOAN";
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private LoanTransactionHelper loanTransactionHelper;
+    private GlobalConfigurationHelper globalConfigurationHelper;
+    private MakercheckersHelper makercheckersHelper;
+    private RolesHelper rolesHelper;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+        this.globalConfigurationHelper = new GlobalConfigurationHelper();
+        this.makercheckersHelper = new MakercheckersHelper(this.requestSpec, this.responseSpec);
+        this.rolesHelper = new RolesHelper();
+    }
+
+    @Test
+    public void testLoanDisbursementMakerCheckerFlow() {
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+            // Enable maker-checker for loan disbursement
+            rolesHelper.updatePermissions(new PutPermissionsRequest().putPermissionsItem(DISBURSE_LOAN_PERMISSION, true));
+
+            // Maker role: base permission only (no checker permission)
+            Integer makerRoleId = RolesHelper.createRole(requestSpec, responseSpec);
+            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, makerRoleId, Map.of(DISBURSE_LOAN_PERMISSION, true));
+
+            // Checker-only role: checker permission only (no base permission)
+            Integer checkerRoleId = RolesHelper.createRole(requestSpec, responseSpec);
+            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, checkerRoleId, Map.of(DISBURSE_LOAN_PERMISSION + "_CHECKER", true));
+
+            Integer staffId = StaffHelper.createStaff(requestSpec, responseSpec);
+            String makerUsername = Utils.uniqueRandomStringGenerator("mkr", 8);
+            Integer makerUserId = (Integer) UserHelper.createUser(requestSpec, responseSpec, makerRoleId, staffId, makerUsername,
+                    "A1b2c3d4e5f$", "resourceId");
+            String checkerUsername = Utils.uniqueRandomStringGenerator("ckr", 8);
+            UserHelper.createUser(requestSpec, responseSpec, checkerRoleId, staffId, checkerUsername, "A1b2c3d4e5f$", "resourceId");
+
+            RequestSpecification makerRequestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build().header(
+                    "Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey(makerUsername, "A1b2c3d4e5f$"));
+            RequestSpecification checkerRequestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build().header(
+                    "Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey(checkerUsername, "A1b2c3d4e5f$"));
+
+            // Admin creates product, client, and three approved loans
+            Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
+            assertNotNull(clientId);
+            Integer loanProductId = loanTransactionHelper.getLoanProductId(new LoanProductTestBuilder().withPrincipal(LOAN_PRINCIPAL)
+                    .withRepaymentTypeAsMonth().withRepaymentAfterEvery(LOAN_REPAYMENT_PERIOD).withNumberOfRepayments(LOAN_TERM_FREQUENCY)
+                    .withinterestRatePerPeriod("0").withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment()
+                    .withInterestTypeAsFlat().build(null));
+
+            Integer loanIdA = createAndApproveLoan(clientId, loanProductId);
+            Integer loanIdB = createAndApproveLoan(clientId, loanProductId);
+            Integer loanIdC = createAndApproveLoan(clientId, loanProductId);
+
+            LoanTransactionHelper makerLoanHelper = new LoanTransactionHelper(makerRequestSpec, responseSpec);
+            LoanTransactionHelper checkerLoanHelper = new LoanTransactionHelper(checkerRequestSpec, responseSpec);
+            ResponseSpecification forbiddenSpec = new ResponseSpecBuilder().expectStatusCode(403).build();
+
+            // Scenario 1: Maker submits disbursement for loan A → queued as AWAITING_APPROVAL
+            HashMap makerResponseA = makerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL, null);
+            assertNull(makerResponseA.get("loanId"), "Disbursement should be queued for checker approval, not immediately processed");
+
+            List<Map<String, Object>> pendingEntries = makercheckersHelper
+                    .getMakerCheckerList(Map.of("actionName", "DISBURSE", "entityName", "LOAN", "makerId", makerUserId.toString()));
+            assertEquals(1, pendingEntries.size(), "Exactly one pending DISBURSE_LOAN command should exist");
+
+            // Scenario 2: Maker submits again for loan A → 403 duplicate pending submission
+            Object duplicateResult = makerLoanHelper.disburseLoanWithTransactionAmount(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL,
+                    forbiddenSpec);
+            List<Map<String, Object>> duplicateErrors = (List<Map<String, Object>>) duplicateResult;
+            assertEquals("error.msg.maker.checker.duplicate.pending.submission",
+                    duplicateErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE), "Duplicate submission should be rejected");
+
+            // Scenario 3: Checker-only user submits for loan B (no pending entry) → 403 cannot initiate
+            Object noEntryResult = checkerLoanHelper.disburseLoanWithTransactionAmount(DISBURSAL_DATE, loanIdB, LOAN_PRINCIPAL,
+                    forbiddenSpec);
+            List<Map<String, Object>> noEntryErrors = (List<Map<String, Object>>) noEntryResult;
+            assertEquals("error.msg.maker.checker.checker.only.cannot.initiate",
+                    noEntryErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE),
+                    "Checker-only user cannot initiate a new disbursement");
+
+            // Scenario 4: Checker-only user submits for loan A (has pending entry) → auto-approves and disburses
+            HashMap checkerResponseA = checkerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL, null);
+            assertNotNull(checkerResponseA.get("loanId"), "Loan A should be disbursed after checker-only user auto-approval");
+
+            // Scenario 5: Traditional /makerchecker/{id}?command=approve flow is unaffected
+            // Maker queues disbursement for loan C
+            HashMap makerResponseC = makerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdC, LOAN_PRINCIPAL, null);
+            assertNull(makerResponseC.get("loanId"), "Loan C disbursement should be queued");
+
+            List<Map<String, Object>> pendingEntriesC = makercheckersHelper.getMakerCheckerList(Map.of("actionName", "DISBURSE",
+                    "entityName", "LOAN", "makerId", makerUserId.toString(), "resourceId", loanIdC.toString()));
+            assertEquals(1, pendingEntriesC.size(), "Exactly one pending entry for loan C");
+            Long pendingCommandIdC = ((Double) pendingEntriesC.get(0).get("id")).longValue();
+
+            // Admin approves via the existing /makerchecker/{id}?command=approve endpoint
+            HashMap approveResult = MakercheckersHelper.approveMakerCheckerEntry(requestSpec, responseSpec, pendingCommandIdC);
+            assertNotNull(approveResult);
+            assertNotNull(approveResult.get("loanId"), "Loan C should be disbursed after traditional checker approval");
+
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            rolesHelper.updatePermissions(new PutPermissionsRequest().putPermissionsItem(DISBURSE_LOAN_PERMISSION, false));
+        }
+    }
+
+    private Integer createAndApproveLoan(Integer clientId, Integer loanProductId) {
+        String loanJson = new LoanApplicationTestBuilder().withPrincipal(LOAN_PRINCIPAL).withLoanTermFrequency(LOAN_TERM_FREQUENCY)
+                .withLoanTermFrequencyAsMonths().withNumberOfRepayments(LOAN_TERM_FREQUENCY).withRepaymentEveryAfter(LOAN_REPAYMENT_PERIOD)
+                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
+                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
+                .withExpectedDisbursementDate(DISBURSAL_DATE).withSubmittedOnDate(LOAN_SUBMISSION_DATE).withLoanType("individual")
+                .build(clientId.toString(), loanProductId.toString(), null);
+        Integer loanId = loanTransactionHelper.getLoanId(loanJson);
+        assertNotNull(loanId);
+        loanTransactionHelper.approveLoan(DISBURSAL_DATE, loanId);
+        return loanId;
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
@@ -91,12 +91,11 @@ public class LoanDisbursementMakerCheckerIntegrationTest {
 
     @Test
     public void testLoanDisbursementMakerCheckerFlow() {
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
-                new PutGlobalConfigurationsRequest().enabled(true));
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
-                new PutGlobalConfigurationsRequest().enabled(false));
-
         try {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(false));
             // Enable maker-checker for loan disbursement
             rolesHelper.updatePermissions(new PutPermissionsRequest().putPermissionsItem(DISBURSE_LOAN_PERMISSION, true));
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanDisbursementMakerCheckerIntegrationTest.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.PutPermissionsRequest;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.commands.MakercheckersHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
+import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
+import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for the CBS-509 / FINERACT-2688 fix: maker-checker support for checker-only users on loan
+ * disbursement.
+ *
+ * <p>
+ * Covers the complete flow:
+ * <ol>
+ * <li>Maker submits disbursement → queued as AWAITING_APPROVAL (HTTP 200, loanId null)</li>
+ * <li>Maker submits again → HTTP 403 duplicate.pending.submission</li>
+ * <li>Checker-only user submits for loan with no pending entry → HTTP 403 checker.only.cannot.initiate</li>
+ * <li>Checker-only user submits for loan A (has pending entry) → auto-approves and disburses (loanId not null)</li>
+ * <li>Traditional /makerchecker/{id}?command=approve flow still works correctly</li>
+ * </ol>
+ */
+public class LoanDisbursementMakerCheckerIntegrationTest {
+
+    private static final String DISBURSAL_DATE = "01 January 2024";
+    private static final String LOAN_SUBMISSION_DATE = "01 January 2024";
+    private static final String LOAN_TERM_FREQUENCY = "12";
+    private static final String LOAN_REPAYMENT_PERIOD = "1";
+    private static final String LOAN_PRINCIPAL = "10000.00";
+    private static final String DISBURSE_LOAN_PERMISSION = "DISBURSE_LOAN";
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private LoanTransactionHelper loanTransactionHelper;
+    private GlobalConfigurationHelper globalConfigurationHelper;
+    private MakercheckersHelper makercheckersHelper;
+    private RolesHelper rolesHelper;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+        this.globalConfigurationHelper = new GlobalConfigurationHelper();
+        this.makercheckersHelper = new MakercheckersHelper(this.requestSpec, this.responseSpec);
+        this.rolesHelper = new RolesHelper();
+    }
+
+    @Test
+    public void testLoanDisbursementMakerCheckerFlow() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                new PutGlobalConfigurationsRequest().enabled(false));
+
+        try {
+            // Enable maker-checker for loan disbursement
+            rolesHelper.updatePermissions(new PutPermissionsRequest().putPermissionsItem(DISBURSE_LOAN_PERMISSION, true));
+
+            // Maker role: base permission only (no checker permission)
+            Integer makerRoleId = RolesHelper.createRole(requestSpec, responseSpec);
+            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, makerRoleId, Map.of(DISBURSE_LOAN_PERMISSION, true));
+
+            // Checker-only role: checker permission only (no base permission)
+            Integer checkerRoleId = RolesHelper.createRole(requestSpec, responseSpec);
+            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, checkerRoleId, Map.of(DISBURSE_LOAN_PERMISSION + "_CHECKER", true));
+
+            Integer staffId = StaffHelper.createStaff(requestSpec, responseSpec);
+            String makerUsername = Utils.uniqueRandomStringGenerator("mkr", 8);
+            Integer makerUserId = (Integer) UserHelper.createUser(requestSpec, responseSpec, makerRoleId, staffId, makerUsername,
+                    "A1b2c3d4e5f$", "resourceId");
+            String checkerUsername = Utils.uniqueRandomStringGenerator("ckr", 8);
+            UserHelper.createUser(requestSpec, responseSpec, checkerRoleId, staffId, checkerUsername, "A1b2c3d4e5f$", "resourceId");
+
+            RequestSpecification makerRequestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build().header(
+                    "Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey(makerUsername, "A1b2c3d4e5f$"));
+            RequestSpecification checkerRequestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build().header(
+                    "Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey(checkerUsername, "A1b2c3d4e5f$"));
+
+            // Admin creates product, client, and three approved loans
+            Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
+            assertNotNull(clientId);
+            Integer loanProductId = loanTransactionHelper.getLoanProductId(new LoanProductTestBuilder().withPrincipal(LOAN_PRINCIPAL)
+                    .withRepaymentTypeAsMonth().withRepaymentAfterEvery(LOAN_REPAYMENT_PERIOD).withNumberOfRepayments(LOAN_TERM_FREQUENCY)
+                    .withinterestRatePerPeriod("0").withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment()
+                    .withInterestTypeAsFlat().build(null));
+
+            Integer loanIdA = createAndApproveLoan(clientId, loanProductId);
+            Integer loanIdB = createAndApproveLoan(clientId, loanProductId);
+            Integer loanIdC = createAndApproveLoan(clientId, loanProductId);
+
+            LoanTransactionHelper makerLoanHelper = new LoanTransactionHelper(makerRequestSpec, responseSpec);
+            LoanTransactionHelper checkerLoanHelper = new LoanTransactionHelper(checkerRequestSpec, responseSpec);
+            ResponseSpecification forbiddenSpec = new ResponseSpecBuilder().expectStatusCode(403).build();
+
+            // Scenario 1: Maker submits disbursement for loan A → queued as AWAITING_APPROVAL
+            HashMap makerResponseA = makerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL, null);
+            assertNull(makerResponseA.get("loanId"), "Disbursement should be queued for checker approval, not immediately processed");
+
+            List<Map<String, Object>> pendingEntries = makercheckersHelper
+                    .getMakerCheckerList(Map.of("actionName", "DISBURSE", "entityName", "LOAN", "makerId", makerUserId.toString()));
+            assertEquals(1, pendingEntries.size(), "Exactly one pending DISBURSE_LOAN command should exist");
+
+            // Scenario 2: Maker submits again for loan A → 403 duplicate pending submission
+            Object duplicateResult = makerLoanHelper.disburseLoanWithTransactionAmount(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL,
+                    forbiddenSpec);
+            List<Map<String, Object>> duplicateErrors = (List<Map<String, Object>>) duplicateResult;
+            assertEquals("error.msg.maker.checker.duplicate.pending.submission",
+                    duplicateErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE), "Duplicate submission should be rejected");
+
+            // Scenario 3: Checker-only user submits for loan B (no pending entry) → 403 cannot initiate
+            Object noEntryResult = checkerLoanHelper.disburseLoanWithTransactionAmount(DISBURSAL_DATE, loanIdB, LOAN_PRINCIPAL,
+                    forbiddenSpec);
+            List<Map<String, Object>> noEntryErrors = (List<Map<String, Object>>) noEntryResult;
+            assertEquals("error.msg.maker.checker.checker.only.cannot.initiate",
+                    noEntryErrors.get(0).get(CommonConstants.RESPONSE_ERROR_MESSAGE_CODE),
+                    "Checker-only user cannot initiate a new disbursement");
+
+            // Scenario 4: Checker-only user submits for loan A (has pending entry) → auto-approves and disburses
+            HashMap checkerResponseA = checkerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdA, LOAN_PRINCIPAL, null);
+            assertNotNull(checkerResponseA.get("loanId"), "Loan A should be disbursed after checker-only user auto-approval");
+
+            // Scenario 5: Traditional /makerchecker/{id}?command=approve flow is unaffected
+            // Maker queues disbursement for loan C
+            HashMap makerResponseC = makerLoanHelper.disburseLoan(DISBURSAL_DATE, loanIdC, LOAN_PRINCIPAL, null);
+            assertNull(makerResponseC.get("loanId"), "Loan C disbursement should be queued");
+
+            List<Map<String, Object>> pendingEntriesC = makercheckersHelper.getMakerCheckerList(Map.of("actionName", "DISBURSE",
+                    "entityName", "LOAN", "makerId", makerUserId.toString(), "resourceId", loanIdC.toString()));
+            assertEquals(1, pendingEntriesC.size(), "Exactly one pending entry for loan C");
+            Long pendingCommandIdC = ((Double) pendingEntriesC.get(0).get("id")).longValue();
+
+            // Admin approves via the existing /makerchecker/{id}?command=approve endpoint
+            HashMap approveResult = MakercheckersHelper.approveMakerCheckerEntry(requestSpec, responseSpec, pendingCommandIdC);
+            assertNotNull(approveResult);
+            assertNotNull(approveResult.get("loanId"), "Loan C should be disbursed after traditional checker approval");
+
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(false));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_SAME_MAKER_CHECKER,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            rolesHelper.updatePermissions(new PutPermissionsRequest().putPermissionsItem(DISBURSE_LOAN_PERMISSION, false));
+        }
+    }
+
+    private Integer createAndApproveLoan(Integer clientId, Integer loanProductId) {
+        String loanJson = new LoanApplicationTestBuilder().withPrincipal(LOAN_PRINCIPAL).withLoanTermFrequency(LOAN_TERM_FREQUENCY)
+                .withLoanTermFrequencyAsMonths().withNumberOfRepayments(LOAN_TERM_FREQUENCY).withRepaymentEveryAfter(LOAN_REPAYMENT_PERIOD)
+                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
+                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
+                .withExpectedDisbursementDate(DISBURSAL_DATE).withSubmittedOnDate(LOAN_SUBMISSION_DATE).withLoanType("individual")
+                .build(clientId.toString(), loanProductId.toString(), null);
+        Integer loanId = loanTransactionHelper.getLoanId(loanJson);
+        assertNotNull(loanId);
+        loanTransactionHelper.approveLoan(DISBURSAL_DATE, loanId);
+        return loanId;
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanNextPaymentDueAmountIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanNextPaymentDueAmountIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.fineract.infrastructure.event.external.data.ExternalEventRespo
 import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,13 @@ public class LoanNextPaymentDueAmountIntegrationTest extends FeignLoanTestBase {
 
     ObjectMapper objectMapper = new ObjectMapper();
     private static final String LOAN_ACCOUNT_DATA_V_1 = "org.apache.fineract.avro.loan.v1.LoanAccountDataV1";
+
+    @AfterEach
+    void disableBusinessEvents() {
+        externalEventHelper.disableBusinessEvent("LoanApprovedBusinessEvent");
+        externalEventHelper.disableBusinessEvent("LoanBalanceChangedBusinessEvent");
+        externalEventHelper.disableBusinessEvent("LoanDisbursalBusinessEvent");
+    }
 
     @Test
     void test_progressive_interest_noRecalculation() {


### PR DESCRIPTION
## Summary                                                                                                                                                                        
                                                                                                                                                                                    
  Fixes a bug where a user holding only a role-specific `_CHECKER` permission (e.g. `DISBURSE_LOAN_CHECKER`) was rejected with a permission error instead of being routed to the    
  pending maker-checker approval queue.                                                                                                                                             
                                                                                                                                                                                    
  **Root causes:**                                                                                                                                                                  
  - `PortfolioCommandSourceWritePlatformServiceImpl.logCommandSource()` called `validateHasPermissionTo(taskPermission)` unconditionally, rejecting checker-only users              
  - `CommandSourceService.validateMakerChecker()` only marked a command as checked for `CHECKER_SUPER_USER`, ignoring role-specific `_CHECKER` permissions                          
                                                                                                                                                                                    
  **Changes:**                                                                                                                                                                      
  - `logCommandSource()`: detect checker-only users (has `_CHECKER` but not base permission), auto-approve the pending AWAITING_APPROVAL entry; block makers from duplicate pending 
  submissions                                                                                                                                                                       
  - `validateMakerChecker()`: replace `isCheckerSuperUser()` with `hasNotPermissionForAnyOf("CHECKER_SUPER_USER", permission + "_CHECKER")`                                         
  - Add `CommandSourceRepository.findPendingByActionAndEntityAndResource()` native SQL query                                                                                        
  - Add `MakerCheckerCheckerOnlyInitiationException` and `MakerCheckerDuplicatePendingSubmissionException` (both → HTTP 403)                                                        
                                                                                                                                                                                    
  ## JIRA                                                                                                                                                                           
  https://issues.apache.org/jira/browse/FINERACT-2688                                                                                                                               
                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                      
  - [ ] Enable maker-checker for loan disbursement                                                                                                                                  
  - [ ] Maker submits → queued as AWAITING_APPROVAL                                                                                                                                 
  - [ ] Maker submits again → HTTP 403 `error.msg.maker.checker.duplicate.pending.submission`                                                                                       
  - [ ] Checker-only user (has `DISBURSE_LOAN_CHECKER`) submits → auto-approves and disburses                                                                                       
  - [ ] Checker-only with no pending entry → HTTP 403 `error.msg.maker.checker.checker.only.cannot.initiate`                                                                        
  - [ ] Existing `/makerchecker/{id}` approve/reject flow unaffected  