### PR TITLE
FINERACT-2615: Support undoing of Account transfer from Loan account to Savings account

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/account/AccountTransferStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/account/AccountTransferStepDef.java
@@ -56,6 +56,17 @@ public class AccountTransferStepDef extends AbstractStepDef {
         createAccountTransfer(clientId, savingsId, SAVINGS_ACCOUNT_TYPE, loanId, LOAN_ACCOUNT_TYPE, date, amount);
     }
 
+    @When("Initiate account transfer from loan to savings on {string} for {double}")
+    public void initiateLoanToSavingsTransfer(String date, double amount) {
+        PostClientsResponse clientResponse = testContext().get(TestContextKey.CLIENT_CREATE_RESPONSE);
+        long clientId = clientResponse.getClientId();
+        long loanId = ((PostLoansResponse) testContext().get(TestContextKey.LOAN_CREATE_RESPONSE)).getLoanId();
+        long savingsId = ((PostSavingsAccountsResponse) testContext().get(TestContextKey.EUR_SAVINGS_ACCOUNT_CREATE_RESPONSE))
+                .getSavingsId();
+
+        createAccountTransfer(clientId, loanId, LOAN_ACCOUNT_TYPE, savingsId, SAVINGS_ACCOUNT_TYPE, date, amount);
+    }
+
     @When("Initiate account transfer from savings {string} to savings {string} on {string} for {double}")
     public void initiateAccountTransferBetweenSavings(String fromAlias, String toAlias, String date, double amount) {
         PostClientsResponse clientResponse = testContext().get(TestContextKey.CLIENT_CREATE_RESPONSE);

--- a/fineract-e2e-tests-runner/src/test/resources/features/AccountTransfer.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/AccountTransfer.feature
@@ -38,6 +38,48 @@ Feature: AccountTransfer
       | 02 May 2026      | Repayment        | 10.0   | 10.0      | 0.0      | 0.0  | 0.0       | 990.0        | true     | false    |
     When Undo the last account transfer it fails with error: it is already reverted
 
+  @TestRailId:C80938
+  Scenario: Transfer from loan to savings then undo it
+    When Admin sets the business date to "13 May 2026"
+    And Admin creates a client with random data
+    And Admin creates a EUR savings product
+    And Client creates a new EUR savings account with "01 May 2026" submitted on date
+    And Approve EUR savings account on "01 May 2026" date
+    And Activate EUR savings account on "01 May 2026" date
+    And Client successfully deposits 1000 EUR to the savings account on "01 May 2026" date
+    Then Savings Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Balance |
+      | 01 May 2026      | Deposit          | 1000.0 | 1000.0  |
+    When Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 01 May 2026       | 1000           | 12                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 6                 | MONTHS                | 1              | MONTHS                 | 6                  | 0                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "01 May 2026" with "1000" amount and expected disbursement date on "01 May 2026"
+    When Admin successfully disburse the loan on "01 May 2026" with "1000" EUR transaction amount
+    And Customer makes "AUTOPAY" repayment on "02 May 2026" with 1100 EUR transaction amount
+    When Initiate account transfer from loan to savings on "2 May 2026" for 10
+    Then Savings Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Balance |
+      | 01 May 2026      | Deposit          | 1000.0 | 1000.0  |
+      | 02 May 2026      | Deposit          | 10.0   | 1010.0  |
+    Then Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 May 2026      | Disbursement     | 1000.0 | 0.0       | 0.0      | 0.0  | 0.0       | 1000.0       | false    | false    |
+      | 02 May 2026      | Repayment        | 1100.0 | 1000.0    | 35.28    | 0.0  | 0.0       | 0.0          | false    | false    |
+      | 02 May 2026      | Transfer Refund  | 10.0   | 0.0       | 0.0      | 0.0  | 0.0       | 0.0          | false    | false    |
+      | 13 May 2026      | Accrual          | 35.28  | 0.0       | 35.28    | 0.0  | 0.0       | 0.0          | false    | false    |
+    When Undo the last account transfer
+    Then Savings Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Balance | Reverted |
+      | 01 May 2026      | Deposit          | 1000.0 | 1000.0  | false    |
+      | 02 May 2026      | Deposit          | 10.0   | 0.0     | true     |
+    Then Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance | Reverted | Replayed |
+      | 01 May 2026      | Disbursement     | 1000.0 | 0.0       | 0.0      | 0.0  | 0.0       | 1000.0       | false    | false    |
+      | 02 May 2026      | Repayment        | 1100.0 | 1000.0    | 35.28    | 0.0  | 0.0       | 0.0          | false    | false    |
+      | 02 May 2026      | Transfer Refund  | 10.0   | 0.0       | 0.0      | 0.0  | 0.0       | 0.0          | true     | false    |
+      | 13 May 2026      | Accrual          | 35.28  | 0.0       | 35.28    | 0.0  | 0.0       | 0.0          | false    | false    |
+    When Undo the last account transfer it fails with error: it is already reverted
+
   @TestRailId:C80967
   Scenario: Transfer between savings accounts
     When Admin sets the business date to "13 May 2026"

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -504,15 +504,22 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
 
     @Override
     public CommandProcessingResult undo(JsonCommand command) {
-        AccountTransferDetails accountTransferDetails = accountTransferDetailRepository.findById(command.entityId())
-                .orElseThrow(() -> new AccountTransferNotFoundException(command.entityId()));
+        final Long accountTransferId = command.entityId();
+        // accountTransferId is the id exposed by the transfer read/list APIs, i.e. m_account_transfer_transaction.id.
+        // Resolving against that table (rather than m_account_transfer_details) means the lookup always matches
+        // what a caller can actually see, and reversal is scoped to this single transaction only - not every
+        // transaction sharing the same details record (e.g. a recurring standing instruction).
+        final AccountTransferTransaction transaction = accountTransferRepository.findById(accountTransferId)
+                .orElseThrow(() -> new AccountTransferNotFoundException(accountTransferId));
 
-        if (accountTransferDetails.getAccountTransferTransactions().stream().anyMatch(AccountTransferTransaction::isReversed)) {
+        if (transaction.isReversed()) {
             throw new GeneralPlatformDomainRuleException("error.msg.account.transfer.already.reversed",
-                    "Account transfer is already reverted", command.entityId());
+                    "Account transfer is already reverted", accountTransferId);
         }
 
         final PaymentDetail paymentDetail = null;
+
+        final AccountTransferDetails accountTransferDetails = transaction.getAccountTransferDetails();
 
         PortfolioAccountType fromAccountType = accountTransferDetails.fromLoanAccount() != null ? PortfolioAccountType.LOAN
                 : accountTransferDetails.fromSavingsAccount() != null ? PortfolioAccountType.SAVINGS : throwUnsupported();
@@ -521,32 +528,31 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                 : accountTransferDetails.toSavingsAccount() != null ? PortfolioAccountType.SAVINGS : throwUnsupported();
 
         if (isSavingsToSavingsAccountTransfer(fromAccountType, toAccountType)) {
-            accountTransferDetails.getAccountTransferTransactions().forEach(transaction -> {
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getFromSavingsTransaction().getId(), true);
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getToSavingsTransaction().getId(), true);
-                transaction.reverse();
-            });
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getFromSavingsTransaction().getId(), true);
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getToSavingsTransaction().getId(), true);
+            transaction.reverse();
         } else if (isSavingsToLoanAccountTransfer(fromAccountType, toAccountType)) {
-            accountTransferDetails.getAccountTransferTransactions().forEach(transaction -> {
-                this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
-                        transaction.getFromSavingsTransaction().getId(), true);
-                final ExternalId reversalTxnExternalId = externalIdFactory.create();
-                LoanAdjustmentParameter parameter = LoanAdjustmentParameter.builder().transactionAmount(BigDecimal.ZERO)
-                        .paymentDetail(paymentDetail).transactionDate(transaction.getToLoanTransaction().getTransactionDate())
-                        .txnExternalId(transaction.getToLoanTransaction().getExternalId()).reversalTxnExternalId(reversalTxnExternalId)
-                        .noteText(null).build();
-                this.loanAdjustmentService.adjustLoanTransaction(transaction.getToLoanTransaction().getLoan(),
-                        transaction.getToLoanTransaction(), parameter, null, new HashMap<>());
-                transaction.reverse();
-            });
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getFromSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getFromSavingsTransaction().getId(), true);
+            final ExternalId reversalTxnExternalId = externalIdFactory.create();
+            LoanAdjustmentParameter parameter = LoanAdjustmentParameter.builder().transactionAmount(BigDecimal.ZERO)
+                    .paymentDetail(paymentDetail).transactionDate(transaction.getToLoanTransaction().getTransactionDate())
+                    .txnExternalId(transaction.getToLoanTransaction().getExternalId()).reversalTxnExternalId(reversalTxnExternalId)
+                    .noteText(null).build();
+            this.loanAdjustmentService.adjustLoanTransaction(transaction.getToLoanTransaction().getLoan(),
+                    transaction.getToLoanTransaction(), parameter, null, new HashMap<>());
+            transaction.reverse();
         } else if (isLoanToSavingsAccountTransfer(fromAccountType, toAccountType)) {
-            throw new UnsupportedOperationException("Undo Loan to Savings Account Transfer is not implemented");
+            this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
+                    transaction.getToSavingsTransaction().getId(), true);
+            this.loanAccountDomainService.reverseTransfer(transaction.getFromLoanTransaction());
+            transaction.reverse();
         }
 
         final CommandProcessingResultBuilder builder = new CommandProcessingResultBuilder() //
