### PR TITLE
FINERACT-2695: enable dismiss stale reviews for PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,6 +32,9 @@ github:
       required_conversation_resolution: true
       required_pull_request_reviews:
         required_approving_review_count: 1
+        # Dismiss stale pull request approvals when new commits are pushed.
+        # New, reviewable commits pushed will dismiss previous pull request review approvals.
+        dismiss_stale_reviews: true
 notifications:
   commits: commits@fineract.apache.org
   pullrequests: issues@fineract.apache.org


### PR DESCRIPTION
## Description

This ensures new commits pushed to a PR are reviewed & approved.

FINERACT-2695

[I learned about the setting from ASF infra](https://the-asf.slack.com/archives/CBX4TSBQ8/p1784573556439389) (humbedooh / Daniel Gruno).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).