### PR TITLE
FINERACT-2684: AbstractLockingService - update queries to use ANY() instead of IN for loan_ids clause

### DIFF
--- a/fineract-cob/src/main/java/org/apache/fineract/cob/domain/AbstractLockingService.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/domain/AbstractLockingService.java
@@ -20,27 +20,28 @@ package org.apache.fineract.cob.domain;
 
 import java.sql.PreparedStatement;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 @Slf4j
 public abstract class AbstractLockingService implements LockingService {
 
     private final JdbcTemplate jdbcTemplate;
-    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final FineractProperties fineractProperties;
 
-    protected AbstractLockingService(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
+    protected AbstractLockingService(JdbcTemplate jdbcTemplate, DatabaseSpecificSQLGenerator sqlGenerator,
+            FineractProperties fineractProperties) {
         this.jdbcTemplate = jdbcTemplate;
-        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+        this.sqlGenerator = sqlGenerator;
         this.fineractProperties = fineractProperties;
     }
 
@@ -64,8 +65,10 @@ public abstract class AbstractLockingService implements LockingService {
         if (loanIds.isEmpty()) {
             return Collections.emptyList();
         }
-        String sql = "SELECT loan_id FROM " + getTableName() + " WHERE loan_id IN (:ids)";
-        return namedParameterJdbcTemplate.queryForList(sql, Map.of("ids", loanIds), Long.class);
+        // Uses DatabaseSpecificSQLGenerator.in() to emit ANY(?) on PostgreSQL instead of IN($1,...$N),
+        // so all batch sizes share one query plan instead of one per distinct size.
+        final String sql = "SELECT loan_id FROM " + getTableName() + " WHERE " + sqlGenerator.in("loan_id", loanIds);
+        return jdbcTemplate.queryForList(sql, Long.class, sqlGenerator.inParametersFor(loanIds));
     }
 
     @Override
@@ -73,8 +76,9 @@ public abstract class AbstractLockingService implements LockingService {
         if (loanIds.isEmpty()) {
             return Collections.emptyList();
         }
-        String sql = "SELECT loan_id FROM " + getTableName() + " WHERE loan_id IN (:ids) AND lock_owner = :owner";
-        return namedParameterJdbcTemplate.queryForList(sql, Map.of("ids", loanIds, "owner", lockOwner.name()), Long.class);
+        final String sql = "SELECT loan_id FROM " + getTableName() + " WHERE " + sqlGenerator.in("loan_id", loanIds)
+                + " AND lock_owner = ?";
+        return jdbcTemplate.queryForList(sql, Long.class, paramsWithLockOwner(loanIds, lockOwner));
     }
 
     @Override
@@ -94,8 +98,8 @@ public abstract class AbstractLockingService implements LockingService {
         if (loanIds.isEmpty()) {
             return;
         }
-        String sql = "DELETE FROM " + getTableName() + " WHERE loan_id IN (:ids) AND lock_owner = :owner";
-        namedParameterJdbcTemplate.update(sql, Map.of("ids", loanIds, "owner", lockOwner.name()));
+        final String sql = "DELETE FROM " + getTableName() + " WHERE " + sqlGenerator.in("loan_id", loanIds) + " AND lock_owner = ?";
+        jdbcTemplate.update(sql, paramsWithLockOwner(loanIds, lockOwner));
     }
 
     @Override
@@ -105,6 +109,13 @@ public abstract class AbstractLockingService implements LockingService {
         if (updated == 0) {
             log.warn("No lock found to update error for loan id: {} with owner: {}", loanId, lockOwner);
         }
+    }
+
+    private Object[] paramsWithLockOwner(final List<Long> loanIds, final LockOwner lockOwner) {
+        final List<Object> params = new ArrayList<>();
+        Collections.addAll(params, sqlGenerator.inParametersFor(loanIds));
+        params.add(lockOwner.name());
+        return params.toArray();
     }
 
     private int getInClauseParameterSizeLimit() {

--- a/fineract-cob/src/test/java/org/apache/fineract/cob/domain/AbstractLockingServiceTest.java
+++ b/fineract-cob/src/test/java/org/apache/fineract/cob/domain/AbstractLockingServiceTest.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.cob.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseType;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseTypeResolver;
+import org.apache.fineract.infrastructure.core.service.database.RoutingDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractLockingServiceTest {
+
+    private static final List<Long> LOAN_IDS = List.of(10L, 20L, 30L);
+    private static final String TABLE_NAME = "test_locks";
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private DatabaseTypeResolver databaseTypeResolver;
+    @Mock
+    private RoutingDataSource dataSource;
+    @Mock
+    private FineractProperties fineractProperties;
+
+    private AbstractLockingService underTest;
+
+    @BeforeEach
+    void setUp() {
+        final DatabaseSpecificSQLGenerator sqlGenerator = new DatabaseSpecificSQLGenerator(databaseTypeResolver, dataSource);
+        underTest = new AbstractLockingService(jdbcTemplate, sqlGenerator, fineractProperties) {
+
+            @Override
+            protected String getTableName() {
+                return TABLE_NAME;
+            }
+
+            @Override
+            protected String getBatchLoanLockInsert() {
+                return "";
+            }
+
+            @Override
+            protected String getBatchLoanLockUpgrade() {
+                return "";
+            }
+        };
+    }
+
+    @Test
+    void findLockIdsByLoanIdInOnMySqlUsesInClauseWithIndividualBindParameters() {
+        when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.MYSQL);
+
+        underTest.findLockIdsByLoanIdIn(LOAN_IDS);
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).queryForList(sqlCaptor.capture(), eq(Long.class), eq(10L), eq(20L), eq(30L));
+        assertEquals("SELECT loan_id FROM " + TABLE_NAME + " WHERE loan_id IN (?,?,?)", sqlCaptor.getValue());
+    }
+
+    @Test
+    void findLockIdsByLoanIdInOnPostgresUsesAnyClauseWithArrayBindParameter() throws SQLException {
+        when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.POSTGRESQL);
+        final Connection connection = mock(Connection.class);
+        final Array loanIdArray = mock(Array.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createArrayOf(eq("bigint"), any(Long[].class))).thenReturn(loanIdArray);
+
+        underTest.findLockIdsByLoanIdIn(LOAN_IDS);
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).queryForList(sqlCaptor.capture(), eq(Long.class), eq(loanIdArray));
+        assertEquals("SELECT loan_id FROM " + TABLE_NAME + " WHERE loan_id = ANY (?)", sqlCaptor.getValue());
+        verify(connection).createArrayOf("bigint", LOAN_IDS.toArray(Long[]::new));
+    }
+
+    @Test
+    void findLockIdsByLoanIdInAndLockOwnerOnPostgresUsesAnyClauseWithArrayBindParameter() throws SQLException {
+        when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.POSTGRESQL);
+        final Connection connection = mock(Connection.class);
+        final Array loanIdArray = mock(Array.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createArrayOf(eq("bigint"), any(Long[].class))).thenReturn(loanIdArray);
+
+        underTest.findLockIdsByLoanIdInAndLockOwner(LOAN_IDS, LockOwner.LOAN_COB_CHUNK_PROCESSING);
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).queryForList(sqlCaptor.capture(), eq(Long.class), eq(loanIdArray),
+                eq(LockOwner.LOAN_COB_CHUNK_PROCESSING.name()));
+        assertEquals("SELECT loan_id FROM " + TABLE_NAME + " WHERE loan_id = ANY (?) AND lock_owner = ?", sqlCaptor.getValue());
+    }
+
+    @Test
+    void deleteByLoanIdInAndLockOwnerOnMySqlUsesInClauseWithIndividualBindParameters() {
+        when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.MYSQL);
+
+        underTest.deleteByLoanIdInAndLockOwner(LOAN_IDS, LockOwner.LOAN_COB_CHUNK_PROCESSING);
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).update(sqlCaptor.capture(), eq(10L), eq(20L), eq(30L), eq(LockOwner.LOAN_COB_CHUNK_PROCESSING.name()));
+        assertEquals("DELETE FROM " + TABLE_NAME + " WHERE loan_id IN (?,?,?) AND lock_owner = ?", sqlCaptor.getValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyLoanIds")
+    void findLockIdsByLoanIdInWithNoIdsSkipsQuery(final List<Long> loanIds) {
+        assertTrue(underTest.findLockIdsByLoanIdIn(loanIds).isEmpty());
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    private static Stream<List<Long>> emptyLoanIds() {
+        return Stream.of(Collections.emptyList());
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.core.service.database;
 import static java.lang.String.format;
 
 import java.math.BigInteger;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
@@ -353,10 +354,13 @@ public class DatabaseSpecificSQLGenerator {
     public Object[] inParametersFor(List<Long> ids) {
         return switch (getDialect()) {
             case POSTGRESQL -> {
+                final Connection con = DataSourceUtils.getConnection(dataSource);
                 try {
-                    yield new Object[] { DataSourceUtils.getConnection(dataSource).createArrayOf("bigint", ids.toArray(new Long[0])) };
+                    yield new Object[] { con.createArrayOf("bigint", ids.toArray(new Long[0])) };
                 } catch (SQLException e) {
                     throw new RuntimeException(e);
+                } finally {
+                    DataSourceUtils.releaseConnection(con, dataSource);
                 }
             }
             case MYSQL -> ids.toArray();

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.fineract.infrastructure.core.service.database;
 
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -62,5 +66,20 @@ public class DatabaseSpecificSQLGeneratorTest {
         String sql = "SELECT 1 FROM test_table WHERE asd=2 OFFSET 2 LIMIT 50";
         String countQuery = databaseSpecificSQLGenerator.countQueryResult(sql);
         Assertions.assertEquals("SELECT COUNT(*) FROM (SELECT 1 FROM test_table WHERE asd=2) AS temp", countQuery);
+    }
+
+    @Test
+    public void testInParametersForOnPostgresReleasesConnectionAfterArrayCreation() throws SQLException {
+        Mockito.when(databaseTypeResolver.databaseType()).thenReturn(DatabaseType.POSTGRESQL);
+        final Connection connection = Mockito.mock(Connection.class);
+        final Array idArray = Mockito.mock(Array.class);
+        Mockito.when(dataSource.getConnection()).thenReturn(connection);
+        Mockito.when(connection.createArrayOf(Mockito.eq("bigint"), Mockito.any(Long[].class))).thenReturn(idArray);
+
+        final Object[] parameters = databaseSpecificSQLGenerator.inParametersFor(List.of(1L, 2L, 3L));
+
+        Assertions.assertArrayEquals(new Object[] { idArray }, parameters);
+        Mockito.verify(connection).createArrayOf("bigint", new Long[] { 1L, 2L, 3L });
+        Mockito.verify(connection).close();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.fineract.cob.loan;
 
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -32,11 +33,13 @@ public class LoanLockingConfiguration {
     @Autowired
     private JdbcTemplate jdbcTemplate;
     @Autowired
+    private DatabaseSpecificSQLGenerator sqlGenerator;
+    @Autowired
     private FineractProperties fineractProperties;
 
     @Bean
     @ConditionalOnMissingBean(name = "retrieveLoanLockingService")
     public LockingService retrieveLoanLockingService() {
-        return new LoanLockingServiceImpl(jdbcTemplate, fineractProperties);
+        return new LoanLockingServiceImpl(jdbcTemplate, sqlGenerator, fineractProperties);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/loan/LoanLockingServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.fineract.cob.loan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.AbstractLockingService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Slf4j
@@ -36,8 +37,9 @@ public class LoanLockingServiceImpl extends AbstractLockingService {
                 UPDATE m_loan_account_locks SET version= version + 1, lock_owner = ?, lock_placed_on = ? WHERE loan_id = ?
             """;
 
-    public LoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
-        super(jdbcTemplate, fineractProperties);
+    public LoanLockingServiceImpl(JdbcTemplate jdbcTemplate, DatabaseSpecificSQLGenerator sqlGenerator,
+            FineractProperties fineractProperties) {
+        super(jdbcTemplate, sqlGenerator, fineractProperties);
     }
 
     @Override

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingConfiguration.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.fineract.cob.workingcapitalloan;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.cob.domain.LockingService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,11 +32,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public class WorkingCapitalLoanLockingConfiguration {
 
     private final JdbcTemplate jdbcTemplate;
+    private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final FineractProperties fineractProperties;
 
     @Bean
     @ConditionalOnMissingBean(name = "workingCapitalLoanLockingService")
     public LockingService workingCapitalLoanLockingService() {
-        return new WorkingCapitalLoanLockingServiceImpl(jdbcTemplate, fineractProperties);
+        return new WorkingCapitalLoanLockingServiceImpl(jdbcTemplate, sqlGenerator, fineractProperties);
     }
 }

--- a/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingServiceImpl.java
+++ b/fineract-working-capital-loan/src/main/java/org/apache/fineract/cob/workingcapitalloan/WorkingCapitalLoanLockingServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.fineract.cob.workingcapitalloan;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.cob.domain.AbstractLockingService;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Slf4j
@@ -36,8 +37,9 @@ public class WorkingCapitalLoanLockingServiceImpl extends AbstractLockingService
                 UPDATE m_wc_loan_account_locks SET version= version + 1, lock_owner = ?, lock_placed_on = ? WHERE loan_id = ?
             """;
 
-    public WorkingCapitalLoanLockingServiceImpl(JdbcTemplate jdbcTemplate, FineractProperties fineractProperties) {
-        super(jdbcTemplate, fineractProperties);
+    public WorkingCapitalLoanLockingServiceImpl(JdbcTemplate jdbcTemplate, DatabaseSpecificSQLGenerator sqlGenerator,
+            FineractProperties fineractProperties) {
+        super(jdbcTemplate, sqlGenerator, fineractProperties);
     }
 
     @Override


### PR DESCRIPTION
## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