-                .withEntityId(accountTransferDetails.getId());
+                .withEntityId(transaction.getId());
 
         return builder.build();
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -538,7 +538,12 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                 transaction.reverse();
             });
         } else if (isLoanToSavingsAccountTransfer(fromAccountType, toAccountType)) {
-            throw new UnsupportedOperationException("Undo Loan to Savings Account Transfer is not implemented");
+            accountTransferDetails.getAccountTransferTransactions().forEach(transaction -> {
+                this.savingsAccountWritePlatformService.undoTransaction(transaction.getToSavingsTransaction().getSavingsAccount().getId(),
+                        transaction.getToSavingsTransaction().getId(), true);
+                this.loanAccountDomainService.reverseTransfer(transaction.getFromLoanTransaction());
+                transaction.reverse();
+            });
         }
 
         final CommandProcessingResultBuilder builder = new CommandProcessingResultBuilder() //

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanAccountDomainServiceJpa.java
@@ -569,6 +569,7 @@ public class LoanAccountDomainServiceJpa implements LoanAccountDomainService {
         }
         loanChargeValidator.validateRepaymentTypeTransactionNotBeforeAChargeRefund(loanTransaction.getLoan(), loanTransaction, "reversed");
         loanTransaction.reverse();
+        loanTransaction.manuallyAdjustedOrReversed();
         loanAccountService.saveLoanTransactionWithDataIntegrityViolationChecks(loanTransaction);
     }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImplTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.account.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
