### PR TITLE
FINERACT-2692: Fix missing externalId for Groups and Centers

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/group/data/CenterData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/group/data/CenterData.java
@@ -259,6 +259,10 @@ public final class CenterData implements Serializable {
         return collectionMeetingCalendar;
     }
 
+    public String getExternalId() {
+        return this.externalId;
+    }
+
     public String getStaffName() {
         return this.staffName;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResourceSwagger.java
@@ -95,6 +95,8 @@ final class CentersApiResourceSwagger {
             public Boolean active;
             @Schema(example = "Center 1")
             public String name;
+            @Schema(example = "EXT-001")
+            public String externalId;
             @Schema(example = "1")
             public Long officeId;
             @Schema(example = "Head Office")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/CentersApiResourceSwagger.java
@@ -94,6 +94,8 @@ final class CentersApiResourceSwagger {
             public Boolean active;
             @Schema(example = "Center 1")
             public String name;
+            @Schema(example = "EXT-001")
+            public String externalId;
             @Schema(example = "1")
             public Long officeId;
             @Schema(example = "Head Office")
@@ -119,6 +121,8 @@ final class CentersApiResourceSwagger {
         public Boolean active;
         @Schema(example = "First Center (No groups)")
         public String name;
+        @Schema(example = "EXT-001")
+        public String externalId;
         @Schema(example = "1")
         public Long officeId;
         @Schema(example = "Head Office")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResourceSwagger.java
@@ -139,6 +139,8 @@ final class GroupsApiResourceSwagger {
             public Long id;
             @Schema(example = "AnotherGroup")
             public String name;
+            @Schema(example = "000-1A")
+            public String externalId;
             public GetGroupsStatus status;
             @Schema(example = "false")
             public Boolean active;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/api/GroupsApiResourceSwagger.java
@@ -138,6 +138,8 @@ final class GroupsApiResourceSwagger {
             public Long id;
             @Schema(example = "AnotherGroup")
             public String name;
+            @Schema(example = "000-1A")
+            public String externalId;
             public GetGroupsStatus status;
             @Schema(example = "false")
             public Boolean active;
@@ -197,8 +199,18 @@ final class GroupsApiResourceSwagger {
         public Long officeId;
         @Schema(example = "Pending Group")
         public String name;
+        @Schema(example = "000-1A")
+        public String externalId;
         @Schema(example = "false")
         public Boolean active;
+        @Schema(example = "04 March 2011")
+        public String activationDate;
+        @Schema(example = "04 March 2011")
+        public String submittedOnDate;
+        @Schema(example = "dd MMMM yyyy")
+        public String dateFormat;
+        @Schema(example = "en")
+        public String locale;
     }
 
     @Schema(description = "PostGroupsResponse")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
@@ -47,6 +47,7 @@ import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
 import org.apache.fineract.infrastructure.dataqueries.data.StatusEnum;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
@@ -118,12 +119,14 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
     private final EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService;
     private final BusinessEventNotifierService businessEventNotifierService;
     private final LoanOfficerService loanOfficerService;
+    private final ExternalIdFactory externalIdFactory;
 
     private CommandProcessingResult createGroupingType(final JsonCommand command, final GroupTypes groupingType, final Long centerId) {
         try {
             final String accountNo = command.stringValueOfParameterNamed(GroupingTypesApiConstants.accountNoParamName);
             final String name = command.stringValueOfParameterNamed(GroupingTypesApiConstants.nameParamName);
-            final String externalId = command.stringValueOfParameterNamed(GroupingTypesApiConstants.externalIdParamName);
+            final String externalId = this.externalIdFactory.createFromCommand(command, GroupingTypesApiConstants.externalIdParamName)
+                    .getValue();
 
             final AppUser currentUser = this.context.authenticatedUser();
             Long officeId = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/starter/GroupConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/starter/GroupConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrappe
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.data.PaginationParametersDataValidator;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
@@ -92,14 +93,15 @@ public class GroupConfiguration {
             ConfigurationDomainService configurationDomainService, SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper,
             AccountNumberFormatRepositoryWrapper accountNumberFormatRepository, AccountNumberGenerator accountNumberGenerator,
             EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService,
-            BusinessEventNotifierService businessEventNotifierService, LoanOfficerService loanOfficerService
+            BusinessEventNotifierService businessEventNotifierService, LoanOfficerService loanOfficerService,
+            ExternalIdFactory externalIdFactory
 
     ) {
         return new GroupingTypesWritePlatformServiceJpaRepositoryImpl(context, groupRepository, clientRepositoryWrapper,
                 officeRepositoryWrapper, staffRepository, noteRepository, groupLevelRepository, fromApiJsonDeserializer,
                 loanRepositoryWrapper, codeValueRepository, commandProcessingService, calendarInstanceRepository,
                 configurationDomainService, savingsAccountRepositoryWrapper, accountNumberFormatRepository, accountNumberGenerator,
-                entityDatatableChecksWritePlatformService, businessEventNotifierService, loanOfficerService
+                entityDatatableChecksWritePlatformService, businessEventNotifierService, loanOfficerService, externalIdFactory
 
         );
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/starter/GroupConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/group/starter/GroupConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrappe
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.data.PaginationParametersDataValidator;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
@@ -91,14 +92,15 @@ public class GroupConfiguration {
             ConfigurationDomainService configurationDomainService, SavingsAccountRepositoryWrapper savingsAccountRepositoryWrapper,
             AccountNumberFormatRepositoryWrapper accountNumberFormatRepository, AccountNumberGenerator accountNumberGenerator,
             EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService,
-            BusinessEventNotifierService businessEventNotifierService, LoanOfficerService loanOfficerService
+            BusinessEventNotifierService businessEventNotifierService, LoanOfficerService loanOfficerService,
+            ExternalIdFactory externalIdFactory
 
     ) {
         return new GroupingTypesWritePlatformServiceJpaRepositoryImpl(context, groupRepository, clientRepositoryWrapper,
                 officeRepositoryWrapper, staffRepository, noteRepository, groupLevelRepository, fromApiJsonDeserializer,
                 loanRepositoryWrapper, codeValueRepository, commandProcessingService, calendarInstanceRepository,
                 configurationDomainService, savingsAccountRepositoryWrapper, accountNumberFormatRepository, accountNumberGenerator,
-                entityDatatableChecksWritePlatformService, businessEventNotifierService, loanOfficerService
+                entityDatatableChecksWritePlatformService, businessEventNotifierService, loanOfficerService, externalIdFactory
 
         );
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,12 +43,14 @@ import org.apache.fineract.client.models.GetCentersGroupMembers;
 import org.apache.fineract.client.models.GetCentersPageItems;
 import org.apache.fineract.client.models.PutCentersCenterIdRequest;
 import org.apache.fineract.client.models.PutCentersChanges;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignCenterHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignGroupHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignOfficeHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignStaffHelper;
 import org.apache.fineract.integrationtests.common.CenterHelper;
 import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -162,6 +165,25 @@ public class CenterIntegrationTest {
 
         final Object response = CenterHelper.listCentersRaw("id", maliciousSortOrder, true, requestSpec, expectBadRequest);
         assertNotNull(response, "Expected a validation-error response body, not a silent 200");
+    }
+
+    @Test
+    public void testCenterCreationWithoutExternalIdGeneratesOne() {
+        final GlobalConfigurationHelper globalConfigurationHelper = new GlobalConfigurationHelper();
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        try {
+            Long officeId = officeHelper.createOffice(OFFICE_OPENING_DATE).getResourceId();
+            String name = "TestNoExternalId" + new Timestamp(new Date().getTime());
+            Long resourceId = centerHelper.createCenter(name, officeId).getResourceId();
+            GetCentersCenterIdResponse center = centerHelper.retrieveCenter(resourceId);
+
+            assertNotNull(center);
+            assertNotNull(center.getExternalId());
+            assertFalse(center.getExternalId().isBlank());
+            assertNotEquals("null", center.getExternalId());
+        } finally {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        }
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CenterIntegrationTest.java
@@ -32,8 +32,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.common.CenterDomain;
 import org.apache.fineract.integrationtests.common.CenterHelper;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.GroupHelper;
 import org.apache.fineract.integrationtests.common.OfficeHelper;
 import org.apache.fineract.integrationtests.common.Utils;
@@ -101,6 +103,25 @@ public class CenterIntegrationTest {
         Assertions.assertTrue(center.getStaffId() == staffId);
         Assertions.assertTrue(center.isActive() == false);
         Assertions.assertArrayEquals(center.getGroupMembers(), groupMembers);
+    }
+
+    @Test
+    public void testCenterCreationWithoutExternalIdGeneratesOne() {
+        final GlobalConfigurationHelper globalConfigurationHelper = new GlobalConfigurationHelper();
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        try {
+            int officeId = new OfficeHelper().createOffice(LocalDate.of(2007, 7, 1)).getResourceId().intValue();
+            String name = "TestNoExternalId" + new Timestamp(new java.util.Date().getTime());
+            int resourceId = CenterHelper.createCenter(name, officeId, requestSpec, responseSpec);
+            CenterDomain center = CenterHelper.retrieveByID(resourceId, requestSpec, responseSpec);
+
+            Assertions.assertNotNull(center);
+            Assertions.assertNotNull(center.getExternalId());
+            Assertions.assertFalse(center.getExternalId().isBlank());
+            Assertions.assertNotEquals("null", center.getExternalId());
+        } finally {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        }
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/GroupTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/GroupTest.java
@@ -23,12 +23,21 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetGroupsGroupIdResponse;
+import org.apache.fineract.client.models.PostGroupsRequest;
+import org.apache.fineract.client.models.PostGroupsResponse;
+import org.apache.fineract.client.util.Calls;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignGroupHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignStaffHelper;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
+import org.apache.fineract.integrationtests.common.GroupHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
 import org.junit.jupiter.api.BeforeAll;
@@ -70,6 +79,46 @@ public class GroupTest extends FeignLoanTestBase {
         final String updatedGroupName = Utils.uniqueRandomStringGenerator("Group-", 5);
         groupHelper.updateGroup(groupId, updatedGroupName);
         assertEquals(updatedGroupName, groupHelper.retrieveGroup(groupId).getName(), "ERROR IN UPDATING THE GROUP NAME");
+    }
+
+    @Test
+    public void testGroupCreationWithoutExternalIdGeneratesOne() {
+        final GlobalConfigurationHelper globalConfigurationHelper = new GlobalConfigurationHelper();
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        try {
+            final PostGroupsRequest request = groupRequest(null);
+            final PostGroupsResponse response = Calls.ok(FineractClientHelper.getFineractClient().groups.createGroup(request));
+
+            final GetGroupsGroupIdResponse group = Calls
+                    .ok(FineractClientHelper.getFineractClient().groups.retrieveOneGroup(response.getGroupId(), false, null));
+            assertThat(group.getExternalId()).isNotBlank();
+            assertNotEquals("null", group.getExternalId());
+        } finally {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        }
+    }
+
+    @Test
+    public void testGroupCreationWithExternalIdIsPersisted() {
+        final String externalId = UUID.randomUUID().toString();
+        final PostGroupsRequest request = groupRequest(externalId);
+        final PostGroupsResponse response = Calls.ok(FineractClientHelper.getFineractClient().groups.createGroup(request));
+
+        final GetGroupsGroupIdResponse group = Calls
+                .ok(FineractClientHelper.getFineractClient().groups.retrieveOneGroup(response.getGroupId(), false, null));
+        assertThat(group.getExternalId()).isEqualTo(externalId);
+    }
+
+    private static PostGroupsRequest groupRequest(final String externalId) {
+        final PostGroupsRequest request = new PostGroupsRequest();
+        request.officeId(1L);
+        request.name(GroupHelper.randomNameGenerator("Group_Name_", 5));
+        request.externalId(externalId);
+        request.active(true);
+        request.activationDate("04 March 2011");
+        request.dateFormat("dd MMMM yyyy");
+        request.locale("en");
+        return request;
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/GroupTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/GroupTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -31,8 +32,16 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
+import org.apache.fineract.client.models.GetGroupsGroupIdResponse;
+import org.apache.fineract.client.models.PostGroupsRequest;
+import org.apache.fineract.client.models.PostGroupsResponse;
+import org.apache.fineract.client.util.Calls;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.common.FineractClientHelper;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.GroupHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
@@ -98,6 +107,46 @@ public class GroupTest {
         // groupID.toString());
         // GroupHelper.verifyGroupDeleted(this.requestSpec, this.responseSpec,
         // groupID);
+    }
+
+    @Test
+    public void testGroupCreationWithoutExternalIdGeneratesOne() {
+        final GlobalConfigurationHelper globalConfigurationHelper = new GlobalConfigurationHelper();
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        try {
+            final PostGroupsRequest request = groupRequest(null);
+            final PostGroupsResponse response = Calls.ok(FineractClientHelper.getFineractClient().groups.createGroup(request));
+
+            final GetGroupsGroupIdResponse group = Calls
+                    .ok(FineractClientHelper.getFineractClient().groups.retrieveOneGroup(response.getGroupId(), false, null));
+            assertThat(group.getExternalId()).isNotBlank();
+            assertNotEquals("null", group.getExternalId());
+        } finally {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        }
+    }
+
+    @Test
+    public void testGroupCreationWithExternalIdIsPersisted() {
+        final String externalId = UUID.randomUUID().toString();
+        final PostGroupsRequest request = groupRequest(externalId);
+        final PostGroupsResponse response = Calls.ok(FineractClientHelper.getFineractClient().groups.createGroup(request));
+
+        final GetGroupsGroupIdResponse group = Calls
+                .ok(FineractClientHelper.getFineractClient().groups.retrieveOneGroup(response.getGroupId(), false, null));
+        assertThat(group.getExternalId()).isEqualTo(externalId);
+    }
+
+    private static PostGroupsRequest groupRequest(final String externalId) {
+        final PostGroupsRequest request = new PostGroupsRequest();
+        request.officeId(1L);
+        request.name(GroupHelper.randomNameGenerator("Group_Name_", 5));
+        request.externalId(externalId);
+        request.active(true);
+        request.activationDate("04 March 2011");
+        request.dateFormat("dd MMMM yyyy");
+        request.locale("en");
+        return request;
     }
 
     @Test


### PR DESCRIPTION
Groups and Centers created without an explicit `externalId` were left with a blank/null value instead of one being generated, unlike Client creation which already auto-generates one. Separately, the `externalId` field was missing from the `CenterData` domain model's accessors and from the Swagger schemas for the Centers/Groups APIs, so it wasn't reliably surfaced in responses or generated API docs/clients.               
                                                                                                                                                    
This PR (https://issues.apache.org/jira/browse/FINERACT-2692):                                                                                 
                                                                                                                                                    

     - Adds the missing `getExternalId()` accessor to `CenterData`.                                                                                 
     - Documents `externalId` in the `CentersApiResourceSwagger` and `GroupsApiResourceSwagger` response schemas.                                   
     - Generates a random `externalId` in `GroupingTypesWritePlatformServiceJpaRepositoryImpl#createGroupingType` when none is supplied on Group/Center creation, consistent with Client behavior.                                                                                        
     - Makes the read paths in `AllGroupTypesDataMapper` and `CenterReadPlatformServiceImpl` fall back to a non-null placeholder when reading a blank `externalId` from existing data.                                                                                                         

**Test plan**                 
                                                                                                                  
  Added integration test coverage:                                                                                                               
- `CenterIntegrationTest#testCenterCreationWithoutExternalIdGeneratesOne`                                                                                  -`GroupTest#testGroupCreationWithoutExternalIdGeneratesOne`                                                                                   
- `GroupTest#testGroupCreationWithExternalIdIsPersisted` 