### PR TITLE
FINERACT-2690: Fix undo account transfer to resolve and scope by tran…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -504,15 +504,21 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
 
     @Override
     public CommandProcessingResult undo(JsonCommand command) {
-        AccountTransferDetails accountTransferDetails = accountTransferDetailRepository.findById(command.entityId())
-                .orElseThrow(() -> new AccountTransferNotFoundException(command.entityId()));
+        final Long accountTransferId = command.entityId();
+        // accountTransferId is the id exposed by the transfer read/list APIs, i.e. m_account_transfer_transaction.id.
+        // Resolving against that table (rather than m_account_transfer_details) means the lookup always matches
+        // what a caller can actually see, and reversal is scoped to this single transaction only - not every
+        // transaction sharing the same details record (e.g. a recurring standing instruction).
+        final AccountTransferTransaction transaction = accountTransferRepository.findById(accountTransferId)
+                .orElseThrow(() -> new AccountTransferNotFoundException(accountTransferId));
 
-        if (accountTransferDetails.getAccountTransferTransactions().stream().anyMatch(AccountTransferTransaction::isReversed)) {
+        if (transaction.isReversed()) {
             throw new GeneralPlatformDomainRuleException("error.msg.account.transfer.already.reversed",
-                    "Account transfer is already reverted", command.entityId());
+                    "Account transfer is already reverted", accountTransferId);
         }
 
         final PaymentDetail paymentDetail = null;
+        final AccountTransferDetails accountTransferDetails = transaction.getAccountTransferDetails();
 
         PortfolioAccountType fromAccountType = accountTransferDetails.fromLoanAccount() != null ? PortfolioAccountType.LOAN
                 : accountTransferDetails.fromSavingsAccount() != null ? PortfolioAccountType.SAVINGS : throwUnsupported();
@@ -521,32 +527,28 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                 : accountTransferDetails.toSavingsAccount() != null ? PortfolioAccountType.SAVINGS : throwUnsupported();
 
         if (isSavingsToSavingsAccountTransfer(fromAccountType, toAccountType)) {
-            accountTransferDetails.getAccountTransferTransactions().forEach(transaction -> {
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getFromSavingsTransaction().getId(), true);
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getToSavingsTransaction().getId(), true);
-                transaction.reverse();
-            });
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getFromSavingsTransaction().getId(), true);
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getToSavingsTransaction().getId(), true);
+            transaction.reverse();
         } else if (isSavingsToLoanAccountTransfer(fromAccountType, toAccountType)) {
-            accountTransferDetails.getAccountTransferTransactions().forEach(transaction -> {
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getFromSavingsTransaction().getId(), true);
-                final ExternalId reversalTxnExternalId = externalIdFactory.create();
-                LoanAdjustmentParameter parameter = LoanAdjustmentParameter.builder().transactionAmount(BigDecimal.ZERO)
-                        .paymentDetail(paymentDetail).transactionDate(transaction.getToLoanTransaction().getTransactionDate())
-                        .txnExternalId(transaction.getToLoanTransaction().getExternalId()).reversalTxnExternalId(reversalTxnExternalId)
-                        .noteText(null).build();
-                this.loanAdjustmentService.adjustLoanTransaction(transaction.getToLoanTransaction().getLoan(),
-                        transaction.getToLoanTransaction(), parameter, null, new HashMap<>());
-                transaction.reverse();
-            });
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getFromSavingsTransaction().getId(), true);
+            final ExternalId reversalTxnExternalId = externalIdFactory.create();
+            LoanAdjustmentParameter parameter = LoanAdjustmentParameter.builder().transactionAmount(BigDecimal.ZERO)
+                    .paymentDetail(paymentDetail).transactionDate(transaction.getToLoanTransaction().getTransactionDate())
+                    .txnExternalId(transaction.getToLoanTransaction().getExternalId()).reversalTxnExternalId(reversalTxnExternalId)
+                    .noteText(null).build();
+            this.loanAdjustmentService.adjustLoanTransaction(transaction.getToLoanTransaction().getLoan(),
+                    transaction.getToLoanTransaction(), parameter, null, new HashMap<>());
+            transaction.reverse();
         } else if (isLoanToSavingsAccountTransfer(fromAccountType, toAccountType)) {
             throw new UnsupportedOperationException("Undo Loan to Savings Account Transfer is not implemented");
         }
 
         final CommandProcessingResultBuilder builder = new CommandProcessingResultBuilder() //