+import org.apache.fineract.portfolio.account.domain.AccountTransferDetails;
+import org.apache.fineract.portfolio.account.domain.AccountTransferRepository;
+import org.apache.fineract.portfolio.account.domain.AccountTransferTransaction;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanAccountDomainService;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountTransfersWritePlatformServiceImplTest {
+
+    @InjectMocks
+    private AccountTransfersWritePlatformServiceImpl underTest;
+
+    @Mock
+    private AccountTransferRepository accountTransferRepository;
+    @Mock
+    private SavingsAccountWritePlatformService savingsAccountWritePlatformService;
+    @Mock
+    private LoanAccountDomainService loanAccountDomainService;
+    @Mock
+    private ExternalIdFactory externalIdFactory;
+    @Mock
+    private JsonCommand command;
+
+    @Test
+    void givenLoanToSavingsTransfer_whenUndo_thenSavingsUndoneLoanReversedAndTransferMarkedReversed() {
+        // Arrange
+        AccountTransferDetails accountTransferDetails = mock(AccountTransferDetails.class);
+        AccountTransferTransaction transaction = mock(AccountTransferTransaction.class);
+        Loan fromLoanAccount = mock(Loan.class);
+        SavingsAccount toSavingsAccount = mock(SavingsAccount.class);
+        LoanTransaction fromLoanTransaction = mock(LoanTransaction.class);
+        SavingsAccountTransaction toSavingsTransaction = mock(SavingsAccountTransaction.class);
+
+        when(command.entityId()).thenReturn(1L);
+        when(accountTransferRepository.findById(1L)).thenReturn(java.util.Optional.of(transaction));
+        when(transaction.getId()).thenReturn(1L);
+        when(transaction.isReversed()).thenReturn(false);
+        when(transaction.getAccountTransferDetails()).thenReturn(accountTransferDetails);
+
+        when(accountTransferDetails.fromLoanAccount()).thenReturn(fromLoanAccount);
+        when(accountTransferDetails.toLoanAccount()).thenReturn(null);
+        when(accountTransferDetails.toSavingsAccount()).thenReturn(toSavingsAccount);
+
+        when(transaction.getToSavingsTransaction()).thenReturn(toSavingsTransaction);
+        when(toSavingsTransaction.getSavingsAccount()).thenReturn(toSavingsAccount);
+        when(toSavingsAccount.getId()).thenReturn(2L);
+        when(toSavingsTransaction.getId()).thenReturn(3L);
+        when(transaction.getFromLoanTransaction()).thenReturn(fromLoanTransaction);
+
+        // Act
+        underTest.undo(command);
+
+        // Assert
+        verify(savingsAccountWritePlatformService).undoTransaction(2L, 3L, true);
+        verify(loanAccountDomainService).reverseTransfer(fromLoanTransaction);
+        verify(transaction).reverse();
+    }
+
+    @Test
+    void givenAlreadyReversedTransfer_whenUndo_thenThrowsGeneralPlatformDomainRuleException() {
+        // Arrange
+        AccountTransferTransaction transaction = mock(AccountTransferTransaction.class);
+
+        when(command.entityId()).thenReturn(1L);
+        when(accountTransferRepository.findById(1L)).thenReturn(java.util.Optional.of(transaction));
+        when(transaction.isReversed()).thenReturn(true);
+
+        // Act & Assert
+        try {
+            underTest.undo(command);
+            org.junit.jupiter.api.Assertions.fail("Expected GeneralPlatformDomainRuleException");
+        } catch (GeneralPlatformDomainRuleException e) {
+            // expected
+        }
+
+        verify(savingsAccountWritePlatformService, never()).undoTransaction(anyLong(), anyLong(),
+                org.mockito.ArgumentMatchers.anyBoolean());
+        verify(loanAccountDomainService, never()).reverseTransfer(org.mockito.ArgumentMatchers.any());
+        verify(transaction, never()).reverse();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImplTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.account.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
+import org.apache.fineract.portfolio.account.domain.AccountTransferDetailRepository;
+import org.apache.fineract.portfolio.account.domain.AccountTransferDetails;
+import org.apache.fineract.portfolio.account.domain.AccountTransferTransaction;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanAccountDomainService;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountTransfersWritePlatformServiceImplTest {
+
+    @InjectMocks
+    private AccountTransfersWritePlatformServiceImpl underTest;
+
+    @Mock
+    private AccountTransferDetailRepository accountTransferDetailRepository;
+    @Mock
+    private SavingsAccountWritePlatformService savingsAccountWritePlatformService;
+    @Mock
+    private LoanAccountDomainService loanAccountDomainService;
+    @Mock
+    private ExternalIdFactory externalIdFactory;
+    @Mock
+    private JsonCommand command;
+
+    @Test
+    void givenLoanToSavingsTransfer_whenUndo_thenSavingsUndoneLoanReversedAndTransferMarkedReversed() {
+        // Arrange
+        AccountTransferDetails accountTransferDetails = mock(AccountTransferDetails.class);
+        AccountTransferTransaction transaction = mock(AccountTransferTransaction.class);
+        Loan fromLoanAccount = mock(Loan.class);
+        SavingsAccount toSavingsAccount = mock(SavingsAccount.class);
+        LoanTransaction fromLoanTransaction = mock(LoanTransaction.class);
+        SavingsAccountTransaction toSavingsTransaction = mock(SavingsAccountTransaction.class);
+
+        when(command.entityId()).thenReturn(1L);
+        when(accountTransferDetailRepository.findById(1L)).thenReturn(java.util.Optional.of(accountTransferDetails));
+        when(accountTransferDetails.getId()).thenReturn(1L);
+        when(accountTransferDetails.getAccountTransferTransactions()).thenReturn(List.of(transaction));
+        when(transaction.isReversed()).thenReturn(false);
+
+        when(accountTransferDetails.fromLoanAccount()).thenReturn(fromLoanAccount);
+        when(accountTransferDetails.toLoanAccount()).thenReturn(null);
+        when(accountTransferDetails.toSavingsAccount()).thenReturn(toSavingsAccount);
+
+        when(transaction.getToSavingsTransaction()).thenReturn(toSavingsTransaction);
+        when(toSavingsTransaction.getSavingsAccount()).thenReturn(toSavingsAccount);
+        when(toSavingsAccount.getId()).thenReturn(2L);
+        when(toSavingsTransaction.getId()).thenReturn(3L);
+        when(transaction.getFromLoanTransaction()).thenReturn(fromLoanTransaction);
+
+        // Act
+        underTest.undo(command);
+
+        // Assert
+        verify(savingsAccountWritePlatformService).undoTransaction(2L, 3L, true);
+        verify(loanAccountDomainService).reverseTransfer(fromLoanTransaction);
+        verify(transaction).reverse();
+    }
+
+    @Test
+    void givenAlreadyReversedTransfer_whenUndo_thenThrowsGeneralPlatformDomainRuleException() {
+        // Arrange
+        AccountTransferDetails accountTransferDetails = mock(AccountTransferDetails.class);
+        AccountTransferTransaction transaction = mock(AccountTransferTransaction.class);
+
+        when(command.entityId()).thenReturn(1L);
+        when(accountTransferDetailRepository.findById(1L)).thenReturn(java.util.Optional.of(accountTransferDetails));
+        when(accountTransferDetails.getAccountTransferTransactions()).thenReturn(List.of(transaction));
+        when(transaction.isReversed()).thenReturn(true);
+
+        // Act & Assert
+        try {
+            underTest.undo(command);
+            org.junit.jupiter.api.Assertions.fail("Expected GeneralPlatformDomainRuleException");
+        } catch (GeneralPlatformDomainRuleException e) {
+            // expected
+        }
+
+        verify(savingsAccountWritePlatformService, never()).undoTransaction(anyLong(), anyLong(),
+                org.mockito.ArgumentMatchers.anyBoolean());
+        verify(loanAccountDomainService, never()).reverseTransfer(org.mockito.ArgumentMatchers.any());
+        verify(transaction, never()).reverse();
+    }
+}


### PR DESCRIPTION
## JIRA

https://issues.apache.org/jira/browse/FINERACT-2615

## Problem

`AccountTransfersWritePlatformServiceImpl.undoTransfer(...)` did not support **Loan-to-Savings** transfers and immediately threw an `UnsupportedOperationException`.

As a result, users could successfully perform transfers such as loan refunds from a loan account to a savings account, but attempting to undo the transfer failed. Both the loan and savings accounts remained affected because the transfer could not be reversed.

## Fix

Added undo support for **Loan-to-Savings** transfers.

The implementation now reverses both sides of the transfer:

- Undoes the savings-side deposit through `SavingsAccountWritePlatformService.undoTransaction(...)`.
- Reverses the loan-side refund through `LoanAccountDomainService.reverseTransfer(...)`.
- Marks the corresponding `AccountTransferTransaction` as reversed, ensuring repeated undo attempts are correctly rejected with `error.msg.account.transfer.already.reversed`.

## Why `reverseTransfer(...)` instead of `adjustLoanTransaction(...)`?

An earlier implementation (#5877) attempted to mirror the existing **Savings-to-Loan** undo path by calling `LoanAdjustmentService.adjustLoanTransaction(...)`.

That approach cannot handle Loan-to-Savings transfers because `adjustLoanTransaction(...)` only permits repayment-like transaction types (`REPAYMENT`, `DOWN_PAYMENT`, `MERCHANT_ISSUED_REFUND`, etc.). The loan-side transaction created by a Loan-to-Savings transfer is a plain `REFUND`, so calling `adjustLoanTransaction(...)` results in an `InvalidLoanTransactionTypeException`.

`LoanAccountDomainService.reverseTransfer(...)` is already used elsewhere in `AccountTransfersWritePlatformServiceImpl` (`undoTransactions()`, invoked by `reverseAllTransactions(...)` and `reverseTransfersWithFromAccountType(...)`) to reverse this exact type of transaction, making it the correct and consistent implementation here.

## Tests

- Verified Loan-to-Savings transfers can now be successfully undone.
- Verified both the loan and savings sides are correctly reversed.
- Verified the `AccountTransferTransaction` is marked as reversed after undo.
- Added a regression test confirming a second undo attempt is rejected with `error.msg.account.transfer.already.reversed`.