### PR TITLE
FINERACT-2687: Remove DISCLAIMER references

### DIFF
--- a/fineract-doc/src/docs/en/chapters/release/process-step09.adoc
+++ b/fineract-doc/src/docs/en/chapters/release/process-step09.adoc
@@ -10,7 +10,7 @@ Make sure release artifacts are hosted at both https://release-test.apache.org/c
 * Verify signatures and hashes. You may have to import the public key of the release manager to verify the signatures. (`gpg --import KEYS` or `gpg --recv-key <key id>`)
 * Git tag matches the released bits (`diff -rf`)
 * Can compile docs and code successfully from source
-* Verify DISCLAIMER, NOTICE and LICENSE (year etc)
+* Verify NOTICE and LICENSE (year etc)
 * All files have correct headers (Rat check should be clean - `./gradlew rat`)
 * No jar files in the source artifacts
 * All tests pass both in CI and locally

--- a/fineract-war/build.gradle
+++ b/fineract-war/build.gradle
@@ -51,7 +51,6 @@ war {
     def legalFiles = [
         file("$rootDir/LICENSE_RELEASE"),
         file("$rootDir/NOTICE_RELEASE"),
-        file("$rootDir/DISCLAIMER")
     ].findAll { it.exists() }
     
     if (!legalFiles.empty) {
@@ -134,7 +133,6 @@ distributions {
             rename ('LICENSE_RELEASE', 'LICENSE')
             rename ('NOTICE_RELEASE', 'NOTICE')
 
-            from "$rootDir/DISCLAIMER"
             from "$rootDir/README.md"
 
             from "$rootDir/fineract-doc/build/docs/pdf/en/index.pdf"


### PR DESCRIPTION
## Description

Removed remaining DISCLAIMER references from the project.

Changes made:
- Removed DISCLAIMER mention from release verification documentation.
- Removed DISCLAIMER references from fineract-war build and distribution configuration.

## Testing

Executed:
./gradlew.bat :fineract-war:build

Result:
BUILD SUCCESSFUL
1247 tests passed

Jira:
FINERACT-2687