### PR TITLE
FINERACT-2593: Fix NullPointerException in DelinquencyReadPlatformServiceImpl when loan product is null

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImpl.java
@@ -156,7 +156,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
 
             // If the Loan is not Active yet or is cancelled (rejected or withdrawn), return template data
             if (loan.isSubmittedAndPendingApproval() || loan.isApproved() || loan.isCancelled()) {
-                if (loan.getLoanProduct() == null || loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
+                if (loan.getLoanProduct() != null && loan.getLoanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
                     collectionData.setAvailableDisbursementAmountWithOverApplied(calculateAvailableDisbursementAmountWithOverApplied(loan));
                 }
                 return collectionData;
@@ -212,7 +212,7 @@ public class DelinquencyReadPlatformServiceImpl implements DelinquencyReadPlatfo
         BigDecimal approvedWithOverApplied = loan.getApprovedPrincipal();
 
         // If over applied amount is enabled, calculate the maximum allowed amount
-        if (loanProduct.isAllowApprovedDisbursedAmountsOverApplied()) {
+        if (loanProduct != null && loanProduct.isAllowApprovedDisbursedAmountsOverApplied()) {
             if (loanProduct.getOverAppliedCalculationType() != null) {
                 if ("percentage".equalsIgnoreCase(loanProduct.getOverAppliedCalculationType())) {
                     final BigDecimal overAppliedNumber = BigDecimal.valueOf(loanProduct.getOverAppliedNumber());

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyReadPlatformServiceImplTest.java
@@ -20,24 +20,36 @@ package org.apache.fineract.portfolio.delinquency.service;
 
 import static java.time.Month.JANUARY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
+import org.apache.fineract.portfolio.delinquency.domain.DelinquencyMinimumPaymentPeriodAndRuleRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyAction;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyActionRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanDelinquencyTagHistoryRepository;
 import org.apache.fineract.portfolio.delinquency.domain.LoanInstallmentDelinquencyTagRepository;
+import org.apache.fineract.portfolio.delinquency.helper.DelinquencyEffectivePauseHelper;
 import org.apache.fineract.portfolio.delinquency.mapper.DelinquencyBucketMapper;
 import org.apache.fineract.portfolio.delinquency.mapper.DelinquencyRangeMapper;
 import org.apache.fineract.portfolio.delinquency.mapper.LoanDelinquencyTagMapper;
 import org.apache.fineract.portfolio.delinquency.validator.LoanDelinquencyActionData;
 import org.apache.fineract.portfolio.loanaccount.data.CollectionData;
 import org.apache.fineract.portfolio.loanaccount.data.DelinquencyPausePeriod;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,6 +86,16 @@ class DelinquencyReadPlatformServiceImplTest {
 
     @Mock
     private LoanDelinquencyActionRepository loanDelinquencyActionRepository;
+    @Mock
+    private DelinquencyMinimumPaymentPeriodAndRuleRepository minimumPaymentPeriodAndRuleRepository;
+    @Mock
+    private DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private LoanTransactionRepository loanTransactionRepository;
+    @Mock
+    private PossibleNextRepaymentCalculationServiceDiscovery possibleNextRepaymentCalculationServiceDiscovery;
 
     @InjectMocks
     private DelinquencyReadPlatformServiceImpl underTest;
@@ -192,4 +214,50 @@ class DelinquencyReadPlatformServiceImplTest {
         return new DelinquencyPausePeriod(active, LocalDate.parse(startDate), LocalDate.parse(endDate));
     }
 
+    @Test
+    public void testCalculateLoanCollectionDataWhenLoanProductIsNullAndLoanIsPendingApproval() {
+        // given
+        Loan loan = mock(Loan.class);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+        // when
+        CollectionData result = underTest.calculateLoanCollectionData(1L);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAvailableDisbursementAmountWithOverApplied()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    public void testCalculateAvailableDisbursementAmountWithOverAppliedWhenLoanProductIsNull() {
+        // given
+        Loan loan = mock(Loan.class);
+        when(loan.getLoanProduct()).thenReturn(null);
+        when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(5000));
+        when(loan.getDisbursedAmount()).thenReturn(BigDecimal.valueOf(2000));
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+        // when
+        BigDecimal result = underTest.calculateAvailableDisbursementAmountWithOverApplied(loan);
+        // then
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(3000));
+    }
+
+    @Test
+    public void testCalculateAvailableDisbursementAmountWithOverAppliedWhenLoanProductPresentAndOverApplyEnabled() {
+        // given
+        Loan loan = mock(Loan.class);
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loanProduct.isAllowApprovedDisbursedAmountsOverApplied()).thenReturn(true);
+        when(loanProduct.getOverAppliedCalculationType()).thenReturn("flat");
+        when(loanProduct.getOverAppliedNumber()).thenReturn(500);
+        when(loan.getProposedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getApprovedPrincipal()).thenReturn(BigDecimal.valueOf(10000));
+        when(loan.getDisbursedAmount()).thenReturn(BigDecimal.ZERO);
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(mock(LoanProductRelatedDetail.class));
+        // when
+        BigDecimal result = underTest.calculateAvailableDisbursementAmountWithOverApplied(loan);
+        // then
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(10500));
+    }
 }


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/FINERACT-2593

### Problem
`DelinquencyReadPlatformServiceImpl.calculateLoanCollectionData` had an inverted null check (`== null ||` instead of `!= null &&`) in the pending/approved/cancelled branch. When `loan.getLoanProduct()` returned null, that inverted condition actually routed execution straight into `calculateAvailableDisbursementAmountWithOverApplied(loan)`, which then dereferenced `loanProduct` with no guard at all. That gave two separate crash surfaces coming from the same root cause, both producing an unhandled NPE (HTTP 500).

### Fix
- Corrected the operator in the pending/approved/cancelled branch, so the helper is only called when a `LoanProduct` is actually present.
- Added a null guard inside `calculateAvailableDisbursementAmountWithOverApplied` itself. This method is part of the public `DelinquencyReadPlatformService` interface and is also called directly by `LoanReadPlatformServiceImpl.retrieveApprovalTemplate` and `retrieveDisbursalTemplate`, so guarding it there protects those call sites too, not just this one.

### Why no other guards were added
Every call path we could find loads the `Loan` and reads `getLoanProduct()` inside the same `@Transactional(readOnly = true)` method, so the lazy-loaded `loanProduct` proxy should always be initializable in practice. Rather than sprinkling defensive null checks everywhere, the fix stays scoped to the two places that were actually broken.

### Tests
- Null product loan hitting the pending/approved/cancelled branch: no exception, over-applied field stays at its default.
- Null product loan calling the helper directly: no exception, returns a sensible value instead of crashing.
- A regression test with a non-null product and over-apply enabled, to make sure the fix didn't break the working case.