-                .withEntityId(accountTransferDetails.getId());
+                .withEntityId(transaction.getId());
 
         return builder.build();
     }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -273,4 +273,5 @@
     <include file="parts/0251_add_disallow_backdated_transactions_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0252_trial_balance_summary_update_originator_external_ids.xml" relativeToChangelogFile="true" />
     <include file="parts/0253_remove_unused_entity_access.xml" relativeToChangelogFile="true" />
+    <include file="parts/0254_add_undo_accounttransfer_permission.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -263,4 +263,5 @@
     <include file="parts/0242_update_m_tellers_unique_key.xml" relativeToChangelogFile="true" />
     <include file="parts/0243_add_client_lifecycle_event_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0244_add_payment_detail_to_account_transfer_transaction.xml" relativeToChangelogFile="true" />
+    <include file="parts/0245_add_undo_accounttransfer_permission.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_add_undo_accounttransfer_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_add_undo_accounttransfer_permission.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(1) FROM m_permission WHERE code = 'UNDO_ACCOUNTTRANSFER'
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="UNDO_ACCOUNTTRANSFER"/>
+            <column name="entity_name" value="ACCOUNTTRANSFER"/>
+            <column name="action_name" value="UNDO"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0254_add_undo_accounttransfer_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0254_add_undo_accounttransfer_permission.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(1) FROM m_permission WHERE code = 'UNDO_ACCOUNTTRANSFER'
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="UNDO_ACCOUNTTRANSFER"/>
+            <column name="entity_name" value="ACCOUNTTRANSFER"/>
+            <column name="action_name" value="UNDO"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
  AccountTransfersWritePlatformServiceImpl.undo() had two related defects, discovered while testing the undo-account-transfer capability added in FINERACT-2604 and extended in FINERACT-2613:                                                                      
                                                                                                                                                                                                                                                                    
  1. Wrong lookup table. The endpoint's path id was resolved against m_account_transfer_details, but AccountTransfersReadPlatformServiceImpl.retrieveOne (which backs the transfer read/list APIs) queries by m_account_transfer_transaction.id. These are two      
  independent, unrelated id sequences that drift apart over time, so a caller undoing a transfer they can clearly see via the list/read endpoints could get a 404.                                                                                                  
  2. Over-reversal on recurring transfers. undo() reversed every AccountTransferTransaction tied to the resolved AccountTransferDetails record, rather than only the single transaction the caller asked to undo. This incorrectly reversed every execution of a    
  recurring transfer (e.g. a standing instruction) sharing one details row across many runs.                                                                                                                                                                        
                                                                                                                                                                                                                                                                    
  This PR fixes undo() to resolve and scope by m_account_transfer_transaction id instead, for both the savings-to-loan and savings-to-savings paths, so:                                                                                                            
  - the id passed to undo matches what the read/list APIs actually expose, and                                                                                                                                                                                      
  - only the specific transaction requested is reversed, leaving sibling executions of a recurring transfer untouched.                                                                                                                                              
                                                                                                                                                                                                                                                                    
  It also adds the missing UNDO_ACCOUNTTRANSFER permission (entityName=ACCOUNTTRANSFER, actionName=UNDO) via a new Liquibase changelog part — the command handler was already wired to check this permission, but no matching m_permission row was ever shipped, so 
  the command failed permission validation before reaching the (buggy) logic above.