### PR TITLE
FINERACT-2678: Release Apache Fineract 1.15.0

### DIFF
--- a/.atr-rat-excludes-src.txt
+++ b/.atr-rat-excludes-src.txt
@@ -35,20 +35,20 @@
 # with en_US.UTF-8 lang/locale
 **/META-INF/fineract-test.config
 **/legacy-docs/
-*.adoc
-*.avsc
-*.feature
-*.html
-*.md
-*.mustache
-*.puml
-*.txt
-.openapi-generator-ignore
+**/*.adoc
+**/*.avsc
+**/features/**
+**/*.html
+**/*.md
+**/*.mustache
+**/*.puml
+**/*.txt
+**/.openapi-generator-ignore
 /.asf.yaml
 /.rat-excludes
 /config/fineractdev-eclipse-preferences.epf
 /fineract-provider/src/test/resources/results/xbrl.xml
 /gradle/wrapper/gradle-wrapper.properties
-org.springframework.boot.autoconfigure.AutoConfiguration.imports
+**/org.springframework.boot.autoconfigure.AutoConfiguration.imports
 
 # vim:ft=conf

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/productmix/handler/ProductMixCreateCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/productmix/handler/ProductMixCreateCommandHandler.java
@@ -4,12 +4,6 @@
  * distributed with this work for additional information
  * regarding copyright ownership. The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
- /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *


### PR DESCRIPTION
This PR fulfills [step 13 of the release process](https://fineract.apache.org/docs/rc/#_step_13_close_release_branch): closing the release branch so release-specific changes and tags are merged to `develop` so they persist for future releases. This also makes sure `git describe` works as expected.